### PR TITLE
Wrong gradle option in docs to export docker context

### DIFF
--- a/jib-gradle-plugin/README.md
+++ b/jib-gradle-plugin/README.md
@@ -127,10 +127,10 @@ Jib can also export a Docker context so that you can build with Docker, if neede
 gradle jibExportDockerContext
 ```
 
-The Docker context will be created at `build/jib-docker-context` by default. You can change this directory with the `targetDir` configuration option or the `---jib.dockerDir` parameter:
+The Docker context will be created at `build/jib-docker-context` by default. You can change this directory with the `targetDir` configuration option or the `---targetDir` parameter:
 
 ```shell
-gradle jibExportDockerContext --jib.dockerDir=my/docker/context/
+gradle jibExportDockerContext --targetDir=my/docker/context/
 ```
 
 You can then build your image with Docker:


### PR DESCRIPTION
In #499, the option from gradle to export the docker context was changed from **--jib.dockerDir** to **--targetDir**, but it wasn't reflected in the docs.