### PR TITLE
Prevent sending multiple requests in a connection

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/Connection.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/Connection.java
@@ -36,12 +36,12 @@ import org.apache.http.NoHttpResponseException;
  *
  * <p>Example usage:
  *
- * <pre>
+ * <pre>{@code
  * try (Connection connection = new Connection(url)) {
  *   Response response = connection.get(request);
  *   // ... process the response
  * }
- * </pre>
+ * }</pre>
  */
 public class Connection implements Closeable {
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/Connection.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/Connection.java
@@ -23,6 +23,7 @@ import com.google.api.client.http.HttpRequestFactory;
 import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.apache.ApacheHttpTransport;
 import com.google.api.client.http.javanet.NetHttpTransport;
+import com.google.common.base.Preconditions;
 import java.io.Closeable;
 import java.io.IOException;
 import java.net.URL;
@@ -30,16 +31,17 @@ import javax.annotation.Nullable;
 import org.apache.http.NoHttpResponseException;
 
 /**
- * Sends an HTTP {@link Request} and stores the {@link Response}.
+ * Sends an HTTP {@link Request} and stores the {@link Response}. Clients should not send more than
+ * one request.
  *
  * <p>Example usage:
  *
- * <pre>{@code
+ * <pre>
  * try (Connection connection = new Connection(url)) {
  *   Response response = connection.get(request);
  *   // ... process the response
  * }
- * }</pre>
+ * </pre>
  */
 public class Connection implements Closeable {
 
@@ -118,6 +120,8 @@ public class Connection implements Closeable {
    * @throws IOException if building the HTTP request fails.
    */
   public Response send(String httpMethod, Request request) throws IOException {
+    Preconditions.checkState(httpResponse == null, "Connection can send only one request");
+
     HttpRequest httpRequest =
         requestFactory
             .buildRequest(httpMethod, url, request.getHttpContent())

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfig.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfig.java
@@ -106,7 +106,7 @@ class DockerConfig {
   DockerCredentialHelper getCredentialHelperFor(
       DockerCredentialHelperFactory dockerCredentialHelperFactory, String registry) {
     List<Predicate<String>> registryMatchers = getRegistryMatchersFor(registry);
-    Map.Entry<String, AuthTemplate> firstMatchInAuths =
+    Map.Entry<String, ?> firstMatchInAuths =
         findFirstInMapByKey(dockerConfigTemplate.getAuths(), registryMatchers);
     if (dockerConfigTemplate.getCredsStore() != null && firstMatchInAuths != null) {
       return dockerCredentialHelperFactory.newDockerCredentialHelper(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/ConnectionTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/ConnectionTest.java
@@ -42,7 +42,6 @@ public class ConnectionTest {
 
   @Mock private HttpRequestFactory mockHttpRequestFactory;
   @Mock private HttpRequest mockHttpRequest;
-  @Mock private HttpResponse mockHttpResponse;
 
   private final ArgumentCaptor<HttpHeaders> httpHeadersArgumentCaptor =
       ArgumentCaptor.forClass(HttpHeaders.class);
@@ -51,6 +50,7 @@ public class ConnectionTest {
 
   private final GenericUrl fakeUrl = new GenericUrl("http://crepecake/fake/url");
   private Request fakeRequest;
+  private HttpResponse mockHttpResponse;
 
   @InjectMocks private final Connection testConnection = new Connection(fakeUrl.toURL());
 
@@ -121,6 +121,7 @@ public class ConnectionTest {
       Mockito.when(mockHttpRequest.setConnectTimeout(Mockito.anyInt())).thenReturn(mockHttpRequest);
       Mockito.when(mockHttpRequest.setReadTimeout(Mockito.anyInt())).thenReturn(mockHttpRequest);
     }
+    mockHttpResponse = Mockito.mock(HttpResponse.class);
     Mockito.when(mockHttpRequest.execute()).thenReturn(mockHttpResponse);
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Google LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.http;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+
+/** Simple local web server for testing. */
+public class TestWebServer implements Closeable {
+
+  private final ServerSocket serverSocket;
+
+  public TestWebServer() throws IOException, InterruptedException {
+    serverSocket = new ServerSocket(0);
+    new Thread(this::serve200).start();
+    waitUntilReady();
+  }
+
+  public String getEndpoint() {
+    String host = serverSocket.getInetAddress().getHostAddress();
+    return "http://" + host + ":" + serverSocket.getLocalPort();
+  }
+
+  @Override
+  public void close() throws IOException {
+    serverSocket.close();
+  }
+
+  private void waitUntilReady() throws IOException, InterruptedException {
+    while (!Thread.interrupted()) {
+      try (Socket socket =
+          new Socket(serverSocket.getInetAddress(), serverSocket.getLocalPort())) {
+        if (socket.isBound()) {
+          return;
+        }
+      }
+      Thread.sleep(50);
+    }
+    Thread.currentThread().interrupt();
+  }
+
+  private void serve200() {
+    try {
+      while (true) {
+        try (Socket socket = serverSocket.accept();
+            OutputStream out = socket.getOutputStream()) {
+          out.write("HTTP/1.1 200 OK\n\nHello World!".getBytes(StandardCharsets.UTF_8));
+        }
+      }
+    } catch (IOException ex) {
+    }
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
@@ -29,20 +29,20 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 
 /** Simple local web server for testing. */
-public class TestWebServer implements Closeable {
+class TestWebServer implements Closeable {
 
   private final ServerSocket serverSocket;
   private final List<Socket> sockets = new ArrayList<>();
   private final ExecutorService executorService = Executors.newSingleThreadExecutor();
   private final Semaphore threadStarted = new Semaphore(0);
 
-  public TestWebServer() throws IOException, InterruptedException {
+  TestWebServer() throws IOException, InterruptedException {
     serverSocket = new ServerSocket(0);
     executorService.submit(this::serve200);
     threadStarted.acquire();
   }
 
-  public String getEndpoint() {
+  String getEndpoint() {
     String host = serverSocket.getInetAddress().getHostAddress();
     return "http://" + host + ":" + serverSocket.getLocalPort();
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
@@ -18,11 +18,10 @@ package com.google.cloud.tools.jib.http;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
@@ -53,21 +52,15 @@ class TestWebServer implements Closeable {
 
   private Void serve200() throws IOException {
     threadStarted.release();
-    List<Socket> socketsToClose = new ArrayList<>();
-    try {
-      while (true) {
-        Socket socket = serverSocket.accept();
-        socketsToClose.add(socket);
+    while (true) {
+      try (Socket socket = serverSocket.accept()) {
         try {
           String response = "HTTP/1.1 200 OK\nContent-Length:12\n\nHello World!";
           socket.getOutputStream().write(response.getBytes(StandardCharsets.UTF_8));
           socket.getOutputStream().flush();
-        } catch (IOException ex) {
-        }
-      }
-    } finally {
-      for (Socket socket : socketsToClose) {
-        try (Socket toClose = socket) {
+
+          InputStream in = socket.getInputStream();
+          for (int ch = in.read(); ch != -1; ch = in.read()) ;
         } catch (IOException ex) {
         }
       }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
@@ -52,18 +52,14 @@ class TestWebServer implements Closeable {
 
   private Void serve200() throws IOException {
     threadStarted.release();
-    while (true) {
-      try (Socket socket = serverSocket.accept()) {
-        try {
-          String response = "HTTP/1.1 200 OK\nContent-Length:12\n\nHello World!";
-          socket.getOutputStream().write(response.getBytes(StandardCharsets.UTF_8));
-          socket.getOutputStream().flush();
+    try (Socket socket = serverSocket.accept()) {
+      String response = "HTTP/1.1 200 OK\nContent-Length:12\n\nHello World!";
+      socket.getOutputStream().write(response.getBytes(StandardCharsets.UTF_8));
+      socket.getOutputStream().flush();
 
-          InputStream in = socket.getInputStream();
-          for (int ch = in.read(); ch != -1; ch = in.read()) ;
-        } catch (IOException ex) {
-        }
-      }
+      InputStream in = socket.getInputStream();
+      for (int ch = in.read(); ch != -1; ch = in.read()) ;
     }
+    return null;
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
@@ -46,8 +46,7 @@ public class TestWebServer implements Closeable {
 
   private void waitUntilReady() throws IOException, InterruptedException {
     while (!Thread.interrupted()) {
-      try (Socket socket =
-          new Socket(serverSocket.getInetAddress(), serverSocket.getLocalPort())) {
+      try (Socket socket = new Socket(serverSocket.getInetAddress(), serverSocket.getLocalPort())) {
         if (socket.isBound()) {
           return;
         }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
@@ -57,6 +57,7 @@ class TestWebServer implements Closeable {
         try {
           String response = "HTTP/1.1 200 OK\nContent-Length:12\n\nHello World!";
           socket.getOutputStream().write(response.getBytes(StandardCharsets.UTF_8));
+          socket.getOutputStream().flush();
 
           InputStream in = socket.getInputStream();
           for (int ch = in.read(); ch != -1; ch = in.read()) ;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
@@ -57,7 +57,6 @@ class TestWebServer implements Closeable {
         try {
           String response = "HTTP/1.1 200 OK\nContent-Length:12\n\nHello World!";
           socket.getOutputStream().write(response.getBytes(StandardCharsets.UTF_8));
-          socket.getOutputStream().flush();
 
           InputStream in = socket.getInputStream();
           for (int ch = in.read(); ch != -1; ch = in.read()) ;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 Google LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.http;
+
+import java.io.ByteArrayOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for {@link Connection} using an actual local server. */
+public class WithServerConnectionTest {
+
+  private static class WebServer implements Closeable {
+
+    private ServerSocket serverSocket;
+    private boolean stop;
+
+    private WebServer() throws IOException {
+      serverSocket = new ServerSocket(8087);
+      new Thread(this::serve200).start();
+    }
+
+    private void serve200() {
+      try {
+        while (!stop) {
+          try (Socket socket = serverSocket.accept();
+              OutputStream out = socket.getOutputStream()) {
+            out.write("HTTP/1.1 200 OK\n\nHello World!".getBytes(StandardCharsets.UTF_8));
+          }
+        }
+      } catch (IOException e) {
+      }
+    }
+
+    @Override
+    public void close() throws IOException {
+      stop = true;
+      serverSocket.close();
+    }
+  }
+
+  @Test
+  public void testGet() throws IOException {
+    try (WebServer server = new WebServer();
+        Connection connection = new Connection(new URL("http://localhost:8087"))) {
+      Response response = connection.send("GET", new Request.Builder().build());
+
+      Assert.assertEquals(200, response.getStatusCode());
+
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      response.getBody().writeTo(out);
+      Assert.assertEquals("Hello World!", new String(out.toByteArray(), StandardCharsets.UTF_8));
+    }
+  }
+
+  @Test
+  public void testErrorOnSecondSend() throws IOException {
+    try (WebServer server = new WebServer();
+        Connection connection = new Connection(new URL("http://localhost:8087"))) {
+      connection.send("GET", new Request.Builder().build());
+      try {
+        connection.send("GET", new Request.Builder().build());
+        Assert.fail("Should fail on the second send");
+      } catch (IllegalStateException ex) {
+        Assert.assertEquals("Connection can send only one request", ex.getMessage());
+      }
+    }
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google LLC. All rights reserved.
+ * Copyright 2018 Google LLC. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.http;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.URL;
 import org.junit.Assert;
@@ -31,6 +32,10 @@ public class WithServerConnectionTest {
       Response response = connection.send("GET", new Request.Builder().build());
 
       Assert.assertEquals(200, response.getStatusCode());
+
+      ByteArrayOutputStream out = new ByteArrayOutputStream();
+      response.getBody().writeTo(out);
+      Assert.assertEquals("Hello World!", out.toString("UTF-8"));
     }
   }
 


### PR DESCRIPTION
Fixes #686.

Had to remove the `@Mock` annotation from the `httpResponse` field, since otherwise it is injected into `Connection` by `@InjectMocks`.

Also added another test class for `Connection` that interacts with a local web server.