### PR TITLE
Allows ReproducibleLayerBuilder to be configured with multiple extraction paths.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
@@ -118,7 +118,7 @@ class BuildAndCacheApplicationLayerStep
       }
 
       ReproducibleLayerBuilder reproducibleLayerBuilder =
-          new ReproducibleLayerBuilder(sourceFiles, extractionPath);
+          new ReproducibleLayerBuilder().addFiles(sourceFiles, extractionPath);
 
       cachedLayer = new CacheWriter(cache).writeLayer(reproducibleLayerBuilder);
 


### PR DESCRIPTION
Part of #473