### PR TITLE
Fixes using base image from registry that requires token authentication.

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.jib.cache.CacheMetadataCorruptedException;
 import com.google.cloud.tools.jib.cache.Caches;
 import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
 import com.google.cloud.tools.jib.image.ImageReference;
+import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.registry.LocalRegistry;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -32,6 +33,7 @@ import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,28 +48,28 @@ public class BuildStepsIntegrationTest {
 
   @Rule public TemporaryFolder temporaryCacheDirectory = new TemporaryFolder();
 
+  private SourceFilesConfiguration sourceFilesConfiguration;
+
+  @Before
+  public void setUp() throws IOException, URISyntaxException {
+    sourceFilesConfiguration = new TestSourceFilesConfiguration();
+  }
+
   @Test
   public void testSteps_forBuildToDockerRegistry()
-      throws IOException, URISyntaxException, InterruptedException, CacheMetadataCorruptedException,
-          ExecutionException, CacheDirectoryNotOwnedException, CacheDirectoryCreationException {
-    SourceFilesConfiguration sourceFilesConfiguration = new TestSourceFilesConfiguration();
-    BuildConfiguration buildConfiguration =
-        BuildConfiguration.builder(logger)
-            .setBaseImage(ImageReference.of("gcr.io", "distroless/java", "latest"))
-            .setTargetImage(ImageReference.of("localhost:5000", "testimage", "testtag"))
-            .setMainClass("HelloWorld")
-            .setJavaArguments(Collections.singletonList("An argument."))
-            .setExposedPorts(
-                ExposedPortsParser.parse(Arrays.asList("1000", "2000-2002/tcp", "3000/udp")))
-            .setAllowHttp(true)
-            .build();
-
-    Path cacheDirectory = temporaryCacheDirectory.newFolder().toPath();
+      throws IOException, InterruptedException, CacheMetadataCorruptedException, ExecutionException,
+          CacheDirectoryNotOwnedException, CacheDirectoryCreationException {
     BuildSteps buildImageSteps =
-        BuildSteps.forBuildToDockerRegistry(
-            buildConfiguration,
-            sourceFilesConfiguration,
-            new Caches.Initializer(cacheDirectory, false, cacheDirectory, false));
+        getBuildSteps(
+            BuildConfiguration.builder(logger)
+                .setBaseImage(ImageReference.of("gcr.io", "distroless/java", "latest"))
+                .setTargetImage(ImageReference.of("localhost:5000", "testimage", "testtag"))
+                .setMainClass("HelloWorld")
+                .setJavaArguments(Collections.singletonList("An argument."))
+                .setExposedPorts(
+                    ExposedPortsParser.parse(Arrays.asList("1000", "2000-2002/tcp", "3000/udp")))
+                .setAllowHttp(true)
+                .build());
 
     long lastTime = System.nanoTime();
     buildImageSteps.run();
@@ -92,10 +94,30 @@ public class BuildStepsIntegrationTest {
   }
 
   @Test
+  public void testSteps_forBuildToDockerRegistry_dockerHubBaseImage()
+      throws InvalidImageReferenceException, IOException, InterruptedException, ExecutionException,
+          CacheDirectoryCreationException, CacheMetadataCorruptedException,
+          CacheDirectoryNotOwnedException {
+    getBuildSteps(
+            BuildConfiguration.builder(logger)
+                .setBaseImage(ImageReference.parse("openjdk:8-alpine"))
+                .setTargetImage(ImageReference.of("localhost:5000", "testimage", "testtag"))
+                .setMainClass("HelloWorld")
+                .setJavaArguments(Collections.singletonList("An argument."))
+                .setAllowHttp(true)
+                .build())
+        .run();
+
+    String imageReference = "localhost:5000/testimage:testtag";
+    new Command("docker", "pull", imageReference).run();
+    Assert.assertEquals(
+        "Hello, world. An argument.\n", new Command("docker", "run", imageReference).run());
+  }
+
+  @Test
   public void testSteps_forBuildToDockerDaemon()
-      throws IOException, URISyntaxException, InterruptedException, CacheMetadataCorruptedException,
-          ExecutionException, CacheDirectoryNotOwnedException, CacheDirectoryCreationException {
-    SourceFilesConfiguration sourceFilesConfiguration = new TestSourceFilesConfiguration();
+      throws IOException, InterruptedException, CacheMetadataCorruptedException, ExecutionException,
+          CacheDirectoryNotOwnedException, CacheDirectoryCreationException {
     BuildConfiguration buildConfiguration =
         BuildConfiguration.builder(logger)
             .setBaseImage(ImageReference.of("gcr.io", "distroless/java", "latest"))
@@ -107,13 +129,12 @@ public class BuildStepsIntegrationTest {
             .build();
 
     Path cacheDirectory = temporaryCacheDirectory.newFolder().toPath();
-    BuildSteps buildDockerSteps =
-        BuildSteps.forBuildToDockerDaemon(
+    BuildSteps.forBuildToDockerDaemon(
             buildConfiguration,
             sourceFilesConfiguration,
-            new Caches.Initializer(cacheDirectory, false, cacheDirectory, false));
+            new Caches.Initializer(cacheDirectory, false, cacheDirectory, false))
+        .run();
 
-    buildDockerSteps.run();
     Assert.assertThat(
         new Command("docker", "inspect", "testdocker").run(),
         CoreMatchers.containsString(
@@ -125,5 +146,13 @@ public class BuildStepsIntegrationTest {
                 + "                \"3000/udp\": {}"));
     Assert.assertEquals(
         "Hello, world. An argument.\n", new Command("docker", "run", "testdocker").run());
+  }
+
+  private BuildSteps getBuildSteps(BuildConfiguration buildConfiguration) throws IOException {
+    Path cacheDirectory = temporaryCacheDirectory.newFolder().toPath();
+    return BuildSteps.forBuildToDockerRegistry(
+        buildConfiguration,
+        sourceFilesConfiguration,
+        new Caches.Initializer(cacheDirectory, false, cacheDirectory, false));
   }
 }

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -100,7 +100,7 @@ public class BuildStepsIntegrationTest {
           CacheDirectoryNotOwnedException {
     getBuildSteps(
             BuildConfiguration.builder(logger)
-                .setBaseImage(ImageReference.parse("openjdk:8-alpine"))
+                .setBaseImage(ImageReference.parse("openjdk:8-jre-alpine"))
                 .setTargetImage(ImageReference.of("localhost:5000", "testimage", "testtag"))
                 .setMainClass("HelloWorld")
                 .setJavaArguments(Collections.singletonList("An argument."))

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverIntegrationTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.registry;
 
 import com.google.cloud.tools.jib.http.Authorization;
 import java.io.IOException;
+import org.junit.Assert;
 import org.junit.Test;
 
 /** Integration tests for {@link AuthenticationMethodRetriever}. */
@@ -27,14 +28,15 @@ public class AuthenticationMethodRetrieverIntegrationTest {
   public void testGetRegistryAuthenticator()
       throws RegistryAuthenticationFailedException, IOException, RegistryException {
     RegistryClient registryClient =
-        RegistryClient.factory("registry.hub.docker.com", "library/busybox")
-            .newWithAuthorization(null);
+        RegistryClient.factory("registry.hub.docker.com", "library/busybox").newRegistryClient();
     RegistryAuthenticator registryAuthenticator = registryClient.getRegistryAuthenticator();
+    Assert.assertNotNull(registryAuthenticator);
     Authorization authorization = registryAuthenticator.authenticatePull();
 
     RegistryClient authorizedRegistryClient =
         RegistryClient.factory("registry.hub.docker.com", "library/busybox")
-            .newWithAuthorization(authorization);
+            .setAuthorization(authorization)
+            .newRegistryClient();
     authorizedRegistryClient.pullManifest("latest");
   }
 }

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
@@ -32,7 +32,7 @@ public class BlobCheckerIntegrationTest {
   @Test
   public void testCheck_exists() throws IOException, RegistryException {
     RegistryClient registryClient =
-        RegistryClient.factory("localhost:5000", "busybox").newAllowHttp();
+        RegistryClient.factory("localhost:5000", "busybox").setAllowHttp(true).newRegistryClient();
     V22ManifestTemplate manifestTemplate =
         registryClient.pullManifest("latest", V22ManifestTemplate.class);
     DescriptorDigest blobDigest = manifestTemplate.getLayers().get(0).getDigest();
@@ -43,7 +43,7 @@ public class BlobCheckerIntegrationTest {
   @Test
   public void testCheck_doesNotExist() throws IOException, RegistryException, DigestException {
     RegistryClient registryClient =
-        RegistryClient.factory("localhost:5000", "busybox").newAllowHttp();
+        RegistryClient.factory("localhost:5000", "busybox").setAllowHttp(true).newRegistryClient();
     DescriptorDigest fakeBlobDigest =
         DescriptorDigest.fromHash(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
@@ -42,7 +42,7 @@ public class BlobPullerIntegrationTest {
   public void testPull() throws IOException, RegistryException {
     // Pulls the busybox image.
     RegistryClient registryClient =
-        RegistryClient.factory("localhost:5000", "busybox").newAllowHttp();
+        RegistryClient.factory("localhost:5000", "busybox").setAllowHttp(true).newRegistryClient();
     V21ManifestTemplate manifestTemplate =
         registryClient.pullManifest("latest", V21ManifestTemplate.class);
 
@@ -64,7 +64,9 @@ public class BlobPullerIntegrationTest {
 
     try {
       RegistryClient registryClient =
-          RegistryClient.factory("localhost:5000", "busybox").newAllowHttp();
+          RegistryClient.factory("localhost:5000", "busybox")
+              .setAllowHttp(true)
+              .newRegistryClient();
       registryClient.pullBlob(nonexistentDigest, Mockito.mock(OutputStream.class));
       Assert.fail("Trying to pull nonexistent blob should have errored");
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPusherIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPusherIntegrationTest.java
@@ -39,7 +39,9 @@ public class BlobPusherIntegrationTest {
             "52a9e4d4ba4333ce593707f98564fee1e6d898db0d3602408c0b2a6a424d357c");
 
     RegistryClient registryClient =
-        RegistryClient.factory("localhost:5000", "testimage").newAllowHttp();
+        RegistryClient.factory("localhost:5000", "testimage")
+            .setAllowHttp(true)
+            .newRegistryClient();
     Assert.assertFalse(registryClient.pushBlob(testBlobDigest, testBlob));
   }
 }

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -33,7 +33,7 @@ public class ManifestPullerIntegrationTest {
   @Test
   public void testPull_v21() throws IOException, RegistryException {
     RegistryClient registryClient =
-        RegistryClient.factory("localhost:5000", "busybox").newAllowHttp();
+        RegistryClient.factory("localhost:5000", "busybox").setAllowHttp(true).newRegistryClient();
     V21ManifestTemplate manifestTemplate =
         registryClient.pullManifest("latest", V21ManifestTemplate.class);
 
@@ -44,7 +44,7 @@ public class ManifestPullerIntegrationTest {
   @Test
   public void testPull_v22() throws IOException, RegistryException {
     RegistryClient registryClient =
-        RegistryClient.factory("gcr.io", "distroless/java").newWithAuthorization(null);
+        RegistryClient.factory("gcr.io", "distroless/java").newRegistryClient();
     ManifestTemplate manifestTemplate = registryClient.pullManifest("latest");
 
     Assert.assertEquals(2, manifestTemplate.getSchemaVersion());
@@ -56,7 +56,9 @@ public class ManifestPullerIntegrationTest {
   public void testPull_unknownManifest() throws RegistryException, IOException {
     try {
       RegistryClient registryClient =
-          RegistryClient.factory("localhost:5000", "busybox").newAllowHttp();
+          RegistryClient.factory("localhost:5000", "busybox")
+              .setAllowHttp(true)
+              .newRegistryClient();
       registryClient.pullManifest("nonexistent-tag");
       Assert.fail("Trying to pull nonexistent image should have errored");
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPusherIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPusherIntegrationTest.java
@@ -37,10 +37,11 @@ public class ManifestPusherIntegrationTest {
   @Test
   public void testPush_missingBlobs() throws IOException, RegistryException {
     RegistryClient registryClient =
-        RegistryClient.factory("gcr.io", "distroless/java").newWithAuthorization(null);
+        RegistryClient.factory("gcr.io", "distroless/java").newRegistryClient();
     ManifestTemplate manifestTemplate = registryClient.pullManifest("latest");
 
-    registryClient = RegistryClient.factory("localhost:5000", "busybox").newAllowHttp();
+    registryClient =
+        RegistryClient.factory("localhost:5000", "busybox").setAllowHttp(true).newRegistryClient();
     try {
       registryClient.pushManifest((V22ManifestTemplate) manifestTemplate, "latest");
       Assert.fail("Pushing manifest without its BLOBs should fail");
@@ -72,7 +73,9 @@ public class ManifestPusherIntegrationTest {
 
     // Pushes the BLOBs.
     RegistryClient registryClient =
-        RegistryClient.factory("localhost:5000", "testimage").newAllowHttp();
+        RegistryClient.factory("localhost:5000", "testimage")
+            .setAllowHttp(true)
+            .newRegistryClient();
     Assert.assertFalse(registryClient.pushBlob(testLayerBlobDigest, testLayerBlob));
     Assert.assertFalse(
         registryClient.pushBlob(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
@@ -69,14 +69,13 @@ class PullAndCacheBaseImageLayerStep implements AsyncStep<CachedLayer>, Callable
   public CachedLayer call() throws IOException, RegistryException {
     try (Timer ignored =
         new Timer(buildConfiguration.getBuildLogger(), String.format(DESCRIPTION, layerDigest))) {
-      RegistryClient.Factory registryClientFactory =
-          RegistryClient.factory(
-              buildConfiguration.getBaseImageRegistry(),
-              buildConfiguration.getBaseImageRepository());
       RegistryClient registryClient =
-          buildConfiguration.getAllowHttp()
-              ? registryClientFactory.newAllowHttp()
-              : registryClientFactory.newWithAuthorization(pullAuthorization);
+          RegistryClient.factory(
+                  buildConfiguration.getBaseImageRegistry(),
+                  buildConfiguration.getBaseImageRepository())
+              .setAllowHttp(buildConfiguration.getAllowHttp())
+              .setAuthorization(pullAuthorization)
+              .newRegistryClient();
 
       // Checks if the layer already exists in the cache.
       CachedLayer cachedLayer = new CacheReader(cache).getLayer(layerDigest);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -68,15 +68,13 @@ class PushBlobStep implements AsyncStep<BlobDescriptor>, Callable<BlobDescriptor
   public BlobDescriptor call() throws IOException, RegistryException, ExecutionException {
     try (Timer timer =
         new Timer(buildConfiguration.getBuildLogger(), DESCRIPTION + blobDescriptor)) {
-      RegistryClient.Factory registryClientFactory =
-          RegistryClient.factory(
-              buildConfiguration.getTargetImageRegistry(),
-              buildConfiguration.getTargetImageRepository());
       RegistryClient registryClient =
-          buildConfiguration.getAllowHttp()
-              ? registryClientFactory.newAllowHttp()
-              : registryClientFactory.newWithAuthorization(
-                  NonBlockingSteps.get(authenticatePushStep));
+          RegistryClient.factory(
+                  buildConfiguration.getTargetImageRegistry(),
+                  buildConfiguration.getTargetImageRepository())
+              .setAllowHttp(buildConfiguration.getAllowHttp())
+              .setAuthorization(NonBlockingSteps.get(authenticatePushStep))
+              .newRegistryClient();
       registryClient.setTimer(timer);
 
       if (registryClient.checkBlob(blobDescriptor.getDigest()) != null) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -116,15 +116,13 @@ class PushImageStep implements AsyncStep<Void>, Callable<Void> {
 
   private Void afterAllPushed() throws IOException, RegistryException, ExecutionException {
     try (Timer ignored = new Timer(buildConfiguration.getBuildLogger(), DESCRIPTION)) {
-      RegistryClient.Factory registryClientFactory =
-          RegistryClient.factory(
-              buildConfiguration.getTargetImageRegistry(),
-              buildConfiguration.getTargetImageRepository());
       RegistryClient registryClient =
-          buildConfiguration.getAllowHttp()
-              ? registryClientFactory.newAllowHttp()
-              : registryClientFactory.newWithAuthorization(
-                  NonBlockingSteps.get(authenticatePushStep));
+          RegistryClient.factory(
+                  buildConfiguration.getTargetImageRegistry(),
+                  buildConfiguration.getTargetImageRepository())
+              .setAllowHttp(buildConfiguration.getAllowHttp())
+              .setAuthorization(NonBlockingSteps.get(authenticatePushStep))
+              .newRegistryClient();
 
       // Constructs the image.
       ImageToJsonTranslator imageToJsonTranslator =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticators.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticators.java
@@ -44,7 +44,7 @@ public abstract class RegistryAuthenticators {
       throws RegistryAuthenticationFailedException, IOException, RegistryException {
     try {
       return RegistryClient.factory(serverUrl, repository)
-          .newWithAuthorization(null)
+          .newRegistryClient()
           .getRegistryAuthenticator();
 
     } catch (MalformedURLException ex) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -63,33 +63,50 @@ public class RegistryClient {
     return this;
   }
 
-  /** Immutable factory for creating {@link RegistryClient}s. */
+  /** Factory for creating {@link RegistryClient}s. */
   public static class Factory {
 
     private final RegistryEndpointRequestProperties registryEndpointRequestProperties;
+
+    private boolean allowHttp = false;
+    @Nullable private Authorization authorization;
 
     private Factory(RegistryEndpointRequestProperties registryEndpointRequestProperties) {
       this.registryEndpointRequestProperties = registryEndpointRequestProperties;
     }
 
     /**
-     * Creates a new {@link RegistryClient} with authentication credentials to use in requests.
+     * Sets whether or not {@code HTTP} should be allowed (credentials should not be sent when set
+     * to {@code true}). Defaults to {@code false}.
      *
-     * @param authorization the {@link Authorization} to access the registry/repository
-     * @return the new {@link RegistryClient}
+     * @param allowHttp if {@code true}, allows {@code HTTP} connections; otherwise, only {@code
+     *     HTTPS} connections are allowed
+     * @return this
      */
-    public RegistryClient newWithAuthorization(@Nullable Authorization authorization) {
-      return new RegistryClient(
-          authorization, registryEndpointRequestProperties, false, makeUserAgent());
+    public Factory setAllowHttp(boolean allowHttp) {
+      this.allowHttp = allowHttp;
+      return this;
     }
 
     /**
-     * Creates a new {@link RegistryClient} that allows communication via HTTP.
+     * Sets the authentication credentials to use to authenticate with the registry.
+     *
+     * @param authorization the {@link Authorization} to access the registry/repository
+     * @return this
+     */
+    public Factory setAuthorization(@Nullable Authorization authorization) {
+      this.authorization = authorization;
+      return this;
+    }
+
+    /**
+     * Creates a new {@link RegistryClient}.
      *
      * @return the new {@link RegistryClient}
      */
-    public RegistryClient newAllowHttp() {
-      return new RegistryClient(null, registryEndpointRequestProperties, true, makeUserAgent());
+    public RegistryClient newRegistryClient() {
+      return new RegistryClient(
+          authorization, registryEndpointRequestProperties, allowHttp, makeUserAgent());
     }
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryUnauthorizedException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryUnauthorizedException.java
@@ -33,7 +33,7 @@ public class RegistryUnauthorizedException extends RegistryException {
    */
   public RegistryUnauthorizedException(
       String registry, String repository, HttpResponseException cause) {
-    super(cause);
+    super("Unauthorized for " + registry + "/" + repository, cause);
     this.registry = registry;
     this.repository = repository;
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
@@ -43,14 +43,16 @@ public class RegistryClientTest {
   public void testGetUserAgent_null() {
     Assert.assertTrue(
         testRegistryClientFactory
-            .newWithAuthorization(mockAuthorization)
+            .setAuthorization(mockAuthorization)
+            .newRegistryClient()
             .getUserAgent()
             .startsWith("jib"));
 
     RegistryClient.setUserAgentSuffix(null);
     Assert.assertTrue(
         testRegistryClientFactory
-            .newWithAuthorization(mockAuthorization)
+            .setAuthorization(mockAuthorization)
+            .newRegistryClient()
             .getUserAgent()
             .startsWith("jib"));
   }
@@ -59,10 +61,16 @@ public class RegistryClientTest {
   public void testGetUserAgent() {
     RegistryClient.setUserAgentSuffix("some user agent suffix");
 
-    Assert.assertTrue(testRegistryClientFactory.newAllowHttp().getUserAgent().startsWith("jib "));
     Assert.assertTrue(
         testRegistryClientFactory
-            .newAllowHttp()
+            .setAllowHttp(true)
+            .newRegistryClient()
+            .getUserAgent()
+            .startsWith("jib "));
+    Assert.assertTrue(
+        testRegistryClientFactory
+            .setAllowHttp(true)
+            .newRegistryClient()
             .getUserAgent()
             .endsWith(" some user agent suffix"));
   }
@@ -70,6 +78,7 @@ public class RegistryClientTest {
   @Test
   public void testGetApiRouteBase() {
     Assert.assertEquals(
-        "some.server.url/v2/", testRegistryClientFactory.newAllowHttp().getApiRouteBase());
+        "some.server.url/v2/",
+        testRegistryClientFactory.setAllowHttp(true).newRegistryClient().getApiRouteBase());
   }
 }

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,6 +9,12 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed regression that broke pulling base images from registries that required token authentication ([]())
+
+## 0.9.3
+
+### Fixed
+
 - Using Docker config for finding registry credentials (was not ignoring extra fields and handling `https` protocol) ([#524](https://github.com/GoogleContainerTools/jib/pull/524))
 
 ## 0.9.2

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed regression that broke pulling base images from registries that required token authentication ([]())
+- Fixed regression that broke pulling base images from registries that required token authentication ([#549](https://github.com/GoogleContainerTools/jib/pull/549))
 
 ## 0.9.3
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed regression that broke pulling base images from registries that required token authentication ([]())
+- Fixed regression that broke pulling base images from registries that required token authentication ([#549](https://github.com/GoogleContainerTools/jib/pull/549))
 
 ### 0.9.3
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Fixed
+
+- Fixed regression that broke pulling base images from registries that required token authentication ([]())
+
+### 0.9.3
+
+### Fixed
 - Using Docker config for finding registry credentials (was not ignoring extra fields and handling `https` protocol) ([#524](https://github.com/GoogleContainerTools/jib/pull/524))
 
 ## 0.9.2


### PR DESCRIPTION
This should be able to fix #541, fix #542, and fix #545

This PR adds token authentication when pulling the base image if the base image registry requires so.