### PR TITLE
Improve logging for pulling base image

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -101,10 +101,7 @@ class PullBaseImageStep
           RegistryAuthenticationFailedException {
     buildConfiguration
         .getBuildLogger()
-        .lifecycle(
-            "Getting base image "
-                + buildConfiguration.getBaseImageReference()
-                + " with no auth...");
+        .lifecycle("Getting base image " + buildConfiguration.getBaseImageReference() + "...");
 
     try (Timer ignored = new Timer(buildConfiguration.getBuildLogger(), DESCRIPTION)) {
       // First, try with no credentials.
@@ -115,7 +112,9 @@ class PullBaseImageStep
         buildConfiguration
             .getBuildLogger()
             .lifecycle(
-                "Trying again for " + buildConfiguration.getBaseImageReference() + " with auth...");
+                "The base image requires auth. Trying again for "
+                    + buildConfiguration.getBaseImageReference()
+                    + "...");
 
         // If failed, then, retrieve base registry credentials and try with retrieved credentials.
         // TODO: Refactor the logic in RetrieveRegistryCredentialsStep out to

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -101,7 +101,10 @@ class PullBaseImageStep
           RegistryAuthenticationFailedException {
     buildConfiguration
         .getBuildLogger()
-        .lifecycle("Getting base image " + buildConfiguration.getBaseImageReference() + "...");
+        .lifecycle(
+            "Getting base image "
+                + buildConfiguration.getBaseImageReference()
+                + " with no auth...");
 
     try (Timer ignored = new Timer(buildConfiguration.getBuildLogger(), DESCRIPTION)) {
       // First, try with no credentials.
@@ -109,6 +112,11 @@ class PullBaseImageStep
         return new BaseImageWithAuthorization(pullBaseImage(null), null);
 
       } catch (RegistryUnauthorizedException ex) {
+        buildConfiguration
+            .getBuildLogger()
+            .lifecycle(
+                "Trying again for " + buildConfiguration.getBaseImageReference() + " with auth...");
+
         // If failed, then, retrieve base registry credentials and try with retrieved credentials.
         // TODO: Refactor the logic in RetrieveRegistryCredentialsStep out to
         // registry.credentials.RegistryCredentialsRetriever to avoid this direct executor hack.


### PR DESCRIPTION
This is sort of related to #620.  This PR adds a little bit of logging around the `PullBaseImageStep` to notify the user that jib will retry when the initial unauthenticated pull fails.
```
[INFO] Building dependencies layer...
[INFO] Building resources layer...
[INFO] Building classes layer...
[INFO] Getting base image nonexistant/image with no auth...
[INFO] Trying again for nonexistant/image with auth...
[INFO] Retrieving registry credentials for registry.hub.docker.com…
```

Perhaps the "auth" is a bit too encoded.