### PR TITLE
More detailed Javadocs

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/async/NonBlockingSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/async/NonBlockingSteps.java
@@ -17,12 +17,21 @@
 package com.google.cloud.tools.jib.async;
 
 import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
 import java.util.concurrent.ExecutionException;
 
-/** Static utility for ensuring {@link ListenableFuture#get} does not block. */
+/**
+ * Static utility for checking at runtime that the caller attempts to get a result only from a
+ * completed {@link AsyncStep} by otherwise throwing a runtime exception.
+ */
 public class NonBlockingSteps {
 
+  /**
+   * Gets the completed computation result of {@code asyncStep}.
+   *
+   * @return the completed computation result
+   * @throws ExecutionException if the {@code Future} failed with an exception
+   * @throws IllegalStateException if {@code asyncStep} has not been completed
+   */
   public static <T> T get(AsyncStep<T> asyncStep) throws ExecutionException {
     return Futures.getDone(asyncStep.getFuture());
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/async/NonBlockingSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/async/NonBlockingSteps.java
@@ -28,6 +28,8 @@ public class NonBlockingSteps {
   /**
    * Gets the completed computation result of {@code asyncStep}.
    *
+   * @param <T> the type of the computation result of {@code asyncStep}
+   * @param asyncStep completed {@link AsyncStep}
    * @return the completed computation result
    * @throws ExecutionException if the {@code Future} failed with an exception
    * @throws IllegalStateException if {@code asyncStep} has not been completed

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -66,7 +66,7 @@ public class TarStreamBuilder {
 
   /**
    * Adds a blob to the archive. Note that this should be used with raw bytes and not file contents;
-   * for adding files to the archive, use {@code TarStreamBuilder#addTarArchiveEntry()}.
+   * for adding files to the archive, use {@link #addTarArchiveEntry()}.
    *
    * @param contents the bytes to add to the tarball
    * @param name the name of the entry (i.e. filename)

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -66,7 +66,7 @@ public class TarStreamBuilder {
 
   /**
    * Adds a blob to the archive. Note that this should be used with raw bytes and not file contents;
-   * for adding files to the archive, use {@link #addTarArchiveEntry()}.
+   * for adding files to the archive, use {@link #addTarArchiveEntry}.
    *
    * @param contents the bytes to add to the tarball
    * @param name the name of the entry (i.e. filename)


### PR DESCRIPTION
I had misunderstood `NonBlocksingSteps` until I read the Javadoc of `Futures.getDone()` to see what it actually does. The current Javadoc did not help; it rather created a false illusion that `get()` will magically give the result of a pending future instantly without blocking (which did not make sense at all).