### PR TITLE
Split BuildConfiguration into multiple classes

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -190,10 +190,8 @@ public class BuildStepsIntegrationTest {
 
   private BuildConfiguration getBuildConfiguration(
       ImageReference baseImage, ImageReference targetImage) {
-    ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder().setImage(baseImage).build();
-    ImageConfiguration targetImageConfiguration =
-        ImageConfiguration.builder().setImage(targetImage).build();
+    ImageConfiguration baseImageConfiguration = ImageConfiguration.builder(baseImage).build();
+    ImageConfiguration targetImageConfiguration = ImageConfiguration.builder(targetImage).build();
     ContainerConfiguration containerConfiguration =
         ContainerConfiguration.builder()
             .setEntrypoint(

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -88,7 +88,6 @@ public class BuildStepsIntegrationTest {
   public void testSteps_forBuildToDockerRegistry()
       throws IOException, InterruptedException, CacheMetadataCorruptedException, ExecutionException,
           CacheDirectoryNotOwnedException, CacheDirectoryCreationException {
-
     BuildSteps buildImageSteps =
         getBuildSteps(
             getBuildConfiguration(

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -22,6 +22,8 @@ import com.google.cloud.tools.jib.cache.CacheDirectoryNotOwnedException;
 import com.google.cloud.tools.jib.cache.CacheMetadataCorruptedException;
 import com.google.cloud.tools.jib.cache.Caches;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
+import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.configuration.LayerConfiguration;
 import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
 import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
@@ -86,20 +88,12 @@ public class BuildStepsIntegrationTest {
   public void testSteps_forBuildToDockerRegistry()
       throws IOException, InterruptedException, CacheMetadataCorruptedException, ExecutionException,
           CacheDirectoryNotOwnedException, CacheDirectoryCreationException {
+
     BuildSteps buildImageSteps =
         getBuildSteps(
-            BuildConfiguration.builder(logger)
-                .setBaseImage(ImageReference.of("gcr.io", "distroless/java", "latest"))
-                .setTargetImage(ImageReference.of("localhost:5000", "testimage", "testtag"))
-                .setJavaArguments(Collections.singletonList("An argument."))
-                .setExposedPorts(
-                    ExposedPortsParser.parse(Arrays.asList("1000", "2000-2002/tcp", "3000/udp")))
-                .setAllowInsecureRegistries(true)
-                .setLayerConfigurations(fakeLayerConfigurations)
-                .setEntrypoint(
-                    JavaEntrypointConstructor.makeDefaultEntrypoint(
-                        Collections.emptyList(), "HelloWorld"))
-                .build());
+            getBuildConfiguration(
+                ImageReference.of("gcr.io", "distroless/java", "latest"),
+                ImageReference.of("localhost:5000", "testimage", "testtag")));
 
     long lastTime = System.nanoTime();
     buildImageSteps.run();
@@ -129,16 +123,9 @@ public class BuildStepsIntegrationTest {
           CacheDirectoryCreationException, CacheMetadataCorruptedException,
           CacheDirectoryNotOwnedException {
     getBuildSteps(
-            BuildConfiguration.builder(logger)
-                .setBaseImage(ImageReference.parse("openjdk:8-jre-alpine"))
-                .setTargetImage(ImageReference.of("localhost:5000", "testimage", "testtag"))
-                .setJavaArguments(Collections.singletonList("An argument."))
-                .setAllowInsecureRegistries(true)
-                .setLayerConfigurations(fakeLayerConfigurations)
-                .setEntrypoint(
-                    JavaEntrypointConstructor.makeDefaultEntrypoint(
-                        Collections.emptyList(), "HelloWorld"))
-                .build())
+            getBuildConfiguration(
+                ImageReference.parse("openjdk:8-jre-alpine"),
+                ImageReference.of("localhost:5000", "testimage", "testtag")))
         .run();
 
     String imageReference = "localhost:5000/testimage:testtag";
@@ -152,18 +139,9 @@ public class BuildStepsIntegrationTest {
       throws IOException, InterruptedException, CacheMetadataCorruptedException, ExecutionException,
           CacheDirectoryNotOwnedException, CacheDirectoryCreationException {
     BuildConfiguration buildConfiguration =
-        BuildConfiguration.builder(logger)
-            .setBaseImage(ImageReference.of("gcr.io", "distroless/java", "latest"))
-            .setTargetImage(ImageReference.of(null, "testdocker", null))
-            .setJavaArguments(Collections.singletonList("An argument."))
-            .setExposedPorts(
-                ExposedPortsParser.parse(Arrays.asList("1000", "2000-2002/tcp", "3000/udp")))
-            .setLayerConfigurations(fakeLayerConfigurations)
-            .setEntrypoint(
-                JavaEntrypointConstructor.makeDefaultEntrypoint(
-                    Collections.emptyList(), "HelloWorld"))
-            .build();
-
+        getBuildConfiguration(
+            ImageReference.of("gcr.io", "distroless/java", "latest"),
+            ImageReference.of(null, "testdocker", null));
     Path cacheDirectory = temporaryFolder.newFolder().toPath();
     BuildSteps.forBuildToDockerDaemon(
             buildConfiguration,
@@ -188,16 +166,9 @@ public class BuildStepsIntegrationTest {
       throws IOException, InterruptedException, CacheMetadataCorruptedException, ExecutionException,
           CacheDirectoryNotOwnedException, CacheDirectoryCreationException {
     BuildConfiguration buildConfiguration =
-        BuildConfiguration.builder(logger)
-            .setBaseImage(ImageReference.of("gcr.io", "distroless/java", "latest"))
-            .setTargetImage(ImageReference.of(null, "testtar", null))
-            .setJavaArguments(Collections.singletonList("An argument."))
-            .setLayerConfigurations(fakeLayerConfigurations)
-            .setEntrypoint(
-                JavaEntrypointConstructor.makeDefaultEntrypoint(
-                    Collections.emptyList(), "HelloWorld"))
-            .build();
-
+        getBuildConfiguration(
+            ImageReference.of("gcr.io", "distroless/java", "latest"),
+            ImageReference.of(null, "testtar", null));
     Path outputPath = temporaryFolder.newFolder().toPath().resolve("test.tar");
     Path cacheDirectory = temporaryFolder.newFolder().toPath();
     BuildSteps.forBuildToTar(
@@ -215,5 +186,29 @@ public class BuildStepsIntegrationTest {
     Path cacheDirectory = temporaryFolder.newFolder().toPath();
     return BuildSteps.forBuildToDockerRegistry(
         buildConfiguration, new Caches.Initializer(cacheDirectory, false, cacheDirectory, false));
+  }
+
+  private BuildConfiguration getBuildConfiguration(
+      ImageReference baseImage, ImageReference targetImage) {
+    ImageConfiguration baseImageConfiguration =
+        ImageConfiguration.builder().setImage(baseImage).build();
+    ImageConfiguration targetImageConfiguration =
+        ImageConfiguration.builder().setImage(targetImage).build();
+    ContainerConfiguration containerConfiguration =
+        ContainerConfiguration.builder()
+            .setEntrypoint(
+                JavaEntrypointConstructor.makeDefaultEntrypoint(
+                    Collections.emptyList(), "HelloWorld"))
+            .setProgramArguments(Collections.singletonList("An argument."))
+            .setExposedPorts(
+                ExposedPortsParser.parse(Arrays.asList("1000", "2000-2002/tcp", "3000/udp")))
+            .build();
+    return BuildConfiguration.builder(logger)
+        .setBaseImageConfiguration(baseImageConfiguration)
+        .setTargetImageConfiguration(targetImageConfiguration)
+        .setContainerConfiguration(containerConfiguration)
+        .setAllowInsecureRegistries(true)
+        .setLayerConfigurations(fakeLayerConfigurations)
+        .build();
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildSteps.java
@@ -212,9 +212,13 @@ public class BuildSteps {
       }
     }
 
-    buildConfiguration.getBuildLogger().lifecycle("");
-    buildConfiguration
-        .getBuildLogger()
-        .lifecycle("Container entrypoint set to " + buildConfiguration.getEntrypoint());
+    if (buildConfiguration.getContainerConfiguration() != null) {
+      buildConfiguration.getBuildLogger().lifecycle("");
+      buildConfiguration
+          .getBuildLogger()
+          .lifecycle(
+              "Container entrypoint set to "
+                  + buildConfiguration.getContainerConfiguration().getEntrypoint());
+    }
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
@@ -108,7 +108,7 @@ class BuildImageStep
 
       imageBuilder.setCreated(buildConfiguration.getCreationTime());
       imageBuilder.setEntrypoint(buildConfiguration.getEntrypoint());
-      imageBuilder.setJavaArguments(buildConfiguration.getJavaArguments());
+      imageBuilder.setJavaArguments(buildConfiguration.getMainArguments());
       imageBuilder.setExposedPorts(buildConfiguration.getExposedPorts());
 
       // Gets the container configuration content descriptor.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.NonBlockingSteps;
 import com.google.cloud.tools.jib.cache.CachedLayer;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
+import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.common.collect.ImmutableList;
@@ -104,12 +105,16 @@ class BuildImageStep
       // Start with environment from base image and overlay build configuration
       imageBuilder.addEnvironment(
           NonBlockingSteps.get(pullBaseImageStep).getBaseImage().getEnvironment());
-      imageBuilder.addEnvironment(buildConfiguration.getEnvironment());
 
-      imageBuilder.setCreated(buildConfiguration.getCreationTime());
-      imageBuilder.setEntrypoint(buildConfiguration.getEntrypoint());
-      imageBuilder.setJavaArguments(buildConfiguration.getProgramArguments());
-      imageBuilder.setExposedPorts(buildConfiguration.getExposedPorts());
+      ContainerConfiguration containerConfiguration =
+          buildConfiguration.getContainerConfiguration();
+      if (containerConfiguration != null) {
+        imageBuilder.addEnvironment(containerConfiguration.getEnvironmentMap());
+        imageBuilder.setCreated(containerConfiguration.getCreationTime());
+        imageBuilder.setEntrypoint(containerConfiguration.getEntrypoint());
+        imageBuilder.setJavaArguments(containerConfiguration.getProgramArguments());
+        imageBuilder.setExposedPorts(containerConfiguration.getExposedPorts());
+      }
 
       // Gets the container configuration content descriptor.
       return imageBuilder.build();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
@@ -108,7 +108,7 @@ class BuildImageStep
 
       imageBuilder.setCreated(buildConfiguration.getCreationTime());
       imageBuilder.setEntrypoint(buildConfiguration.getEntrypoint());
-      imageBuilder.setJavaArguments(buildConfiguration.getMainArguments());
+      imageBuilder.setJavaArguments(buildConfiguration.getProgramArguments());
       imageBuilder.setExposedPorts(buildConfiguration.getExposedPorts());
 
       // Gets the container configuration content descriptor.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
@@ -49,16 +49,34 @@ public class BuildConfiguration {
       this.buildLogger = buildLogger;
     }
 
+    /**
+     * Sets the base image configuration.
+     *
+     * @param imageConfiguration the {@link ImageConfiguration} describing the base image
+     * @return this
+     */
     public Builder setBaseImageConfiguration(ImageConfiguration imageConfiguration) {
       this.baseImageConfiguration = imageConfiguration;
       return this;
     }
 
+    /**
+     * Sets the target image configuration.
+     *
+     * @param imageConfiguration the {@link ImageConfiguration} describing the target image
+     * @return this
+     */
     public Builder setTargetImageConfiguration(ImageConfiguration imageConfiguration) {
       this.targetImageConfiguration = imageConfiguration;
       return this;
     }
 
+    /**
+     * Sets configuration parameters for the container.
+     *
+     * @param containerConfiguration the {@link ContainerConfiguration}
+     * @return this
+     */
     public Builder setContainerConfiguration(ContainerConfiguration containerConfiguration) {
       this.containerConfiguration = containerConfiguration;
       return this;
@@ -121,7 +139,11 @@ public class BuildConfiguration {
       return this;
     }
 
-    /** @return the corresponding build configuration */
+    /**
+     * Builds a new {@link BuildConfiguration} using the parameters passed into the builder.
+     *
+     * @return the corresponding build configuration
+     */
     public BuildConfiguration build() {
       // Validates the parameters.
       List<String> errorMessages = new ArrayList<>();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
@@ -192,7 +192,7 @@ public class BuildConfiguration {
   @Nullable private final String targetImageCredentialHelperName;
   @Nullable private final RegistryCredentials knownTargetRegistryCredentials;
   private final Instant creationTime;
-  @Nullable private final ImmutableList<String> mainArguments;
+  @Nullable private final ImmutableList<String> programArguments;
   @Nullable private final ImmutableMap<String, String> environmentMap;
   @Nullable private final ImmutableList<Port> exposedPorts;
   private final Class<? extends BuildableManifestTemplate> targetFormat;
@@ -213,7 +213,7 @@ public class BuildConfiguration {
       @Nullable RegistryCredentials knownTargetRegistryCredentials,
       Instant creationTime,
       @Nullable ImmutableList<String> entrypoint,
-      @Nullable ImmutableList<String> mainArguments,
+      @Nullable ImmutableList<String> programArguments,
       @Nullable ImmutableMap<String, String> environmentMap,
       @Nullable ImmutableList<Port> exposedPorts,
       Class<? extends BuildableManifestTemplate> targetFormat,
@@ -229,7 +229,7 @@ public class BuildConfiguration {
     this.targetImageCredentialHelperName = targetImageCredentialHelperName;
     this.knownTargetRegistryCredentials = knownTargetRegistryCredentials;
     this.creationTime = creationTime;
-    this.mainArguments = mainArguments;
+    this.programArguments = programArguments;
     this.environmentMap = environmentMap;
     this.exposedPorts = exposedPorts;
     this.targetFormat = targetFormat;
@@ -316,8 +316,8 @@ public class BuildConfiguration {
    * @return the list of arguments, or {@code null} if not set
    */
   @Nullable
-  public ImmutableList<String> getMainArguments() {
-    return mainArguments;
+  public ImmutableList<String> getProgramArguments() {
+    return programArguments;
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.tools.jib.configuration;
 
-import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
-import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -39,7 +37,6 @@ public class ContainerConfiguration {
     @Nullable private ImmutableList<String> programArguments;
     @Nullable private ImmutableMap<String, String> environmentMap;
     @Nullable private ImmutableList<Port> exposedPorts;
-    private Class<? extends BuildableManifestTemplate> targetFormat = V22ManifestTemplate.class;
 
     /**
      * Sets the image creation time.
@@ -59,7 +56,9 @@ public class ContainerConfiguration {
      * @return this
      */
     public Builder setProgramArguments(@Nullable List<String> programArguments) {
-      if (programArguments != null) {
+      if (programArguments == null) {
+        this.programArguments = null;
+      } else {
         Preconditions.checkArgument(!programArguments.contains(null));
         this.programArguments = ImmutableList.copyOf(programArguments);
       }
@@ -76,9 +75,8 @@ public class ContainerConfiguration {
       if (environmentMap == null) {
         this.environmentMap = null;
       } else {
-        Preconditions.checkArgument(
-            !Iterables.any(environmentMap.keySet(), Objects::isNull)
-                && !Iterables.any(environmentMap.values(), Objects::isNull));
+        Preconditions.checkArgument(!Iterables.any(environmentMap.keySet(), Objects::isNull));
+        Preconditions.checkArgument(!Iterables.any(environmentMap.values(), Objects::isNull));
         this.environmentMap = ImmutableMap.copyOf(environmentMap);
       }
       return this;
@@ -117,24 +115,13 @@ public class ContainerConfiguration {
     }
 
     /**
-     * Sets the container's target format.
-     *
-     * @param targetFormat the target format
-     * @return this
-     */
-    public Builder setTargetFormat(Class<? extends BuildableManifestTemplate> targetFormat) {
-      this.targetFormat = targetFormat;
-      return this;
-    }
-
-    /**
      * Builds the {@link ContainerConfiguration}.
      *
      * @return the corresponding {@link ContainerConfiguration}
      */
     public ContainerConfiguration build() {
       return new ContainerConfiguration(
-          creationTime, entrypoint, programArguments, environmentMap, exposedPorts, targetFormat);
+          creationTime, entrypoint, programArguments, environmentMap, exposedPorts);
     }
 
     private Builder() {}
@@ -149,48 +136,41 @@ public class ContainerConfiguration {
   @Nullable private final ImmutableList<String> programArguments;
   @Nullable private final ImmutableMap<String, String> environmentMap;
   @Nullable private final ImmutableList<Port> exposedPorts;
-  private final Class<? extends BuildableManifestTemplate> targetFormat;
 
   private ContainerConfiguration(
       Instant creationTime,
       @Nullable ImmutableList<String> entrypoint,
       @Nullable ImmutableList<String> programArguments,
       @Nullable ImmutableMap<String, String> environmentMap,
-      @Nullable ImmutableList<Port> exposedPorts,
-      Class<? extends BuildableManifestTemplate> targetFormat) {
+      @Nullable ImmutableList<Port> exposedPorts) {
     this.creationTime = creationTime;
     this.entrypoint = entrypoint;
     this.programArguments = programArguments;
     this.environmentMap = environmentMap;
     this.exposedPorts = exposedPorts;
-    this.targetFormat = targetFormat;
   }
 
-  Instant getCreationTime() {
+  public Instant getCreationTime() {
     return creationTime;
   }
 
   @Nullable
-  ImmutableList<String> getEntrypoint() {
+  public ImmutableList<String> getEntrypoint() {
     return entrypoint;
   }
 
   @Nullable
-  ImmutableList<String> getProgramArguments() {
+  public ImmutableList<String> getProgramArguments() {
     return programArguments;
   }
 
   @Nullable
-  ImmutableMap<String, String> getEnvironmentMap() {
+  public ImmutableMap<String, String> getEnvironmentMap() {
     return environmentMap;
   }
 
   @Nullable
-  ImmutableList<Port> getExposedPorts() {
+  public ImmutableList<Port> getExposedPorts() {
     return exposedPorts;
-  }
-
-  Class<? extends BuildableManifestTemplate> getTargetFormat() {
-    return targetFormat;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -151,10 +151,6 @@ public class ContainerConfiguration {
   @Nullable private final ImmutableList<Port> exposedPorts;
   private final Class<? extends BuildableManifestTemplate> targetFormat;
 
-  ContainerConfiguration() {
-    this(Instant.EPOCH, null, null, null, null, V22ManifestTemplate.class);
-  }
-
   private ContainerConfiguration(
       Instant creationTime,
       @Nullable ImmutableList<String> entrypoint,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2018 Google LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.configuration;
+
+import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
+import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
+
+/** Immutable configuration options for the container. */
+public class ContainerConfiguration {
+
+  /** Builder for instantiating a {@link ContainerConfiguration}. */
+  public static class Builder {
+
+    private Instant creationTime = Instant.EPOCH;
+    @Nullable private ImmutableList<String> entrypoint;
+    @Nullable private ImmutableList<String> programArguments;
+    @Nullable private ImmutableMap<String, String> environmentMap;
+    @Nullable private ImmutableList<Port> exposedPorts;
+    private Class<? extends BuildableManifestTemplate> targetFormat = V22ManifestTemplate.class;
+
+    /**
+     * Sets the image creation time.
+     *
+     * @param creationTime the creation time
+     * @return this
+     */
+    public Builder setCreationTime(Instant creationTime) {
+      this.creationTime = creationTime;
+      return this;
+    }
+
+    /**
+     * Sets the commandline arguments for main.
+     *
+     * @param programArguments the list of arguments
+     * @return this
+     */
+    public Builder setProgramArguments(@Nullable List<String> programArguments) {
+      if (programArguments != null) {
+        Preconditions.checkArgument(!programArguments.contains(null));
+        this.programArguments = ImmutableList.copyOf(programArguments);
+      }
+      return this;
+    }
+
+    /**
+     * Sets the container's environment variables, mapping variable name to value.
+     *
+     * @param environmentMap the map
+     * @return this
+     */
+    public Builder setEnvironment(@Nullable Map<String, String> environmentMap) {
+      if (environmentMap == null) {
+        this.environmentMap = null;
+      } else {
+        Preconditions.checkArgument(
+            !Iterables.any(environmentMap.keySet(), Objects::isNull)
+                && !Iterables.any(environmentMap.values(), Objects::isNull));
+        this.environmentMap = ImmutableMap.copyOf(environmentMap);
+      }
+      return this;
+    }
+
+    /**
+     * Sets the container's exposed ports.
+     *
+     * @param exposedPorts the list of ports
+     * @return this
+     */
+    public Builder setExposedPorts(@Nullable List<Port> exposedPorts) {
+      if (exposedPorts == null) {
+        this.exposedPorts = null;
+      } else {
+        Preconditions.checkArgument(!exposedPorts.contains(null));
+        this.exposedPorts = ImmutableList.copyOf(exposedPorts);
+      }
+      return this;
+    }
+
+    /**
+     * Sets the container entrypoint.
+     *
+     * @param entrypoint the tokenized command to run when the container starts
+     * @return this
+     */
+    public Builder setEntrypoint(@Nullable List<String> entrypoint) {
+      if (entrypoint == null) {
+        this.entrypoint = null;
+      } else {
+        Preconditions.checkArgument(!entrypoint.contains(null));
+        this.entrypoint = ImmutableList.copyOf(entrypoint);
+      }
+      return this;
+    }
+
+    /**
+     * Sets the container's target format.
+     *
+     * @param targetFormat the target format
+     * @return this
+     */
+    public Builder setTargetFormat(Class<? extends BuildableManifestTemplate> targetFormat) {
+      this.targetFormat = targetFormat;
+      return this;
+    }
+
+    /**
+     * Builds the {@link ContainerConfiguration}.
+     *
+     * @return the corresponding {@link ContainerConfiguration}
+     */
+    public ContainerConfiguration build() {
+      return new ContainerConfiguration(
+          creationTime, entrypoint, programArguments, environmentMap, exposedPorts, targetFormat);
+    }
+
+    private Builder() {}
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private final Instant creationTime;
+  @Nullable private final ImmutableList<String> entrypoint;
+  @Nullable private final ImmutableList<String> programArguments;
+  @Nullable private final ImmutableMap<String, String> environmentMap;
+  @Nullable private final ImmutableList<Port> exposedPorts;
+  private final Class<? extends BuildableManifestTemplate> targetFormat;
+
+  ContainerConfiguration() {
+    this(Instant.EPOCH, null, null, null, null, V22ManifestTemplate.class);
+  }
+
+  private ContainerConfiguration(
+      Instant creationTime,
+      @Nullable ImmutableList<String> entrypoint,
+      @Nullable ImmutableList<String> programArguments,
+      @Nullable ImmutableMap<String, String> environmentMap,
+      @Nullable ImmutableList<Port> exposedPorts,
+      Class<? extends BuildableManifestTemplate> targetFormat) {
+    this.creationTime = creationTime;
+    this.entrypoint = entrypoint;
+    this.programArguments = programArguments;
+    this.environmentMap = environmentMap;
+    this.exposedPorts = exposedPorts;
+    this.targetFormat = targetFormat;
+  }
+
+  Instant getCreationTime() {
+    return creationTime;
+  }
+
+  @Nullable
+  ImmutableList<String> getEntrypoint() {
+    return entrypoint;
+  }
+
+  @Nullable
+  ImmutableList<String> getProgramArguments() {
+    return programArguments;
+  }
+
+  @Nullable
+  ImmutableMap<String, String> getEnvironmentMap() {
+    return environmentMap;
+  }
+
+  @Nullable
+  ImmutableList<Port> getExposedPorts() {
+    return exposedPorts;
+  }
+
+  Class<? extends BuildableManifestTemplate> getTargetFormat() {
+    return targetFormat;
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -127,6 +127,11 @@ public class ContainerConfiguration {
     private Builder() {}
   }
 
+  /**
+   * Constructs a builder for a {@link ContainerConfiguration}.
+   *
+   * @return the builder
+   */
   public static Builder builder() {
     return new Builder();
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
@@ -26,20 +26,9 @@ public class ImageConfiguration {
   /** Builder for instantiating an {@link ImageConfiguration}. */
   public static class Builder {
 
-    @Nullable private ImageReference imageReference;
+    private ImageReference imageReference;
     @Nullable private String credentialHelper;
     @Nullable private RegistryCredentials knownRegistryCredentials;
-
-    /**
-     * Sets the image reference.
-     *
-     * @param imageReference the image reference containing the registry, repository, and tag.
-     * @return this
-     */
-    public Builder setImage(@Nullable ImageReference imageReference) {
-      this.imageReference = imageReference;
-      return this;
-    }
 
     /**
      * Sets the credential helper name used for authenticating with the image's registry.
@@ -55,12 +44,12 @@ public class ImageConfiguration {
     /**
      * Sets known credentials used for authenticating with the image's registry.
      *
-     * @param knownRegistryCrendentials the credentials.
+     * @param knownRegistryCredentials the credentials.
      * @return this
      */
     public Builder setKnownRegistryCredentials(
-        @Nullable RegistryCredentials knownRegistryCrendentials) {
-      this.knownRegistryCredentials = knownRegistryCrendentials;
+        @Nullable RegistryCredentials knownRegistryCredentials) {
+      this.knownRegistryCredentials = knownRegistryCredentials;
       return this;
     }
 
@@ -73,23 +62,27 @@ public class ImageConfiguration {
       return new ImageConfiguration(imageReference, credentialHelper, knownRegistryCredentials);
     }
 
-    private Builder() {}
+    private Builder(ImageReference imageReference) {
+      this.imageReference = imageReference;
+    }
   }
 
-  public static Builder builder() {
-    return new Builder();
+  /**
+   * Constructs a builder for an {@link ImageConfiguration}.
+   *
+   * @param imageReference the image reference, which is a required field
+   * @return the builder
+   */
+  public static Builder builder(ImageReference imageReference) {
+    return new Builder(imageReference);
   }
 
-  @Nullable private final ImageReference image;
+  private final ImageReference image;
   @Nullable private final String credentialHelper;
   @Nullable private final RegistryCredentials knownRegistryCredentials;
 
-  ImageConfiguration() {
-    this(null, null, null);
-  }
-
   private ImageConfiguration(
-      @Nullable ImageReference image,
+      ImageReference image,
       @Nullable String credentialHelper,
       @Nullable RegistryCredentials knownRegistryCredentials) {
     this.image = image;
@@ -97,7 +90,6 @@ public class ImageConfiguration {
     this.knownRegistryCredentials = knownRegistryCredentials;
   }
 
-  @Nullable
   ImageReference getImage() {
     return image;
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
@@ -90,17 +90,17 @@ public class ImageConfiguration {
     this.knownRegistryCredentials = knownRegistryCredentials;
   }
 
-  ImageReference getImage() {
+  public ImageReference getImage() {
     return image;
   }
 
   @Nullable
-  String getCredentialHelper() {
+  public String getCredentialHelper() {
     return credentialHelper;
   }
 
   @Nullable
-  RegistryCredentials getKnownRegistryCredentials() {
+  public RegistryCredentials getKnownRegistryCredentials() {
     return knownRegistryCredentials;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2018 Google LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.configuration;
+
+import com.google.cloud.tools.jib.image.ImageReference;
+import com.google.cloud.tools.jib.registry.credentials.RegistryCredentials;
+import javax.annotation.Nullable;
+
+/** Immutable configuration options for an image reference with credentials. */
+public class ImageConfiguration {
+
+  /** Builder for instantiating an {@link ImageConfiguration}. */
+  public static class Builder {
+
+    @Nullable private ImageReference imageReference;
+    @Nullable private String credentialHelper;
+    @Nullable private RegistryCredentials knownRegistryCredentials;
+
+    /**
+     * Sets the image reference.
+     *
+     * @param imageReference the image reference containing the registry, repository, and tag.
+     * @return this
+     */
+    public Builder setImage(@Nullable ImageReference imageReference) {
+      this.imageReference = imageReference;
+      return this;
+    }
+
+    /**
+     * Sets the credential helper name used for authenticating with the image's registry.
+     *
+     * @param credentialHelper the credential helper's suffix.
+     * @return this
+     */
+    public Builder setCredentialHelper(@Nullable String credentialHelper) {
+      this.credentialHelper = credentialHelper;
+      return this;
+    }
+
+    /**
+     * Sets known credentials used for authenticating with the image's registry.
+     *
+     * @param knownRegistryCrendentials the credentials.
+     * @return this
+     */
+    public Builder setKnownRegistryCredentials(
+        @Nullable RegistryCredentials knownRegistryCrendentials) {
+      this.knownRegistryCredentials = knownRegistryCrendentials;
+      return this;
+    }
+
+    /**
+     * Builds the {@link ImageConfiguration}.
+     *
+     * @return the corresponding {@link ImageConfiguration}
+     */
+    public ImageConfiguration build() {
+      return new ImageConfiguration(imageReference, credentialHelper, knownRegistryCredentials);
+    }
+
+    private Builder() {}
+  }
+
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  @Nullable private final ImageReference image;
+  @Nullable private final String credentialHelper;
+  @Nullable private final RegistryCredentials knownRegistryCredentials;
+
+  ImageConfiguration() {
+    this(null, null, null);
+  }
+
+  private ImageConfiguration(
+      @Nullable ImageReference image,
+      @Nullable String credentialHelper,
+      @Nullable RegistryCredentials knownRegistryCredentials) {
+    this.image = image;
+    this.credentialHelper = credentialHelper;
+    this.knownRegistryCredentials = knownRegistryCredentials;
+  }
+
+  @Nullable
+  ImageReference getImage() {
+    return image;
+  }
+
+  @Nullable
+  String getCredentialHelper() {
+    return credentialHelper;
+  }
+
+  @Nullable
+  RegistryCredentials getKnownRegistryCredentials() {
+    return knownRegistryCredentials;
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
@@ -68,7 +68,7 @@ public class BuildImageStepTest {
     Mockito.when(mockBuildConfiguration.getBuildLogger()).thenReturn(mockBuildLogger);
     Mockito.when(mockBuildConfiguration.getCreationTime()).thenReturn(Instant.EPOCH);
     Mockito.when(mockBuildConfiguration.getEnvironment()).thenReturn(ImmutableMap.of());
-    Mockito.when(mockBuildConfiguration.getJavaArguments()).thenReturn(ImmutableList.of());
+    Mockito.when(mockBuildConfiguration.getMainArguments()).thenReturn(ImmutableList.of());
     Mockito.when(mockBuildConfiguration.getExposedPorts()).thenReturn(ImmutableList.of());
     Mockito.when(mockBuildConfiguration.getEntrypoint()).thenReturn(ImmutableList.of());
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.builder.BuildLogger;
 import com.google.cloud.tools.jib.cache.CachedLayer;
 import com.google.cloud.tools.jib.cache.CachedLayerWithMetadata;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
+import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.Layer;
@@ -46,6 +47,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class BuildImageStepTest {
 
   @Mock private BuildConfiguration mockBuildConfiguration;
+  @Mock private ContainerConfiguration mockContainerConfiguration;
   @Mock private BuildLogger mockBuildLogger;
   @Mock private PullBaseImageStep mockPullBaseImageStep;
   @Mock private PullAndCacheBaseImageLayersStep mockPullAndCacheBaseImageLayersStep;
@@ -66,11 +68,13 @@ public class BuildImageStepTest {
             null);
 
     Mockito.when(mockBuildConfiguration.getBuildLogger()).thenReturn(mockBuildLogger);
-    Mockito.when(mockBuildConfiguration.getCreationTime()).thenReturn(Instant.EPOCH);
-    Mockito.when(mockBuildConfiguration.getEnvironment()).thenReturn(ImmutableMap.of());
-    Mockito.when(mockBuildConfiguration.getProgramArguments()).thenReturn(ImmutableList.of());
-    Mockito.when(mockBuildConfiguration.getExposedPorts()).thenReturn(ImmutableList.of());
-    Mockito.when(mockBuildConfiguration.getEntrypoint()).thenReturn(ImmutableList.of());
+    Mockito.when(mockBuildConfiguration.getContainerConfiguration())
+        .thenReturn(mockContainerConfiguration);
+    Mockito.when(mockContainerConfiguration.getCreationTime()).thenReturn(Instant.EPOCH);
+    Mockito.when(mockContainerConfiguration.getEnvironmentMap()).thenReturn(ImmutableMap.of());
+    Mockito.when(mockContainerConfiguration.getProgramArguments()).thenReturn(ImmutableList.of());
+    Mockito.when(mockContainerConfiguration.getExposedPorts()).thenReturn(ImmutableList.of());
+    Mockito.when(mockContainerConfiguration.getEntrypoint()).thenReturn(ImmutableList.of());
 
     Image<Layer> baseImage =
         Image.builder().addEnvironment(ImmutableMap.of("NAME", "VALUE")).build();
@@ -111,7 +115,7 @@ public class BuildImageStepTest {
   @Test
   public void test_propagateBaseImageConfiguration()
       throws ExecutionException, InterruptedException {
-    Mockito.when(mockBuildConfiguration.getEnvironment())
+    Mockito.when(mockContainerConfiguration.getEnvironmentMap())
         .thenReturn(ImmutableMap.of("BASE", "IMAGE"));
     BuildImageStep buildImageStep =
         new BuildImageStep(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
@@ -68,7 +68,7 @@ public class BuildImageStepTest {
     Mockito.when(mockBuildConfiguration.getBuildLogger()).thenReturn(mockBuildLogger);
     Mockito.when(mockBuildConfiguration.getCreationTime()).thenReturn(Instant.EPOCH);
     Mockito.when(mockBuildConfiguration.getEnvironment()).thenReturn(ImmutableMap.of());
-    Mockito.when(mockBuildConfiguration.getMainArguments()).thenReturn(ImmutableList.of());
+    Mockito.when(mockBuildConfiguration.getProgramArguments()).thenReturn(ImmutableList.of());
     Mockito.when(mockBuildConfiguration.getExposedPorts()).thenReturn(ImmutableList.of());
     Mockito.when(mockBuildConfiguration.getEntrypoint()).thenReturn(ImmutableList.of());
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
@@ -118,7 +118,7 @@ public class BuildConfigurationTest {
     Assert.assertEquals(
         expectedTargetImageCredentialHelperName,
         buildConfiguration.getTargetImageCredentialHelperName());
-    Assert.assertEquals(expectedJavaArguments, buildConfiguration.getMainArguments());
+    Assert.assertEquals(expectedJavaArguments, buildConfiguration.getProgramArguments());
     Assert.assertEquals(expectedEnvironment, buildConfiguration.getEnvironment());
     Assert.assertEquals(expectedExposedPorts, buildConfiguration.getExposedPorts());
     Assert.assertEquals(expectedTargetFormat, buildConfiguration.getTargetFormat());
@@ -166,7 +166,7 @@ public class BuildConfigurationTest {
     Assert.assertNull(buildConfiguration.getKnownBaseRegistryCredentials());
     Assert.assertNull(buildConfiguration.getTargetImageCredentialHelperName());
     Assert.assertNull(buildConfiguration.getKnownTargetRegistryCredentials());
-    Assert.assertNull(buildConfiguration.getMainArguments());
+    Assert.assertNull(buildConfiguration.getProgramArguments());
     Assert.assertNull(buildConfiguration.getEnvironment());
     Assert.assertNull(buildConfiguration.getExposedPorts());
     Assert.assertEquals(V22ManifestTemplate.class, buildConfiguration.getTargetFormat());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
@@ -70,16 +70,14 @@ public class BuildConfigurationTest {
             LayerConfiguration.builder().addEntry(Collections.emptyList(), "destination").build());
 
     ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder()
-            .setImage(
+        ImageConfiguration.builder(
                 ImageReference.of(
                     expectedBaseImageServerUrl, expectedBaseImageName, expectedBaseImageTag))
             .setCredentialHelper(expectedBaseImageCredentialHelperName)
             .setKnownRegistryCredentials(expectedKnownBaseRegistryCredentials)
             .build();
     ImageConfiguration targetImageConfiguration =
-        ImageConfiguration.builder()
-            .setImage(
+        ImageConfiguration.builder(
                 ImageReference.of(
                     expectedTargetServerUrl, expectedTargetImageName, expectedTargetTag))
             .setCredentialHelper(expectedTargetImageCredentialHelperName)
@@ -144,14 +142,12 @@ public class BuildConfigurationTest {
     String expectedTargetTag = "targettag";
 
     ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder()
-            .setImage(
+        ImageConfiguration.builder(
                 ImageReference.of(
                     expectedBaseImageServerUrl, expectedBaseImageName, expectedBaseImageTag))
             .build();
     ImageConfiguration targetImageConfiguration =
-        ImageConfiguration.builder()
-            .setImage(
+        ImageConfiguration.builder(
                 ImageReference.of(
                     expectedTargetServerUrl, expectedTargetImageName, expectedTargetTag))
             .build();
@@ -183,12 +179,12 @@ public class BuildConfigurationTest {
     try {
       BuildConfiguration.builder(Mockito.mock(BuildLogger.class))
           .setBaseImageConfiguration(
-              ImageConfiguration.builder().setImage(Mockito.mock(ImageReference.class)).build())
+              ImageConfiguration.builder(Mockito.mock(ImageReference.class)).build())
           .build();
       Assert.fail("Build configuration should not be built with missing values");
 
     } catch (IllegalStateException ex) {
-      Assert.assertEquals("target image is required but not set", ex.getMessage());
+      Assert.assertEquals("target image configuration is required but not set", ex.getMessage());
     }
 
     // All required fields missing
@@ -198,7 +194,7 @@ public class BuildConfigurationTest {
 
     } catch (IllegalStateException ex) {
       Assert.assertEquals(
-          "base image is required but not set and target image is required but not set",
+          "base image configuration is required but not set and target image configuration is required but not set",
           ex.getMessage());
     }
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
@@ -90,7 +90,6 @@ public class BuildConfigurationTest {
             .setProgramArguments(expectedJavaArguments)
             .setEnvironment(expectedEnvironment)
             .setExposedPorts(expectedExposedPorts)
-            .setTargetFormat(OCIManifestTemplate.class)
             .build();
     BuildConfiguration.Builder buildConfigurationBuilder =
         BuildConfiguration.builder(Mockito.mock(BuildLogger.class))
@@ -99,11 +98,14 @@ public class BuildConfigurationTest {
             .setContainerConfiguration(containerConfiguration)
             .setApplicationLayersCacheConfiguration(expectedApplicationLayersCacheConfiguration)
             .setBaseImageLayersCacheConfiguration(expectedBaseImageLayersCacheConfiguration)
+            .setTargetFormat(OCIManifestTemplate.class)
             .setAllowInsecureRegistries(true)
             .setLayerConfigurations(expectedLayerConfigurations);
     BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();
 
-    Assert.assertEquals(expectedCreationTime, buildConfiguration.getCreationTime());
+    Assert.assertNotNull(buildConfiguration.getContainerConfiguration());
+    Assert.assertEquals(
+        expectedCreationTime, buildConfiguration.getContainerConfiguration().getCreationTime());
     Assert.assertEquals(expectedBaseImageServerUrl, buildConfiguration.getBaseImageRegistry());
     Assert.assertEquals(expectedBaseImageName, buildConfiguration.getBaseImageRepository());
     Assert.assertEquals(expectedBaseImageTag, buildConfiguration.getBaseImageTag());
@@ -116,9 +118,13 @@ public class BuildConfigurationTest {
     Assert.assertEquals(
         expectedTargetImageCredentialHelperName,
         buildConfiguration.getTargetImageCredentialHelperName());
-    Assert.assertEquals(expectedJavaArguments, buildConfiguration.getProgramArguments());
-    Assert.assertEquals(expectedEnvironment, buildConfiguration.getEnvironment());
-    Assert.assertEquals(expectedExposedPorts, buildConfiguration.getExposedPorts());
+    Assert.assertEquals(
+        expectedJavaArguments,
+        buildConfiguration.getContainerConfiguration().getProgramArguments());
+    Assert.assertEquals(
+        expectedEnvironment, buildConfiguration.getContainerConfiguration().getEnvironmentMap());
+    Assert.assertEquals(
+        expectedExposedPorts, buildConfiguration.getContainerConfiguration().getExposedPorts());
     Assert.assertEquals(expectedTargetFormat, buildConfiguration.getTargetFormat());
     Assert.assertEquals(
         expectedApplicationLayersCacheConfiguration,
@@ -128,7 +134,8 @@ public class BuildConfigurationTest {
         buildConfiguration.getBaseImageLayersCacheConfiguration());
     Assert.assertTrue(buildConfiguration.getAllowInsecureRegistries());
     Assert.assertEquals(expectedLayerConfigurations, buildConfiguration.getLayerConfigurations());
-    Assert.assertEquals(expectedEntrypoint, buildConfiguration.getEntrypoint());
+    Assert.assertEquals(
+        expectedEntrypoint, buildConfiguration.getContainerConfiguration().getEntrypoint());
   }
 
   @Test
@@ -157,20 +164,17 @@ public class BuildConfigurationTest {
             .setTargetImageConfiguration(targetImageConfiguration)
             .build();
 
-    Assert.assertEquals(buildConfiguration.getCreationTime(), Instant.EPOCH);
     Assert.assertNull(buildConfiguration.getBaseImageCredentialHelperName());
     Assert.assertNull(buildConfiguration.getKnownBaseRegistryCredentials());
     Assert.assertNull(buildConfiguration.getTargetImageCredentialHelperName());
     Assert.assertNull(buildConfiguration.getKnownTargetRegistryCredentials());
-    Assert.assertNull(buildConfiguration.getProgramArguments());
-    Assert.assertNull(buildConfiguration.getEnvironment());
-    Assert.assertNull(buildConfiguration.getExposedPorts());
     Assert.assertEquals(V22ManifestTemplate.class, buildConfiguration.getTargetFormat());
     Assert.assertNull(buildConfiguration.getApplicationLayersCacheConfiguration());
     Assert.assertNull(buildConfiguration.getBaseImageLayersCacheConfiguration());
+    Assert.assertNull(buildConfiguration.getContainerConfiguration());
+    Assert.assertEquals(buildConfiguration.getTargetFormat(), V22ManifestTemplate.class);
     Assert.assertFalse(buildConfiguration.getAllowInsecureRegistries());
     Assert.assertEquals(Collections.emptyList(), buildConfiguration.getLayerConfigurations());
-    Assert.assertNull(buildConfiguration.getEntrypoint());
   }
 
   @Test

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -108,14 +108,12 @@ public class BuildDockerTask extends DefaultTask {
     // Builds the BuildConfiguration.
     // TODO: Consolidate with BuildImageTask.
     ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder()
-            .setImage(ImageReference.parse(jibExtension.getBaseImage()))
+        ImageConfiguration.builder(ImageReference.parse(jibExtension.getBaseImage()))
             .setCredentialHelper(jibExtension.getFrom().getCredHelper())
             .setKnownRegistryCredentials(knownBaseRegistryCredentials)
             .build();
 
-    ImageConfiguration targetImageConfiguration =
-        ImageConfiguration.builder().setImage(targetImage).build();
+    ImageConfiguration targetImageConfiguration = ImageConfiguration.builder(targetImage).build();
 
     ContainerConfiguration.Builder containerConfigurationBuilder =
         ContainerConfiguration.builder()

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -19,6 +19,8 @@ package com.google.cloud.tools.jib.gradle;
 import com.google.cloud.tools.jib.cache.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.configuration.CacheConfiguration;
+import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.docker.DockerClient;
 import com.google.cloud.tools.jib.frontend.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.frontend.BuildStepsRunner;
@@ -105,19 +107,36 @@ public class BuildDockerTask extends DefaultTask {
 
     // Builds the BuildConfiguration.
     // TODO: Consolidate with BuildImageTask.
-    BuildConfiguration.Builder buildConfigurationBuilder =
-        BuildConfiguration.builder(gradleBuildLogger)
-            .setBaseImage(ImageReference.parse(jibExtension.getBaseImage()))
-            .setTargetImage(targetImage)
-            .setBaseImageCredentialHelperName(jibExtension.getFrom().getCredHelper())
-            .setKnownBaseRegistryCredentials(knownBaseRegistryCredentials)
-            .setJavaArguments(jibExtension.getArgs())
-            .setExposedPorts(ExposedPortsParser.parse(jibExtension.getExposedPorts()))
-            .setAllowInsecureRegistries(jibExtension.getAllowInsecureRegistries())
-            .setLayerConfigurations(gradleProjectProperties.getLayerConfigurations())
+    ImageConfiguration baseImageConfiguration =
+        ImageConfiguration.builder()
+            .setImage(ImageReference.parse(jibExtension.getBaseImage()))
+            .setCredentialHelper(jibExtension.getFrom().getCredHelper())
+            .setKnownRegistryCredentials(knownBaseRegistryCredentials)
+            .build();
+
+    ImageConfiguration targetImageConfiguration =
+        ImageConfiguration.builder().setImage(targetImage).build();
+
+    ContainerConfiguration.Builder containerConfigurationBuilder =
+        ContainerConfiguration.builder()
             .setEntrypoint(
                 JavaEntrypointConstructor.makeDefaultEntrypoint(
-                    jibExtension.getJvmFlags(), mainClass));
+                    jibExtension.getJvmFlags(), mainClass))
+            .setProgramArguments(jibExtension.getArgs())
+            .setExposedPorts(ExposedPortsParser.parse(jibExtension.getExposedPorts()));
+    if (jibExtension.getUseCurrentTimestamp()) {
+      gradleBuildLogger.warn(
+          "Setting image creation time to current time; your image may not be reproducible.");
+      containerConfigurationBuilder.setCreationTime(Instant.now());
+    }
+
+    BuildConfiguration.Builder buildConfigurationBuilder =
+        BuildConfiguration.builder(gradleBuildLogger)
+            .setBaseImageConfiguration(baseImageConfiguration)
+            .setTargetImageConfiguration(targetImageConfiguration)
+            .setContainerConfiguration(containerConfigurationBuilder.build())
+            .setAllowInsecureRegistries(jibExtension.getAllowInsecureRegistries())
+            .setLayerConfigurations(gradleProjectProperties.getLayerConfigurations());
     CacheConfiguration applicationLayersCacheConfiguration =
         CacheConfiguration.forPath(gradleProjectProperties.getCacheDirectory());
     buildConfigurationBuilder.setApplicationLayersCacheConfiguration(
@@ -125,11 +144,6 @@ public class BuildDockerTask extends DefaultTask {
     if (jibExtension.getUseOnlyProjectCache()) {
       buildConfigurationBuilder.setBaseImageLayersCacheConfiguration(
           applicationLayersCacheConfiguration);
-    }
-    if (jibExtension.getUseCurrentTimestamp()) {
-      gradleBuildLogger.warn(
-          "Setting image creation time to current time; your image may not be reproducible.");
-      buildConfigurationBuilder.setCreationTime(Instant.now());
     }
 
     BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -130,8 +130,7 @@ public class BuildImageTask extends DefaultTask {
                 JavaEntrypointConstructor.makeDefaultEntrypoint(
                     jibExtension.getJvmFlags(), mainClass))
             .setProgramArguments(jibExtension.getArgs())
-            .setExposedPorts(ExposedPortsParser.parse(jibExtension.getExposedPorts()))
-            .setTargetFormat(jibExtension.getFormat());
+            .setExposedPorts(ExposedPortsParser.parse(jibExtension.getExposedPorts()));
     if (jibExtension.getUseCurrentTimestamp()) {
       gradleBuildLogger.warn(
           "Setting image creation time to current time; your image may not be reproducible.");
@@ -143,6 +142,7 @@ public class BuildImageTask extends DefaultTask {
             .setBaseImageConfiguration(baseImageConfiguration)
             .setTargetImageConfiguration(targetImageConfiguration)
             .setContainerConfiguration(containerConfigurationBuilder.build())
+            .setTargetFormat(jibExtension.getFormat())
             .setAllowInsecureRegistries(jibExtension.getAllowInsecureRegistries())
             .setLayerConfigurations(gradleProjectProperties.getLayerConfigurations());
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -113,15 +113,13 @@ public class BuildImageTask extends DefaultTask {
 
     // Builds the BuildConfiguration.
     ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder()
-            .setImage(ImageReference.parse(jibExtension.getBaseImage()))
+        ImageConfiguration.builder(ImageReference.parse(jibExtension.getBaseImage()))
             .setCredentialHelper(jibExtension.getFrom().getCredHelper())
             .setKnownRegistryCredentials(knownBaseRegistryCredentials)
             .build();
 
     ImageConfiguration targetImageConfiguration =
-        ImageConfiguration.builder()
-            .setImage(ImageReference.parse(jibExtension.getTargetImage()))
+        ImageConfiguration.builder(ImageReference.parse(jibExtension.getTargetImage()))
             .setCredentialHelper(jibExtension.getTo().getCredHelper())
             .setKnownRegistryCredentials(knownTargetRegistryCredentials)
             .build();

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -136,14 +136,12 @@ public class BuildTarTask extends DefaultTask {
     // Builds the BuildConfiguration.
     // TODO: Consolidate with BuildImageTask/BuildDockerTask.
     ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder()
-            .setImage(ImageReference.parse(jibExtension.getBaseImage()))
+        ImageConfiguration.builder(ImageReference.parse(jibExtension.getBaseImage()))
             .setCredentialHelper(jibExtension.getFrom().getCredHelper())
             .setKnownRegistryCredentials(knownBaseRegistryCredentials)
             .build();
 
-    ImageConfiguration targetImageConfiguration =
-        ImageConfiguration.builder().setImage(targetImage).build();
+    ImageConfiguration targetImageConfiguration = ImageConfiguration.builder(targetImage).build();
 
     ContainerConfiguration.Builder containerConfigurationBuilder =
         ContainerConfiguration.builder()

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -19,6 +19,8 @@ package com.google.cloud.tools.jib.gradle;
 import com.google.cloud.tools.jib.cache.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.configuration.CacheConfiguration;
+import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.frontend.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.frontend.BuildStepsRunner;
 import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
@@ -133,19 +135,36 @@ public class BuildTarTask extends DefaultTask {
 
     // Builds the BuildConfiguration.
     // TODO: Consolidate with BuildImageTask/BuildDockerTask.
-    BuildConfiguration.Builder buildConfigurationBuilder =
-        BuildConfiguration.builder(gradleBuildLogger)
-            .setBaseImage(ImageReference.parse(jibExtension.getBaseImage()))
-            .setTargetImage(targetImage)
-            .setBaseImageCredentialHelperName(jibExtension.getFrom().getCredHelper())
-            .setKnownBaseRegistryCredentials(knownBaseRegistryCredentials)
-            .setJavaArguments(jibExtension.getArgs())
-            .setExposedPorts(ExposedPortsParser.parse(jibExtension.getExposedPorts()))
-            .setAllowInsecureRegistries(jibExtension.getAllowInsecureRegistries())
-            .setLayerConfigurations(gradleProjectProperties.getLayerConfigurations())
+    ImageConfiguration baseImageConfiguration =
+        ImageConfiguration.builder()
+            .setImage(ImageReference.parse(jibExtension.getBaseImage()))
+            .setCredentialHelper(jibExtension.getFrom().getCredHelper())
+            .setKnownRegistryCredentials(knownBaseRegistryCredentials)
+            .build();
+
+    ImageConfiguration targetImageConfiguration =
+        ImageConfiguration.builder().setImage(targetImage).build();
+
+    ContainerConfiguration.Builder containerConfigurationBuilder =
+        ContainerConfiguration.builder()
             .setEntrypoint(
                 JavaEntrypointConstructor.makeDefaultEntrypoint(
-                    jibExtension.getJvmFlags(), mainClass));
+                    jibExtension.getJvmFlags(), mainClass))
+            .setProgramArguments(jibExtension.getArgs())
+            .setExposedPorts(ExposedPortsParser.parse(jibExtension.getExposedPorts()));
+    if (jibExtension.getUseCurrentTimestamp()) {
+      gradleBuildLogger.warn(
+          "Setting image creation time to current time; your image may not be reproducible.");
+      containerConfigurationBuilder.setCreationTime(Instant.now());
+    }
+
+    BuildConfiguration.Builder buildConfigurationBuilder =
+        BuildConfiguration.builder(gradleBuildLogger)
+            .setBaseImageConfiguration(baseImageConfiguration)
+            .setTargetImageConfiguration(targetImageConfiguration)
+            .setContainerConfiguration(containerConfigurationBuilder.build())
+            .setAllowInsecureRegistries(jibExtension.getAllowInsecureRegistries())
+            .setLayerConfigurations(gradleProjectProperties.getLayerConfigurations());
     CacheConfiguration applicationLayersCacheConfiguration =
         CacheConfiguration.forPath(gradleProjectProperties.getCacheDirectory());
     buildConfigurationBuilder.setApplicationLayersCacheConfiguration(
@@ -153,11 +172,6 @@ public class BuildTarTask extends DefaultTask {
     if (jibExtension.getUseOnlyProjectCache()) {
       buildConfigurationBuilder.setBaseImageLayersCacheConfiguration(
           applicationLayersCacheConfiguration);
-    }
-    if (jibExtension.getUseCurrentTimestamp()) {
-      gradleBuildLogger.warn(
-          "Setting image creation time to current time; your image may not be reproducible.");
-      buildConfigurationBuilder.setCreationTime(Instant.now());
     }
 
     BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ImageParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ImageParameters.java
@@ -34,7 +34,7 @@ import org.gradle.api.tasks.Optional;
  * <p>{@code image} (required) is the image reference and {@code credHelper} (optional) is the name
  * (after {@code docker-credential} of the credential helper for accessing the {@code image}.
  */
-public class ImageConfiguration {
+public class ImageParameters {
 
   private AuthConfiguration auth;
 
@@ -42,7 +42,7 @@ public class ImageConfiguration {
   @Nullable private String credHelper;
 
   @Inject
-  public ImageConfiguration(ObjectFactory objectFactory) {
+  public ImageParameters(ObjectFactory objectFactory) {
     auth = objectFactory.newInstance(AuthConfiguration.class);
   }
 
@@ -78,7 +78,7 @@ public class ImageConfiguration {
     action.execute(auth);
   }
 
-  /** Converts the {@link ImageConfiguration} to an {@link Authorization}. */
+  /** Converts the {@link ImageParameters} to an {@link Authorization}. */
   @Internal
   @Nullable
   Authorization getImageAuthorization() {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -72,8 +72,8 @@ public class JibExtension {
     return projectDirectory.resolve("src").resolve("main").resolve("jib");
   }
 
-  private final ImageConfiguration from;
-  private final ImageConfiguration to;
+  private final ImageParameters from;
+  private final ImageParameters to;
   private final ContainerParameters container;
   private final Property<Boolean> useOnlyProjectCache;
   private final Property<Boolean> allowInsecureRegistries;
@@ -91,8 +91,8 @@ public class JibExtension {
     projectDir = project.getProjectDir().toPath();
     ObjectFactory objectFactory = project.getObjects();
 
-    from = objectFactory.newInstance(ImageConfiguration.class);
-    to = objectFactory.newInstance(ImageConfiguration.class);
+    from = objectFactory.newInstance(ImageParameters.class);
+    to = objectFactory.newInstance(ImageParameters.class);
     container = objectFactory.newInstance(ContainerParameters.class);
 
     jvmFlags = objectFactory.listProperty(String.class);
@@ -152,11 +152,11 @@ public class JibExtension {
     }
   }
 
-  public void from(Action<? super ImageConfiguration> action) {
+  public void from(Action<? super ImageParameters> action) {
     action.execute(from);
   }
 
-  public void to(Action<? super ImageConfiguration> action) {
+  public void to(Action<? super ImageParameters> action) {
     action.execute(to);
   }
 
@@ -205,13 +205,13 @@ public class JibExtension {
 
   @Nested
   @Optional
-  public ImageConfiguration getFrom() {
+  public ImageParameters getFrom() {
     return from;
   }
 
   @Nested
   @Optional
-  public ImageConfiguration getTo() {
+  public ImageParameters getTo() {
     return to;
   }
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -19,6 +19,8 @@ package com.google.cloud.tools.jib.maven;
 import com.google.cloud.tools.jib.cache.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.configuration.CacheConfiguration;
+import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.docker.DockerClient;
 import com.google.cloud.tools.jib.frontend.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.frontend.BuildStepsRunner;
@@ -88,19 +90,36 @@ public class BuildDockerMojo extends JibPluginConfiguration {
 
     // Builds the BuildConfiguration.
     // TODO: Consolidate with BuildImageMojo.
+    ImageConfiguration baseImageConfiguration =
+        ImageConfiguration.builder()
+            .setImage(baseImage)
+            .setCredentialHelper(getBaseImageCredentialHelperName())
+            .setKnownRegistryCredentials(knownBaseRegistryCredentials)
+            .build();
+
+    ImageConfiguration targetImageConfiguration =
+        ImageConfiguration.builder().setImage(targetImage).build();
+
+    ContainerConfiguration.Builder containerConfigurationBuilder =
+        ContainerConfiguration.builder()
+            .setEntrypoint(
+                JavaEntrypointConstructor.makeDefaultEntrypoint(getJvmFlags(), mainClass))
+            .setProgramArguments(getArgs())
+            .setEnvironment(getEnvironment())
+            .setExposedPorts(ExposedPortsParser.parse(getExposedPorts()));
+    if (getUseCurrentTimestamp()) {
+      mavenBuildLogger.warn(
+          "Setting image creation time to current time; your image may not be reproducible.");
+      containerConfigurationBuilder.setCreationTime(Instant.now());
+    }
+
     BuildConfiguration.Builder buildConfigurationBuilder =
         BuildConfiguration.builder(mavenBuildLogger)
-            .setBaseImage(baseImage)
-            .setBaseImageCredentialHelperName(getBaseImageCredentialHelperName())
-            .setKnownBaseRegistryCredentials(knownBaseRegistryCredentials)
-            .setTargetImage(targetImage)
-            .setJavaArguments(getArgs())
-            .setEnvironment(getEnvironment())
-            .setExposedPorts(ExposedPortsParser.parse(getExposedPorts()))
+            .setBaseImageConfiguration(baseImageConfiguration)
+            .setTargetImageConfiguration(targetImageConfiguration)
+            .setContainerConfiguration(containerConfigurationBuilder.build())
             .setAllowInsecureRegistries(getAllowInsecureRegistries())
-            .setLayerConfigurations(mavenProjectProperties.getLayerConfigurations())
-            .setEntrypoint(
-                JavaEntrypointConstructor.makeDefaultEntrypoint(getJvmFlags(), mainClass));
+            .setLayerConfigurations(mavenProjectProperties.getLayerConfigurations());
     CacheConfiguration applicationLayersCacheConfiguration =
         CacheConfiguration.forPath(mavenProjectProperties.getCacheDirectory());
     buildConfigurationBuilder.setApplicationLayersCacheConfiguration(
@@ -108,11 +127,6 @@ public class BuildDockerMojo extends JibPluginConfiguration {
     if (getUseOnlyProjectCache()) {
       buildConfigurationBuilder.setBaseImageLayersCacheConfiguration(
           applicationLayersCacheConfiguration);
-    }
-    if (getUseCurrentTimestamp()) {
-      mavenBuildLogger.warn(
-          "Setting image creation time to current time; your image may not be reproducible.");
-      buildConfigurationBuilder.setCreationTime(Instant.now());
     }
 
     BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -91,14 +91,12 @@ public class BuildDockerMojo extends JibPluginConfiguration {
     // Builds the BuildConfiguration.
     // TODO: Consolidate with BuildImageMojo.
     ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder()
-            .setImage(baseImage)
+        ImageConfiguration.builder(baseImage)
             .setCredentialHelper(getBaseImageCredentialHelperName())
             .setKnownRegistryCredentials(knownBaseRegistryCredentials)
             .build();
 
-    ImageConfiguration targetImageConfiguration =
-        ImageConfiguration.builder().setImage(targetImage).build();
+    ImageConfiguration targetImageConfiguration = ImageConfiguration.builder(targetImage).build();
 
     ContainerConfiguration.Builder containerConfigurationBuilder =
         ContainerConfiguration.builder()

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -131,8 +131,7 @@ public class BuildImageMojo extends JibPluginConfiguration {
                 JavaEntrypointConstructor.makeDefaultEntrypoint(getJvmFlags(), mainClass))
             .setProgramArguments(getArgs())
             .setEnvironment(getEnvironment())
-            .setExposedPorts(ExposedPortsParser.parse(getExposedPorts()))
-            .setTargetFormat(ImageFormat.valueOf(getFormat()).getManifestTemplateClass());
+            .setExposedPorts(ExposedPortsParser.parse(getExposedPorts()));
     if (getUseCurrentTimestamp()) {
       mavenBuildLogger.warn(
           "Setting image creation time to current time; your image may not be reproducible.");
@@ -144,6 +143,7 @@ public class BuildImageMojo extends JibPluginConfiguration {
             .setBaseImageConfiguration(baseImageConfiguration)
             .setTargetImageConfiguration(targetImageConfiguration)
             .setContainerConfiguration(containerConfigurationBuilder.build())
+            .setTargetFormat(ImageFormat.valueOf(getFormat()).getManifestTemplateClass())
             .setAllowInsecureRegistries(getAllowInsecureRegistries())
             .setLayerConfigurations(mavenProjectProperties.getLayerConfigurations());
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -114,15 +114,13 @@ public class BuildImageMojo extends JibPluginConfiguration {
 
     // Builds the BuildConfiguration.
     ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder()
-            .setImage(baseImage)
+        ImageConfiguration.builder(baseImage)
             .setCredentialHelper(getBaseImageCredentialHelperName())
             .setKnownRegistryCredentials(knownBaseRegistryCredentials)
             .build();
 
     ImageConfiguration targetImageConfiguration =
-        ImageConfiguration.builder()
-            .setImage(targetImage)
+        ImageConfiguration.builder(targetImage)
             .setCredentialHelper(getTargetImageCredentialHelperName())
             .setKnownRegistryCredentials(knownTargetRegistryCredentials)
             .build();

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -89,14 +89,12 @@ public class BuildTarMojo extends JibPluginConfiguration {
     // Builds the BuildConfiguration.
     // TODO: Consolidate with BuildImageMojo.
     ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder()
-            .setImage(baseImage)
+        ImageConfiguration.builder(baseImage)
             .setCredentialHelper(getBaseImageCredentialHelperName())
             .setKnownRegistryCredentials(knownBaseRegistryCredentials)
             .build();
 
-    ImageConfiguration targetImageConfiguration =
-        ImageConfiguration.builder().setImage(targetImage).build();
+    ImageConfiguration targetImageConfiguration = ImageConfiguration.builder(targetImage).build();
 
     ContainerConfiguration.Builder containerConfigurationBuilder =
         ContainerConfiguration.builder()

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -19,6 +19,8 @@ package com.google.cloud.tools.jib.maven;
 import com.google.cloud.tools.jib.cache.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.configuration.CacheConfiguration;
+import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.frontend.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.frontend.BuildStepsRunner;
 import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
@@ -86,19 +88,36 @@ public class BuildTarMojo extends JibPluginConfiguration {
 
     // Builds the BuildConfiguration.
     // TODO: Consolidate with BuildImageMojo.
+    ImageConfiguration baseImageConfiguration =
+        ImageConfiguration.builder()
+            .setImage(baseImage)
+            .setCredentialHelper(getBaseImageCredentialHelperName())
+            .setKnownRegistryCredentials(knownBaseRegistryCredentials)
+            .build();
+
+    ImageConfiguration targetImageConfiguration =
+        ImageConfiguration.builder().setImage(targetImage).build();
+
+    ContainerConfiguration.Builder containerConfigurationBuilder =
+        ContainerConfiguration.builder()
+            .setEntrypoint(
+                JavaEntrypointConstructor.makeDefaultEntrypoint(getJvmFlags(), mainClass))
+            .setProgramArguments(getArgs())
+            .setEnvironment(getEnvironment())
+            .setExposedPorts(ExposedPortsParser.parse(getExposedPorts()));
+    if (getUseCurrentTimestamp()) {
+      mavenBuildLogger.warn(
+          "Setting image creation time to current time; your image may not be reproducible.");
+      containerConfigurationBuilder.setCreationTime(Instant.now());
+    }
+
     BuildConfiguration.Builder buildConfigurationBuilder =
         BuildConfiguration.builder(mavenBuildLogger)
-            .setBaseImage(baseImage)
-            .setBaseImageCredentialHelperName(getBaseImageCredentialHelperName())
-            .setKnownBaseRegistryCredentials(knownBaseRegistryCredentials)
-            .setTargetImage(targetImage)
-            .setJavaArguments(getArgs())
-            .setEnvironment(getEnvironment())
-            .setExposedPorts(ExposedPortsParser.parse(getExposedPorts()))
+            .setBaseImageConfiguration(baseImageConfiguration)
+            .setTargetImageConfiguration(targetImageConfiguration)
+            .setContainerConfiguration(containerConfigurationBuilder.build())
             .setAllowInsecureRegistries(getAllowInsecureRegistries())
-            .setLayerConfigurations(mavenProjectProperties.getLayerConfigurations())
-            .setEntrypoint(
-                JavaEntrypointConstructor.makeDefaultEntrypoint(getJvmFlags(), mainClass));
+            .setLayerConfigurations(mavenProjectProperties.getLayerConfigurations());
     CacheConfiguration applicationLayersCacheConfiguration =
         CacheConfiguration.forPath(mavenProjectProperties.getCacheDirectory());
     buildConfigurationBuilder.setApplicationLayersCacheConfiguration(
@@ -106,11 +125,6 @@ public class BuildTarMojo extends JibPluginConfiguration {
     if (getUseOnlyProjectCache()) {
       buildConfigurationBuilder.setBaseImageLayersCacheConfiguration(
           applicationLayersCacheConfiguration);
-    }
-    if (getUseCurrentTimestamp()) {
-      mavenBuildLogger.warn(
-          "Setting image creation time to current time; your image may not be reproducible.");
-      buildConfigurationBuilder.setCreationTime(Instant.now());
     }
 
     BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();


### PR DESCRIPTION
Fixes #684, fixes #709

Breaks `BuildConfiguration` parameters into new `ImageConfiguration` (`from`/`to`) and `ContainerConfiguration` classes.