### PR TITLE
System property 'jibSerialize' causes build steps to be executed serially

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import javax.annotation.Nullable;
 
@@ -44,8 +45,7 @@ import javax.annotation.Nullable;
  */
 public class StepsRunner {
 
-  private final ListeningExecutorService listeningExecutorService =
-      MoreExecutors.listeningDecorator(Executors.newCachedThreadPool());
+  private final ListeningExecutorService listeningExecutorService;
   private final BuildConfiguration buildConfiguration;
   private final SourceFilesConfiguration sourceFilesConfiguration;
   private final Cache baseLayersCache;
@@ -76,6 +76,12 @@ public class StepsRunner {
     this.sourceFilesConfiguration = sourceFilesConfiguration;
     this.baseLayersCache = baseLayersCache;
     this.applicationLayersCache = applicationLayersCache;
+
+    ExecutorService executorService =
+        System.getProperty("jibSerialized") == null
+            ? Executors.newCachedThreadPool()
+            : MoreExecutors.newDirectExecutorService();
+    listeningExecutorService = MoreExecutors.listeningDecorator(executorService);
   }
 
   public StepsRunner runRetrieveTargetRegistryCredentialsStep() {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -78,9 +78,9 @@ public class StepsRunner {
     this.applicationLayersCache = applicationLayersCache;
 
     ExecutorService executorService =
-        System.getProperty("jibSerialized") == null
-            ? Executors.newCachedThreadPool()
-            : MoreExecutors.newDirectExecutorService();
+        Boolean.getBoolean("jibSerialized")
+            ? MoreExecutors.newDirectExecutorService()
+            : Executors.newCachedThreadPool();
     listeningExecutorService = MoreExecutors.listeningDecorator(executorService);
   }
 


### PR DESCRIPTION
For #681.  If system property `jibSerialize` is set then we run all build steps on the main thread.

Our lifecycle messages don't change however — I still see lifecycle messages before any HTTP traffic begins, and we still have some operations happening in parallel (you can see requests for `distroless/java` and to `registry.hub.docker`), suggesting that we still have some parallelism happening without the StepsRunner.

```
[INFO] --- jib-maven-plugin:0.9.8-SNAPSHOT:build (default-cli) @ first ---
[WARNING] Base image 'gcr.io/distroless/java' does not use a specific image digest - build may not be reproducible
[INFO] 
[INFO] Containerizing application to foo/bar/baz...
[INFO] 
[INFO] Retrieving registry credentials for registry.hub.docker.com...
[INFO] Getting base image gcr.io/distroless/java...
[INFO] Building dependencies layer...
[INFO] Building classes layer...
[INFO] Building resources layer...
Jul 20, 2018 2:25:29 PM com.google.api.client.http.HttpRequest execute
CONFIG: -------------- REQUEST  --------------
GET https://gcr.io/v2/distroless/java/manifests/latest
Accept: application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+json
Accept-Encoding: gzip
User-Agent: jib 0.9.8-SNAPSHOT jib-maven-plugin Google-HTTP-Java-Client/1.23.0 (gzip)

Jul 20, 2018 2:25:29 PM com.google.api.client.http.HttpRequest execute
CONFIG: curl -v --compressed -H 'Accept: application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json,application/vnd.docker.distribution.manifest.v1+json' -H 'Accept-Encoding: gzip' -H 'User-Agent: jib 0.9.8-SNAPSHOT jib-maven-plugin Google-HTTP-Java-Client/1.23.0 (gzip)' -- 'https://gcr.io/v2/distroless/java/manifests/latest'
Jul 20, 2018 2:25:29 PM com.google.api.client.http.HttpRequest execute
CONFIG: -------------- REQUEST  --------------
GET https://registry.hub.docker.com/v2/
Accept: 
Accept-Encoding: gzip
User-Agent: jib 0.9.8-SNAPSHOT jib-maven-plugin Google-HTTP-Java-Client/1.23.0 (gzip)
```
