### PR TITLE
Suggests the user to clean their build cache upon CacheDirectoryNotOwnedException.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/BuildStepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/BuildStepsRunner.java
@@ -238,8 +238,16 @@ public class BuildStepsRunner {
       throw new BuildStepsExecutionException(helpfulSuggestions.none(), ex);
 
     } catch (CacheDirectoryNotOwnedException ex) {
-      throw new BuildStepsExecutionException(
-          helpfulSuggestions.forCacheDirectoryNotOwned(ex.getCacheDirectory()), ex);
+      String helpfulSuggestion =
+          helpfulSuggestions.forCacheDirectoryNotOwned(ex.getCacheDirectory());
+      CacheConfiguration applicationLayersCacheConfiguration =
+          buildSteps.getBuildConfiguration().getApplicationLayersCacheConfiguration();
+      if (applicationLayersCacheConfiguration != null
+          && ex.getCacheDirectory()
+              .equals(applicationLayersCacheConfiguration.getCacheDirectory())) {
+        helpfulSuggestion = helpfulSuggestions.forCacheNeedsClean();
+      }
+      throw new BuildStepsExecutionException(helpfulSuggestion, ex);
     }
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/HelpfulSuggestions.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/HelpfulSuggestions.java
@@ -70,6 +70,10 @@ public class HelpfulSuggestions {
     return suggest("make sure that the registry you configured exists/is spelled properly");
   }
 
+  public String forCacheNeedsClean() {
+    return suggest("run `clean` to clear your build cache");
+  }
+
   public String forCacheDirectoryNotOwned(Path cacheDirectory) {
     return suggest(
         "check that '"

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/HelpfulSuggestionsTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/HelpfulSuggestionsTest.java
@@ -44,6 +44,9 @@ public class HelpfulSuggestionsTest {
         "messagePrefix, perhaps you should make sure that the registry you configured exists/is spelled properly",
         TEST_HELPFUL_SUGGESTIONS.forUnknownHost());
     Assert.assertEquals(
+        "messagePrefix, perhaps you should run `clean` to clear your build cache",
+        TEST_HELPFUL_SUGGESTIONS.forCacheNeedsClean());
+    Assert.assertEquals(
         "messagePrefix, perhaps you should check that 'cacheDirectory' is not used by another application or set the `useOnlyProjectCache` configuration",
         TEST_HELPFUL_SUGGESTIONS.forCacheDirectoryNotOwned(Paths.get("cacheDirectory")));
     Assert.assertEquals(


### PR DESCRIPTION
Fixes #471 

Now it will say, for example:

```
Execution failed for task ':jib'.
> Build image failed, perhaps you should run `clean` to clear your build cache
```