### PR TITLE
Log RegistryErrorExceptions

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/BuildStepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/BuildStepsRunner.java
@@ -31,8 +31,10 @@ import com.google.cloud.tools.jib.configuration.CacheConfiguration;
 import com.google.cloud.tools.jib.registry.InsecureRegistryException;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticationFailedException;
 import com.google.cloud.tools.jib.registry.RegistryCredentialsNotSentException;
+import com.google.cloud.tools.jib.registry.RegistryErrorException;
 import com.google.cloud.tools.jib.registry.RegistryUnauthorizedException;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Verify;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
@@ -254,6 +256,14 @@ public class BuildStepsRunner {
       } else if (exceptionDuringBuildSteps instanceof InsecureRegistryException) {
         throw new BuildStepsExecutionException(
             helpfulSuggestions.forInsecureRegistry(), exceptionDuringBuildSteps);
+
+      } else if (exceptionDuringBuildSteps instanceof RegistryErrorException) {
+        // RegistryErrorExceptions have good messages
+        RegistryErrorException registryErrorException =
+            (RegistryErrorException) exceptionDuringBuildSteps;
+        String message =
+            Verify.verifyNotNull(registryErrorException.getMessage()); // keep null-away happy
+        throw new BuildStepsExecutionException(message, exceptionDuringBuildSteps);
 
       } else {
         throw new BuildStepsExecutionException(


### PR DESCRIPTION
Towards #620 

`RegistryErrorExceptions` were not explicitly handled in `BuildStepRunner#build()` and so were caught by the [catch-all `else` handler](https://github.com/GoogleContainerTools/jib/compare/i620-RegistryErrorException?expand=1#diff-644d63cbab71bf85ab42dba1ce499fe1R269) which just threw a `BuildStepsExecutionException` with the helper message _Build image failed_.  Although Maven reports the underlying `RegistryErrorException`, Gradle just shows a rather opaque _Build image failed_:

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':jib'.
> Build image failed
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':jib'.
> Build image failed

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
```

Since `RegistryErrorExceptions` seem to carry pretty useful messages, we just report the exception message directly and skip the `HelpfulSuggestions`.

Maven:
```
[ERROR] Failed to execute goal com.google.cloud.tools:jib-maven-plugin:0.9.8-SNAPSHOT:dockerBuild (default-package) on project first: Tried to pull image manifest for registry.hub.docker.com/briandealwis/foo:bar but failed because: manifest unknown | If this is a bug, please file an issue at https://github.com/GoogleContainerTools/jib/issues/new: 404 Not Found
[ERROR] {"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown","detail":{"Tag":"bar"}}]}
[ERROR] -> [Help 1]
```

Gradle:
```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':jibDockerBuild'.
> Tried to pull image manifest for registry.hub.docker.com/briandealwis/foo:bar but failed because: manifest unknown | If this is a bug, please file an issue at https://github.com/GoogleContainerTools/jib/issues/new
```

It might be better to move the `RegistryErrorExceptionBuilder` message-generation logic into `BuildStepsRunner`.