### PR TITLE
Fix javadoc warnings when building gradle plugin

### DIFF
--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -81,7 +81,7 @@ tasks.withType(JavaCompile) {
 
 // Fail build on javadoc warnings
 tasks.withType(Javadoc) {
-    options.addStringOption('Xwerror', '-quiet')
+    options.addBooleanOption('Xwerror', true)
 }
 
 tasks.withType(Test) {

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -80,10 +80,8 @@ tasks.withType(JavaCompile) {
 }
 
 // Fail build on javadoc warnings
-if (JavaVersion.current().isJava8Compatible()) {
-    tasks.withType(Javadoc) {
-        options.addStringOption('Xwerror', '-quiet')
-    }
+tasks.withType(Javadoc) {
+    options.addStringOption('Xwerror', '-quiet')
 }
 
 tasks.withType(Test) {

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -79,6 +79,13 @@ tasks.withType(JavaCompile) {
     }
 }
 
+// Fail build on javadoc warnings
+if (JavaVersion.current().isJava8Compatible()) {
+    tasks.withType(Javadoc) {
+        options.addStringOption('Xwerror', '-quiet')
+    }
+}
+
 tasks.withType(Test) {
     reports.html.setDestination file("${reporting.baseDir}/${name}")
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blob.java
@@ -27,6 +27,7 @@ public interface Blob {
    *
    * @param outputStream the {@link OutputStream} to write to
    * @return the {@link BlobDescriptor} of the written BLOB
+   * @throws IOException if writing the BlobDescriptor fails
    */
   BlobDescriptor writeTo(OutputStream outputStream) throws IOException;
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blob.java
@@ -27,7 +27,7 @@ public interface Blob {
    *
    * @param outputStream the {@link OutputStream} to write to
    * @return the {@link BlobDescriptor} of the written BLOB
-   * @throws IOException if writing the BlobDescriptor fails
+   * @throws IOException if writing the BLOB fails
    */
   BlobDescriptor writeTo(OutputStream outputStream) throws IOException;
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/BlobDescriptor.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/BlobDescriptor.java
@@ -34,6 +34,11 @@ public class BlobDescriptor {
   /**
    * Creates a new {@link BlobDescriptor} from the contents of an {@link InputStream} while piping
    * to an {@link OutputStream}. Does not close either streams.
+   *
+   * @param inputStream the stream to read the contents from
+   * @param outputStream the {@link OutputStream} to pipe to
+   * @return a {@link BlobDescriptor} created from the {@link InputStream}
+   * @throws IOException if reading from or writing to the streams fails
    */
   static BlobDescriptor fromPipe(InputStream inputStream, OutputStream outputStream)
       throws IOException {
@@ -49,7 +54,11 @@ public class BlobDescriptor {
     this.digest = digest;
   }
 
-  /** Initialize with just digest. */
+  /**
+   * Initialize with just digest.
+   *
+   * @param digest the digest to initialize the {@link BlobDescriptor} from
+   */
   public BlobDescriptor(DescriptorDigest digest) {
     this(-1, digest);
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/BlobDescriptor.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/BlobDescriptor.java
@@ -37,7 +37,7 @@ public class BlobDescriptor {
    *
    * @param inputStream the stream to read the contents from
    * @param outputStream the {@link OutputStream} to pipe to
-   * @return a {@link BlobDescriptor} created from the {@link InputStream}
+   * @return a {@link BlobDescriptor} of the piped contents
    * @throws IOException if reading from or writing to the streams fails
    */
   static BlobDescriptor fromPipe(InputStream inputStream, OutputStream outputStream)

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blobs.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blobs.java
@@ -41,12 +41,24 @@ public class Blobs {
     return new WriterBlob(writer);
   }
 
-  /** Writes the BLOB to a string. */
+  /**
+   * Writes the BLOB to a string.
+   *
+   * @param blob the BLOB to write
+   * @return the BLOB contents as a string
+   * @throws IOException if writing out the BLOB contents fails
+   */
   public static String writeToString(Blob blob) throws IOException {
     return new String(writeToByteArray(blob), StandardCharsets.UTF_8);
   }
 
-  /** Writes the BLOB to a byte array. */
+  /**
+   * Writes the BLOB to a byte array.
+   *
+   * @param blob the BLOB to write
+   * @return the BLOB contents as a byte array
+   * @throws IOException if writing out the BLOB contents fails
+   */
   public static byte[] writeToByteArray(Blob blob) throws IOException {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     blob.writeTo(byteArrayOutputStream);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildConfiguration.java
@@ -181,6 +181,7 @@ public class BuildConfiguration {
   }
 
   /**
+   * @param className the class name to check
    * @return {@code true} if {@code className} is a valid Java class name; {@code false} otherwise
    */
   public static boolean isValidJavaClass(String className) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildLogger.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildLogger.java
@@ -20,6 +20,11 @@ public interface BuildLogger {
 
   void error(CharSequence message);
 
+  /**
+   * Logs messages as part of normal execution (default log level).
+   *
+   * @param message the message to log
+   */
   void lifecycle(CharSequence message);
 
   void warn(CharSequence message);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildLogger.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildLogger.java
@@ -20,7 +20,6 @@ public interface BuildLogger {
 
   void error(CharSequence message);
 
-  /** Logs messages as part of normal execution (default log level). */
   void lifecycle(CharSequence message);
 
   void warn(CharSequence message);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildSteps.java
@@ -50,7 +50,14 @@ public class BuildSteps {
   private static final String SUCCESS_MESSAGE_FORMAT_FOR_DOCKER_DAEMON =
       "Built image to Docker daemon as \u001B[36m%s\u001B[0m";
 
-  /** All the steps to build an image to a Docker registry. */
+  /**
+   * All the steps to build an image to a Docker registry.
+   *
+   * @param buildConfiguration the configuration parameters for the build
+   * @param sourceFilesConfiguration the source/destination file configuration for the image
+   * @param cachesInitializer the {@link Caches.Initializer} used to setup the cache
+   * @return a new {@link BuildSteps} for building to a registry
+   */
   public static BuildSteps forBuildToDockerRegistry(
       BuildConfiguration buildConfiguration,
       SourceFilesConfiguration sourceFilesConfiguration,
@@ -84,7 +91,14 @@ public class BuildSteps {
                 .waitOnPushImageStep());
   }
 
-  /** All the steps to build to Docker daemon */
+  /**
+   * All the steps to build to Docker daemon
+   *
+   * @param buildConfiguration the configuration parameters for the build
+   * @param sourceFilesConfiguration the source/destination file configuration for the image
+   * @param cachesInitializer the {@link Caches.Initializer} used to setup the cache
+   * @return a new {@link BuildSteps} for building to a Docker daemon
+   */
   public static BuildSteps forBuildToDockerDaemon(
       BuildConfiguration buildConfiguration,
       SourceFilesConfiguration sourceFilesConfiguration,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/EntrypointBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/EntrypointBuilder.java
@@ -26,6 +26,11 @@ public class EntrypointBuilder {
    * Builds the container entrypoint.
    *
    * <p>The entrypoint is {@code java [jvm flags] -cp [classpaths] [main class]}.
+   *
+   * @param sourceFilesConfiguration configuration defining where files are copied onto the image
+   * @param jvmFlags the JVM flags to start the container with
+   * @param mainClass the name of the main class to run on startup
+   * @return a list of the entrypoint tokens
    */
   public static ImmutableList<String> makeEntrypoint(
       SourceFilesConfiguration sourceFilesConfiguration, List<String> jvmFlags, String mainClass) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
@@ -41,6 +41,11 @@ public class Cache implements Closeable {
   /**
    * Initializes a cache with a directory. This also loads the cache metadata if it exists in the
    * directory.
+   *
+   * @param cacheDirectory the directory to use for the cache.
+   * @return the initialized cache.
+   * @throws NotDirectoryException if {@code cacheDirectory} is not a directory.
+   * @throws CacheMetadataCorruptedException if loading the cache metadata fails.
    */
   public static Cache init(Path cacheDirectory)
       throws NotDirectoryException, CacheMetadataCorruptedException {
@@ -76,13 +81,23 @@ public class Cache implements Closeable {
     this.cacheMetadata = cacheMetadata;
   }
 
-  /** Finishes the use of the cache by flushing any unsaved changes. */
+  /**
+   * Finishes the use of the cache by flushing any unsaved changes.
+   *
+   * @throws IOException if saving the cache metadata fails.
+   */
   @Override
   public void close() throws IOException {
     saveCacheMetadata(cacheDirectory);
   }
 
-  /** Adds the cached layer to the cache metadata. */
+  /**
+   * Adds the cached layer to the cache metadata.
+   *
+   * @param cachedLayer the layer to add.
+   * @param layerMetadata the metadata to add the layer to.
+   * @throws LayerPropertyNotFoundException if adding the layer fails.
+   */
   void addLayerToMetadata(CachedLayer cachedLayer, @Nullable LayerMetadata layerMetadata)
       throws LayerPropertyNotFoundException {
     cacheMetadata.addLayer(new CachedLayerWithMetadata(cachedLayer, layerMetadata));

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheReader.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheReader.java
@@ -33,8 +33,10 @@ import javax.annotation.Nullable;
 public class CacheReader {
 
   /**
+   * @param path the file to check.
    * @return the last modified time for the file at {@code path}. Recursively finds the most recent
    *     last modified time for all subfiles if the file is a directory.
+   * @throws IOException if checking the last modified time fails.
    */
   private static FileTime getLastModifiedTime(Path path) throws IOException {
     if (Files.isDirectory(path)) {
@@ -61,7 +63,11 @@ public class CacheReader {
     this.cache = cache;
   }
 
-  /** @return the cached layer with digest {@code layerDigest}, or {@code null} if not found */
+  /**
+   * @param layerDigest the layer digest of the layer to get.
+   * @return the cached layer with digest {@code layerDigest}, or {@code null} if not found.
+   * @throws LayerPropertyNotFoundException if getting the layer fails.
+   */
   @Nullable
   public CachedLayer getLayer(DescriptorDigest layerDigest) throws LayerPropertyNotFoundException {
     return cache.getMetadata().getLayers().get(layerDigest);
@@ -70,9 +76,10 @@ public class CacheReader {
   /**
    * Finds the file that stores the content BLOB for an application layer.
    *
-   * @param sourceFiles the source files the layer must be built from
+   * @param sourceFiles the source files the layer must be built from.
    * @return the newest cached layer file that matches the {@code layerType} and {@code
-   *     sourceFiles}, or {@code null} if there is no match
+   *     sourceFiles}, or {@code null} if there is no match.
+   * @throws CacheMetadataCorruptedException if getting the cache metadata fails.
    */
   @Nullable
   public Path getLayerFile(ImmutableList<Path> sourceFiles) throws CacheMetadataCorruptedException {
@@ -104,7 +111,12 @@ public class CacheReader {
    *
    * <p>The method returns the first up-to-date layer found. This is safe because the source files
    * will not have been modified since creation of any up-to-date layer (ie. all up-to-date layers
-   * should have the same file contents)
+   * should have the same file contents).
+   *
+   * @param sourceFiles the layer's source files.
+   * @return an up-to-date layer containing the source files.
+   * @throws IOException if reading the source files fails.
+   * @throws CacheMetadataCorruptedException if reading the cache metadata fails.
    */
   @Nullable
   public CachedLayer getUpToDateLayerBySourceFiles(ImmutableList<Path> sourceFiles)

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheWriter.java
@@ -49,8 +49,10 @@ public class CacheWriter {
    * Builds an {@link UnwrittenLayer} from a {@link ReproducibleLayerBuilder} and compresses and
    * writes the {@link UnwrittenLayer}'s uncompressed layer content BLOB to cache.
    *
-   * @param reproducibleLayerBuilder the layer builder
-   * @return the cached layer
+   * @param reproducibleLayerBuilder the layer builder.
+   * @return the cached layer.
+   * @throws IOException if writing the layer to file fails.
+   * @throws LayerPropertyNotFoundException if adding the layer to the cache metadata fails.
    */
   public CachedLayer writeLayer(ReproducibleLayerBuilder reproducibleLayerBuilder)
       throws IOException, LayerPropertyNotFoundException {
@@ -92,8 +94,10 @@ public class CacheWriter {
   }
 
   /**
+   * @param layerDigest the written layer's digest.
    * @return the {@link CountingOutputStream} to write to to cache a layer with the specified
-   *     compressed digest
+   *     compressed digest.
+   * @throws IOException if writing to the layer file's output stream fails.
    */
   public CountingOutputStream getLayerOutputStream(DescriptorDigest layerDigest)
       throws IOException {
@@ -102,8 +106,12 @@ public class CacheWriter {
   }
 
   /**
+   * @param layerDigest the digest of the layer to retrieve.
+   * @param countingOutputStream the output stream the BLOB was written to.
    * @return a {@link CachedLayer} from a layer digest and the {@link CountingOutputStream} the
-   *     layer BLOB was written to
+   *     layer BLOB was written to.
+   * @throws IOException if closing the output stream or getting the layer diff ID fails.
+   * @throws LayerPropertyNotFoundException if adding the layer to the cache metadata fails.
    */
   public CachedLayer getCachedLayer(
       DescriptorDigest layerDigest, CountingOutputStream countingOutputStream)
@@ -120,12 +128,19 @@ public class CacheWriter {
     return cachedLayer;
   }
 
-  /** @return the path to the file for the layer with the specified compressed digest */
+  /**
+   * @param compressedDigest the compressed digest of the layer to find.
+   * @return the path to the file for the layer with the specified compressed digest.
+   */
   private Path getLayerFile(DescriptorDigest compressedDigest) {
     return CacheFiles.getLayerFile(cache.getCacheDirectory(), compressedDigest);
   }
 
-  /** @return the layer diff ID by decompressing the layer content file */
+  /**
+   * @param layerFile the layer content file.
+   * @return the layer diff ID by decompressing the layer content file.
+   * @throws IOException if reading the layer file fails.
+   */
   private DescriptorDigest getDiffId(Path layerFile) throws IOException {
     CountingDigestOutputStream diffIdCaptureOutputStream =
         new CountingDigestOutputStream(ByteStreams.nullOutputStream());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
@@ -72,8 +72,11 @@ public class DockerClient {
    * Loads an image tarball into the Docker daemon.
    *
    * @see <a
-   *     href="https://docs.docker.com/engine/reference/commandline/load/">https://docs.docker.com/engine/reference/commandline/load/</a>
-   * @return stdout from {@code docker}
+   *     href="https://docs.docker.com/engine/reference/commandline/load/">https://docs.docker.com/engine/reference/commandline/load</a>
+   * @param imageTarballBlob the built container tarball.
+   * @return stdout from {@code docker}.
+   * @throws InterruptedException if the 'docker load' process is interrupted.
+   * @throws IOException if streaming the blob to 'docker load' fails.
    */
   public String load(Blob imageTarballBlob) throws InterruptedException, IOException {
     // Runs 'docker load'.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerContextGenerator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerContextGenerator.java
@@ -60,31 +60,54 @@ public class DockerContextGenerator {
   /**
    * Sets the base image for the {@code FROM} directive. This must be called before {@link
    * #generate}.
+   *
+   * @param baseImage the base image.
+   * @return The {@link DockerContextGenerator} with the base image set.
    */
   public DockerContextGenerator setBaseImage(String baseImage) {
     this.baseImage = baseImage;
     return this;
   }
 
-  /** Sets the JVM flags used in the {@code ENTRYPOINT}. */
+  /**
+   * Sets the JVM flags used in the {@code ENTRYPOINT}.
+   *
+   * @param jvmFlags the jvm flags.
+   * @return The {@link DockerContextGenerator} with the jvm flags set.
+   */
   public DockerContextGenerator setJvmFlags(List<String> jvmFlags) {
     this.jvmFlags = jvmFlags;
     return this;
   }
 
-  /** Sets the main class used in the {@code ENTRYPOINT}. */
+  /**
+   * Sets the main class used in the {@code ENTRYPOINT}.
+   *
+   * @param mainClass the name of the main class.
+   * @return The {@link DockerContextGenerator} with the main class set.
+   */
   public DockerContextGenerator setMainClass(String mainClass) {
     this.mainClass = mainClass;
     return this;
   }
 
-  /** Sets the arguments used in the {@code CMD}. */
+  /**
+   * Sets the arguments used in the {@code CMD}.
+   *
+   * @param javaArguments the list of arguments to pass into main.
+   * @return The {@link DockerContextGenerator} with the main arguments set.
+   */
   public DockerContextGenerator setJavaArguments(List<String> javaArguments) {
     this.javaArguments = javaArguments;
     return this;
   }
 
-  /** Creates the Docker context in {@code #targetDirectory}. */
+  /**
+   * Creates the Docker context in {@code #targetDirectory}.
+   *
+   * @param targetDirectory the directory to generate the Docker context in.
+   * @throws IOException if the export fails.
+   */
   public void generate(Path targetDirectory) throws IOException {
     Preconditions.checkNotNull(baseImage);
 
@@ -117,7 +140,12 @@ public class DockerContextGenerator {
         targetDirectory.resolve("Dockerfile"), makeDockerfile().getBytes(StandardCharsets.UTF_8));
   }
 
-  /** Makes a {@code Dockerfile} from the {@code DockerfileTemplate}. */
+  /**
+   * Makes a {@code Dockerfile} from the {@code DockerfileTemplate}.
+   *
+   * @return the {@code Dockerfile} contents.
+   * @throws IOException if reading the Dockerfile template fails.
+   */
   @VisibleForTesting
   String makeDockerfile() throws IOException {
     Preconditions.checkNotNull(baseImage);
@@ -143,6 +171,8 @@ public class DockerContextGenerator {
    *
    * @see <a
    *     href="https://docs.docker.com/engine/reference/builder/#exec-form-entrypoint-example">https://docs.docker.com/engine/reference/builder/#exec-form-entrypoint-example</a>
+   * @param items the list of items to join into an array.
+   * @return a string in the format: ["item1","item2",...]
    */
   @VisibleForTesting
   static String joinAsJsonArray(List<String> items) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerContextGenerator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerContextGenerator.java
@@ -62,7 +62,7 @@ public class DockerContextGenerator {
    * #generate}.
    *
    * @param baseImage the base image.
-   * @return The {@link DockerContextGenerator} with the base image set.
+   * @return this
    */
   public DockerContextGenerator setBaseImage(String baseImage) {
     this.baseImage = baseImage;
@@ -73,7 +73,7 @@ public class DockerContextGenerator {
    * Sets the JVM flags used in the {@code ENTRYPOINT}.
    *
    * @param jvmFlags the jvm flags.
-   * @return The {@link DockerContextGenerator} with the jvm flags set.
+   * @return this
    */
   public DockerContextGenerator setJvmFlags(List<String> jvmFlags) {
     this.jvmFlags = jvmFlags;
@@ -84,7 +84,7 @@ public class DockerContextGenerator {
    * Sets the main class used in the {@code ENTRYPOINT}.
    *
    * @param mainClass the name of the main class.
-   * @return The {@link DockerContextGenerator} with the main class set.
+   * @return this
    */
   public DockerContextGenerator setMainClass(String mainClass) {
     this.mainClass = mainClass;
@@ -95,7 +95,7 @@ public class DockerContextGenerator {
    * Sets the arguments used in the {@code CMD}.
    *
    * @param javaArguments the list of arguments to pass into main.
-   * @return The {@link DockerContextGenerator} with the main arguments set.
+   * @return this
    */
   public DockerContextGenerator setJavaArguments(List<String> javaArguments) {
     this.javaArguments = javaArguments;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/ImageToTarballTranslator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/ImageToTarballTranslator.java
@@ -39,7 +39,11 @@ public class ImageToTarballTranslator {
 
   private final Image<CachedLayer> image;
 
-  /** Instantiate with an {@link Image}. */
+  /**
+   * Instantiate with an {@link Image}.
+   *
+   * @param image the image to convert into a tarball.
+   */
   public ImageToTarballTranslator(Image<CachedLayer> image) {
     this.image = image;
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/DirectoryWalker.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/DirectoryWalker.java
@@ -47,8 +47,9 @@ public class DirectoryWalker {
   /**
    * Adds a filter to the walked paths.
    *
-   * @param pathFilter the filter.
-   * @return the {@link DirectoryWalker} with the path filter set.
+   * @param pathFilter the filter. {@code pathFilter} returns {@code true} if the path should be
+   *     accepted and {@code false} otherwise.
+   * @return this
    */
   public DirectoryWalker filter(Predicate<Path> pathFilter) {
     this.pathFilter = this.pathFilter.and(pathFilter);
@@ -58,7 +59,7 @@ public class DirectoryWalker {
   /**
    * Filters away the {@code rootDir}.
    *
-   * @return the {@link DirectoryWalker} with the root directory filtered out.
+   * @return this
    */
   public DirectoryWalker filterRoot() {
     filter(path -> !path.equals(rootDir));

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/DirectoryWalker.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/DirectoryWalker.java
@@ -31,7 +31,12 @@ public class DirectoryWalker {
 
   private Predicate<Path> pathFilter = path -> true;
 
-  /** Initialize with a root directory to walk. */
+  /**
+   * Initialize with a root directory to walk.
+   *
+   * @param rootDir the root directory.
+   * @throws NotDirectoryException if the root directory is not a directory.
+   */
   public DirectoryWalker(Path rootDir) throws NotDirectoryException {
     if (!Files.isDirectory(rootDir)) {
       throw new NotDirectoryException(rootDir + " is not a directory");
@@ -39,13 +44,22 @@ public class DirectoryWalker {
     this.rootDir = rootDir;
   }
 
-  /** Adds a filter to the walked paths. */
+  /**
+   * Adds a filter to the walked paths.
+   *
+   * @param pathFilter the filter.
+   * @return the {@link DirectoryWalker} with the path filter set.
+   */
   public DirectoryWalker filter(Predicate<Path> pathFilter) {
     this.pathFilter = this.pathFilter.and(pathFilter);
     return this;
   }
 
-  /** Filters away the {@code rootDir}. */
+  /**
+   * Filters away the {@code rootDir}.
+   *
+   * @return the {@link DirectoryWalker} with the root directory filtered out.
+   */
   public DirectoryWalker filterRoot() {
     filter(path -> !path.equals(rootDir));
     return this;
@@ -54,6 +68,10 @@ public class DirectoryWalker {
   /**
    * Walks {@link #rootDir} and applies {@code pathConsumer} to each file. Note that {@link
    * #rootDir} itself is visited as well.
+   *
+   * @param pathConsumer the consumer that is applied to each file.
+   * @return a list of Paths that were walked.
+   * @throws IOException if the walk fails.
    */
   public ImmutableList<Path> walk(PathConsumer pathConsumer) throws IOException {
     ImmutableList<Path> files = walk();
@@ -63,7 +81,12 @@ public class DirectoryWalker {
     return files;
   }
 
-  /** Walks {@link #rootDir} and returns the walked files. */
+  /**
+   * Walks {@link #rootDir}.
+   *
+   * @return the walked files.
+   * @throws IOException if walking the files fails.
+   */
   public ImmutableList<Path> walk() throws IOException {
     try (Stream<Path> fileStream = Files.walk(rootDir)) {
       Stream<Path> filteredFileStream = fileStream;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/FileOperations.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/FileOperations.java
@@ -24,7 +24,13 @@ import java.nio.file.Path;
 /** Static methods for operating on the filesystem. */
 public class FileOperations {
 
-  /** Copies {@code sourceFiles} to the {@code destDir} directory. */
+  /**
+   * Copies {@code sourceFiles} to the {@code destDir} directory.
+   *
+   * @param sourceFiles the list of source files.
+   * @param destDir the directory to copy the files to.
+   * @throws IOException if the copy fails.
+   */
   public static void copy(ImmutableList<Path> sourceFiles, Path destDir) throws IOException {
     for (Path sourceFile : sourceFiles) {
       PathConsumer copyPathConsumer =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/BuildStepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/BuildStepsRunner.java
@@ -42,8 +42,12 @@ public class BuildStepsRunner {
   /**
    * Creates a runner to build an image. Creates a directory for the cache, if needed.
    *
+   * @param buildConfiguration the configuration parameters for the build
+   * @param sourceFilesConfiguration the source/destination file configuration for the image
+   * @param cacheDirectory the directory to use for the cache
    * @param useOnlyProjectCache if {@code true}, sets the base layers cache directory to be the same
    *     as the application layers cache directory
+   * @return a {@link BuildStepsRunner} for building to a registry
    * @throws CacheDirectoryCreationException if the {@code cacheDirectory} could not be created
    */
   public static BuildStepsRunner forBuildImage(
@@ -61,8 +65,12 @@ public class BuildStepsRunner {
   /**
    * Creates a runner to build to the Docker daemon. Creates a directory for the cache, if needed.
    *
+   * @param buildConfiguration the configuration parameters for the build
+   * @param sourceFilesConfiguration the source/destination file configuration for the image
+   * @param cacheDirectory the directory to use for the cache
    * @param useOnlyProjectCache if {@code true}, sets the base layers cache directory to be the same
    *     as the application layers cache directory
+   * @return a {@link BuildStepsRunner} for building to a Docker daemon
    * @throws CacheDirectoryCreationException if the {@code cacheDirectory} could not be created
    */
   public static BuildStepsRunner forBuildToDockerDaemon(
@@ -155,6 +163,7 @@ public class BuildStepsRunner {
    * Runs the {@link BuildSteps}.
    *
    * @param helpfulSuggestions suggestions to use in help messages for exceptions
+   * @throws BuildStepsExecutionException if another exception is thrown during the build
    */
   public void build(HelpfulSuggestions helpfulSuggestions) throws BuildStepsExecutionException {
     try {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/HelpfulSuggestions.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/HelpfulSuggestions.java
@@ -113,7 +113,7 @@ public class HelpfulSuggestions {
   }
 
   /**
-   * @param suggestion a suggested fix for the problem described by {@code messagePrefix}
+   * @param suggestion a suggested fix for the problem described by {@link #messagePrefix}
    * @return the message containing the suggestion
    */
   public String suggest(String suggestion) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/HelpfulSuggestions.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/HelpfulSuggestions.java
@@ -112,7 +112,10 @@ public class HelpfulSuggestions {
     return messagePrefix;
   }
 
-  /** @return the message containing a suggestion */
+  /**
+   * @param suggestion a suggested fix for the problem described by {@code messagePrefix}
+   * @return the message containing the suggestion
+   */
   public String suggest(String suggestion) {
     return messagePrefix + ", perhaps you should " + suggestion;
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
@@ -50,6 +50,11 @@ public class MainClassFinder {
    * </ul>
    *
    * <p>Warns if main class is not valid, or throws an error if no valid main class is not found.
+   *
+   * @param mainClass the explicitly configured main class ({@code null} if not configured).
+   * @param projectProperties properties containing plugin information and help messages.
+   * @return the name of the main class to be used for the container entrypoint.
+   * @throws MainClassInferenceException if no valid main class is configured or discovered.
    */
   public static String resolveMainClass(
       @Nullable String mainClass, ProjectProperties projectProperties)
@@ -117,7 +122,10 @@ public class MainClassFinder {
   /**
    * Finds the classes with {@code public static void main(String[] args)} in {@code rootDirectory}.
    *
-   * @param rootDirectory directory containing the {@code .class} files
+   * @param rootDirectory directory containing the {@code .class} files.
+   * @param buildLogger used for displaying status messages.
+   * @return a list of class names containing a main method.
+   * @throws IOException if searching the root directory fails.
    */
   @VisibleForTesting
   static List<String> findMainClasses(Path rootDirectory, BuildLogger buildLogger)

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/ProjectProperties.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/ProjectProperties.java
@@ -41,6 +41,9 @@ public interface ProjectProperties {
   @Nullable
   String getMainClassFromJar();
 
-  /** @return a {@link HelpfulSuggestions} instance for main class inference failure. */
+  /**
+   * @param prefix the prefix message for the {@link HelpfulSuggestions}.
+   * @return a {@link HelpfulSuggestions} instance for main class inference failure.
+   */
   HelpfulSuggestions getMainClassHelpfulSuggestions(String prefix);
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/hash/CountingDigestOutputStream.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/hash/CountingDigestOutputStream.java
@@ -33,7 +33,11 @@ public class CountingDigestOutputStream extends DigestOutputStream {
   /** Keeps track of the total number of bytes appended. */
   private long totalBytes = 0;
 
-  /** Wraps the {@code outputStream}. */
+  /**
+   * Wraps the {@code outputStream}.
+   *
+   * @param outputStream the {@link OutputStream} to wrap.
+   */
   public CountingDigestOutputStream(OutputStream outputStream) {
     super(outputStream, null);
     try {
@@ -47,6 +51,8 @@ public class CountingDigestOutputStream extends DigestOutputStream {
   /**
    * Builds a {@link BlobDescriptor} with the hash and size of the bytes written. The buffer resets
    * after this method is called, so this method should only be called once per BlobDescriptor.
+   *
+   * @return the built {@link BlobDescriptor}.
    */
   public BlobDescriptor toBlobDescriptor() {
     try {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/Authorizations.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/Authorizations.java
@@ -22,12 +22,19 @@ import java.nio.charset.StandardCharsets;
 /** Static initializers for {@link Authorization}. */
 public class Authorizations {
 
-  /** Creates an {@link Authorization} with a {@code Bearer} token. */
+  /**
+   * @param token the token
+   * @return an {@link Authorization} with a {@code Bearer} token
+   */
   public static Authorization withBearerToken(String token) {
     return new Authorization("Bearer", token);
   }
 
-  /** Creates an {@link Authorization} with a {@code Basic} credentials. */
+  /**
+   * @param username the username
+   * @param secret the secret
+   * @return an {@link Authorization} with a {@code Basic} credentials
+   */
   public static Authorization withBasicCredentials(String username, String secret) {
     String credentials = username + ":" + secret;
     String token =
@@ -37,7 +44,10 @@ public class Authorizations {
     return new Authorization("Basic", token);
   }
 
-  /** Creates an {@link Authorization} with a base64-encoded {@code username:password} string. */
+  /**
+   * @param token the token
+   * @return an {@link Authorization} with a base64-encoded {@code username:password} string
+   */
   public static Authorization withBasicToken(String token) {
     return new Authorization("Basic", token);
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/Connection.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/Connection.java
@@ -59,6 +59,8 @@ public class Connection implements Closeable {
 
   /**
    * Make sure to wrap with a try-with-resource to ensure that the connection is closed after usage.
+   *
+   * @param url the url to send the request to
    */
   public Connection(URL url) {
     this.url = new GenericUrl(url);
@@ -73,22 +75,47 @@ public class Connection implements Closeable {
     httpResponse.disconnect();
   }
 
-  /** Sends the request with method GET. */
+  /**
+   * Sends the request with method GET.
+   *
+   * @param request the request to send
+   * @return the response to the sent request
+   * @throws IOException if sending the request fails
+   */
   public Response get(Request request) throws IOException {
     return send(HttpMethods.GET, request);
   }
 
-  /** Sends the request with method POST. */
+  /**
+   * Sends the request with method POST.
+   *
+   * @param request the request to send
+   * @return the response to the sent request
+   * @throws IOException if sending the request fails
+   */
   public Response post(Request request) throws IOException {
     return send(HttpMethods.POST, request);
   }
 
-  /** Sends the request with method PUT. */
+  /**
+   * Sends the request with method PUT.
+   *
+   * @param request the request to send
+   * @return the response to the sent request
+   * @throws IOException if sending the request fails
+   */
   public Response put(Request request) throws IOException {
     return send(HttpMethods.PUT, request);
   }
 
-  /** Sends the request. */
+  /**
+   * Sends the request.
+   *
+   * @param httpMethod the HTTP request method
+   * @param request the request to send
+   * @return the response to the sent request
+   * @throws IOException if building the HTTP request fails.
+   */
   public Response send(String httpMethod, Request request) throws IOException {
     httpResponse =
         requestFactory

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/Request.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/Request.java
@@ -38,7 +38,12 @@ public class Request {
       return new Request(this);
     }
 
-    /** Sets the {@code Authorization} header. */
+    /**
+     * Sets the {@code Authorization} header.
+     *
+     * @param authorization the authorization
+     * @return this
+     */
     public Builder setAuthorization(@Nullable Authorization authorization) {
       if (authorization != null) {
         headers.setAuthorization(authorization.toString());
@@ -46,19 +51,34 @@ public class Request {
       return this;
     }
 
-    /** Sets the {@code Accept} header. */
+    /**
+     * Sets the {@code Accept} header.
+     *
+     * @param mimeTypes the items to pass into the accept header
+     * @return this
+     */
     public Builder setAccept(List<String> mimeTypes) {
       headers.setAccept(String.join(",", mimeTypes));
       return this;
     }
 
-    /** Sets the {@code User-Agent} header. */
+    /**
+     * Sets the {@code User-Agent} header.
+     *
+     * @param userAgent the user agent
+     * @return this
+     */
     public Builder setUserAgent(String userAgent) {
       headers.setUserAgent(userAgent);
       return this;
     }
 
-    /** Sets the body and its corresponding {@code Content-Type} header. */
+    /**
+     * Sets the body and its corresponding {@code Content-Type} header.
+     *
+     * @param blobHttpContent the body content
+     * @return this
+     */
     public Builder setBody(@Nullable BlobHttpContent blobHttpContent) {
       this.body = blobHttpContent;
       return this;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/Response.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/Response.java
@@ -32,17 +32,23 @@ public class Response {
     this.httpResponse = httpResponse;
   }
 
-  /** Gets the HTTP status code of the response. */
+  /** @return the HTTP status code of the response */
   public int getStatusCode() {
     return httpResponse.getStatusCode();
   }
 
-  /** Gets a header in the response. */
+  /**
+   * @param headerName the header name
+   * @return a list of headers in the response
+   */
   public List<String> getHeader(String headerName) {
     return httpResponse.getHeaders().getHeaderStringValues(headerName);
   }
 
-  /** @return the first {@code Content-Length} header, or {@code -1} if not found */
+  /**
+   * @return the first {@code Content-Length} header, or {@code -1} if not found
+   * @throws NumberFormatException if parsing the content length header fails
+   */
   public long getContentLength() throws NumberFormatException {
     String contentLengthHeader =
         httpResponse.getHeaders().getFirstHeaderStringValue(HttpHeaders.CONTENT_LENGTH);
@@ -57,7 +63,10 @@ public class Response {
     }
   }
 
-  /** Gets the HTTP response body as a {@link Blob}. */
+  /**
+   * @return the HTTP response body as a {@link Blob}.
+   * @throws IOException if getting the HTTP response content fails.
+   */
   public Blob getBody() throws IOException {
     return Blobs.from(httpResponse.getContent());
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/DescriptorDigest.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/DescriptorDigest.java
@@ -45,7 +45,13 @@ public class DescriptorDigest {
 
   private final String hash;
 
-  /** Creates a new instance from a valid hash string. */
+  /**
+   * Creates a new instance from a valid hash string.
+   *
+   * @param hash the hash to generate the {@link DescriptorDigest} from
+   * @return a new {@link DescriptorDigest} created from the hash
+   * @throws DigestException if the hash is invalid
+   */
   public static DescriptorDigest fromHash(String hash) throws DigestException {
     if (!hash.matches(HASH_REGEX)) {
       throw new DigestException("Invalid hash: " + hash);
@@ -54,7 +60,13 @@ public class DescriptorDigest {
     return new DescriptorDigest(hash);
   }
 
-  /** Creates a new instance from a valid digest string. */
+  /**
+   * Creates a new instance from a valid digest string.
+   *
+   * @param digest the digest to generate the {@link DescriptorDigest} from
+   * @return a new {@link DescriptorDigest} created from the digest
+   * @throws DigestException if the digest is invalid
+   */
   public static DescriptorDigest fromDigest(String digest) throws DigestException {
     if (!digest.matches(DIGEST_REGEX)) {
       throw new DigestException("Invalid digest: " + digest);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/DigestOnlyLayer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/DigestOnlyLayer.java
@@ -25,7 +25,11 @@ public class DigestOnlyLayer implements Layer {
   /** The {@link BlobDescriptor} of the compressed layer content. */
   private final BlobDescriptor blobDescriptor;
 
-  /** Instantiate with a {@link DescriptorDigest}. */
+  /**
+   * Instantiate with a {@link DescriptorDigest}.
+   *
+   * @param digest the digest to instantiate the {@link DigestOnlyLayer} from
+   */
   public DigestOnlyLayer(DescriptorDigest digest) {
     blobDescriptor = new BlobDescriptor(digest);
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/Image.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/Image.java
@@ -60,7 +60,7 @@ public class Image<T extends Layer> {
     /**
      * Adds an environment variable definition in the format {@code NAME=VALUE}.
      *
-     * @param environmentVariableDefinition the string to add
+     * @param environmentVariableDefinition the definition to add
      * @return this
      */
     public Builder<T> addEnvironmentVariableDefinition(String environmentVariableDefinition) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/Image.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/Image.java
@@ -32,7 +32,12 @@ public class Image<T extends Layer> {
     private ImmutableList<String> entrypoint = ImmutableList.of();
     private ImmutableList<String> javaArguments = ImmutableList.of();
 
-    /** Sets the environment with a map from environment variable names to values. */
+    /**
+     * Sets the environment with a map from environment variable names to values.
+     *
+     * @param environment the map of environment variables
+     * @return this
+     */
     public Builder<T> setEnvironment(Map<String, String> environment) {
       for (Map.Entry<String, String> environmentVariable : environment.entrySet()) {
         setEnvironmentVariable(environmentVariable.getKey(), environmentVariable.getValue());
@@ -40,28 +45,58 @@ public class Image<T extends Layer> {
       return this;
     }
 
+    /**
+     * Adds an environment variable with a given name and value.
+     *
+     * @param name the name of the variable
+     * @param value the value to set it to
+     * @return this
+     */
     public Builder<T> setEnvironmentVariable(String name, String value) {
       environmentBuilder.add(name + "=" + value);
       return this;
     }
 
-    /** Adds an environment variable definition in the format {@code NAME=VALUE}. */
+    /**
+     * Adds an environment variable definition in the format {@code NAME=VALUE}.
+     *
+     * @param environmentVariableDefinition the string to add
+     * @return this
+     */
     public Builder<T> addEnvironmentVariableDefinition(String environmentVariableDefinition) {
       environmentBuilder.add(environmentVariableDefinition);
       return this;
     }
 
+    /**
+     * Sets the entrypoint of the image.
+     *
+     * @param entrypoint the list of entrypoint tokens
+     * @return this
+     */
     public Builder<T> setEntrypoint(List<String> entrypoint) {
       this.entrypoint = ImmutableList.copyOf(entrypoint);
       return this;
     }
 
-    /** Sets the items in the "Cmd" field in the container configuration (i.e. the main args). */
+    /**
+     * Sets the items in the "Cmd" field in the container configuration (i.e. the main args).
+     *
+     * @param javaArguments the list of main args to add
+     * @return this
+     */
     public Builder<T> setJavaArguments(List<String> javaArguments) {
       this.javaArguments = ImmutableList.copyOf(javaArguments);
       return this;
     }
 
+    /**
+     * Adds a layer to the image.
+     *
+     * @param layer the layer to add
+     * @return this
+     * @throws LayerPropertyNotFoundException if adding the layer fails
+     */
     public Builder<T> addLayer(T layer) throws LayerPropertyNotFoundException {
       imageLayersBuilder.add(layer);
       return this;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
@@ -124,7 +124,7 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
 
   /**
    * @param digest the digest used to retrieve the layer
-   * @return the layer by digest, or {@code null} if not found
+   * @return the layer found, or {@code null} if not found
    * @throws LayerPropertyNotFoundException if getting the layer's blob descriptor fails
    */
   @Nullable

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
@@ -37,6 +37,8 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
      * Adds a layer.
      *
      * @param layer the layer to add
+     * @return this
+     * @throws LayerPropertyNotFoundException if adding the layer fails
      */
     public Builder<T> add(T layer) throws LayerPropertyNotFoundException {
       // Doesn't add the layer if the last layer is the same.
@@ -49,7 +51,14 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
       return this;
     }
 
-    /** Adds all layers in {@code layers}. */
+    /**
+     * Adds all layers in {@code layers}.
+     *
+     * @param <U> child type of {@link Layer}
+     * @param layers the layers to add
+     * @return this
+     * @throws LayerPropertyNotFoundException if adding a layer fails
+     */
     public <U extends T> Builder<T> addAll(ImageLayers<U> layers)
         throws LayerPropertyNotFoundException {
       for (U layer : layers) {
@@ -62,7 +71,11 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
       return new ImageLayers<>(layersBuilder.build(), layerDigestsBuilder.build());
     }
 
-    /** @return {@code true} if {@code layer} is the same as the last layer in {@link #layers} */
+    /**
+     * @param layer the layer to compare
+     * @return {@code true} if {@code layer} is the same as the last layer in {@link #layers}
+     * @throws LayerPropertyNotFoundException if getting the last layer's blob descriptor fails
+     */
     private boolean isSameAsLastLayer(T layer) throws LayerPropertyNotFoundException {
       return lastLayer != null
           && layer
@@ -87,7 +100,7 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
     this.layerDigests = layerDigests;
   }
 
-  /** Returns a read-only view of the image layers. */
+  /** @return a read-only view of the image layers. */
   public ImmutableList<T> getLayers() {
     return layers;
   }
@@ -101,12 +114,19 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
     return layers.isEmpty();
   }
 
-  /** @return the layer at the specified index */
+  /**
+   * @param index the index of the layer to get
+   * @return the layer at the specified index
+   */
   public T get(int index) {
     return layers.get(index);
   }
 
-  /** @return the layer by digest, or {@code null} if not found */
+  /**
+   * @param digest the digest used to retrieve the layer
+   * @return the layer by digest, or {@code null} if not found
+   * @throws LayerPropertyNotFoundException if getting the layer's blob descriptor fails
+   */
   @Nullable
   public T get(DescriptorDigest digest) throws LayerPropertyNotFoundException {
     if (!has(digest)) {
@@ -120,7 +140,10 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
     throw new IllegalStateException("Layer digest exists but layer not found");
   }
 
-  /** @return true if the layer with the specified digest exists; false otherwise */
+  /**
+   * @param digest the digest to check for
+   * @return true if the layer with the specified digest exists; false otherwise
+   */
   public boolean has(DescriptorDigest digest) {
     return layerDigests.contains(digest);
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
@@ -75,7 +75,11 @@ public class ImageReference {
 
   private static final Pattern REFERENCE_PATTERN = Pattern.compile(REFERENCE_REGEX);
 
-  /** Parses an image reference. */
+  /**
+   * @param reference the string to parse
+   * @return an {@link ImageReference} parsed from the string
+   * @throws InvalidImageReferenceException if {@code reference} is formatted incorrectly
+   */
   public static ImageReference parse(String reference) throws InvalidImageReferenceException {
     Matcher matcher = REFERENCE_PATTERN.matcher(reference);
 
@@ -130,7 +134,12 @@ public class ImageReference {
     return new ImageReference(registry, repository, tag);
   }
 
-  /** Builds an image reference from a registry, repository, and tag. */
+  /**
+   * @param registry the image registry
+   * @param repository the image repository
+   * @param tag the image tag
+   * @return an {@link ImageReference} built from the given registry, repository, and tag
+   */
   public static ImageReference of(
       @Nullable String registry, String repository, @Nullable String tag) {
     if (Strings.isNullOrEmpty(registry)) {
@@ -142,17 +151,26 @@ public class ImageReference {
     return new ImageReference(registry, repository, tag);
   }
 
-  /** @return {@code true} if is a valid registry; {@code false} otherwise */
+  /**
+   * @param registry the registry to check
+   * @return {@code true} if is a valid registry; {@code false} otherwise
+   */
   public static boolean isValidRegistry(String registry) {
     return registry.matches(REGISTRY_REGEX);
   }
 
-  /** @return {@code true} if is a valid repository; {@code false} otherwise */
+  /**
+   * @param repository the repository to check
+   * @return {@code true} if is a valid repository; {@code false} otherwise
+   */
   public static boolean isValidRepository(String repository) {
     return repository.matches(REPOSITORY_REGEX);
   }
 
-  /** @return {@code true} if is a valid tag; {@code false} otherwise */
+  /**
+   * @param tag the tag to check
+   * @return {@code true} if is a valid tag; {@code false} otherwise
+   */
   public static boolean isValidTag(String tag) {
     return tag.matches(TAG_REGEX);
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReferenceLayer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReferenceLayer.java
@@ -31,7 +31,12 @@ public class ReferenceLayer implements Layer {
   /** The digest of the uncompressed layer content. */
   private final DescriptorDigest diffId;
 
-  /** Instantiate with a {@link BlobDescriptor} and diff ID. */
+  /**
+   * Instantiate with a {@link BlobDescriptor} and diff ID.
+   *
+   * @param blobDescriptor the blob descriptor
+   * @param diffId the diff ID
+   */
   public ReferenceLayer(BlobDescriptor blobDescriptor, DescriptorDigest diffId) {
     this.blobDescriptor = blobDescriptor;
     this.diffId = diffId;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReferenceNoDiffIdLayer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReferenceNoDiffIdLayer.java
@@ -28,7 +28,11 @@ public class ReferenceNoDiffIdLayer implements Layer {
   /** The {@link BlobDescriptor} of the compressed layer content. */
   private final BlobDescriptor blobDescriptor;
 
-  /** Instantiate with a {@link BlobDescriptor} and diff ID. */
+  /**
+   * Instantiate with a {@link BlobDescriptor} and no diff ID.
+   *
+   * @param blobDescriptor the blob descriptor
+   */
   public ReferenceNoDiffIdLayer(BlobDescriptor blobDescriptor) {
     this.blobDescriptor = blobDescriptor;
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
@@ -51,7 +51,12 @@ public class ReproducibleLayerBuilder {
     this.extractionPath = extractionPath;
   }
 
-  /** Builds and returns the layer. */
+  /**
+   * Builds and returns the layer.
+   *
+   * @return the new layer
+   * @throws IOException if walking the source files fails
+   */
   public UnwrittenLayer build() throws IOException {
     List<TarArchiveEntry> filesystemEntries = new ArrayList<>();
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/UnwrittenLayer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/UnwrittenLayer.java
@@ -28,7 +28,11 @@ public class UnwrittenLayer implements Layer {
 
   private final Blob uncompressedBlob;
 
-  /** Initializes with the uncompressed {@link Blob} of the layer content. */
+  /**
+   * Initializes with the uncompressed {@link Blob} of the layer content.
+   *
+   * @param uncompressedBlob the uncompressed {@link Blob} of the layer content
+   */
   public UnwrittenLayer(Blob uncompressedBlob) {
     this.uncompressedBlob = uncompressedBlob;
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
@@ -83,9 +83,19 @@ public interface BuildableManifestTemplate extends ManifestTemplate {
   /** @return an unmodifiable view of the layers */
   List<ContentDescriptorTemplate> getLayers();
 
-  /** Sets the content descriptor of the container configuration. */
+  /**
+   * Sets the content descriptor of the container configuration.
+   *
+   * @param size the size of the container configuration.
+   * @param digest the container configuration content descriptor digest.
+   */
   void setContainerConfiguration(long size, DescriptorDigest digest);
 
-  /** Adds a layer to the manifest. */
+  /**
+   * Adds a layer to the manifest.
+   *
+   * @param size the size of the layer.
+   * @param digest the layer descriptor digest.
+   */
   void addLayer(long size, DescriptorDigest digest);
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslator.java
@@ -40,12 +40,20 @@ public class ImageToJsonTranslator {
 
   private final Image<CachedLayer> image;
 
-  /** Instantiate with an {@link Image}. */
+  /**
+   * Instantiate with an {@link Image}.
+   *
+   * @param image the image to translate.
+   */
   public ImageToJsonTranslator(Image<CachedLayer> image) {
     this.image = image;
   }
 
-  /** Gets the container configuration as a {@link Blob}. */
+  /**
+   * Gets the container configuration as a {@link Blob}.
+   *
+   * @return the container configuration {@link Blob}.
+   */
   public Blob getContainerConfigurationBlob() {
     // Set up the JSON template.
     ContainerConfigurationTemplate template = new ContainerConfigurationTemplate();
@@ -72,6 +80,11 @@ public class ImageToJsonTranslator {
    * Gets the manifest as a JSON template. The {@code containerConfigurationBlobDescriptor} must be
    * the [@link BlobDescriptor} obtained by writing out the container configuration {@link Blob}
    * returned from {@link #getContainerConfigurationBlob()}.
+   *
+   * @param <T> child type of {@link BuildableManifestTemplate}.
+   * @param manifestTemplateClass the JSON template to translate the image to.
+   * @param containerConfigurationBlobDescriptor the container configuration descriptor.
+   * @return the image contents serialized as JSON.
    */
   public <T extends BuildableManifestTemplate> T getManifestTemplate(
       Class<T> manifestTemplateClass, BlobDescriptor containerConfigurationBlobDescriptor) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
@@ -31,7 +31,13 @@ import java.util.List;
 /** Translates {@link V21ManifestTemplate} and {@link V22ManifestTemplate} into {@link Image}. */
 public class JsonToImageTranslator {
 
-  /** Translates {@link V21ManifestTemplate} to {@link Image}. */
+  /**
+   * Translates {@link V21ManifestTemplate} to {@link Image}.
+   *
+   * @param manifestTemplate the template containing the image layers.
+   * @return the translated {@link Image}.
+   * @throws LayerPropertyNotFoundException if adding image layers fails.
+   */
   public static Image<Layer> toImage(V21ManifestTemplate manifestTemplate)
       throws LayerPropertyNotFoundException {
     Image.Builder<Layer> imageBuilder = Image.builder();
@@ -46,6 +52,14 @@ public class JsonToImageTranslator {
   /**
    * Translates {@link BuildableManifestTemplate} to {@link Image}. Uses the corresponding {@link
    * ContainerConfigurationTemplate} to get the layer diff IDs.
+   *
+   * @param manifestTemplate the template containing the image layers.
+   * @param containerConfigurationTemplate the template containing the diff IDs and container
+   *     configuration properties.
+   * @return the translated {@link Image}.
+   * @throws LayerCountMismatchException if the manifest and configuration contain conflicting layer
+   *     information.
+   * @throws LayerPropertyNotFoundException if adding image layers fails.
    */
   public static Image<Layer> toImage(
       BuildableManifestTemplate manifestTemplate,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/json/JsonTemplateMapper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/json/JsonTemplateMapper.java
@@ -52,6 +52,7 @@ public class JsonTemplateMapper {
   /**
    * Deserializes a JSON file via a JSON object template.
    *
+   * @param <T> child type of {@link JsonTemplate}
    * @param jsonFile a file containing a JSON string
    * @param templateClass the template to deserialize the string to
    * @return the template filled with the values parsed from {@code jsonFile}
@@ -62,13 +63,27 @@ public class JsonTemplateMapper {
     return objectMapper.readValue(Files.newInputStream(jsonFile), templateClass);
   }
 
-  /** Deserializes a JSON object from a JSON string. */
+  /** Deserializes a JSON object from a JSON string.
+   *
+   * @param <T> child type of {@link JsonTemplate}
+   * @param jsonString a JSON string
+   * @param templateClass the template to deserialize the string to
+   * @return the template filled with the values parsed from {@code jsonString}
+   * @throws IOException if an error occurred during parsing the JSON
+   */
   public static <T extends JsonTemplate> T readJson(String jsonString, Class<T> templateClass)
       throws IOException {
     return objectMapper.readValue(jsonString, templateClass);
   }
 
-  /** Deserializes a JSON object list from a JSON string. */
+  /** Deserializes a JSON object list from a JSON string.
+   *
+   * @param <T> child type of {@link ListOfJsonTemplate}
+   * @param jsonString a JSON string
+   * @param templateClass the template to deserialize the string to
+   * @return the template filled with the values parsed from {@code jsonFile}
+   * @throws IOException if an error occurred during parsing the JSON
+   */
   public static <T extends ListOfJsonTemplate> List<T> readListOfJson(
       String jsonString, Class<T> templateClass) throws IOException {
     return objectMapper.readValue(
@@ -76,12 +91,22 @@ public class JsonTemplateMapper {
         objectMapper.getTypeFactory().constructCollectionType(List.class, templateClass));
   }
 
-  /** Convert a {@link JsonTemplate} to a {@link Blob} of the JSON string. */
+  /**
+   * Convert a {@link JsonTemplate} to a {@link Blob} of the JSON string.
+   *
+   * @param template the JSON template to convert
+   * @return a {@link Blob} of the JSON string
+   */
   public static Blob toBlob(JsonTemplate template) {
     return toBlob((Object) template);
   }
 
-  /** Convert a {@link ListOfJsonTemplate} to a {@link Blob} of the JSON string. */
+  /**
+   * Convert a {@link ListOfJsonTemplate} to a {@link Blob} of the JSON string.
+   *
+   * @param template the list of JSON templates to convert
+   * @return a {@link Blob} of the JSON string
+   */
   public static Blob toBlob(ListOfJsonTemplate template) {
     return toBlob(template.getList());
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/json/JsonTemplateMapper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/json/JsonTemplateMapper.java
@@ -63,7 +63,8 @@ public class JsonTemplateMapper {
     return objectMapper.readValue(Files.newInputStream(jsonFile), templateClass);
   }
 
-  /** Deserializes a JSON object from a JSON string.
+  /**
+   * Deserializes a JSON object from a JSON string.
    *
    * @param <T> child type of {@link JsonTemplate}
    * @param jsonString a JSON string
@@ -76,7 +77,8 @@ public class JsonTemplateMapper {
     return objectMapper.readValue(jsonString, templateClass);
   }
 
-  /** Deserializes a JSON object list from a JSON string.
+  /**
+   * Deserializes a JSON object list from a JSON string.
    *
    * @param <T> child type of {@link ListOfJsonTemplate}
    * @param jsonString a JSON string

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/json/ListOfJsonTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/json/ListOfJsonTemplate.java
@@ -26,6 +26,6 @@ import java.util.List;
  */
 public interface ListOfJsonTemplate extends JsonTemplate {
 
-  /** Returns the JsonTemplate wrapped as a list. e.g.: [{"property":"value"}] */
+  /** @return the JsonTemplate wrapped as a list. e.g.: [{"property":"value"}] */
   List<JsonTemplate> getList();
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
@@ -47,6 +47,9 @@ public class RegistryAuthenticator {
    *
    * @param authenticationMethod the {@code WWW-Authenticate} header value
    * @param repository the repository/image name
+   * @return a new {@link RegistryAuthenticator} for authenticating with the registry service
+   * @throws RegistryAuthenticationFailedException if authentication fails
+   * @throws MalformedURLException TODO: it doesn't really
    * @see <a
    *     href="https://docs.docker.com/registry/spec/auth/token/#how-to-authenticate">https://docs.docker.com/registry/spec/auth/token/#how-to-authenticate</a>
    */
@@ -105,18 +108,33 @@ public class RegistryAuthenticator {
     authenticationUrlBase = realm + "?service=" + service + "&scope=repository:" + repository + ":";
   }
 
-  /** Sets an {@code Authorization} header to authenticate with. */
+  /**
+   * Sets an {@code Authorization} header to authenticate with.
+   *
+   * @param authorization the authorization header
+   * @return this
+   */
   public RegistryAuthenticator setAuthorization(@Nullable Authorization authorization) {
     this.authorization = authorization;
     return this;
   }
 
-  /** Authenticates permissions to pull. */
+  /**
+   * Authenticates permissions to pull.
+   *
+   * @return an {@code Authorization} authenticating the pull
+   * @throws RegistryAuthenticationFailedException if authentication fails
+   */
   public Authorization authenticatePull() throws RegistryAuthenticationFailedException {
     return authenticate("pull");
   }
 
-  /** Authenticates permission to pull and push. */
+  /**
+   * Authenticates permission to pull and push.
+   *
+   * @return an {@code Authorization} authenticating the push
+   * @throws RegistryAuthenticationFailedException if authentication fails
+   */
   public Authorization authenticatePush() throws RegistryAuthenticationFailedException {
     return authenticate("pull,push");
   }
@@ -130,6 +148,8 @@ public class RegistryAuthenticator {
    * Sends the authentication request and retrieves the Bearer authorization token.
    *
    * @param scope the scope of permissions to authenticate for
+   * @return the {@link Authorization} response
+   * @throws RegistryAuthenticationFailedException if authentication fails
    * @see <a
    *     href="https://docs.docker.com/registry/spec/auth/token/#how-to-authenticate">https://docs.docker.com/registry/spec/auth/token/#how-to-authenticate</a>
    */

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -77,12 +77,16 @@ public class RegistryClient {
   @Nullable private static String userAgentSuffix;
 
   // TODO: Inject via a RegistryClientFactory.
-  /** Sets a suffix to append to {@code User-Agent} headers. */
+  /**
+   * Sets a suffix to append to {@code User-Agent} headers.
+   *
+   * @param userAgentSuffix the suffix to append
+   */
   public static void setUserAgentSuffix(@Nullable String userAgentSuffix) {
     RegistryClient.userAgentSuffix = userAgentSuffix;
   }
 
-  /** Gets the {@code User-Agent} header to send. */
+  /** @return the {@code User-Agent} header to send. */
   @VisibleForTesting
   static String getUserAgent() {
     String version = RegistryClient.class.getPackage().getImplementationVersion();
@@ -108,6 +112,8 @@ public class RegistryClient {
   /**
    * @return the {@link RegistryAuthenticator} to authenticate pulls/pushes with the registry, or
    *     {@code null} if no token authentication is necessary
+   * @throws IOException if communicating with the endpoint fails
+   * @throws RegistryException if communicating with the endpoint fails
    */
   @Nullable
   public RegistryAuthenticator getRegistryAuthenticator() throws IOException, RegistryException {
@@ -119,9 +125,13 @@ public class RegistryClient {
   /**
    * Pulls the image manifest for a specific tag.
    *
+   * @param <T> child type of ManifestTemplate
    * @param imageTag the tag to pull on
    * @param manifestTemplateClass the specific version of manifest template to pull, or {@link
    *     ManifestTemplate} to pull either {@link V22ManifestTemplate} or {@link V21ManifestTemplate}
+   * @return the manifest template
+   * @throws IOException if communicating with the endpoint fails
+   * @throws RegistryException if communicating with the endpoint fails
    */
   public <T extends ManifestTemplate> T pullManifest(
       String imageTag, Class<T> manifestTemplateClass) throws IOException, RegistryException {
@@ -138,7 +148,14 @@ public class RegistryClient {
     return pullManifest(imageTag, ManifestTemplate.class);
   }
 
-  /** Pushes the image manifest for a specific tag. */
+  /**
+   * Pushes the image manifest for a specific tag.
+   *
+   * @param manifestTemplate the image manifest
+   * @param imageTag the tag to push on
+   * @throws IOException if communicating with the endpoint fails
+   * @throws RegistryException if communicating with the endpoint fails
+   */
   public void pushManifest(BuildableManifestTemplate manifestTemplate, String imageTag)
       throws IOException, RegistryException {
     callRegistryEndpoint(
@@ -146,8 +163,11 @@ public class RegistryClient {
   }
 
   /**
+   * @param blobDigest the blob digest to check for
    * @return the BLOB's {@link BlobDescriptor} if the BLOB exists on the registry, or {@code null}
    *     if it doesn't
+   * @throws IOException if communicating with the endpoint fails
+   * @throws RegistryException if communicating with the endpoint fails
    */
   @Nullable
   public BlobDescriptor checkBlob(DescriptorDigest blobDigest)
@@ -163,6 +183,8 @@ public class RegistryClient {
    * @param destinationOutputStream the {@link OutputStream} to write the BLOB to
    * @return a {@link Blob} backed by the file at {@code destPath}. The file at {@code destPath}
    *     must exist for {@link Blob} to be valid.
+   * @throws IOException if communicating with the endpoint fails
+   * @throws RegistryException if communicating with the endpoint fails
    */
   public Void pullBlob(DescriptorDigest blobDigest, OutputStream destinationOutputStream)
       throws RegistryException, IOException {
@@ -179,6 +201,8 @@ public class RegistryClient {
    * @param blob the BLOB to push
    * @return {@code true} if the BLOB already exists on the registry and pushing was skipped; false
    *     if the BLOB was pushed
+   * @throws IOException if communicating with the endpoint fails
+   * @throws RegistryException if communicating with the endpoint fails
    */
   public boolean pushBlob(DescriptorDigest blobDigest, Blob blob)
       throws IOException, RegistryException {
@@ -220,6 +244,8 @@ public class RegistryClient {
    * Calls the registry endpoint.
    *
    * @param registryEndpointProvider the {@link RegistryEndpointProvider} to the endpoint
+   * @throws IOException if communicating with the endpoint fails
+   * @throws RegistryException if communicating with the endpoint fails
    */
   @Nullable
   private <T> T callRegistryEndpoint(RegistryEndpointProvider<T> registryEndpointProvider)
@@ -233,6 +259,8 @@ public class RegistryClient {
    * @param url the endpoint URL to call, or {@code null} to use default from {@code
    *     registryEndpointProvider}
    * @param registryEndpointProvider the {@link RegistryEndpointProvider} to the endpoint
+   * @throws IOException if communicating with the endpoint fails
+   * @throws RegistryException if communicating with the endpoint fails
    */
   @Nullable
   private <T> T callRegistryEndpoint(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryUnauthorizedException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryUnauthorizedException.java
@@ -24,7 +24,13 @@ public class RegistryUnauthorizedException extends RegistryException {
   private final String registry;
   private final String repository;
 
-  /** Identifies the image registry and repository that denied access. */
+  /**
+   * Identifies the image registry and repository that denied access.
+   *
+   * @param registry the image registry
+   * @param repository the image repository
+   * @param cause the cause
+   */
   public RegistryUnauthorizedException(
       String registry, String repository, HttpResponseException cause) {
     super(cause);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
@@ -61,10 +61,8 @@ public class DockerCredentialHelper {
 
   /**
    * @return the Docker credentials by calling the corresponding CLI.
-   *
-   * <p>The credential helper CLI is called in the form:
-   *
-   * <pre>{@code
+   *     <p>The credential helper CLI is called in the form:
+   *     <pre>{@code
    * echo -n <server URL> | docker-credential-<credential helper suffix> get
    * }</pre>
    *

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
@@ -60,13 +60,17 @@ public class DockerCredentialHelper {
   }
 
   /**
-   * Retrieves the Docker credentials by calling the corresponding CLI.
+   * @return the Docker credentials by calling the corresponding CLI.
    *
    * <p>The credential helper CLI is called in the form:
    *
    * <pre>{@code
    * echo -n <server URL> | docker-credential-<credential helper suffix> get
    * }</pre>
+   *
+   * @throws IOException if writing/reading process input/output fails.
+   * @throws NonexistentServerUrlDockerCredentialHelperException if credentials are not found.
+   * @throws NonexistentDockerCredentialHelperException if the credential helper CLI doesn't exist.
    */
   public Authorization retrieve()
       throws IOException, NonexistentServerUrlDockerCredentialHelperException,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperFactory.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperFactory.java
@@ -26,8 +26,8 @@ public class DockerCredentialHelperFactory {
   }
 
   /**
-   * @return a {@link DockerCredentialHelper} that uses the {@code
-   *     docker-credential-[credentialHelperSuffix]} command
+   * @param credentialHelperSuffix the suffix of the docker-credential-[suffix] command to be run.
+   * @return a {@link DockerCredentialHelper} retrieved from the command.
    */
   public DockerCredentialHelper withCredentialHelperSuffix(String credentialHelperSuffix) {
     return new DockerCredentialHelper(registry, credentialHelperSuffix);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
@@ -76,6 +76,7 @@ public class DockerConfigTemplate implements JsonTemplate {
   private final Map<String, String> credHelpers = new HashMap<>();
 
   /**
+   * @param registry the registry to get the authorization for
    * @return the base64-encoded {@code Basic} authorization for {@code registry}, or {@code null} if
    *     none exists
    */
@@ -88,6 +89,7 @@ public class DockerConfigTemplate implements JsonTemplate {
   }
 
   /**
+   * @param registry the registry to get the credential helpers for
    * @return {@code credsStore} if {@code registry} is present in {@code auths}; otherwise, searches
    *     {@code credHelpers}; otherwise, {@code null} if not found
    */

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -98,9 +98,7 @@ public class TarStreamBuilder {
             tarArchiveOutputStream.write(contents.getBytes(StandardCharsets.UTF_8)));
   }
 
-  /**
-   * @return a new {@link Blob} that can stream the uncompressed tarball archive BLOB.
-   */
+  /** @return a new {@link Blob} that can stream the uncompressed tarball archive BLOB. */
   public Blob toBlob() {
     return Blobs.from(this::writeEntriesAsTarArchive);
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -45,7 +45,12 @@ public class TarStreamBuilder {
   private final LinkedHashMap<TarArchiveEntry, TarArchiveOutputStreamConsumer> archiveMap =
       new LinkedHashMap<>();
 
-  /** Writes each entry in the filesystem to the tarball archive stream. */
+  /**
+   * Writes each entry in the filesystem to the tarball archive stream.
+   *
+   * @param tarByteStream the stream to write to.
+   * @throws IOException if building the tarball fails.
+   */
   private void writeEntriesAsTarArchive(OutputStream tarByteStream) throws IOException {
     try (TarArchiveOutputStream tarArchiveOutputStream =
         new TarArchiveOutputStream(tarByteStream)) {
@@ -60,7 +65,11 @@ public class TarStreamBuilder {
     }
   }
 
-  /** Adds an entry to the archive. */
+  /**
+   * Adds an entry to the archive.
+   *
+   * @param entry the entry to add.
+   */
   public void addEntry(TarArchiveEntry entry) {
     archiveMap.put(
         entry,
@@ -74,7 +83,12 @@ public class TarStreamBuilder {
         });
   }
 
-  /** Adds a blob to the archive. */
+  /**
+   * Adds a blob to the archive.
+   *
+   * @param contents the blob contents to add to the tarball.
+   * @param name the name of the entry (i.e. filename).
+   */
   public void addEntry(String contents, String name) {
     TarArchiveEntry entry = new TarArchiveEntry(name);
     entry.setSize(contents.length());
@@ -84,7 +98,9 @@ public class TarStreamBuilder {
             tarArchiveOutputStream.write(contents.getBytes(StandardCharsets.UTF_8)));
   }
 
-  /** Builds a {@link Blob} that can stream the uncompressed tarball archive BLOB. */
+  /**
+   * @return a new {@link Blob} that can stream the uncompressed tarball archive BLOB.
+   */
   public Blob toBlob() {
     return Blobs.from(this::writeEntriesAsTarArchive);
   }

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -98,6 +98,13 @@ tasks.withType(JavaCompile) {
     }
 }
 
+// Fail build on javadoc warnings
+if (JavaVersion.current().isJava8Compatible()) {
+    tasks.withType(Javadoc) {
+        options.addStringOption('Xwerror', '-quiet')
+    }
+}
+
 tasks.withType(Test) {
     reports.html.setDestination file("${reporting.baseDir}/${name}")
 }

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -98,11 +98,6 @@ tasks.withType(JavaCompile) {
     }
 }
 
-// Suppress javadoc warnings
-tasks.withType(Javadoc) {
-    options.addStringOption('Xdoclint:none', '-quiet')
-}
-
 tasks.withType(Test) {
     reports.html.setDestination file("${reporting.baseDir}/${name}")
 }

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -98,6 +98,7 @@ tasks.withType(JavaCompile) {
     }
 }
 
+// Suppress javadoc warnings
 tasks.withType(Javadoc) {
     options.addStringOption('Xdoclint:none', '-quiet')
 }

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -98,6 +98,10 @@ tasks.withType(JavaCompile) {
     }
 }
 
+tasks.withType(Javadoc) {
+    options.addStringOption('Xdoclint:none', '-quiet')
+}
+
 tasks.withType(Test) {
     reports.html.setDestination file("${reporting.baseDir}/${name}")
 }

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -100,7 +100,7 @@ tasks.withType(JavaCompile) {
 
 // Fail build on javadoc warnings
 tasks.withType(Javadoc) {
-    options.addStringOption('Xwerror', '-quiet')
+    options.addBooleanOption('Xwerror', true)
 }
 
 tasks.withType(Test) {

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -99,10 +99,8 @@ tasks.withType(JavaCompile) {
 }
 
 // Fail build on javadoc warnings
-if (JavaVersion.current().isJava8Compatible()) {
-    tasks.withType(Javadoc) {
-        options.addStringOption('Xwerror', '-quiet')
-    }
+tasks.withType(Javadoc) {
+    options.addStringOption('Xwerror', '-quiet')
 }
 
 tasks.withType(Test) {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -50,6 +50,8 @@ public class BuildDockerTask extends DefaultTask {
   /**
    * This will call the property {@code "jib"} so that it is the same name as the extension. This
    * way, the user would see error messages for missing configuration with the prefix {@code jib.}.
+   *
+   * @return the {@link JibExtension}.
    */
   @Nested
   @Nullable
@@ -57,7 +59,11 @@ public class BuildDockerTask extends DefaultTask {
     return jibExtension;
   }
 
-  /** The target image can be overridden with the {@code --image} command line option. */
+  /**
+   * The target image can be overridden with the {@code --image} command line option.
+   *
+   * @param targetImage the name of the 'to' image.
+   */
   @Option(option = "image", description = "The image reference for the target image")
   public void setTargetImage(String targetImage) {
     Preconditions.checkNotNull(jibExtension).getTo().setImage(targetImage);

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -49,6 +49,8 @@ public class BuildImageTask extends DefaultTask {
   /**
    * This will call the property {@code "jib"} so that it is the same name as the extension. This
    * way, the user would see error messages for missing configuration with the prefix {@code jib.}.
+   *
+   * @return the {@link JibExtension}.
    */
   @Nested
   @Nullable
@@ -56,7 +58,11 @@ public class BuildImageTask extends DefaultTask {
     return jibExtension;
   }
 
-  /** The target image can be overridden with the {@code --image} command line option. */
+  /**
+   * The target image can be overridden with the {@code --image} command line option.
+   *
+   * @param targetImage the name of the 'to' image.
+   */
   @Option(option = "image", description = "The image reference for the target image")
   public void setTargetImage(String targetImage) {
     Preconditions.checkNotNull(jibExtension).getTo().setImage(targetImage);

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerContextTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerContextTask.java
@@ -43,6 +43,8 @@ public class DockerContextTask extends DefaultTask {
   /**
    * This will call the property {@code "jib"} so that it is the same name as the extension. This
    * way, the user would see error messages for missing configuration with the prefix {@code jib.}.
+   *
+   * @return the {@link JibExtension}.
    */
   @Nested
   @Nullable
@@ -51,8 +53,8 @@ public class DockerContextTask extends DefaultTask {
   }
 
   /**
-   * The input files to this task are all the output files for all the dependencies of the {@code
-   * classes} task.
+   * @return the input files to this task are all the output files for all the dependencies of the
+   *     {@code classes} task.
    */
   @InputFiles
   public FileCollection getInputFiles() {
@@ -67,7 +69,10 @@ public class DockerContextTask extends DefaultTask {
     return getProject().files(dependencyFileCollections);
   }
 
-  /** The output directory for the Docker context is by default {@code build/jib-docker-context}. */
+  /**
+   * @return the output directory for the Docker context is by default {@code build/jib-docker-
+   *     context}.
+   */
   @OutputDirectory
   public String getTargetDir() {
     if (targetDir == null) {
@@ -76,7 +81,11 @@ public class DockerContextTask extends DefaultTask {
     return targetDir;
   }
 
-  /** The output directory can be overriden with the {@code --jib.dockerDir} command line option. */
+  /**
+   * The output directory can be overriden with the {@code --jib.dockerDir} command line option.
+   *
+   * @param targetDir the output directory.
+   */
   @Option(option = "jib.dockerDir", description = "Directory to output the Docker context to")
   public void setTargetDir(String targetDir) {
     this.targetDir = targetDir;

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/HelpfulSuggestionsProvider.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/HelpfulSuggestionsProvider.java
@@ -21,6 +21,10 @@ import com.google.cloud.tools.jib.frontend.HelpfulSuggestions;
 /** Provider for Maven-specific {@link HelpfulSuggestions}. */
 class HelpfulSuggestionsProvider {
 
+  /**
+   * @param messagePrefix the prefix
+   * @return a new {@link HelpfulSuggestions} with the specified message prefix
+   */
   static HelpfulSuggestions get(String messagePrefix) {
     return new HelpfulSuggestions(
         messagePrefix,

--- a/jib-maven-plugin/config/google-checks-no-indent.xml
+++ b/jib-maven-plugin/config/google-checks-no-indent.xml
@@ -211,7 +211,7 @@
     <module name="JavadocMethod">
       <property name="scope" value="package"/>
       <property name="minLineCount" value="2"/>
-      <property name="allowedAnnotations" value="Override, Test"/>
+      <property name="allowedAnnotations" value="Override, Test, VisibleForTesting"/>
       <property name="allowThrowsTagsForSubclasses" value="true"/>
     </module>
     <module name="MethodName">

--- a/jib-maven-plugin/config/google-checks-no-indent.xml
+++ b/jib-maven-plugin/config/google-checks-no-indent.xml
@@ -209,10 +209,7 @@
       <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="public"/>
-      <property name="allowMissingParamTags" value="true"/>
-      <property name="allowMissingThrowsTags" value="true"/>
-      <property name="allowMissingReturnTag" value="true"/>
+      <property name="scope" value="package"/>
       <property name="minLineCount" value="2"/>
       <property name="allowedAnnotations" value="Override, Test"/>
       <property name="allowThrowsTagsForSubclasses" value="true"/>

--- a/jib-maven-plugin/pom.xml
+++ b/jib-maven-plugin/pom.xml
@@ -382,7 +382,7 @@
           </dependency>
         </dependencies>
         <configuration>
-          <consoleOutput>false</consoleOutput>
+          <logViolationsToConsole>true</logViolationsToConsole>
           <failOnViolation>true</failOnViolation>
           <violationSeverity>warning</violationSeverity>
           <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -54,13 +54,13 @@ public class BuildDockerMojo extends JibPluginConfiguration {
     }
 
     // Parses 'from' and 'to' into image reference.
-    ImageReference baseImage = parseBaseImageReference(getBaseImage());
+    ImageReference baseImage = parseImageReference(getBaseImage(), "from");
 
     // TODO: Validate that project name and version are valid repository/tag
     ImageReference targetImage =
         Strings.isNullOrEmpty(getTargetImage())
             ? ImageReference.of(null, getProject().getName(), getProject().getVersion())
-            : parseTargetImageReference(getTargetImage());
+            : parseImageReference(getTargetImage(), "to");
 
     // Checks Maven settings for registry credentials.
     MavenSettingsServerCredentials mavenSettingsServerCredentials =

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -64,7 +64,7 @@ public class BuildImageMojo extends JibPluginConfiguration {
     }
 
     // Parses 'from' into image reference.
-    ImageReference baseImage = parseBaseImageReference(getBaseImage());
+    ImageReference baseImage = parseImageReference(getBaseImage(), "from");
 
     // Parses 'to' into image reference.
     if (Strings.isNullOrEmpty(getTargetImage())) {
@@ -73,7 +73,7 @@ public class BuildImageMojo extends JibPluginConfiguration {
               .forToNotConfigured(
                   "<to><image>", "pom.xml", "mvn compile jib:build -Dimage=<your image name>"));
     }
-    ImageReference targetImage = parseTargetImageReference(getTargetImage());
+    ImageReference targetImage = parseImageReference(getTargetImage(), "to");
 
     // Checks Maven settings for registry credentials.
     MavenSettingsServerCredentials mavenSettingsServerCredentials =

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/HelpfulSuggestionsProvider.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/HelpfulSuggestionsProvider.java
@@ -25,6 +25,10 @@ class HelpfulSuggestionsProvider {
   private static final Function<String, String> AUTH_CONFIGURATION_SUGGESTION =
       registry -> "set credentials for '" + registry + "' in your Maven settings";
 
+  /**
+   * @param messagePrefix the prefix
+   * @return a new {@link HelpfulSuggestions} with the specified message prefix
+   */
   static HelpfulSuggestions get(String messagePrefix) {
     return new HelpfulSuggestions(
         messagePrefix,

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -59,7 +59,7 @@ abstract class JibPluginConfiguration extends AbstractMojo {
 
   /**
    * @param image the image reference string to parse.
-   * @param type the type of image (e.g. "to" or "from").
+   * @param type name of the parameter being parsed (e.g. "to" or "from").
    * @return the {@link ImageReference} parsed from {@code from}.
    */
   static ImageReference parseImageReference(String image, String type) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -58,26 +58,15 @@ abstract class JibPluginConfiguration extends AbstractMojo {
   }
 
   /**
-   * @param from the image reference string to parse.
+   * @param image the image reference string to parse.
+   * @param type the type of image (e.g. "to" or "from").
    * @return the {@link ImageReference} parsed from {@code from}.
    */
-  static ImageReference parseBaseImageReference(String from) {
+  static ImageReference parseImageReference(String image, String type) {
     try {
-      return ImageReference.parse(from);
+      return ImageReference.parse(image);
     } catch (InvalidImageReferenceException ex) {
-      throw new IllegalStateException("Parameter 'from' is invalid", ex);
-    }
-  }
-
-  /**
-   * @param to the image reference string to parse.
-   * @return the {@link ImageReference} parsed from {@code to}.
-   */
-  static ImageReference parseTargetImageReference(String to) {
-    try {
-      return ImageReference.parse(to);
-    } catch (InvalidImageReferenceException ex) {
-      throw new IllegalStateException("Parameter 'to' is invalid", ex);
+      throw new IllegalStateException("Parameter '" + type + "' is invalid", ex);
     }
   }
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -57,7 +57,10 @@ abstract class JibPluginConfiguration extends AbstractMojo {
     }
   }
 
-  /** @return the {@link ImageReference} parsed from {@code from}. */
+  /**
+   * @param from the image reference string to parse.
+   * @return the {@link ImageReference} parsed from {@code from}.
+   */
   static ImageReference parseBaseImageReference(String from) {
     try {
       return ImageReference.parse(from);
@@ -66,7 +69,10 @@ abstract class JibPluginConfiguration extends AbstractMojo {
     }
   }
 
-  /** @return the {@link ImageReference} parsed from {@code to}. */
+  /**
+   * @param to the image reference string to parse.
+   * @return the {@link ImageReference} parsed from {@code to}.
+   */
   static ImageReference parseTargetImageReference(String to) {
     try {
       return ImageReference.parse(to);

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -62,13 +62,6 @@ class MavenProjectProperties implements ProjectProperties {
   private final MavenBuildLogger mavenBuildLogger;
   private final SourceFilesConfiguration sourceFilesConfiguration;
 
-  /**
-   * Constructor used for testing purposes.
-   *
-   * @param project the {@link MavenProject}
-   * @param mavenBuildLogger the {@link BuildLogger}
-   * @param sourceFilesConfiguration the project files configuration
-   */
   @VisibleForTesting
   MavenProjectProperties(
       MavenProject project,

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -38,7 +38,12 @@ class MavenProjectProperties implements ProjectProperties {
   private static final String PLUGIN_NAME = "jib-maven-plugin";
   private static final String JAR_PLUGIN_NAME = "'maven-jar-plugin'";
 
-  /** @return a MavenProjectProperties from the given project and logger. */
+  /**
+   * @param project the {@link MavenProject} for the plugin.
+   * @param mavenBuildLogger the logger used for printing status messages.
+   * @return a MavenProjectProperties from the given project and logger.
+   * @throws MojoExecutionException if no class files are found in the output directory.
+   */
   static MavenProjectProperties getForProject(
       MavenProject project, MavenBuildLogger mavenBuildLogger) throws MojoExecutionException {
     try {
@@ -57,6 +62,13 @@ class MavenProjectProperties implements ProjectProperties {
   private final MavenBuildLogger mavenBuildLogger;
   private final SourceFilesConfiguration sourceFilesConfiguration;
 
+  /**
+   * Constructor used for testing purposes.
+   *
+   * @param project the {@link MavenProject}
+   * @param mavenBuildLogger the {@link BuildLogger}
+   * @param sourceFilesConfiguration the project files configuration
+   */
   @VisibleForTesting
   MavenProjectProperties(
       MavenProject project,
@@ -126,6 +138,8 @@ class MavenProjectProperties implements ProjectProperties {
   /**
    * Tries to resolve the main class.
    *
+   * @param jibPluginConfiguration the mojo configuration properties.
+   * @return the configured main class, or the inferred main class if none is configured.
    * @throws MojoExecutionException if resolving the main class fails.
    */
   String getMainClass(JibPluginConfiguration jibPluginConfiguration) throws MojoExecutionException {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentials.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentials.java
@@ -37,7 +37,12 @@ class MavenSettingsServerCredentials {
     this.settings = settings;
   }
 
-  /** Attempts to retrieve credentials for {@code registry} from Maven settings. */
+  /**
+   * Attempts to retrieve credentials for {@code registry} from Maven settings.
+   *
+   * @param registry the registry
+   * @return the credentials for the registry
+   */
   @Nullable
   RegistryCredentials retrieve(@Nullable String registry) {
     if (registry == null) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSourceFilesConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSourceFilesConfiguration.java
@@ -37,7 +37,13 @@ class MavenSourceFilesConfiguration implements SourceFilesConfiguration {
   private static final String RESOURCES_PATH_ON_IMAGE = "/app/resources/";
   private static final String CLASSES_PATH_ON_IMAGE = "/app/classes/";
 
-  /** Resolves the source files configuration for a Maven {@link MavenProject}. */
+  /**
+   * Resolves the source files configuration for a Maven {@link MavenProject}.
+   *
+   * @param project the {@link MavenProject}
+   * @return a new {@link MavenSourceFilesConfiguration} for the project
+   * @throws IOException if collecting the project files fails
+   */
   static MavenSourceFilesConfiguration getForProject(MavenProject project) throws IOException {
     return new MavenSourceFilesConfiguration(project);
   }


### PR DESCRIPTION
Fixes #280 

Although we may want to look into this more, and either fix all the warnings by fixing our javadocs, or limit the type of warnings that's suppressed (more options here: https://gist.github.com/hekar/62772af5b0fe0b6731bb)