### PR TITLE
Moves registry endpoint calling to separate class that manages request state.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -16,32 +16,21 @@
 
 package com.google.cloud.tools.jib.registry;
 
-import com.google.api.client.http.GenericUrl;
-import com.google.api.client.http.HttpResponseException;
-import com.google.api.client.http.HttpStatusCodes;
 import com.google.cloud.tools.jib.Timer;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.builder.BuildLogger;
 import com.google.cloud.tools.jib.http.Authorization;
-import com.google.cloud.tools.jib.http.Connection;
-import com.google.cloud.tools.jib.http.Request;
-import com.google.cloud.tools.jib.http.Response;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
-import com.google.cloud.tools.jib.json.JsonTemplateMapper;
-import com.google.cloud.tools.jib.registry.json.ErrorEntryTemplate;
-import com.google.cloud.tools.jib.registry.json.ErrorResponseTemplate;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLPeerUnverifiedException;
-import org.apache.http.NoHttpResponseException;
 
 /** Interfaces with a registry. */
 public class RegistryClient {
@@ -71,8 +60,6 @@ public class RegistryClient {
     this.parentTimer = parentTimer;
     return this;
   }
-
-  private static final String PROTOCOL = "https";
 
   @Nullable private static String userAgentSuffix;
 
@@ -210,10 +197,10 @@ public class RegistryClient {
     }
   }
 
