### PR TITLE
Remove Gradle and Maven plugins duplicated doc reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,6 @@
 
 Jib builds Docker and OCI images for your Java applications and is available as plugins for [Maven](jib-maven-plugin) and [Gradle](jib-gradle-plugin).
 
-[Maven](https://maven.apache.org/): See documentation for [jib-maven-plugin](jib-maven-plugin).\
-[Gradle](https://gradle.org/): See documentation for [jib-gradle-plugin](jib-gradle-plugin).
-
 *Jib as a container-building library for Java is work-in-progress. Watch for updates.*
 
 ## Goals

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ## What is Jib?
 
-Jib builds Docker and OCI images for your Java applications and is available as plugins for [Maven](jib-maven-plugin) and [Gradle](jib-gradle-plugin).
+Jib builds Docker and OCI images for your Java applications and is available as plugins for [Maven](https://maven.apache.org/) and [Gradle](https://gradle.org).
 
 *Jib as a container-building library for Java is work-in-progress. Watch for updates.*
 


### PR DESCRIPTION
Removed unnecessary Gradle and Maven plugins documentation reference from introduction as it is already referenced on the line above and on the Quickstart section.