### PR TITLE
Make allowInsecureRegistries follow Docker semantics

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -30,6 +30,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.security.GeneralSecurityException;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLPeerUnverifiedException;
@@ -50,6 +51,10 @@ class RegistryEndpointCaller<T> {
   @VisibleForTesting static final int STATUS_CODE_PERMANENT_REDIRECT = 308;
 
   private static final String DEFAULT_PROTOCOL = "https";
+
+  private static boolean isHttpsProtocol(URL url) {
+    return "https".equals(url.getProtocol());
+  }
 
   private final URL initialRequestUrl;
   private final String userAgent;
@@ -125,7 +130,39 @@ class RegistryEndpointCaller<T> {
    */
   @Nullable
   T call() throws IOException, RegistryException {
-    return call(initialRequestUrl);
+    return callWithInsecureRegistryHandling(initialRequestUrl);
+  }
+
+  @VisibleForTesting
+  @Nullable
+  T callWithInsecureRegistryHandling(URL url) throws IOException, RegistryException {
+    try {
+      if (!isHttpsProtocol(url) && !allowInsecureRegistries) {
+        throw new InsecureRegistryException(url);
+      }
+      return call(url, connectionFactory);
+
+    } catch (SSLPeerUnverifiedException exception) {
+      // Cannot verify the server (e.g., self-signed certificate or plain HTTP).
+      if (!allowInsecureRegistries) {
+        throw new InsecureRegistryException(url);
+      }
+
+      try {
+        if (insecureConnectionFactory == null) {
+          insecureConnectionFactory = Connection.getInsecureConnectionFactory();
+        }
+        return call(url, insecureConnectionFactory);
+
+      } catch (GeneralSecurityException ex) {
+        throw new RegistryException("cannot turn off TLS peer verification", ex);
+      } catch (SSLPeerUnverifiedException | HttpHostConnectException ex) {
+        // Try HTTP as a last resort.
+        GenericUrl httpUrl = new GenericUrl(url);
+        httpUrl.setScheme("http");
+        return call(httpUrl.toURL(), connectionFactory);
+      }
+    }
   }
 
   /**
@@ -136,15 +173,11 @@ class RegistryEndpointCaller<T> {
    * @throws IOException for most I/O exceptions when making the request
    * @throws RegistryException for known exceptions when interacting with the registry
    */
-  @VisibleForTesting
   @Nullable
-  T call(URL url) throws IOException, RegistryException {
-    boolean isHttpProtocol = "http".equals(url.getProtocol());
-    if (!allowInsecureRegistries && isHttpProtocol) {
-      throw new InsecureRegistryException(url);
-    }
+  private T call(URL url, Function<URL, Connection> connectionFactory)
+      throws IOException, RegistryException {
     // Only sends authorization if using HTTPS or explicitly forcing over HTTP.
-    boolean sendCredentials = !isHttpProtocol || Boolean.getBoolean("sendCredentialsOverHttp");
+    boolean sendCredentials = isHttpsProtocol(url) || Boolean.getBoolean("sendCredentialsOverHttp");
 
     try (Connection connection = connectionFactory.apply(url)) {
       Request.Builder requestBuilder =
@@ -211,25 +244,13 @@ class RegistryEndpointCaller<T> {
             || httpResponseException.getStatusCode() == STATUS_CODE_PERMANENT_REDIRECT) {
           // 'Location' header can be relative or absolute.
           URL redirectLocation = new URL(url, httpResponseException.getHeaders().getLocation());
-          return call(redirectLocation);
+          return callWithInsecureRegistryHandling(redirectLocation);
 
         } else {
           // Unknown
           throw httpResponseException;
         }
       }
-
-    } catch (HttpHostConnectException | SSLPeerUnverifiedException ex) {
-      // Tries to call with HTTP protocol if HTTPS failed to connect.
-      // Note that this will not succeed if 'allowInsecureRegistries' is false.
-      if ("https".equals(url.getProtocol())) {
-        GenericUrl httpUrl = new GenericUrl(url);
-        httpUrl.setScheme("http");
-        return call(httpUrl.toURL());
-      }
-
-      throw ex;
-
     } catch (NoHttpResponseException ex) {
       throw new RegistryNoResponseException(ex);
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -133,9 +133,8 @@ class RegistryEndpointCaller<T> {
     return callWithInsecureRegistryHandling(initialRequestUrl);
   }
 
-  @VisibleForTesting
   @Nullable
-  T callWithInsecureRegistryHandling(URL url) throws IOException, RegistryException {
+  private T callWithInsecureRegistryHandling(URL url) throws IOException, RegistryException {
     try {
       if (!isHttpsProtocol(url) && !allowInsecureRegistries) {
         throw new InsecureRegistryException(url);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -150,13 +150,12 @@ class RegistryEndpointCaller<T> {
       return call(url, connectionFactory);
 
     } catch (SSLPeerUnverifiedException ex) {
-      return handleUnverifiableServerException(url, ex);
+      return handleUnverifiableServerException(url);
     }
   }
 
   @Nullable
-  private T handleUnverifiableServerException(URL url, SSLPeerUnverifiedException exception)
-      throws IOException, RegistryException {
+  private T handleUnverifiableServerException(URL url) throws IOException, RegistryException {
     if (!allowInsecureRegistries) {
       throw new InsecureRegistryException(url);
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -137,7 +137,7 @@ class RegistryEndpointCaller<T> {
   @Nullable
   private T callWithAllowInsecureRegistryHandling(URL url) throws IOException, RegistryException {
     if (allowInsecureRegistries) {
-      return possbilyInsecureCall(url);
+      return possiblyInsecureCall(url);
     }
 
     try {
@@ -151,7 +151,7 @@ class RegistryEndpointCaller<T> {
   }
 
   @Nullable
-  private T possbilyInsecureCall(URL url) throws IOException, RegistryException {
+  private T possiblyInsecureCall(URL url) throws IOException, RegistryException {
     Preconditions.checkState(allowInsecureRegistries);
     try {
       return call(url, connectionFactory);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -130,11 +130,11 @@ class RegistryEndpointCaller<T> {
    */
   @Nullable
   T call() throws IOException, RegistryException {
-    return callWithInsecureRegistryHandling(initialRequestUrl);
+    return callWithAllowInsecureRegistryHandling(initialRequestUrl);
   }
 
   @Nullable
-  private T callWithInsecureRegistryHandling(URL url) throws IOException, RegistryException {
+  private T callWithAllowInsecureRegistryHandling(URL url) throws IOException, RegistryException {
     try {
       if (!isHttpsProtocol(url) && !allowInsecureRegistries) {
         throw new InsecureRegistryException(url);
@@ -154,6 +154,7 @@ class RegistryEndpointCaller<T> {
 
       } catch (GeneralSecurityException ex) {
         throw new RegistryException("cannot turn off TLS peer verification", ex);
+
       } catch (SSLPeerUnverifiedException | HttpHostConnectException ex) {
         // Try HTTP as a last resort.
         GenericUrl httpUrl = new GenericUrl(url);
@@ -242,7 +243,7 @@ class RegistryEndpointCaller<T> {
             || httpResponseException.getStatusCode() == STATUS_CODE_PERMANENT_REDIRECT) {
           // 'Location' header can be relative or absolute.
           URL redirectLocation = new URL(url, httpResponseException.getHeaders().getLocation());
-          return callWithInsecureRegistryHandling(redirectLocation);
+          return callWithAllowInsecureRegistryHandling(redirectLocation);
 
         } else {
           // Unknown

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -143,12 +143,11 @@ class RegistryEndpointCaller<T> {
       return call(url, connectionFactory);
 
     } catch (SSLPeerUnverifiedException exception) {
-      // Cannot verify the server (e.g., self-signed certificate or plain HTTP).
-      if (!allowInsecureRegistries) {
-        throw new InsecureRegistryException(url);
-      }
-
       try {
+        // Cannot verify the server (e.g., self-signed certificate or plain HTTP).
+        if (!allowInsecureRegistries) {
+          throw new InsecureRegistryException(url);
+        }
         if (insecureConnectionFactory == null) {
           insecureConnectionFactory = Connection.getInsecureConnectionFactory();
         }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
@@ -233,7 +233,6 @@ public class RegistryEndpointCallerTest {
     Mockito.when(mockInsecureConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
         .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class)); // server is not HTTPS
 
-    Assert.assertNull(System.getProperty("jib.httpTimeout"));
     RegistryEndpointCaller<String> insecureEndpointCaller = createRegistryEndpointCaller(true);
     try {
       insecureEndpointCaller.call();

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
@@ -96,6 +96,12 @@ public class RegistryEndpointCallerTest {
     return mock;
   }
 
+  private static HttpResponse mockRedirectHttpResponse(String redirectLocation)
+      throws IOException {
+    int code307 = HttpStatusCodes.STATUS_CODE_TEMPORARY_REDIRECT;
+    return mockHttpResponse(code307, new HttpHeaders().setLocation(redirectLocation));
+  }
+
   @Mock private Connection mockConnection;
   @Mock private Connection mockInsecureConnection;
   @Mock private Response mockResponse;
@@ -217,11 +223,7 @@ public class RegistryEndpointCallerTest {
 
   @Test
   public void testCall_credentialsNotSentOverHttp() throws IOException, RegistryException {
-    HttpResponse redirectResponse =
-        mockHttpResponse(
-            HttpStatusCodes.STATUS_CODE_TEMPORARY_REDIRECT,
-            new HttpHeaders().setLocation("http://newlocation"));
-
+    HttpResponse redirectResponse = mockRedirectHttpResponse("http://newlocation");
     HttpResponse unauthroizedResponse =
         mockHttpResponse(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED, null);
 
@@ -247,10 +249,7 @@ public class RegistryEndpointCallerTest {
 
   @Test
   public void testCall_credentialsForcedOverHttp() throws IOException, RegistryException {
-    HttpResponse redirectResponse =
-        mockHttpResponse(
-            HttpStatusCodes.STATUS_CODE_TEMPORARY_REDIRECT,
-            new HttpHeaders().setLocation("http://newlocation"));
+    HttpResponse redirectResponse = mockRedirectHttpResponse("http://newlocation");
 
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
         .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class)) // server is not HTTPS
@@ -320,10 +319,7 @@ public class RegistryEndpointCallerTest {
   @Test
   public void testCall_disallowInsecure() throws IOException, RegistryException {
     // Mocks a response for temporary redirect to a new location.
-    HttpResponse redirectResponse =
-        mockHttpResponse(
-            HttpStatusCodes.STATUS_CODE_TEMPORARY_REDIRECT,
-            new HttpHeaders().setLocation("http://newlocation"));
+    HttpResponse redirectResponse = mockRedirectHttpResponse("http://newlocation");
 
     HttpResponseException redirectException = new HttpResponseException(redirectResponse);
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
@@ -96,8 +96,7 @@ public class RegistryEndpointCallerTest {
     return mock;
   }
 
-  private static HttpResponse mockRedirectHttpResponse(String redirectLocation)
-      throws IOException {
+  private static HttpResponse mockRedirectHttpResponse(String redirectLocation) throws IOException {
     int code307 = HttpStatusCodes.STATUS_CODE_TEMPORARY_REDIRECT;
     return mockHttpResponse(code307, new HttpHeaders().setLocation(redirectLocation));
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
@@ -26,13 +26,9 @@ import com.google.cloud.tools.jib.http.BlobHttpContent;
 import com.google.cloud.tools.jib.http.Connection;
 import com.google.cloud.tools.jib.http.MockConnection;
 import com.google.cloud.tools.jib.http.Response;
-import com.google.cloud.tools.jib.json.JsonTemplateMapper;
-import com.google.cloud.tools.jib.registry.json.ErrorEntryTemplate;
-import com.google.cloud.tools.jib.registry.json.ErrorResponseTemplate;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.security.GeneralSecurityException;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
@@ -91,10 +87,20 @@ public class RegistryEndpointCallerTest {
     }
   }
 
+  private static HttpResponse mockHttpResponse(int statusCode, @Nullable HttpHeaders headers)
+      throws IOException {
+    HttpResponse mock = Mockito.mock(HttpResponse.class);
+    Mockito.when(mock.getStatusCode()).thenReturn(statusCode);
+    Mockito.when(mock.parseAsString()).thenReturn("");
+    Mockito.when(mock.getHeaders()).thenReturn(headers != null ? headers : new HttpHeaders());
+    return mock;
+  }
+
   @Mock private Connection mockConnection;
+  @Mock private Connection mockInsecureConnection;
   @Mock private Response mockResponse;
   @Mock private Function<URL, Connection> mockConnectionFactory;
-  @Mock private HttpResponse mockHttpResponse;
+  @Mock private Function<URL, Connection> mockInsecureConnectionFactory;
 
   private RegistryEndpointCaller<String> testRegistryEndpointCallerSecure;
 
@@ -103,8 +109,8 @@ public class RegistryEndpointCallerTest {
     testRegistryEndpointCallerSecure = createRegistryEndpointCaller(false);
 
     Mockito.when(mockConnectionFactory.apply(Mockito.any())).thenReturn(mockConnection);
-    Mockito.when(mockHttpResponse.parseAsString()).thenReturn("");
-    Mockito.when(mockHttpResponse.getHeaders()).thenReturn(new HttpHeaders());
+    Mockito.when(mockInsecureConnectionFactory.apply(Mockito.any()))
+        .thenReturn(mockInsecureConnection);
     Mockito.when(mockResponse.getBody()).thenReturn(Blobs.from("body"));
   }
 
@@ -115,15 +121,80 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testCall_httpsPeerUnverified()
-      throws IOException, RegistryException, GeneralSecurityException {
-    verifyRetriesWithHttp(SSLPeerUnverifiedException.class);
+  public void testCall_secureCallerOnUnverifiableServer() throws IOException, RegistryException {
+    Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
+        .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class));
+
+    try {
+      testRegistryEndpointCallerSecure.call();
+      Assert.fail("Secure caller should fail if cannot verify server");
+    } catch (InsecureRegistryException ex) {
+      Assert.assertEquals(
+          "Failed to verify the server at https://apiRouteBase/api because only secure connections are allowed.",
+          ex.getMessage());
+    }
   }
 
   @Test
-  public void testCall_retryWithHttp()
-      throws IOException, RegistryException, GeneralSecurityException {
-    verifyRetriesWithHttp(HttpHostConnectException.class);
+  public void testCall_insecureCallerOnUnverifiableServer() throws IOException, RegistryException {
+    Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
+        .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class));
+    Mockito.when(mockInsecureConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
+        .thenReturn(mockResponse);
+
+    RegistryEndpointCaller<String> testRegistryEndpointCallerInsecure =
+        createRegistryEndpointCaller(true);
+    Assert.assertEquals("body", testRegistryEndpointCallerInsecure.call());
+
+    ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
+    Mockito.verify(mockConnectionFactory, Mockito.times(1)).apply(urlCaptor.capture());
+    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(0));
+
+    Mockito.verify(mockInsecureConnectionFactory, Mockito.times(1)).apply(urlCaptor.capture());
+    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(1));
+  }
+
+  @Test
+  public void testCall_insecureCallerOnHttpServer() throws IOException, RegistryException {
+    Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
+        .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class))
+        .thenReturn(mockResponse);
+    Mockito.when(mockInsecureConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
+        .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class));
+
+    RegistryEndpointCaller<String> testRegistryEndpointCallerInsecure =
+        createRegistryEndpointCaller(true);
+    Assert.assertEquals("body", testRegistryEndpointCallerInsecure.call());
+
+    ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
+    Mockito.verify(mockConnectionFactory, Mockito.times(2)).apply(urlCaptor.capture());
+    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("http://apiRouteBase/api"), urlCaptor.getAllValues().get(1));
+
+    Mockito.verify(mockInsecureConnectionFactory, Mockito.times(1)).apply(urlCaptor.capture());
+    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(2));
+  }
+
+  @Test
+  public void testCall_insecureCallerOnHttpServerByHttpHostConnectException()
+      throws IOException, RegistryException {
+    Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
+        .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class))
+        .thenReturn(mockResponse);
+    Mockito.when(mockInsecureConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
+        .thenThrow(Mockito.mock(HttpHostConnectException.class));
+
+    RegistryEndpointCaller<String> testRegistryEndpointCallerInsecure =
+        createRegistryEndpointCaller(true);
+    Assert.assertEquals("body", testRegistryEndpointCallerInsecure.call());
+
+    ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
+    Mockito.verify(mockConnectionFactory, Mockito.times(2)).apply(urlCaptor.capture());
+    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("http://apiRouteBase/api"), urlCaptor.getAllValues().get(1));
+
+    Mockito.verify(mockInsecureConnectionFactory, Mockito.times(1)).apply(urlCaptor.capture());
+    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(2));
   }
 
   @Test
@@ -148,18 +219,27 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testCall_credentialsNotSent() throws IOException, RegistryException {
-    Mockito.when(mockHttpResponse.getStatusCode())
-        .thenReturn(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
+  public void testCall_credentialsNotSentOverHttp() throws IOException, RegistryException {
+    HttpResponse redirectResponse =
+        mockHttpResponse(
+            HttpStatusCodes.STATUS_CODE_TEMPORARY_REDIRECT,
+            new HttpHeaders().setLocation("http://newlocation"));
 
-    HttpResponseException httpResponseException = new HttpResponseException(mockHttpResponse);
+    HttpResponse unauthroizedResponse =
+        mockHttpResponse(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED, null);
+
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
-        .thenThrow(httpResponseException);
+        .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class))
+        .thenThrow(new HttpResponseException(redirectResponse))
+        .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class))
+        .thenThrow(new HttpResponseException(unauthroizedResponse));
+    Mockito.when(mockInsecureConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
+        .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class));
 
     RegistryEndpointCaller<String> testRegistryEndpointCallerInsecure =
         createRegistryEndpointCaller(true);
     try {
-      testRegistryEndpointCallerInsecure.call(new URL("http://location"));
+      testRegistryEndpointCallerInsecure.call();
       Assert.fail("Call should have failed");
 
     } catch (RegistryCredentialsNotSentException ex) {
@@ -170,15 +250,25 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testCall_sendingCredentialsForced() throws IOException, RegistryException {
+  public void testCall_credentialsForcedOverHttp() throws IOException, RegistryException {
+    HttpResponse redirectResponse =
+        mockHttpResponse(
+            HttpStatusCodes.STATUS_CODE_TEMPORARY_REDIRECT,
+            new HttpHeaders().setLocation("http://newlocation"));
+
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
+        .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class))
+        .thenThrow(new HttpResponseException(redirectResponse))
+        .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class))
         .thenReturn(mockResponse);
+    Mockito.when(mockInsecureConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
+        .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class));
 
     RegistryEndpointCaller<String> testRegistryEndpointCallerInsecure =
         createRegistryEndpointCaller(true);
+
     System.setProperty("sendCredentialsOverHttp", "true");
-    Assert.assertEquals(
-        "body", testRegistryEndpointCallerInsecure.call(new URL("http://location")));
+    Assert.assertEquals("body", testRegistryEndpointCallerInsecure.call());
   }
 
   @Test
@@ -203,8 +293,8 @@ public class RegistryEndpointCallerTest {
 
   @Test
   public void testCall_unknown() throws IOException, RegistryException {
-    Mockito.when(mockHttpResponse.getStatusCode())
-        .thenReturn(HttpStatusCodes.STATUS_CODE_SERVER_ERROR);
+    HttpResponse mockHttpResponse =
+        mockHttpResponse(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, null);
     HttpResponseException httpResponseException = new HttpResponseException(mockHttpResponse);
 
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
@@ -220,34 +310,31 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testCall_temporaryRedirect()
-      throws IOException, RegistryException, GeneralSecurityException {
+  public void testCall_temporaryRedirect() throws IOException, RegistryException {
     verifyRetriesWithNewLocation(HttpStatusCodes.STATUS_CODE_TEMPORARY_REDIRECT);
   }
 
   @Test
-  public void testCall_movedPermanently()
-      throws IOException, RegistryException, GeneralSecurityException {
+  public void testCall_movedPermanently() throws IOException, RegistryException {
     verifyRetriesWithNewLocation(HttpStatusCodes.STATUS_CODE_MOVED_PERMANENTLY);
   }
 
   @Test
-  public void testCall_permanentRedirect()
-      throws IOException, RegistryException, GeneralSecurityException {
+  public void testCall_permanentRedirect() throws IOException, RegistryException {
     verifyRetriesWithNewLocation(RegistryEndpointCaller.STATUS_CODE_PERMANENT_REDIRECT);
   }
 
   @Test
   public void testCall_disallowInsecure() throws IOException, RegistryException {
     // Mocks a response for temporary redirect to a new location.
-    Mockito.when(mockHttpResponse.getStatusCode())
-        .thenReturn(HttpStatusCodes.STATUS_CODE_TEMPORARY_REDIRECT);
-    Mockito.when(mockHttpResponse.getHeaders())
-        .thenReturn(new HttpHeaders().setLocation("http://newlocation"));
+    HttpResponse redirectResponse =
+        mockHttpResponse(
+            HttpStatusCodes.STATUS_CODE_TEMPORARY_REDIRECT,
+            new HttpHeaders().setLocation("http://newlocation"));
 
-    HttpResponseException httpResponseException = new HttpResponseException(mockHttpResponse);
+    HttpResponseException redirectException = new HttpResponseException(redirectResponse);
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
-        .thenThrow(httpResponseException)
+        .thenThrow(redirectException)
         .thenReturn(mockResponse);
 
     try {
@@ -260,8 +347,7 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testHttpTimeout_propertyNotSet()
-      throws IOException, RegistryException, GeneralSecurityException {
+  public void testHttpTimeout_propertyNotSet() throws IOException, RegistryException {
     MockConnection mockConnection = new MockConnection((httpMethod, request) -> mockResponse);
     Mockito.when(mockConnectionFactory.apply(Mockito.any())).thenReturn(mockConnection);
 
@@ -274,8 +360,7 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testHttpTimeout_stringValue()
-      throws IOException, RegistryException, GeneralSecurityException {
+  public void testHttpTimeout_stringValue() throws IOException, RegistryException {
     MockConnection mockConnection = new MockConnection((httpMethod, request) -> mockResponse);
     Mockito.when(mockConnectionFactory.apply(Mockito.any())).thenReturn(mockConnection);
 
@@ -286,8 +371,7 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testHttpTimeout_negativeValue()
-      throws IOException, RegistryException, GeneralSecurityException {
+  public void testHttpTimeout_negativeValue() throws IOException, RegistryException {
     MockConnection mockConnection = new MockConnection((httpMethod, request) -> mockResponse);
     Mockito.when(mockConnectionFactory.apply(Mockito.any())).thenReturn(mockConnection);
 
@@ -300,8 +384,7 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testHttpTimeout_0accepted()
-      throws IOException, RegistryException, GeneralSecurityException {
+  public void testHttpTimeout_0accepted() throws IOException, RegistryException {
     System.setProperty("jib.httpTimeout", "0");
 
     MockConnection mockConnection = new MockConnection((httpMethod, request) -> mockResponse);
@@ -313,7 +396,7 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testHttpTimeout() throws IOException, RegistryException, GeneralSecurityException {
+  public void testHttpTimeout() throws IOException, RegistryException {
     System.setProperty("jib.httpTimeout", "7593");
 
     MockConnection mockConnection = new MockConnection((httpMethod, request) -> mockResponse);
@@ -324,32 +407,13 @@ public class RegistryEndpointCallerTest {
     Assert.assertEquals(Integer.valueOf(7593), mockConnection.getRequestedHttpTimeout());
   }
 
-  /** Verifies a request is retried with HTTP protocol if {@code exceptionClass} is thrown. */
-  private void verifyRetriesWithHttp(Class<? extends Throwable> exceptionClass)
-      throws IOException, RegistryException, GeneralSecurityException {
-    // Has mockConnection.send throw first, then succeed.
-    Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
-        .thenThrow(Mockito.mock(exceptionClass))
-        .thenReturn(mockResponse);
-
-    RegistryEndpointCaller<String> testRegistryEndpointCallerInsecure =
-        createRegistryEndpointCaller(true);
-    Assert.assertEquals("body", testRegistryEndpointCallerInsecure.call());
-
-    // Checks that the URL protocol was first HTTPS, then HTTP.
-    ArgumentCaptor<URL> urlArgumentCaptor = ArgumentCaptor.forClass(URL.class);
-    Mockito.verify(mockConnectionFactory, Mockito.times(2)).apply(urlArgumentCaptor.capture());
-    Assert.assertEquals("https", urlArgumentCaptor.getAllValues().get(0).getProtocol());
-    Assert.assertEquals("http", urlArgumentCaptor.getAllValues().get(1).getProtocol());
-  }
-
   /**
    * Verifies that a response with {@code httpStatusCode} throws {@link
    * RegistryUnauthorizedException}.
    */
   private void verifyThrowsRegistryUnauthorizedException(int httpStatusCode)
       throws IOException, RegistryException {
-    Mockito.when(mockHttpResponse.getStatusCode()).thenReturn(httpStatusCode);
+    HttpResponse mockHttpResponse = mockHttpResponse(httpStatusCode, null);
     HttpResponseException httpResponseException = new HttpResponseException(mockHttpResponse);
 
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
@@ -372,12 +436,9 @@ public class RegistryEndpointCallerTest {
    */
   private void verifyThrowsRegistryErrorException(int httpStatusCode)
       throws IOException, RegistryException {
-    ErrorResponseTemplate errorResponseTemplate =
-        new ErrorResponseTemplate().addError(new ErrorEntryTemplate("code", "message"));
-
-    Mockito.when(mockHttpResponse.getStatusCode()).thenReturn(httpStatusCode);
+    HttpResponse mockHttpResponse = mockHttpResponse(httpStatusCode, null);
     Mockito.when(mockHttpResponse.parseAsString())
-        .thenReturn(Blobs.writeToString(JsonTemplateMapper.toBlob(errorResponseTemplate)));
+        .thenReturn("{\"errors\":[{\"code\":\"code\",\"message\":\"message\"}]}");
     HttpResponseException httpResponseException = new HttpResponseException(mockHttpResponse);
 
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
@@ -400,16 +461,15 @@ public class RegistryEndpointCallerTest {
    * Location} header.
    */
   private void verifyRetriesWithNewLocation(int httpStatusCode)
-      throws IOException, RegistryException, GeneralSecurityException {
+      throws IOException, RegistryException {
     // Mocks a response for temporary redirect to a new location.
-    Mockito.when(mockHttpResponse.getStatusCode()).thenReturn(httpStatusCode);
-    Mockito.when(mockHttpResponse.getHeaders())
-        .thenReturn(new HttpHeaders().setLocation("https://newlocation"));
+    HttpResponse redirectResponse =
+        mockHttpResponse(httpStatusCode, new HttpHeaders().setLocation("https://newlocation"));
 
     // Has mockConnection.send throw first, then succeed.
-    HttpResponseException httpResponseException = new HttpResponseException(mockHttpResponse);
+    HttpResponseException redirectException = new HttpResponseException(redirectResponse);
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
-        .thenThrow(httpResponseException)
+        .thenThrow(redirectException)
         .thenReturn(mockResponse);
 
     Assert.assertEquals("body", testRegistryEndpointCallerSecure.call());
@@ -432,6 +492,6 @@ public class RegistryEndpointCallerTest {
         new RegistryEndpointRequestProperties("serverUrl", "imageName"),
         allowInsecure,
         mockConnectionFactory,
-        null);
+        mockInsecureConnectionFactory);
   }
 }

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Propagates environment variables from the base image ([#716](https://github.com/GoogleContainerTools/jib/pull/716))
+- `allowInsecureRegistries` allows connecting to insecure HTTPS registries (for example, registries using self-signed certificates) ([#733](https://github.com/GoogleContainerTools/jib/pull/733))
 
 ### Fixed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 
 - Propagates environment variables from the base image ([#716](https://github.com/GoogleContainerTools/jib/pull/716))
 - Skips execution if packaging is `pom` ([#735](https://github.com/GoogleContainerTools/jib/pull/735))
+- `allowInsecureRegistries` allows connecting to insecure HTTPS registries (for example, registries using self-signed certificates) ([#733](https://github.com/GoogleContainerTools/jib/pull/733))
 
 ### Fixed
 


### PR DESCRIPTION
Fixes #643.

Before:
`call(URL)` embedded the logic for handling `allowInsecureRegistries`.

Now:
The logic is broken out of `call(URL)` into `callWithInsecureRegistryHandling()`. `call(URL)` always contacts the endpoint and is irrelevant of `allowInsecureRegistries`. `callWithInsecureRegistryHandling()` is the one that handles `allowInsecureRegistries`.