### PR TITLE
Moves async to .jib.async and steps to .jib.builder.steps.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/async/AsyncStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/async/AsyncStep.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.async;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -34,7 +34,7 @@ import java.util.concurrent.Callable;
  *
  * @param <T> the object type passed on by this step
  */
-interface AsyncStep<T> {
+public interface AsyncStep<T> {
 
   /** @return the submitted future */
   // TODO: Consider changing this to be orchestrated by an AsyncStepsBuilder.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/async/AsyncSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/async/AsyncSteps.java
@@ -14,18 +14,18 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.async;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
-import java.util.concurrent.ExecutionException;
 
-/** Static utility for ensuring {@link ListenableFuture#get} does not block. */
-class NonBlockingSteps {
+/** Static methods for {@link AsyncStep}. */
+public class AsyncSteps {
 
-  static <T> T get(AsyncStep<T> asyncStep) throws ExecutionException {
-    return Futures.getDone(asyncStep.getFuture());
+  public static <T> AsyncStep<T> immediate(T returnValue) {
+    ListenableFuture<T> future = Futures.immediateFuture(returnValue);
+    return () -> future;
   }
 
-  private NonBlockingSteps() {}
+  private AsyncSteps() {}
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/async/NonBlockingSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/async/NonBlockingSteps.java
@@ -14,18 +14,18 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.async;
 
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
+import java.util.concurrent.ExecutionException;
 
-/** Static methods for {@link AsyncStep}. */
-class AsyncSteps {
+/** Static utility for ensuring {@link ListenableFuture#get} does not block. */
+public class NonBlockingSteps {
 
-  static <T> AsyncStep<T> immediate(T returnValue) {
-    ListenableFuture<T> future = Futures.immediateFuture(returnValue);
-    return () -> future;
+  public static <T> T get(AsyncStep<T> asyncStep) throws ExecutionException {
+    return Futures.getDone(asyncStep.getFuture());
   }
 
-  private AsyncSteps() {}
+  private NonBlockingSteps() {}
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildDockerSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildDockerSteps.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.builder;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.builder.steps.StepsRunner;
 import com.google.cloud.tools.jib.cache.Cache;
 import com.google.cloud.tools.jib.cache.CacheDirectoryNotOwnedException;
 import com.google.cloud.tools.jib.cache.CacheMetadataCorruptedException;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildImageSteps.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.builder;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.builder.steps.StepsRunner;
 import com.google.cloud.tools.jib.cache.Cache;
 import com.google.cloud.tools.jib.cache.CacheDirectoryNotOwnedException;
 import com.google.cloud.tools.jib.cache.CacheMetadataCorruptedException;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePullStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePullStep.java
@@ -14,9 +14,12 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
 import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticationFailedException;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticator;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
@@ -14,9 +14,12 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
 import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticationFailedException;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticator;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
@@ -14,9 +14,12 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
+import com.google.cloud.tools.jib.builder.SourceFilesConfiguration;
 import com.google.cloud.tools.jib.cache.Cache;
 import com.google.cloud.tools.jib.cache.CacheMetadataCorruptedException;
 import com.google.cloud.tools.jib.cache.CacheReader;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
@@ -14,9 +14,12 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.common.collect.ImmutableList;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildTarballAndLoadDockerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildTarballAndLoadDockerStep.java
@@ -14,10 +14,13 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.async.NonBlockingSteps;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.Blobs;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
 import com.google.cloud.tools.jib.cache.CachedLayer;
 import com.google.cloud.tools.jib.docker.json.DockerLoadManifestTemplate;
 import com.google.cloud.tools.jib.image.Image;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/FinalizingStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/FinalizingStep.java
@@ -14,8 +14,11 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
@@ -14,9 +14,12 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
 import com.google.cloud.tools.jib.cache.Cache;
 import com.google.cloud.tools.jib.cache.CacheReader;
 import com.google.cloud.tools.jib.cache.CacheWriter;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayersStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayersStep.java
@@ -14,9 +14,12 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
 import com.google.cloud.tools.jib.cache.Cache;
 import com.google.cloud.tools.jib.image.Layer;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -14,10 +14,13 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.async.NonBlockingSteps;
 import com.google.cloud.tools.jib.blob.Blobs;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.LayerCountMismatchException;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -62,8 +62,7 @@ class PushBlobStep implements AsyncStep<Void>, Callable<Void> {
   }
 
   @Override
-  public Void call()
-      throws IOException, RegistryException, ExecutionException {
+  public Void call() throws IOException, RegistryException, ExecutionException {
     CachedLayer layer = NonBlockingSteps.get(cachedLayerStep);
     DescriptorDigest layerDigest = layer.getBlobDescriptor().getDigest();
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -14,9 +14,12 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
 import com.google.cloud.tools.jib.cache.CachedLayer;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.registry.RegistryClient;
@@ -60,7 +63,7 @@ class PushBlobStep implements AsyncStep<Void>, Callable<Void> {
 
   @Override
   public Void call()
-      throws IOException, RegistryException, ExecutionException, InterruptedException {
+      throws IOException, RegistryException, ExecutionException {
     CachedLayer layer = NonBlockingSteps.get(cachedLayerStep);
     DescriptorDigest layerDigest = layer.getBlobDescriptor().getDigest();
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushContainerConfigurationStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushContainerConfigurationStep.java
@@ -14,11 +14,14 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.async.NonBlockingSteps;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
 import com.google.cloud.tools.jib.hash.CountingDigestOutputStream;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -14,9 +14,12 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ImageToJsonTranslator;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayersStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayersStep.java
@@ -14,9 +14,12 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
 import com.google.cloud.tools.jib.cache.CachedLayer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStep.java
@@ -14,9 +14,12 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.Timer;
+import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
+import com.google.cloud.tools.jib.builder.BuildLogger;
 import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.registry.credentials.DockerConfigCredentialRetriever;
 import com.google.cloud.tools.jib.registry.credentials.DockerCredentialHelperFactory;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -14,8 +14,11 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
+import com.google.cloud.tools.jib.async.AsyncSteps;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
+import com.google.cloud.tools.jib.builder.SourceFilesConfiguration;
 import com.google.cloud.tools.jib.cache.Cache;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -33,7 +36,7 @@ import javax.annotation.Nullable;
  * <p>Use by constructing the runner and calling {@code run...} each step. Make sure that steps are
  * run before other steps that depend on them. Wait on the last step.
  */
-class StepsRunner {
+public class StepsRunner {
 
   private final ListeningExecutorService listeningExecutorService =
       MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
@@ -59,7 +62,7 @@ class StepsRunner {
   @Nullable private PushImageStep pushImageStep;
   @Nullable private BuildTarballAndLoadDockerStep buildTarballAndLoadDockerStep;
 
-  StepsRunner(
+  public StepsRunner(
       BuildConfiguration buildConfiguration,
       SourceFilesConfiguration sourceFilesConfiguration,
       Cache baseLayersCache,
@@ -70,20 +73,20 @@ class StepsRunner {
     this.applicationLayersCache = applicationLayersCache;
   }
 
-  StepsRunner runRetrieveBaseRegistryCredentialsStep() {
+  public StepsRunner runRetrieveBaseRegistryCredentialsStep() {
     retrieveBaseRegistryCredentialsStep =
         RetrieveRegistryCredentialsStep.forBaseImage(listeningExecutorService, buildConfiguration);
     return this;
   }
 
-  StepsRunner runRetrieveTargetRegistryCredentialsStep() {
+  public StepsRunner runRetrieveTargetRegistryCredentialsStep() {
     retrieveTargetRegistryCredentialsStep =
         RetrieveRegistryCredentialsStep.forTargetImage(
             listeningExecutorService, buildConfiguration);
     return this;
   }
 
-  StepsRunner runAuthenticatePushStep() {
+  public StepsRunner runAuthenticatePushStep() {
     authenticatePushStep =
         new AuthenticatePushStep(
             listeningExecutorService,
@@ -92,7 +95,7 @@ class StepsRunner {
     return this;
   }
 
-  StepsRunner runAuthenticatePullStep() {
+  public StepsRunner runAuthenticatePullStep() {
     authenticatePullStep =
         new AuthenticatePullStep(
             listeningExecutorService,
@@ -101,7 +104,7 @@ class StepsRunner {
     return this;
   }
 
-  StepsRunner runPullBaseImageStep() {
+  public StepsRunner runPullBaseImageStep() {
     pullBaseImageStep =
         new PullBaseImageStep(
             listeningExecutorService,
@@ -110,7 +113,7 @@ class StepsRunner {
     return this;
   }
 
-  StepsRunner runPullAndCacheBaseImageLayersStep() {
+  public StepsRunner runPullAndCacheBaseImageLayersStep() {
     pullAndCacheBaseImageLayersStep =
         new PullAndCacheBaseImageLayersStep(
             listeningExecutorService,
@@ -121,7 +124,7 @@ class StepsRunner {
     return this;
   }
 
-  StepsRunner runPushBaseImageLayersStep() {
+  public StepsRunner runPushBaseImageLayersStep() {
     pushBaseImageLayersStep =
         new PushLayersStep(
             listeningExecutorService,
@@ -131,7 +134,7 @@ class StepsRunner {
     return this;
   }
 
-  StepsRunner runBuildAndCacheApplicationLayerSteps() {
+  public StepsRunner runBuildAndCacheApplicationLayerSteps() {
     buildAndCacheApplicationLayerSteps =
         BuildAndCacheApplicationLayerStep.makeList(
             listeningExecutorService,
@@ -141,7 +144,7 @@ class StepsRunner {
     return this;
   }
 
-  StepsRunner runBuildImageStep(ImmutableList<String> entrypoint) {
+  public StepsRunner runBuildImageStep(ImmutableList<String> entrypoint) {
     buildImageStep =
         new BuildImageStep(
             listeningExecutorService,
@@ -152,7 +155,7 @@ class StepsRunner {
     return this;
   }
 
-  StepsRunner runPushContainerConfigurationStep() {
+  public StepsRunner runPushContainerConfigurationStep() {
     pushContainerConfigurationStep =
         new PushContainerConfigurationStep(
             listeningExecutorService,
@@ -162,7 +165,7 @@ class StepsRunner {
     return this;
   }
 
-  StepsRunner runPushApplicationLayersStep() {
+  public StepsRunner runPushApplicationLayersStep() {
     pushApplicationLayersStep =
         new PushLayersStep(
             listeningExecutorService,
@@ -172,7 +175,7 @@ class StepsRunner {
     return this;
   }
 
-  StepsRunner runFinalizingPushStep() {
+  public StepsRunner runFinalizingPushStep() {
     new FinalizingStep(
         listeningExecutorService,
         buildConfiguration,
@@ -183,7 +186,7 @@ class StepsRunner {
     return this;
   }
 
-  StepsRunner runFinalizingBuildStep() {
+  public StepsRunner runFinalizingBuildStep() {
     new FinalizingStep(
         listeningExecutorService,
         buildConfiguration,
@@ -192,7 +195,7 @@ class StepsRunner {
     return this;
   }
 
-  StepsRunner runPushImageStep() {
+  public StepsRunner runPushImageStep() {
     pushImageStep =
         new PushImageStep(
             listeningExecutorService,
@@ -205,7 +208,7 @@ class StepsRunner {
     return this;
   }
 
-  StepsRunner runBuildTarballAndLoadDockerStep() {
+  public StepsRunner runBuildTarballAndLoadDockerStep() {
     buildTarballAndLoadDockerStep =
         new BuildTarballAndLoadDockerStep(
             listeningExecutorService,
@@ -216,11 +219,12 @@ class StepsRunner {
     return this;
   }
 
-  void waitOnPushImageStep() throws ExecutionException, InterruptedException {
+  public void waitOnPushImageStep() throws ExecutionException, InterruptedException {
     Preconditions.checkNotNull(pushImageStep).getFuture().get();
   }
 
-  void waitOnBuildTarballAndLoadDockerStep() throws ExecutionException, InterruptedException {
+  public void waitOnBuildTarballAndLoadDockerStep()
+      throws ExecutionException, InterruptedException {
     Preconditions.checkNotNull(buildTarballAndLoadDockerStep).getFuture().get();
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/TestSourceFilesConfiguration.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/TestSourceFilesConfiguration.java
@@ -26,8 +26,11 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-/** Implementation of {@link SourceFilesConfiguration} that uses test resources. */
-class TestSourceFilesConfiguration implements SourceFilesConfiguration {
+/**
+ * Implementation of {@link com.google.cloud.tools.jib.builder.SourceFilesConfiguration} that uses
+ * test resources.
+ */
+public class TestSourceFilesConfiguration implements SourceFilesConfiguration {
 
   private static final String EXTRACTION_PATH = "/some/extraction/path/";
 
@@ -35,7 +38,7 @@ class TestSourceFilesConfiguration implements SourceFilesConfiguration {
   private final List<Path> resourcesSourceFiles;
   private final List<Path> classesSourceFiles;
 
-  TestSourceFilesConfiguration() throws URISyntaxException, IOException {
+  public TestSourceFilesConfiguration() throws URISyntaxException, IOException {
     dependenciesSourceFiles = getFilesList("application/dependencies");
     resourcesSourceFiles = getFilesList("application/resources");
     classesSourceFiles = getFilesList("application/classes");

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/TestSourceFilesConfiguration.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/TestSourceFilesConfiguration.java
@@ -26,10 +26,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-/**
- * Implementation of {@link com.google.cloud.tools.jib.builder.SourceFilesConfiguration} that uses
- * test resources.
- */
+/** Implementation of {@link SourceFilesConfiguration} that uses test resources. */
 public class TestSourceFilesConfiguration implements SourceFilesConfiguration {
 
   private static final String EXTRACTION_PATH = "/some/extraction/path/";

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStepTest.java
@@ -14,8 +14,12 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
+import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
+import com.google.cloud.tools.jib.builder.TestBuildLogger;
+import com.google.cloud.tools.jib.builder.TestSourceFilesConfiguration;
 import com.google.cloud.tools.jib.cache.Cache;
 import com.google.cloud.tools.jib.cache.CacheMetadataCorruptedException;
 import com.google.cloud.tools.jib.cache.CacheReader;
@@ -37,7 +41,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/** Tests for {@link BuildAndCacheApplicationLayerStep}. */
+/** Tests for {@link com.google.cloud.tools.jib.builder.steps.BuildAndCacheApplicationLayerStep}. */
 @RunWith(MockitoJUnitRunner.class)
 public class BuildAndCacheApplicationLayerStepTest {
 
@@ -48,7 +52,7 @@ public class BuildAndCacheApplicationLayerStepTest {
   @Test
   public void testRun()
       throws LayerPropertyNotFoundException, IOException, CacheMetadataCorruptedException,
-          URISyntaxException, ExecutionException, InterruptedException {
+          URISyntaxException, ExecutionException {
     Mockito.when(mockBuildConfiguration.getBuildLogger()).thenReturn(new TestBuildLogger());
     TestSourceFilesConfiguration testSourceFilesConfiguration = new TestSourceFilesConfiguration();
     Path temporaryCacheDirectory = temporaryFolder.newFolder().toPath();

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStepTest.java
@@ -41,7 +41,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/** Tests for {@link com.google.cloud.tools.jib.builder.steps.BuildAndCacheApplicationLayerStep}. */
+/** Tests for {@link BuildAndCacheApplicationLayerStep}. */
 @RunWith(MockitoJUnitRunner.class)
 public class BuildAndCacheApplicationLayerStepTest {
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
@@ -14,9 +14,11 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
+import com.google.cloud.tools.jib.builder.BuildLogger;
 import com.google.cloud.tools.jib.cache.CachedLayer;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.Image;
@@ -37,7 +39,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/** Tests for {@link BuildImageStep}. */
+/** Tests for {@link com.google.cloud.tools.jib.builder.steps.BuildImageStep}. */
 @RunWith(MockitoJUnitRunner.class)
 public class BuildImageStepTest {
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
@@ -39,7 +39,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/** Tests for {@link com.google.cloud.tools.jib.builder.steps.BuildImageStep}. */
+/** Tests for {@link BuildImageStep}. */
 @RunWith(MockitoJUnitRunner.class)
 public class BuildImageStepTest {
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
@@ -36,7 +36,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/** Tests for {@link com.google.cloud.tools.jib.builder.steps.RetrieveRegistryCredentialsStep}. */
+/** Tests for {@link RetrieveRegistryCredentialsStep}. */
 @RunWith(MockitoJUnitRunner.class)
 public class RetrieveRegistryCredentialsStepTest {
 
@@ -150,10 +150,7 @@ public class RetrieveRegistryCredentialsStepTest {
     Mockito.verify(mockBuildLogger).warn("warning");
   }
 
-  /**
-   * Creates a fake {@link com.google.cloud.tools.jib.builder.steps.RetrieveRegistryCredentialsStep}
-   * for {@code registry}.
-   */
+  /** Creates a fake {@link RetrieveRegistryCredentialsStep} for {@code registry}. */
   private RetrieveRegistryCredentialsStep makeRetrieveRegistryCredentialsStep(
       String registry,
       @Nullable String credentialHelperSuffix,

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
@@ -14,8 +14,10 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.builder;
+package com.google.cloud.tools.jib.builder.steps;
 
+import com.google.cloud.tools.jib.builder.BuildConfiguration;
+import com.google.cloud.tools.jib.builder.BuildLogger;
 import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.registry.credentials.DockerConfigCredentialRetriever;
 import com.google.cloud.tools.jib.registry.credentials.DockerCredentialHelper;
@@ -34,7 +36,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/** Tests for {@link RetrieveRegistryCredentialsStep}. */
+/** Tests for {@link com.google.cloud.tools.jib.builder.steps.RetrieveRegistryCredentialsStep}. */
 @RunWith(MockitoJUnitRunner.class)
 public class RetrieveRegistryCredentialsStepTest {
 
@@ -148,7 +150,10 @@ public class RetrieveRegistryCredentialsStepTest {
     Mockito.verify(mockBuildLogger).warn("warning");
   }
 
-  /** Creates a fake {@link RetrieveRegistryCredentialsStep} for {@code registry}. */
+  /**
+   * Creates a fake {@link com.google.cloud.tools.jib.builder.steps.RetrieveRegistryCredentialsStep}
+   * for {@code registry}.
+   */
   private RetrieveRegistryCredentialsStep makeRetrieveRegistryCredentialsStep(
       String registry,
       @Nullable String credentialHelperSuffix,


### PR DESCRIPTION
Addresses https://github.com/GoogleContainerTools/jib/pull/307#issuecomment-391126516

`.jib.builder` package was getting too cluttered