### PR TITLE
Synchronizes CacheMetadata methods to avoid concurrency issue.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheMetadata.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheMetadata.java
@@ -83,7 +83,9 @@ class CacheMetadata {
     }
   }
 
-  ImageLayers<CachedLayerWithMetadata> getLayers() {
+  // TODO: Remove explicit synchronization by refactoring build steps to not mutate a common
+  // CacheMetadata.
+  synchronized ImageLayers<CachedLayerWithMetadata> getLayers() {
     return layersBuilder.build();
   }
 
@@ -91,7 +93,7 @@ class CacheMetadata {
     layersBuilder.add(layer);
   }
 
-  LayerFilter filterLayers() {
+  synchronized LayerFilter filterLayers() {
     return new LayerFilter(layersBuilder.build());
   }
 }


### PR DESCRIPTION
Fixes #369 

Follow-up #370