### PR TITLE
Simplify RegistryEndpointCaller code

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
@@ -86,7 +86,7 @@ public class RegistryAuthenticator {
         throw new RegistryAuthenticationFailedException(ex);
 
       } catch (InsecureRegistryException ex) {
-        // HTTP is not allowed, so just return null.
+        // Cannot skip certificate validation or use HTTP, so just return null.
         return null;
       }
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
@@ -86,7 +86,7 @@ public class RegistryAuthenticator {
         throw new RegistryAuthenticationFailedException(ex);
 
       } catch (InsecureRegistryException ex) {
-        // Cannot skip certificate validation or use HTTP, so just return null.
+        // HTTP is not allowed, so just return null.
         return null;
       }
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -123,7 +123,7 @@ class RegistryEndpointCaller<T> {
   }
 
   /**
-   * Calls the registry endpoint with a certain {@link RequestState}.
+   * Calls the registry endpoint with a certain {@link URL}.
    *
    * @param url the endpoint URL to call
    * @return an object representing the response, or {@code null}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
@@ -28,7 +28,6 @@ import com.google.cloud.tools.jib.http.Connection;
 import com.google.cloud.tools.jib.http.MockConnection;
 import com.google.cloud.tools.jib.http.Response;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
-import com.google.cloud.tools.jib.registry.RegistryEndpointCaller.RequestState;
 import com.google.cloud.tools.jib.registry.json.ErrorEntryTemplate;
 import com.google.cloud.tools.jib.registry.json.ErrorResponseTemplate;
 import java.io.IOException;
@@ -175,8 +174,7 @@ public class RegistryEndpointCallerTest {
             true,
             mockConnectionFactory);
     try {
-      testRegistryEndpointCallerInsecure.call(
-          new RequestState(Authorizations.withBasicToken("token"), new URL("http://location")));
+      testRegistryEndpointCallerInsecure.call(new URL("http://location"));
       Assert.fail("Call should have failed");
 
     } catch (RegistryCredentialsNotSentException ex) {


### PR DESCRIPTION
I notice that `RequestState.authorization` is always the value given to the `RegistryEndpointCaller` constructor, so there is not much reason to carry this around in `RequestState`.

After that, `RequestState` becomes a meaningless class holding only a single `URL` field, so it seems obvious to get rid of it.