### PR TITLE
Initializes docs directory.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-slate

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+Replace this


### PR DESCRIPTION
Mimics https://github.com/GoogleContainerTools/skaffold/tree/master/docs

This will become a Github Pages.

The proposal for how to organize this is to have docs by under a directory for their version, including a directory called `head` for unreleased docs.