### PR TITLE
Makes jibExportDockerContext.targetDir configurable from build.gradle.

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Can configure `jibExportDockerContext` output directory with `jibExportDockerContext.targetDir` ([#492](https://github.com/GoogleContainerTools/jib/pull/492))
+
 ### Changed
 
 ### Fixed

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerContextTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerContextTask.java
@@ -30,6 +30,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
 import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.OutputDirectory;
@@ -74,6 +75,7 @@ public class DockerContextTask extends DefaultTask {
    * @return the output directory for the Docker context is by default {@code build/jib-docker-
    *     context}.
    */
+  @Input
   @OutputDirectory
   public String getTargetDir() {
     if (targetDir == null) {


### PR DESCRIPTION
This makes `jibExportDockerContext` configurable like:

`build.gradle`:
```groovy
jibExportDockerContext {
    targetDir = 'my-dir'
}
```

Whereas before it could only be configured from a command line property `--jib.dockerDir`