### PR TITLE
Additionally allow suffix matching for cred lookup

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
@@ -19,8 +19,12 @@ package com.google.cloud.tools.jib.registry.credentials.json;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
 import javax.annotation.Nullable;
 
 /**
@@ -83,15 +87,29 @@ public class DockerConfigTemplate implements JsonTemplate {
    */
   @Nullable
   public String getAuthFor(String registry) {
-    AuthTemplate registryAuth = auths.get(registry);
-    if (registryAuth == null) {
-      // The registry could be prefixed with the HTTPS protocol.
-      registryAuth = auths.get("https://" + registry);
-    }
-    if (registryAuth != null) {
-      return registryAuth.auth;
-    }
-    return null;
+    Predicate<String> exactMatch = registry::equals;
+    Predicate<String> withHttps = ("https://" + registry)::equals;
+    Predicate<String> startsWith = name -> name.startsWith(registry);
+    Predicate<String> startsWithAndWithHttps = name -> name.startsWith("https://" + registry);
+    AuthTemplate authTemplate =
+        getAuthTemplate(Arrays.asList(exactMatch, withHttps, startsWith, startsWithAndWithHttps));
+
+    return authTemplate != null ? authTemplate.auth : null;
+  }
+
+  /** Returns {@link AuthTemplate} matching the given predicate. */
+  private AuthTemplate getAuthTemplate(Predicate<String> registryMatch) {
+    return auths.keySet().stream().filter(registryMatch).map(auths::get).findFirst().orElse(null);
+  }
+
+  /** Returns the first {@link AuthTemplate} matching the given predicates (short-circuiting). */
+  private AuthTemplate getAuthTemplate(List<Predicate<String>> registryMatches) {
+    return registryMatches
+        .stream()
+        .map(this::getAuthTemplate)
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
@@ -81,6 +81,16 @@ public class DockerConfigTemplate implements JsonTemplate {
   private final Map<String, String> credHelpers = new HashMap<>();
 
   /**
+   * Returns the base64-encoded {@code Basic} authorization for {@code registry}, or {@code null} if
+   * none exists. The order of lookup preference:
+   *
+   * <ol>
+   *   <li>Exact registry name
+   *   <li>https:// + registry name
+   *   <li>registry name + arbitrary suffix
+   *   <li>https:// + registry name + arbitrary suffix
+   * </ol>
+   *
    * @param registry the registry to get the authorization for
    * @return the base64-encoded {@code Basic} authorization for {@code registry}, or {@code null} if
    *     none exists
@@ -97,11 +107,6 @@ public class DockerConfigTemplate implements JsonTemplate {
     return authTemplate != null ? authTemplate.auth : null;
   }
 
-  /** Returns {@link AuthTemplate} matching the given predicate. */
-  private AuthTemplate getAuthTemplate(Predicate<String> registryMatch) {
-    return auths.keySet().stream().filter(registryMatch).map(auths::get).findFirst().orElse(null);
-  }
-
   /** Returns the first {@link AuthTemplate} matching the given predicates (short-circuiting). */
   private AuthTemplate getAuthTemplate(List<Predicate<String>> registryMatches) {
     return registryMatches
@@ -110,6 +115,11 @@ public class DockerConfigTemplate implements JsonTemplate {
         .filter(Objects::nonNull)
         .findFirst()
         .orElse(null);
+  }
+
+  /** Returns {@link AuthTemplate} matching the given predicate. */
+  private AuthTemplate getAuthTemplate(Predicate<String> registryMatch) {
+    return auths.keySet().stream().filter(registryMatch).map(auths::get).findFirst().orElse(null);
   }
 
   /**

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
@@ -135,4 +135,30 @@ public class DockerConfigCredentialRetrieverTest {
     Authorization authorization = dockerConfigCredentialRetriever.retrieve();
     Assert.assertEquals(mockAuthorization, authorization);
   }
+
+  @Test
+  public void testRetrieve_suffixMatching() throws IOException, URISyntaxException {
+    Path dockerConfigFile =
+        Paths.get(Resources.getResource("json/dockerconfig_index_docker_io_v1.json").toURI());
+
+    DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
+        new DockerConfigCredentialRetriever(
+            "index.docker.io", dockerConfigFile, mockDockerCredentialHelperFactory);
+
+    Authorization authorization = dockerConfigCredentialRetriever.retrieve();
+    Assert.assertEquals("token for index.docker.io/v1/", authorization.getToken());
+  }
+
+  @Test
+  public void testRetrieve_suffixMatchingFromAlias() throws IOException, URISyntaxException {
+    Path dockerConfigFile =
+        Paths.get(Resources.getResource("json/dockerconfig_index_docker_io_v1.json").toURI());
+
+    DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
+        new DockerConfigCredentialRetriever(
+            "registry.hub.docker.com", dockerConfigFile, mockDockerCredentialHelperFactory);
+
+    Authorization authorization = dockerConfigCredentialRetriever.retrieve();
+    Assert.assertEquals("token for index.docker.io/v1/", authorization.getToken());
+  }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplateTest.java
@@ -57,4 +57,20 @@ public class DockerConfigTemplateTest {
         dockerConfigTemplate.getCredentialHelperFor("another registry"));
     Assert.assertEquals(null, dockerConfigTemplate.getCredentialHelperFor("unknonwn registry"));
   }
+
+  @Test
+  public void testGetAuthFor_orderOfMatchPreference() throws URISyntaxException, IOException {
+    Path json = Paths.get(Resources.getResource("json/dockerconfig_extra_matches.json").toURI());
+
+    DockerConfigTemplate dockerConfig =
+        JsonTemplateMapper.readJsonFromFile(json, DockerConfigTemplate.class);
+
+    Assert.assertEquals("my-registry: exact match", dockerConfig.getAuthFor("my-registry"));
+    Assert.assertEquals("cool-registry: with https", dockerConfig.getAuthFor("cool-registry"));
+    Assert.assertEquals(
+        "awesome-registry: starting with name", dockerConfig.getAuthFor("awesome-registry"));
+    Assert.assertEquals(
+        "dull-registry: starting with name and with https",
+        dockerConfig.getAuthFor("dull-registry"));
+  }
 }

--- a/jib-core/src/test/resources/json/dockerconfig_extra_matches.json
+++ b/jib-core/src/test/resources/json/dockerconfig_extra_matches.json
@@ -1,0 +1,17 @@
+{
+  "auths":{
+    "https://my-registry/v1/":{"auth":"my-registry: starting with name and with https"},
+    "my-registry/v4/":{"auth":"my-registry: starting with name"},
+    "https://my-registry":{"auth":"my-registry: with https"},
+    "my-registry":{"auth":"my-registry: exact match"},
+
+    "https://cool-registry":{"auth":"cool-registry: with https"},
+    "cool-registry/v8/":{"auth":"cool-registry: starting with registry"},
+    "https://cool-registry/v1/":{"auth":"cool-registry: starting with name and with https"},
+
+    "https://awesome-registry/v9/":{"auth":"awesome-registry: starting with name and with https"},
+    "awesome-registry/v9/":{"auth":"awesome-registry: starting with name"},
+
+    "https://dull-registry/v3/":{"auth":"dull-registry: starting with name and with https"}
+  }
+}

--- a/jib-core/src/test/resources/json/dockerconfig_index_docker_io_v1.json
+++ b/jib-core/src/test/resources/json/dockerconfig_index_docker_io_v1.json
@@ -1,0 +1,5 @@
+{
+  "auths":{
+    "index.docker.io/v1/":{"auth":"token for index.docker.io/v1/"}
+  }
+}


### PR DESCRIPTION
Part of #586 (https://github.com/GoogleContainerTools/jib/issues/586#issuecomment-405619066).

Order of preference for finding a matching credential:
1. Exact registry name
1. `https://` + registry name
1. registry name + arbitrary suffix
1. `https://` registry name + arbitrary suffix