### PR TITLE
Fixes FileOperations#copy for possible duplicate directories.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/FileOperations.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/FileOperations.java
@@ -38,7 +38,7 @@ public class FileOperations {
             // Creates the same path in the destDir.
             Path destPath = destDir.resolve(sourceFile.getParent().relativize(path));
             if (Files.isDirectory(path)) {
-              Files.createDirectory(destPath);
+              Files.createDirectories(destPath);
             } else {
               Files.copy(path, destPath);
             }


### PR DESCRIPTION
This should fix the export Docker context bug mentioned in https://github.com/GoogleContainerTools/jib/issues/457#issuecomment-401066278