### PR TITLE
Updates formatter version.

### DIFF
--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'checkstyle'
-    id 'com.github.sherter.google-java-format' version '0.6'
+    id 'com.github.sherter.google-java-format' version '0.7.1'
     id 'net.ltgt.apt' version '0.13'
     id 'net.ltgt.errorprone' version '0.0.13'
 }
@@ -92,7 +92,7 @@ tasks.withType(Test) {
 
 /* GOOGLE JAVA FORMAT */
 googleJavaFormat {
-    toolVersion = '1.5'
+    toolVersion = '1.6'
 }
 check.dependsOn verifyGoogleJavaFormat
 /* GOOGLE JAVA FORMAT */

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/json/JsonTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/json/JsonTemplate.java
@@ -26,9 +26,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonAutoDetect(
-  fieldVisibility = JsonAutoDetect.Visibility.ANY,
-  getterVisibility = JsonAutoDetect.Visibility.NONE,
-  setterVisibility = JsonAutoDetect.Visibility.NONE,
-  creatorVisibility = JsonAutoDetect.Visibility.NONE
-)
+    fieldVisibility = JsonAutoDetect.Visibility.ANY,
+    getterVisibility = JsonAutoDetect.Visibility.NONE,
+    setterVisibility = JsonAutoDetect.Visibility.NONE,
+    creatorVisibility = JsonAutoDetect.Visibility.NONE)
 public interface JsonTemplate {}

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java-gradle-plugin'
     id 'checkstyle'
-    id 'com.github.sherter.google-java-format' version '0.6'
+    id 'com.github.sherter.google-java-format' version '0.7.1'
 
     // For local install
     id 'maven'
@@ -110,7 +110,7 @@ tasks.withType(Test) {
 
 /* GOOGLE JAVA FORMAT */
 googleJavaFormat {
-    toolVersion = '1.5'
+    toolVersion = '1.6'
 }
 check.dependsOn verifyGoogleJavaFormat
 /* GOOGLE JAVA FORMAT */

--- a/jib-maven-plugin/pom.xml
+++ b/jib-maven-plugin/pom.xml
@@ -355,12 +355,12 @@
       <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.1.0</version>
+        <version>2.5.0</version>
         <dependencies>
           <dependency>
             <groupId>com.google.googlejavaformat</groupId>
             <artifactId>google-java-format</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
           </dependency>
         </dependencies>
         <executions>

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -36,9 +36,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /** Builds a container image and exports to the default Docker daemon. */
 @Mojo(
-  name = BuildDockerMojo.GOAL_NAME,
-  requiresDependencyResolution = ResolutionScope.RUNTIME_PLUS_SYSTEM
-)
+    name = BuildDockerMojo.GOAL_NAME,
+    requiresDependencyResolution = ResolutionScope.RUNTIME_PLUS_SYSTEM)
 public class BuildDockerMojo extends JibPluginConfiguration {
 
   @VisibleForTesting static final String GOAL_NAME = "dockerBuild";

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -38,9 +38,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /** Builds a container image. */
 @Mojo(
-  name = BuildImageMojo.GOAL_NAME,
-  requiresDependencyResolution = ResolutionScope.RUNTIME_PLUS_SYSTEM
-)
+    name = BuildImageMojo.GOAL_NAME,
+    requiresDependencyResolution = ResolutionScope.RUNTIME_PLUS_SYSTEM)
 public class BuildImageMojo extends JibPluginConfiguration {
 
   @VisibleForTesting static final String GOAL_NAME = "build";

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/DockerContextMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/DockerContextMojo.java
@@ -32,19 +32,17 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /** Exports to a Docker context. */
 @Mojo(
-  name = DockerContextMojo.GOAL_NAME,
-  requiresDependencyResolution = ResolutionScope.RUNTIME_PLUS_SYSTEM
-)
+    name = DockerContextMojo.GOAL_NAME,
+    requiresDependencyResolution = ResolutionScope.RUNTIME_PLUS_SYSTEM)
 public class DockerContextMojo extends JibPluginConfiguration {
 
   @VisibleForTesting static final String GOAL_NAME = "exportDockerContext";
 
   @Nullable
   @Parameter(
-    property = "jib.dockerDir",
-    defaultValue = "${project.build.directory}/jib-docker-context",
-    required = true
-  )
+      property = "jib.dockerDir",
+      defaultValue = "${project.build.directory}/jib-docker-context",
+      required = true)
   private String targetDir;
 
   @Override


### PR DESCRIPTION
This may fix the breaking macOS builds. The sherter/google-java-format plugin was updated to support the latest google-java-format version.