### PR TITLE
Adds BlobDescriptor#toString.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/BlobDescriptor.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/BlobDescriptor.java
@@ -102,4 +102,9 @@ public class BlobDescriptor {
     result = 31 * result + (int) (size ^ (size >>> 32));
     return result;
   }
+
+  @Override
+  public String toString() {
+    return "digest: " + digest + ", size: " + size;
+  }
 }


### PR DESCRIPTION
Some of our debug messages print `BlobDescriptor` so this makes it more useful to read.