### PR TITLE
Make assemble task depend on javadoc so it runs automatically when building jib-core

### DIFF
--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -83,6 +83,7 @@ tasks.withType(JavaCompile) {
 tasks.withType(Javadoc) {
     options.addBooleanOption('Xwerror', true)
 }
+assemble.dependsOn javadoc
 
 tasks.withType(Test) {
     reports.html.setDestination file("${reporting.baseDir}/${name}")


### PR DESCRIPTION
Fixes #405 