### PR TITLE
 Adds link to OCI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## What is Jib?
 
-Jib builds Docker and OCI images for your Java applications and is available as plugins for [Maven](jib-maven-plugin) and [Gradle](jib-gradle-plugin).
+Jib builds Docker and [OCI](https://github.com/opencontainers/image-spec) images for your Java applications and is available as plugins for [Maven](jib-maven-plugin) and [Gradle](jib-gradle-plugin).
 
 [Maven](https://maven.apache.org/): See documentation for [jib-maven-plugin](jib-maven-plugin).\
 [Gradle](https://gradle.org/): See documentation for [jib-gradle-plugin](jib-gradle-plugin).

--- a/jib-gradle-plugin/README.md
+++ b/jib-gradle-plugin/README.md
@@ -5,7 +5,7 @@
 
 # Jib - Containerize your Gradle Java project
 
-Jib is [Gradle](https://gradle.org/) plugin for building Docker and OCI images for your Java applications.
+Jib is [Gradle](https://gradle.org/) plugin for building Docker and [OCI](https://github.com/opencontainers/image-spec) images for your Java applications.
 
 For information about the project, see the [Jib project README](../README.md).
 For the Maven plugin, see the [jib-maven-plugin project](../jib-maven-plugin).

--- a/jib-maven-plugin/README.md
+++ b/jib-maven-plugin/README.md
@@ -5,7 +5,7 @@
 
 # Jib - Containerize your Maven project
 
-Jib is a [Maven](https://maven.apache.org/) plugin for building Docker and OCI images for your Java applications.
+Jib is a [Maven](https://maven.apache.org/) plugin for building Docker and [OCI](https://github.com/opencontainers/image-spec) images for your Java applications.
 
 For information about the project, see the [Jib project README](../README.md).
 For the Gradle plugin, see the [jib-gradle-plugin project](../jib-gradle-plugin).


### PR DESCRIPTION
So users unfamiliar with what OCI is can get a direct link. https://github.com/opencontainers/image-spec