-  /** @return the registry endpoint's API root URL */
+  /** @return the registry endpoint's API root, without the protocol */
   @VisibleForTesting
   String getApiRouteBase() {
-    return PROTOCOL + "://" + registryEndpointProperties.getServerUrl() + "/v2/";
+    return registryEndpointProperties.getServerUrl() + "/v2/";
   }
 
   /**
@@ -224,85 +211,12 @@ public class RegistryClient {
   @Nullable
   private <T> T callRegistryEndpoint(RegistryEndpointProvider<T> registryEndpointProvider)
       throws IOException, RegistryException {
-    return callRegistryEndpoint(null, registryEndpointProvider);
-  }
-
-  /**
-   * Calls the registry endpoint with an override URL.
-   *
-   * @param url the endpoint URL to call, or {@code null} to use default from {@code
-   *     registryEndpointProvider}
-   * @param registryEndpointProvider the {@link RegistryEndpointProvider} to the endpoint
-   */
-  @Nullable
-  private <T> T callRegistryEndpoint(
-      @Nullable URL url, RegistryEndpointProvider<T> registryEndpointProvider)
-      throws IOException, RegistryException {
-    if (url == null) {
-      url = registryEndpointProvider.getApiRoute(getApiRouteBase());
-    }
-
-    try (Connection connection = new Connection(url)) {
-      Request request =
-          Request.builder()
-              .setAuthorization(authorization)
-              .setUserAgent(getUserAgent())
-              .setAccept(registryEndpointProvider.getAccept())
-              .setBody(registryEndpointProvider.getContent())
-              .build();
-      Response response = connection.send(registryEndpointProvider.getHttpMethod(), request);
-
-      return registryEndpointProvider.handleResponse(response);
-
-    } catch (HttpResponseException ex) {
-      // First, see if the endpoint provider handles an exception as an expected response.
-      try {
-        return registryEndpointProvider.handleHttpResponseException(ex);
-
-      } catch (HttpResponseException httpResponseException) {
-        if (httpResponseException.getStatusCode() == HttpStatusCodes.STATUS_CODE_BAD_REQUEST
-            || httpResponseException.getStatusCode() == HttpStatusCodes.STATUS_CODE_NOT_FOUND
-            || httpResponseException.getStatusCode()
-                == HttpStatusCodes.STATUS_CODE_METHOD_NOT_ALLOWED) {
-          // The name or reference was invalid.
-          ErrorResponseTemplate errorResponse =
-              JsonTemplateMapper.readJson(
-                  httpResponseException.getContent(), ErrorResponseTemplate.class);
-          RegistryErrorExceptionBuilder registryErrorExceptionBuilder =
-              new RegistryErrorExceptionBuilder(
-                  registryEndpointProvider.getActionDescription(), httpResponseException);
-          for (ErrorEntryTemplate errorEntry : errorResponse.getErrors()) {
-            registryErrorExceptionBuilder.addReason(errorEntry);
-          }
-
-          throw registryErrorExceptionBuilder.build();
-
-        } else if (httpResponseException.getStatusCode() == HttpStatusCodes.STATUS_CODE_UNAUTHORIZED
-            || httpResponseException.getStatusCode() == HttpStatusCodes.STATUS_CODE_FORBIDDEN) {
-          throw new RegistryUnauthorizedException(
-              registryEndpointProperties.getServerUrl(),
-              registryEndpointProperties.getImageName(),
-              httpResponseException);
-
-        } else if (httpResponseException.getStatusCode()
-            == HttpStatusCodes.STATUS_CODE_TEMPORARY_REDIRECT) {
-          return callRegistryEndpoint(
-              new URL(httpResponseException.getHeaders().getLocation()), registryEndpointProvider);
-
-        } else {
-          // Unknown
-          throw httpResponseException;
-        }
-      }
-
-    } catch (NoHttpResponseException ex) {
-      throw new RegistryNoResponseException(ex);
-
-    } catch (SSLPeerUnverifiedException ex) {
-      // Fall-back to HTTP
-      GenericUrl httpUrl = new GenericUrl(url);
-      httpUrl.setScheme("http");
-      return callRegistryEndpoint(httpUrl.toURL(), registryEndpointProvider);
-    }
+    return new RegistryEndpointCaller<>(
+            getUserAgent(),
+            getApiRouteBase(),
+            registryEndpointProvider,
+            authorization,
+            registryEndpointProperties)
+        .call();
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright 2018 Google LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.registry;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpResponseException;
+import com.google.api.client.http.HttpStatusCodes;
+import com.google.cloud.tools.jib.http.Authorization;
+import com.google.cloud.tools.jib.http.Connection;
+import com.google.cloud.tools.jib.http.Request;
+import com.google.cloud.tools.jib.http.Response;
+import com.google.cloud.tools.jib.json.JsonTemplateMapper;
+import com.google.cloud.tools.jib.registry.json.ErrorEntryTemplate;
+import com.google.cloud.tools.jib.registry.json.ErrorResponseTemplate;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import org.apache.http.NoHttpResponseException;
+
+/** Makes requests to a registry endpoint. */
+class RegistryEndpointCaller<T> {
+
+  private static final String PROTOCOL = "https";
+
+  /** Maintains the state of a request. This is used to retry requests with different parameters. */
+  private static class RequestState {
+
+    @Nullable private final Authorization authorization;
+    private final URL url;
+
+    /**
+     * @param authorization authentication credentials
+     * @param url the endpoint URL to call, or {@code null} to use default from {@code
+     *     registryEndpointProvider}
+     */
+    private RequestState(@Nullable Authorization authorization, URL url) {
+      this.authorization = authorization;
+      this.url = url;
+    }
+  }
+
+  private final RequestState initialRequestState;
+  private final String userAgent;
+  private final RegistryEndpointProvider<T> registryEndpointProvider;
+  private final RegistryEndpointProperties registryEndpointProperties;
+
+  /**
+   * Constructs with parameters for making the request.
+   *
+   * @param userAgent {@code User-Agent} header to send with the request
+   * @param apiRouteBase the endpoint's API root, without the protocol
+   * @param registryEndpointProvider the {@link RegistryEndpointProvider} to the endpoint
+   * @param authorization optional authentication credentials to use
+   * @param registryEndpointProperties properties of the registry endpoint request
+   */
+  RegistryEndpointCaller(
+      String userAgent,
+      String apiRouteBase,
+      RegistryEndpointProvider<T> registryEndpointProvider,
+      @Nullable Authorization authorization,
+      RegistryEndpointProperties registryEndpointProperties)
+      throws MalformedURLException {
+    this.initialRequestState =
+        new RequestState(
+            authorization, registryEndpointProvider.getApiRoute(PROTOCOL + "://" + apiRouteBase));
+    this.userAgent = userAgent;
+    this.registryEndpointProvider = registryEndpointProvider;
+    this.registryEndpointProperties = registryEndpointProperties;
+  }
+
+  /** Makes the request to the endpoint. */
+  @Nullable
+  T call() throws IOException, RegistryException {
+    return call(initialRequestState);
+  }
+
+  /** Calls the registry endpoint with a certain {@link RequestState}. */
+  @Nullable
+  private T call(RequestState requestState) throws IOException, RegistryException {
+    try (Connection connection = new Connection(requestState.url)) {
+      Request request =
+          Request.builder()
+              .setAuthorization(requestState.authorization)
+              .setUserAgent(userAgent)
+              .setAccept(registryEndpointProvider.getAccept())
+              .setBody(registryEndpointProvider.getContent())
+              .build();
+      Response response = connection.send(registryEndpointProvider.getHttpMethod(), request);
+
+      return registryEndpointProvider.handleResponse(response);
+
+    } catch (HttpResponseException ex) {
+      // First, see if the endpoint provider handles an exception as an expected response.
+      try {
+        return registryEndpointProvider.handleHttpResponseException(ex);
+
+      } catch (HttpResponseException httpResponseException) {
+        if (httpResponseException.getStatusCode() == HttpStatusCodes.STATUS_CODE_BAD_REQUEST
+            || httpResponseException.getStatusCode() == HttpStatusCodes.STATUS_CODE_NOT_FOUND
+            || httpResponseException.getStatusCode()
+                == HttpStatusCodes.STATUS_CODE_METHOD_NOT_ALLOWED) {
+          // The name or reference was invalid.
+          ErrorResponseTemplate errorResponse =
+              JsonTemplateMapper.readJson(
+                  httpResponseException.getContent(), ErrorResponseTemplate.class);
+          RegistryErrorExceptionBuilder registryErrorExceptionBuilder =
+              new RegistryErrorExceptionBuilder(
+                  registryEndpointProvider.getActionDescription(), httpResponseException);
+          for (ErrorEntryTemplate errorEntry : errorResponse.getErrors()) {
+            registryErrorExceptionBuilder.addReason(errorEntry);
+          }
+
+          throw registryErrorExceptionBuilder.build();
+
+        } else if (httpResponseException.getStatusCode() == HttpStatusCodes.STATUS_CODE_UNAUTHORIZED
+            || httpResponseException.getStatusCode() == HttpStatusCodes.STATUS_CODE_FORBIDDEN) {
+          throw new RegistryUnauthorizedException(
+              registryEndpointProperties.getServerUrl(),
+              registryEndpointProperties.getImageName(),
+              httpResponseException);
+
+        } else if (httpResponseException.getStatusCode()
+            == HttpStatusCodes.STATUS_CODE_TEMPORARY_REDIRECT) {
+          // TODO: Use copy-construct builder.
+          return call(
+              new RequestState(
+                  requestState.authorization,
+                  new URL(httpResponseException.getHeaders().getLocation())));
+
+        } else {
+          // Unknown
+          throw httpResponseException;
+        }
+      }
+
+    } catch (NoHttpResponseException ex) {
+      throw new RegistryNoResponseException(ex);
+
+    } catch (SSLPeerUnverifiedException ex) {
+      // Fall-back to HTTP
+      GenericUrl httpUrl = new GenericUrl(requestState.url);
+      httpUrl.setScheme("http");
+      return call(new RequestState(requestState.authorization, httpUrl.toURL()));
+    }
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -36,7 +36,7 @@ import org.apache.http.NoHttpResponseException;
 /** Makes requests to a registry endpoint. */
 class RegistryEndpointCaller<T> {
 
-  private static final String PROTOCOL = "https";
+  private static final String DEFAULT_PROTOCOL = "https";
 
   /** Maintains the state of a request. This is used to retry requests with different parameters. */
   private static class RequestState {
@@ -78,7 +78,7 @@ class RegistryEndpointCaller<T> {
       throws MalformedURLException {
     this.initialRequestState =
         new RequestState(
-            authorization, registryEndpointProvider.getApiRoute(PROTOCOL + "://" + apiRouteBase));
+            authorization, registryEndpointProvider.getApiRoute(DEFAULT_PROTOCOL + "://" + apiRouteBase));
     this.userAgent = userAgent;
     this.registryEndpointProvider = registryEndpointProvider;
     this.registryEndpointProperties = registryEndpointProperties;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -78,7 +78,8 @@ class RegistryEndpointCaller<T> {
       throws MalformedURLException {
     this.initialRequestState =
         new RequestState(
-            authorization, registryEndpointProvider.getApiRoute(DEFAULT_PROTOCOL + "://" + apiRouteBase));
+            authorization,
+            registryEndpointProvider.getApiRoute(DEFAULT_PROTOCOL + "://" + apiRouteBase));
     this.userAgent = userAgent;
     this.registryEndpointProvider = registryEndpointProvider;
     this.registryEndpointProperties = registryEndpointProperties;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -33,7 +33,11 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import org.apache.http.NoHttpResponseException;
 
-/** Makes requests to a registry endpoint. */
+/**
+ * Makes requests to a registry endpoint.
+ *
+ * @param <T> the type returned by calling the endpoint
+ */
 class RegistryEndpointCaller<T> {
 
   private static final String DEFAULT_PROTOCOL = "https";
@@ -68,6 +72,7 @@ class RegistryEndpointCaller<T> {
    * @param registryEndpointProvider the {@link RegistryEndpointProvider} to the endpoint
    * @param authorization optional authentication credentials to use
    * @param registryEndpointProperties properties of the registry endpoint request
+   * @throws MalformedURLException if the URL generated for the endpoint is malformed
    */
   RegistryEndpointCaller(
       String userAgent,
@@ -85,7 +90,13 @@ class RegistryEndpointCaller<T> {
     this.registryEndpointProperties = registryEndpointProperties;
   }
 
-  /** Makes the request to the endpoint. */
+  /**
+   * Makes the request to the endpoint.
+   *
+   * @return an object representing the response, or {@code null}
+   * @throws IOException for most I/O exceptions when making the request
+   * @throws RegistryException for known exceptions when interacting with the registry
+   */
   @Nullable
   T call() throws IOException, RegistryException {
     return call(initialRequestState);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointProperties.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointProperties.java
@@ -16,7 +16,8 @@
 
 package com.google.cloud.tools.jib.registry;
 
-/** Properties of registry endpoints. */
+/** Properties of registry endpoint requests. */
+// TODO: Probably rename to RegistryEndpointRequestProperties.
 class RegistryEndpointProperties {
 
   private final String serverUrl;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
@@ -58,6 +58,6 @@ public class RegistryClientTest {
 
   @Test
   public void testGetApiRouteBase() {
-    Assert.assertEquals("https://some.server.url/v2/", testRegistryClient.getApiRouteBase());
+    Assert.assertEquals("some.server.url/v2/", testRegistryClient.getApiRouteBase());
   }
 }


### PR DESCRIPTION
This should help with fixing #388, as it requires handling `HttpHostConnectException` with different requests.