### PR TITLE
Add 'auth' configuration to maven plugin

### DIFF
--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- <to><auth> and <from><auth> parameters with <username> and <password> fields for simple authentication, similar to the Gradle plugin ([#693](https://github.com/GoogleContainerTools/jib/issues/693))
+- Can set credentials via commandline using `jib.to.auth.username`, `jib.to.auth.password`, `jib.from.auth.username`, and `jib.from.auth.password` system properties ([#693](https://github.com/GoogleContainerTools/jib/issues/693))
+
 ### Changed
 
 - Propagates environment variables from the base image ([#716](https://github.com/GoogleContainerTools/jib/pull/716))

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- <to><auth> and <from><auth> parameters with <username> and <password> fields for simple authentication, similar to the Gradle plugin ([#693](https://github.com/GoogleContainerTools/jib/issues/693))
+- `<to><auth>` and `<from><auth>` parameters with `<username>` and `<password>` fields for simple authentication, similar to the Gradle plugin ([#693](https://github.com/GoogleContainerTools/jib/issues/693))
 - Can set credentials via commandline using `jib.to.auth.username`, `jib.to.auth.password`, `jib.from.auth.username`, and `jib.from.auth.password` system properties ([#693](https://github.com/GoogleContainerTools/jib/issues/693))
 
 ### Changed

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -26,6 +26,7 @@ import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
 import com.google.cloud.tools.jib.frontend.HelpfulSuggestions;
 import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
 import com.google.cloud.tools.jib.frontend.SystemPropertyValidator;
+import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.cloud.tools.jib.registry.credentials.RegistryCredentials;
@@ -76,8 +77,11 @@ public class BuildDockerMojo extends JibPluginConfiguration {
     MavenSettingsServerCredentials mavenSettingsServerCredentials =
         new MavenSettingsServerCredentials(
             Preconditions.checkNotNull(session).getSettings(), settingsDecrypter, mavenBuildLogger);
+    Authorization fromAuthorization = getBaseImageAuth();
     RegistryCredentials knownBaseRegistryCredentials =
-        mavenSettingsServerCredentials.retrieve(baseImage.getRegistry());
+        fromAuthorization != null
+            ? new RegistryCredentials("<jib><from><auth>", fromAuthorization)
+            : mavenSettingsServerCredentials.retrieve(baseImage.getRegistry());
 
     String mainClass = mavenProjectProperties.getMainClass(this);
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -80,7 +80,8 @@ public class BuildDockerMojo extends JibPluginConfiguration {
     Authorization fromAuthorization = getBaseImageAuth();
     RegistryCredentials knownBaseRegistryCredentials =
         fromAuthorization != null
-            ? new RegistryCredentials("<jib><from><auth>", fromAuthorization)
+            ? new RegistryCredentials(
+                "jib-maven-plugin <from><auth> configuration", fromAuthorization)
             : mavenSettingsServerCredentials.retrieve(baseImage.getRegistry());
 
     String mainClass = mavenProjectProperties.getMainClass(this);

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -97,12 +97,13 @@ public class BuildImageMojo extends JibPluginConfiguration {
     Authorization fromAuthorization = getBaseImageAuth();
     RegistryCredentials knownBaseRegistryCredentials =
         fromAuthorization != null
-            ? new RegistryCredentials("<jib><from><auth>", fromAuthorization)
+            ? new RegistryCredentials(
+                "jib-maven-plugin <from><auth> configuration", fromAuthorization)
             : mavenSettingsServerCredentials.retrieve(baseImage.getRegistry());
     Authorization toAuthorization = getTargetImageAuth();
     RegistryCredentials knownTargetRegistryCredentials =
         toAuthorization != null
-            ? new RegistryCredentials("<jib><to><auth>", toAuthorization)
+            ? new RegistryCredentials("jib-maven-plugin <to><auth> configuration", toAuthorization)
             : mavenSettingsServerCredentials.retrieve(targetImage.getRegistry());
 
     MavenProjectProperties mavenProjectProperties =

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -78,7 +78,8 @@ public class BuildTarMojo extends JibPluginConfiguration {
     Authorization fromAuthorization = getBaseImageAuth();
     RegistryCredentials knownBaseRegistryCredentials =
         fromAuthorization != null
-            ? new RegistryCredentials("<jib><from><auth>", fromAuthorization)
+            ? new RegistryCredentials(
+                "jib-maven-plugin <from><auth> configuration", fromAuthorization)
             : mavenSettingsServerCredentials.retrieve(baseImage.getRegistry());
 
     String mainClass = mavenProjectProperties.getMainClass(this);

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
 import com.google.cloud.tools.jib.frontend.HelpfulSuggestions;
 import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
 import com.google.cloud.tools.jib.frontend.SystemPropertyValidator;
+import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.cloud.tools.jib.registry.credentials.RegistryCredentials;
@@ -74,8 +75,11 @@ public class BuildTarMojo extends JibPluginConfiguration {
     MavenSettingsServerCredentials mavenSettingsServerCredentials =
         new MavenSettingsServerCredentials(
             Preconditions.checkNotNull(session).getSettings(), settingsDecrypter, mavenBuildLogger);
+    Authorization fromAuthorization = getBaseImageAuth();
     RegistryCredentials knownBaseRegistryCredentials =
-        mavenSettingsServerCredentials.retrieve(baseImage.getRegistry());
+        fromAuthorization != null
+            ? new RegistryCredentials("<jib><from><auth>", fromAuthorization)
+            : mavenSettingsServerCredentials.retrieve(baseImage.getRegistry());
 
     String mainClass = mavenProjectProperties.getMainClass(this);
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -168,12 +168,12 @@ abstract class JibPluginConfiguration extends AbstractMojo {
   @Parameter(defaultValue = "${session}", readonly = true)
   MavenSession session;
 
-  @Parameter private FromConfiguration from = new FromConfiguration();
+  @Parameter private final FromConfiguration from = new FromConfiguration();
 
   @Parameter(property = "image")
-  private ToConfiguration to = new ToConfiguration();
+  private final ToConfiguration to = new ToConfiguration();
 
-  @Parameter private ContainerParameters container = new ContainerParameters();
+  @Parameter private final ContainerParameters container = new ContainerParameters();
 
   @Deprecated @Parameter private List<String> jvmFlags = Collections.emptyList();
 
@@ -212,9 +212,10 @@ abstract class JibPluginConfiguration extends AbstractMojo {
 
   /**
    * Gets an {@code Authorization} from system properties, or from the {@code <from><auth>}
-   * configuration if the system properties are not set.
+   * configuration if the system properties are not set, or {@code null} if neither are set.
    *
-   * @return a new {@code Authorization} from the configured username and password.
+   * @return a new {@code Authorization} from the configured username and password, or {@code null}
+   *     if one isn't configured.
    */
   @Nullable
   Authorization getBaseImageAuth() {
@@ -239,9 +240,10 @@ abstract class JibPluginConfiguration extends AbstractMojo {
 
   /**
    * Gets an {@code Authorization} from system properties, or from the {@code <to><auth>}
-   * configuration if the system properties are not set.
+   * configuration if the system properties are not set, or {@code null} if neither are set.
    *
-   * @return a new {@code Authorization} from the configured username and password.
+   * @return a new {@code Authorization} from the configured username and password, or {@code null}
+   *     if one isn't configured.
    */
   @Nullable
   Authorization getTargetImageAuth() {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -48,6 +48,16 @@ abstract class JibPluginConfiguration extends AbstractMojo {
 
     @Nullable @Parameter private String password;
 
+    @VisibleForTesting
+    void setUsername(String username) {
+      this.username = username;
+    }
+
+    @VisibleForTesting
+    void setPassword(String password) {
+      this.password = password;
+    }
+
     /**
      * Converts the {@link AuthConfiguration} to an {@link Authorization}.
      *
@@ -132,8 +142,9 @@ abstract class JibPluginConfiguration extends AbstractMojo {
    * @return a new {@link Authorization} from the system properties or build configuration, or
    *     {@code null} if neither is configured.
    */
+  @VisibleForTesting
   @Nullable
-  private static Authorization getImageAuth(
+  static Authorization getImageAuth(
       String usernameProperty, String passwordProperty, AuthConfiguration auth) {
     // System property takes priority over build configuration
     String commandlineUsername = System.getProperty(usernameProperty);

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -122,6 +122,28 @@ abstract class JibPluginConfiguration extends AbstractMojo {
     }
   }
 
+  /**
+   * Gets an {@link Authorization} from a username and password. First tries system properties, then
+   * tries build configuration, otherwise returns null.
+   *
+   * @param usernameProperty the name of the username system property
+   * @param passwordProperty the name of the password system property
+   * @param auth the configured credentials
+   * @return a new {@link Authorization} from the system properties or build configuration, or
+   *     {@code null} if neither is configured.
+   */
+  @Nullable
+  private static Authorization getImageAuth(
+      String usernameProperty, String passwordProperty, AuthConfiguration auth) {
+    // System property takes priority over build configuration
+    String commandlineUsername = System.getProperty(usernameProperty);
+    String commandlinePassword = System.getProperty(passwordProperty);
+    if (commandlineUsername != null && commandlinePassword != null) {
+      return Authorizations.withBasicCredentials(commandlineUsername, commandlinePassword);
+    }
+    return auth.getAuthorization();
+  }
+
   @Nullable
   @Parameter(defaultValue = "${session}", readonly = true)
   MavenSession session;
@@ -306,27 +328,5 @@ abstract class JibPluginConfiguration extends AbstractMojo {
   @VisibleForTesting
   void setExtraDirectory(String extraDirectory) {
     this.extraDirectory = extraDirectory;
-  }
-
-  /**
-   * Gets an {@link Authorization} from a username and password. First tries system properties, then
-   * tries build configuration, otherwise returns null.
-   *
-   * @param usernameProperty the name of the username system property
-   * @param passwordProperty the name of the password system property
-   * @param auth the configured credentials
-   * @return a new {@link Authorization} from the system properties or build configuration, or
-   *     {@code null} if neither is configured.
-   */
-  @Nullable
-  private static Authorization getImageAuth(
-      String usernameProperty, String passwordProperty, AuthConfiguration auth) {
-    // System property takes priority over build configuration
-    String commandlineUsername = System.getProperty(usernameProperty);
-    String commandlinePassword = System.getProperty(passwordProperty);
-    if (commandlineUsername != null && commandlinePassword != null) {
-      return Authorizations.withBasicCredentials(commandlineUsername, commandlinePassword);
-    }
-    return auth.getAuthorization();
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
@@ -17,6 +17,9 @@
 package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.builder.BuildLogger;
+import com.google.cloud.tools.jib.http.Authorization;
+import com.google.cloud.tools.jib.http.Authorizations;
+import com.google.cloud.tools.jib.maven.JibPluginConfiguration.AuthConfiguration;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import org.junit.Assert;
@@ -65,5 +68,31 @@ public class JibPluginConfigurationTest {
     Assert.assertEquals(Arrays.asList("arg1", "arg2", "arg3"), testPluginConfiguration.getArgs());
     Assert.assertEquals("OCI", testPluginConfiguration.getFormat());
     Assert.assertEquals(Paths.get("some/path"), testPluginConfiguration.getExtraDirectory());
+  }
+
+  @Test
+  public void testGetImageAuth() {
+    AuthConfiguration auth = new AuthConfiguration();
+    auth.setUsername("vwxyz");
+    auth.setPassword("98765");
+
+    System.setProperty("jib.test.auth.user", "abcde");
+    System.setProperty("jib.test.auth.pass", "12345");
+    Authorization expected = Authorizations.withBasicCredentials("abcde", "12345");
+    Authorization actual =
+        JibPluginConfiguration.getImageAuth("jib.test.auth.user", "jib.test.auth.pass", auth);
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(expected.toString(), actual.toString());
+
+    System.clearProperty("jib.test.auth.user");
+    System.clearProperty("jib.test.auth.pass");
+    expected = Authorizations.withBasicCredentials("vwxyz", "98765");
+    actual = JibPluginConfiguration.getImageAuth("jib.test.auth.user", "jib.test.auth.pass", auth);
+    Assert.assertNotNull(actual);
+    Assert.assertEquals(expected.toString(), actual.toString());
+
+    auth = new AuthConfiguration();
+    actual = JibPluginConfiguration.getImageAuth("jib.test.auth.user", "jib.test.auth.pass", auth);
+    Assert.assertNull(actual);
   }
 }


### PR DESCRIPTION
So now I think the order of auth checking is something like:
1. Cred helper in build config
2. Username/password system properties
3. Username/password in build config
4. Maven settings
5. Common cred helpers
6. Docker config

Fix #693 