### PR TITLE
Fixes validation log message for 'format' parameter.

### DIFF
--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -62,10 +62,10 @@ public class BuildImageMojo extends JibPluginConfiguration {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    // Validate 'imageFormat'.
+    // Validates 'format'.
     if (Arrays.stream(ImageFormat.values()).noneMatch(value -> value.name().equals(getFormat()))) {
       throw new MojoFailureException(
-          "<imageFormat> parameter is configured with value '"
+          "<format> parameter is configured with value '"
               + getFormat()
               + "', but the only valid configuration options are '"
               + ImageFormat.Docker


### PR DESCRIPTION
The new parameter is `format` rather than `imageFormat`.