### PR TITLE
Fix regex bug

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
@@ -54,8 +54,7 @@ public class ImageReference {
    *
    * <p>A separator is either an underscore, a dot, two underscores, or any number of dashes.
    */
-  private static final String REPOSITORY_COMPONENT_REGEX =
-      "[a-z\\d]+(?:(?:[_.]|__|-+)[a-z\\d]+)*";
+  private static final String REPOSITORY_COMPONENT_REGEX = "[a-z\\d]+(?:(?:[_.]|__|-+)[a-z\\d]+)*";
 
   /** Matches all repetitions of {@code REPOSITORY_COMPONENT_REGEX} separated by a backslash. */
   private static final String REPOSITORY_REGEX =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
@@ -55,7 +55,7 @@ public class ImageReference {
    * <p>A separator is either an underscore, a dot, two underscores, or any number of dashes.
    */
   private static final String REPOSITORY_COMPONENT_REGEX =
-      "[a-z\\d]+(?:(?:[_.]|__|[-]+)[a-z\\d]+)*";
+      "[a-z\\d]+(?:(?:[_.]|__|-+)[a-z\\d]+)*";
 
   /** Matches all repetitions of {@code REPOSITORY_COMPONENT_REGEX} separated by a backslash. */
   private static final String REPOSITORY_REGEX =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
@@ -55,7 +55,7 @@ public class ImageReference {
    * <p>A separator is either an underscore, a dot, two underscores, or any number of dashes.
    */
   private static final String REPOSITORY_COMPONENT_REGEX =
-      "[a-z\\d]+(?:(?:[_.]|__|[-]*)[a-z\\d]+)*";
+      "[a-z\\d]+(?:(?:[_.]|__|[-]+)[a-z\\d]+)*";
 
   /** Matches all repetitions of {@code REPOSITORY_COMPONENT_REGEX} separated by a backslash. */
   private static final String REPOSITORY_REGEX =


### PR DESCRIPTION
Fixes #323 #678

The Javadoc says
```
<p>A separator is either an underscore, a dot, two underscores, or any number of dashes.
```
So, it did not make sense to allow a zero-length separator, essentially allowing not needing a separator at all.

```java
    ImageReference.parse("gcr.io/qingyangc-sandbox/jibtestimage:askfjl/waegawvw/aweg");
```
The above took 206.050 secs. Now 0.014s.