### PR TITLE
Fixes jibExportDockerContext Input vs. OutputDirectory and changes CLI option to --targetDir.

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Set `jibExportDockerContext` output directory with command line option `--targetDir` ([]())
+- Set `jibExportDockerContext` output directory with command line option `--targetDir` ([#499](https://github.com/GoogleContainerTools/jib/pull/499))
 
 ## 0.9.1
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Set `jibExportDockerContext` output directory with command line option `--targetDir` ([]())
+
 ## 0.9.1
 
 ### Added

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerContextTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerContextTask.java
@@ -72,11 +72,22 @@ public class DockerContextTask extends DefaultTask {
   }
 
   /**
-   * @return the output directory for the Docker context is by default {@code build/jib-docker-
-   *     context}.
+   * The output directory to check for task up-to-date.
+   *
+   * @return the output directory
+   */
+  @OutputDirectory
+  public String getOutputDirectory() {
+    return getTargetDir();
+  }
+
+  /**
+   * Returns the output directory for the Docker context. By default, it is {@code
+   * build/jib-docker-context}.
+   *
+   * @return the output directory
    */
   @Input
-  @OutputDirectory
   public String getTargetDir() {
     if (targetDir == null) {
       return getProject().getBuildDir().toPath().resolve("jib-docker-context").toString();
@@ -85,11 +96,11 @@ public class DockerContextTask extends DefaultTask {
   }
 
   /**
-   * The output directory can be overriden with the {@code --jib.dockerDir} command line option.
+   * The output directory can be overriden with the {@code --targetDir} command line option.
    *
    * @param targetDir the output directory.
    */
-  @Option(option = "jib.dockerDir", description = "Directory to output the Docker context to")
+  @Option(option = "targetDir", description = "Directory to output the Docker context to")
   public void setTargetDir(String targetDir) {
     this.targetDir = targetDir;
   }


### PR DESCRIPTION
Placing `@Input` and `@OutputDirectory` on the same getter invalidates the up-to-date check for `@OutputDirectory`. The CLI option `--jib.dockerDir` also was not valid since it contained a dot.