### PR TITLE
Removes Azure container registry not supported limitation.

### DIFF
--- a/jib-gradle-plugin/README.md
+++ b/jib-gradle-plugin/README.md
@@ -274,12 +274,6 @@ jib {
 
 See the [Jib project README](/../../#how-jib-works).
 
-## Known Limitations
-
-These limitations will be fixed in later releases.
-
-* Pushing to Azure Container Registry is not currently supported.
-
 ## Frequently Asked Questions (FAQ)
 
 See the [Jib project README](/../../#frequently-asked-questions-faq).

--- a/jib-maven-plugin/README.md
+++ b/jib-maven-plugin/README.md
@@ -300,12 +300,6 @@ If you're considering putting credentials in Maven, we highly *recommend* using 
 
 See the [Jib project README](/../../#how-jib-works).
 
-## Known Limitations
- 
-These limitations will be fixed in later releases.
-
-* Pushing to Azure Container Registry is not currently supported.
-
 ## Frequently Asked Questions (FAQ)
 
 See the [Jib project README](/../../#frequently-asked-questions-faq).


### PR DESCRIPTION
Fixed in `v0.9.1` (#415)

To be merged after documentation is updated to `v0.9.1`