### PR TITLE
Move disableHttpLogging to BuildLoggers

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -100,7 +100,7 @@ public class BuildDockerTask extends DefaultTask {
             .build();
 
     // TODO: Instead of disabling logging, have authentication credentials be provided
-    GradleProjectProperties.disableHttpLogging();
+    GradleBuildLogger.disableHttpLogging();
 
     RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -105,7 +105,7 @@ public class BuildImageTask extends DefaultTask {
             .build();
 
     // TODO: Instead of disabling logging, have authentication credentials be provided
-    GradleProjectProperties.disableHttpLogging();
+    GradleBuildLogger.disableHttpLogging();
 
     RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.gradle;
 
-import com.google.api.client.http.HttpTransport;
 import com.google.cloud.tools.jib.builder.BuildLogger;
 import com.google.cloud.tools.jib.builder.SourceFilesConfiguration;
 import com.google.cloud.tools.jib.frontend.HelpfulSuggestions;
@@ -28,17 +27,11 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 import javax.annotation.Nullable;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.internal.logging.events.LogEvent;
-import org.gradle.internal.logging.events.OutputEventListener;
-import org.gradle.internal.logging.slf4j.OutputEventListenerBackedLoggerContext;
 import org.gradle.jvm.tasks.Jar;
-import org.slf4j.LoggerFactory;
 
 /** Obtains information about a Gradle {@link Project} that uses Jib. */
 class GradleProjectProperties implements ProjectProperties {
@@ -59,27 +52,6 @@ class GradleProjectProperties implements ProjectProperties {
               + "jib\" instead of \"gradle clean compileJava jib\"?)",
           ex);
     }
-  }
-
-  /**
-   * Disables annoying Apache/Google HTTP client logging. Note that this is a hack and depends on
-   * internal Gradle classes.
-   */
-  static void disableHttpLogging() {
-    // Disables Apache HTTP client logging.
-    OutputEventListenerBackedLoggerContext context =
-        (OutputEventListenerBackedLoggerContext) LoggerFactory.getILoggerFactory();
-    OutputEventListener defaultOutputEventListener = context.getOutputEventListener();
-    context.setOutputEventListener(
-        event -> {
-          LogEvent logEvent = (LogEvent) event;
-          if (!logEvent.getCategory().contains("org.apache")) {
-            defaultOutputEventListener.onOutput(event);
-          }
-        });
-
-    // Disables Google HTTP client logging.
-    Logger.getLogger(HttpTransport.class.getName()).setLevel(Level.OFF);
   }
 
   private final Project project;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -86,7 +86,7 @@ public class BuildDockerMojo extends JibPluginConfiguration {
             .build();
 
     // TODO: Instead of disabling logging, have authentication credentials be provided
-    MavenProjectProperties.disableHttpLogging();
+    MavenBuildLogger.disableHttpLogging();
 
     RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -105,7 +105,7 @@ public class BuildImageMojo extends JibPluginConfiguration {
             .build();
 
     // TODO: Instead of disabling logging, have authentication credentials be provided
-    MavenProjectProperties.disableHttpLogging();
+    MavenBuildLogger.disableHttpLogging();
 
     RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenBuildLogger.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenBuildLogger.java
@@ -22,6 +22,13 @@ import org.apache.maven.plugin.logging.Log;
 /** Implementation of {@link BuildLogger} for Maven plugins. */
 class MavenBuildLogger implements BuildLogger {
 
+  /** Disables annoying Apache HTTP client logging. */
+  static void disableHttpLogging() {
+    System.setProperty(
+        "org.apache.commons.logging.Log", "org.apache.commons.logging.impl.SimpleLog");
+    System.setProperty("org.apache.commons.logging.simplelog.defaultlog", "error");
+  }
+
   private final Log log;
 
   MavenBuildLogger(Log log) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -53,13 +53,6 @@ class MavenProjectProperties implements ProjectProperties {
     }
   }
 
-  /** Disables annoying Apache HTTP client logging. */
-  static void disableHttpLogging() {
-    System.setProperty(
-        "org.apache.commons.logging.Log", "org.apache.commons.logging.impl.SimpleLog");
-    System.setProperty("org.apache.commons.logging.simplelog.defaultlog", "error");
-  }
-
   private final MavenProject project;
   private final MavenBuildLogger mavenBuildLogger;
   private final SourceFilesConfiguration sourceFilesConfiguration;


### PR DESCRIPTION
Seems like a more appropriate place for the method.

Also fixes #365 since there isn't really a need to rename them anymore.