### PR TITLE
Uses matched registry alias for credential helper.

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperIntegrationTest.java
@@ -39,7 +39,7 @@ public class DockerCredentialHelperIntegrationTest {
         .run(Files.readAllBytes(Paths.get(Resources.getResource("credentials.json").toURI())));
 
     DockerCredentialHelper dockerCredentialHelper =
-        new DockerCredentialHelperFactory("myregistry").withCredentialHelperSuffix("gcr");
+        new DockerCredentialHelperFactory().newDockerCredentialHelper("myregistry", "gcr");
 
     Authorization authorization = dockerCredentialHelper.retrieve();
 
@@ -52,7 +52,7 @@ public class DockerCredentialHelperIntegrationTest {
       throws IOException, NonexistentServerUrlDockerCredentialHelperException {
     try {
       DockerCredentialHelper fakeDockerCredentialHelper =
-          new DockerCredentialHelperFactory("").withCredentialHelperSuffix("fake-cloud-provider");
+          new DockerCredentialHelperFactory().newDockerCredentialHelper("", "fake-cloud-provider");
 
       fakeDockerCredentialHelper.retrieve();
 
@@ -69,7 +69,7 @@ public class DockerCredentialHelperIntegrationTest {
       throws IOException, NonexistentDockerCredentialHelperException {
     try {
       DockerCredentialHelper fakeDockerCredentialHelper =
-          new DockerCredentialHelperFactory("fake.server.url").withCredentialHelperSuffix("gcr");
+          new DockerCredentialHelperFactory().newDockerCredentialHelper("fake.server.url", "gcr");
 
       fakeDockerCredentialHelper.retrieve();
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStep.java
@@ -109,7 +109,7 @@ class RetrieveRegistryCredentialsStep implements AsyncStep<Authorization>, Calla
         registry,
         credentialHelperSuffix,
         knownRegistryCredentials,
-        new DockerCredentialHelperFactory(registry),
+        new DockerCredentialHelperFactory(),
         new DockerConfigCredentialRetriever(registry));
   }
 
@@ -195,7 +195,7 @@ class RetrieveRegistryCredentialsStep implements AsyncStep<Authorization>, Calla
     try {
       Authorization authorization =
           dockerCredentialHelperFactory
-              .withCredentialHelperSuffix(credentialHelperSuffix)
+              .newDockerCredentialHelper(registry, credentialHelperSuffix)
               .retrieve();
       logGotCredentialsFrom("docker-credential-" + credentialHelperSuffix);
       return authorization;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfig.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfig.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2018 Google LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.registry.credentials;
+
+import com.google.cloud.tools.jib.registry.credentials.json.DockerConfigTemplate;
+import com.google.cloud.tools.jib.registry.credentials.json.DockerConfigTemplate.AuthTemplate;
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
+
+/** Handles getting useful information from a {@link DockerConfigTemplate}. */
+class DockerConfig {
+
+  /**
+   * Returns the first entry matching the given key predicates (short-circuiting in the order of
+   * predicates).
+   */
+  @Nullable
+  private static <K, T> Map.Entry<K, T> findFirstInMapByKey(
+      Map<K, T> map, List<Predicate<K>> keyMatches) {
+    return keyMatches
+        .stream()
+        .map(keyMatch -> findFirstInMapByKey(map, keyMatch))
+        .filter(Objects::nonNull)
+        .findFirst()
+        .orElse(null);
+  }
+
+  /** Returns the first entry matching the given key predicate. */
+  @Nullable
+  private static <K, T> Map.Entry<K, T> findFirstInMapByKey(Map<K, T> map, Predicate<K> keyMatch) {
+    return map.entrySet()
+        .stream()
+        .filter(entry -> keyMatch.test(entry.getKey()))
+        .findFirst()
+        .orElse(null);
+  }
+
+  private final DockerConfigTemplate dockerConfigTemplate;
+
+  DockerConfig(DockerConfigTemplate dockerConfigTemplate) {
+    this.dockerConfigTemplate = dockerConfigTemplate;
+  }
+
+  /**
+   * Returns the base64-encoded {@code Basic} authorization for {@code registry}, or {@code null} if
+   * none exists. The order of lookup preference:
+   *
+   * <ol>
+   *   <li>Exact registry name
+   *   <li>https:// + registry name
+   *   <li>registry name + / + arbitrary suffix
+   *   <li>https:// + registry name + / arbitrary suffix
+   * </ol>
+   *
+   * @param registry the registry to get the authorization for
+   * @return the base64-encoded {@code Basic} authorization for {@code registry}, or {@code null} if
+   *     none exists
+   */
+  @Nullable
+  String getAuthFor(String registry) {
+    Map.Entry<String, AuthTemplate> authEntry =
+        findFirstInMapByKey(dockerConfigTemplate.getAuths(), getRegistryMatchersFor(registry));
+    return authEntry != null ? authEntry.getValue().getAuth() : null;
+  }
+
+  @VisibleForTesting
+  @Nullable
+  DockerCredentialHelper getCredentialHelperFor(String registry) {
+    return getCredentialHelperFor(new DockerCredentialHelperFactory(), registry);
+  }
+
+  /**
+   * Determines a {@link DockerCredentialHelper} to use for {@code registry}.
+   *
+   * <p>If there exists a matching registry entry (or its aliases) in {@code auths} for {@code
+   * registry}, the credential helper is {@code credStore}; otherwise, if there exists a matching
+   * registry entry (or its aliases) in {@code credHelpers}, the corresponding credential helper
+   * suffix is used.
+   *
+   * <p>See {@link #getRegistryMatchersFor} for the alias lookup order.
+   *
+   * @param registry the registry to get the credential helpers for
+   * @return the {@link DockerCredentialHelper} or {@code null} if none is found for the given
+   *     registry
+   */
+  @Nullable
+  DockerCredentialHelper getCredentialHelperFor(
+      DockerCredentialHelperFactory dockerCredentialHelperFactory, String registry) {
+    List<Predicate<String>> registryMatchers = getRegistryMatchersFor(registry);
+    Map.Entry<String, AuthTemplate> firstMatchInAuths =
+        findFirstInMapByKey(dockerConfigTemplate.getAuths(), registryMatchers);
+    if (dockerConfigTemplate.getCredsStore() != null && firstMatchInAuths != null) {
+      return dockerCredentialHelperFactory.newDockerCredentialHelper(
+          firstMatchInAuths.getKey(), dockerConfigTemplate.getCredsStore());
+    }
+    Map.Entry<String, String> firstMatchInCredHelpers =
+        findFirstInMapByKey(dockerConfigTemplate.getCredHelpers(), registryMatchers);
+    if (firstMatchInCredHelpers == null) {
+      return null;
+    }
+    return dockerCredentialHelperFactory.newDockerCredentialHelper(
+        firstMatchInCredHelpers.getKey(), firstMatchInCredHelpers.getValue());
+  }
+
+  /**
+   * Registry alias matches in the following order:
+   *
+   * <ol>
+   *   <li>Exact registry name
+   *   <li>https:// + registry name
+   *   <li>registry name + / + arbitrary suffix
+   *   <li>https:// + registry name + / + arbitrary suffix
+   * </ol>
+   *
+   * @param registry the registry to get matchers for
+   * @return the list of predicates to match possible aliases
+   */
+  private List<Predicate<String>> getRegistryMatchersFor(String registry) {
+    Predicate<String> exactMatch = registry::equals;
+    Predicate<String> withHttps = ("https://" + registry)::equals;
+    Predicate<String> withSuffix = name -> name.startsWith(registry + "/");
+    Predicate<String> withHttpsAndSuffix = name -> name.startsWith("https://" + registry + "/");
+    return Arrays.asList(exactMatch, withHttps, withSuffix, withHttpsAndSuffix);
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
@@ -77,6 +77,8 @@ public class DockerConfigCredentialRetriever {
   }
 
   /**
+   * Retrieves credentials for a registry. Tries all possible known aliases.
+   *
    * @return {@link Authorization} found for {@code registry}, or {@code null} if not found
    * @throws IOException if failed to parse the config JSON
    */
@@ -98,6 +100,13 @@ public class DockerConfigCredentialRetriever {
     return null;
   }
 
+  /**
+   * Retrieves credentials for a registry alias from a {@link DockerConfig}.
+   *
+   * @param dockerConfig the {@link DockerConfig} to retrieve from
+   * @param registryAlias the registry alias to use
+   * @return the retrieved credentials, or {@code null} if none are found
+   */
   @Nullable
   private Authorization retrieve(DockerConfig dockerConfig, String registryAlias) {
     // First, tries to find defined auth.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
@@ -22,6 +22,7 @@ import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.http.Authorizations;
 import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.CharStreams;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -130,5 +131,15 @@ public class DockerCredentialHelper {
 
       throw ex;
     }
+  }
+
+  @VisibleForTesting
+  String getServerUrl() {
+    return serverUrl;
+  }
+
+  @VisibleForTesting
+  String getCredentialHelperSuffix() {
+    return credentialHelperSuffix;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperFactory.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperFactory.java
@@ -19,17 +19,15 @@ package com.google.cloud.tools.jib.registry.credentials;
 /** Factory class for constructing {@link DockerCredentialHelper}. */
 public class DockerCredentialHelperFactory {
 
-  private final String registry;
-
-  public DockerCredentialHelperFactory(String registry) {
-    this.registry = registry;
-  }
+  public DockerCredentialHelperFactory() {}
 
   /**
+   * @param registry the {@code ServerURL} stored by the credential helper
    * @param credentialHelperSuffix the suffix of the docker-credential-[suffix] command to be run.
    * @return a {@link DockerCredentialHelper} retrieved from the command.
    */
-  public DockerCredentialHelper withCredentialHelperSuffix(String credentialHelperSuffix) {
+  public DockerCredentialHelper newDockerCredentialHelper(
+      String registry, String credentialHelperSuffix) {
     return new DockerCredentialHelper(registry, credentialHelperSuffix);
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
@@ -85,8 +85,8 @@ public class RetrieveRegistryCredentialsStepTest {
   public void testCall_useCredentialHelper()
       throws IOException, NonexistentDockerCredentialHelperException {
     Mockito.when(
-            mockDockerCredentialHelperFactory.withCredentialHelperSuffix(
-                "someOtherCredentialHelper"))
+            mockDockerCredentialHelperFactory.newDockerCredentialHelper(
+                "someRegistry", "someOtherCredentialHelper"))
         .thenReturn(mockDockerCredentialHelper);
 
     Assert.assertEquals(
@@ -117,7 +117,8 @@ public class RetrieveRegistryCredentialsStepTest {
       throws IOException, NonexistentDockerCredentialHelperException {
     // Credential helper does not have credentials.
     Mockito.when(
-            mockDockerCredentialHelperFactory.withCredentialHelperSuffix("someCredentialHelper"))
+            mockDockerCredentialHelperFactory.newDockerCredentialHelper(
+                "someRegistry", "someCredentialHelper"))
         .thenReturn(mockNonexistentServerUrlDockerCredentialHelper);
 
     Mockito.when(mockDockerConfigCredentialRetriever.retrieve()).thenReturn(mockAuthorization);
@@ -134,9 +135,12 @@ public class RetrieveRegistryCredentialsStepTest {
   @Test
   public void testCall_inferCommonCredentialHelpers()
       throws IOException, NonexistentDockerCredentialHelperException {
-    Mockito.when(mockDockerCredentialHelperFactory.withCredentialHelperSuffix("gcr"))
+    Mockito.when(
+            mockDockerCredentialHelperFactory.newDockerCredentialHelper("something.gcr.io", "gcr"))
         .thenReturn(mockDockerCredentialHelper);
-    Mockito.when(mockDockerCredentialHelperFactory.withCredentialHelperSuffix("ecr-login"))
+    Mockito.when(
+            mockDockerCredentialHelperFactory.newDockerCredentialHelper(
+                "something.amazonaws.com", "ecr-login"))
         .thenReturn(mockNonexistentDockerCredentialHelper);
 
     Assert.assertEquals(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
@@ -36,7 +36,6 @@ public class DockerConfigCredentialRetrieverTest {
 
   @Mock private Authorization mockAuthorization;
   @Mock private DockerCredentialHelper mockDockerCredentialHelper;
-
   @Mock private DockerCredentialHelperFactory mockDockerCredentialHelperFactory;
 
   private Path dockerConfigFile;
@@ -71,7 +70,8 @@ public class DockerConfigCredentialRetrieverTest {
   @Test
   public void testRetrieve_useCredsStore() throws IOException {
     Mockito.when(
-            mockDockerCredentialHelperFactory.withCredentialHelperSuffix("some credential store"))
+            mockDockerCredentialHelperFactory.newDockerCredentialHelper(
+                "just registry", "some credential store"))
         .thenReturn(mockDockerCredentialHelper);
 
     DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
@@ -85,7 +85,8 @@ public class DockerConfigCredentialRetrieverTest {
   @Test
   public void testRetrieve_useCredsStore_withProtocol() throws IOException {
     Mockito.when(
-            mockDockerCredentialHelperFactory.withCredentialHelperSuffix("some credential store"))
+            mockDockerCredentialHelperFactory.newDockerCredentialHelper(
+                "https://with.protocol", "some credential store"))
         .thenReturn(mockDockerCredentialHelper);
 
     DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
@@ -99,8 +100,8 @@ public class DockerConfigCredentialRetrieverTest {
   @Test
   public void testRetrieve_useCredHelper() throws IOException {
     Mockito.when(
-            mockDockerCredentialHelperFactory.withCredentialHelperSuffix(
-                "another credential helper"))
+            mockDockerCredentialHelperFactory.newDockerCredentialHelper(
+                "another registry", "another credential helper"))
         .thenReturn(mockDockerCredentialHelper);
 
     DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
@@ -121,11 +122,9 @@ public class DockerConfigCredentialRetrieverTest {
 
   @Test
   public void testRetrieve_credentialFromAlias() throws IOException {
-    Mockito.when(mockDockerCredentialHelperFactory.withCredentialHelperSuffix(Mockito.anyString()))
-        .thenReturn(Mockito.mock(DockerCredentialHelper.class));
     Mockito.when(
-            mockDockerCredentialHelperFactory.withCredentialHelperSuffix(
-                "index.docker.io credential helper"))
+            mockDockerCredentialHelperFactory.newDockerCredentialHelper(
+                "index.docker.io", "index.docker.io credential helper"))
         .thenReturn(mockDockerCredentialHelper);
 
     DockerConfigCredentialRetriever dockerConfigCredentialRetriever =


### PR DESCRIPTION
Credential helpers store credentials for ServerURLs and those credentials are fetched via the exact ServerURL. For example, a Docker config with:

```
	"auths": {
		"https://index.docker.io/v1/": {},
	},
        "credsStore": "gcr"
```

means that even if the original registry was `registry.hub.docker.com`, we need to fetch the credentials using `https://index.docker.io/v1/`.

Also fixes #651 because it needed to.