### PR TITLE
Makes sure there are no duplicate cache entries.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CachedLayer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CachedLayer.java
@@ -67,4 +67,21 @@ public class CachedLayer implements Layer {
   public DescriptorDigest getDiffId() {
     return diffId;
   }
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == this) {
+      return true;
+    }
+    if (!(other instanceof CachedLayer)) {
+      return false;
+    }
+    CachedLayer otherLayer = (CachedLayer) other;
+    return getBlobDescriptor().getDigest().equals(otherLayer.getBlobDescriptor().getDigest());
+  }
+
+  @Override
+  public int hashCode() {
+    return getBlobDescriptor().getDigest().hashCode();
+  }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
@@ -32,9 +32,9 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
         ImmutableSet.builder();
 
     /**
-     * Adds a layer. Removes any prior occurrences of the same layer. Note that not all {@link
-     * Layer} types implement {@code equals/hashCode} - only those that are intended to be not
-     * duplicated will.
+     * Adds a layer. Removes any prior occurrences of the same layer.
+     *
+     * Note that only subclasses of {@link Layer} that implement {@code equals/hashCode} will be guaranteed to not be duplicated.
      *
      * @param layer the layer to add
      * @return this

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
@@ -34,7 +34,8 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
     /**
      * Adds a layer. Removes any prior occurrences of the same layer.
      *
-     * Note that only subclasses of {@link Layer} that implement {@code equals/hashCode} will be guaranteed to not be duplicated.
+     * <p>Note that only subclasses of {@link Layer} that implement {@code equals/hashCode} will be
+     * guaranteed to not be duplicated.
      *
      * @param layer the layer to add
      * @return this

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
@@ -43,6 +43,8 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
      */
     public Builder<T> add(T layer) throws LayerPropertyNotFoundException {
       layerDigestsBuilder.add(layer.getBlobDescriptor().getDigest());
+
+      // Remove necessary to move layer to the end of the LinkedHashSet.
       layers.remove(layer);
       layers.add(layer);
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
@@ -20,20 +20,16 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
-import java.util.Set;
 import javax.annotation.Nullable;
 
-/** Holds the layers for an image. Makes sure that each layer is only added once. */
+/** Holds the layers for an image. Makes sure that there are no duplicate layers. */
 public class ImageLayers<T extends Layer> implements Iterable<T> {
 
   public static class Builder<T extends Layer> {
 
-    private final Set<T> layersBuilder = new LinkedHashSet<>();
+    private final LinkedHashSet<T> layers = new LinkedHashSet<>();
     private final ImmutableSet.Builder<DescriptorDigest> layerDigestsBuilder =
         ImmutableSet.builder();
-
-    /** The last layer added. */
-    @Nullable private T lastLayer;
 
     /**
      * Adds a layer. Removes any prior occurrences of the same layer. Note that not all {@link
@@ -46,9 +42,8 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
      */
     public Builder<T> add(T layer) throws LayerPropertyNotFoundException {
       layerDigestsBuilder.add(layer.getBlobDescriptor().getDigest());
-      layersBuilder.remove(layer);
-      layersBuilder.add(layer);
-      lastLayer = layer;
+      layers.remove(layer);
+      layers.add(layer);
 
       return this;
     }
@@ -70,7 +65,7 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
     }
 
     public ImageLayers<T> build() {
-      return new ImageLayers<>(ImmutableList.copyOf(layersBuilder), layerDigestsBuilder.build());
+      return new ImageLayers<>(ImmutableList.copyOf(layers), layerDigestsBuilder.build());
     }
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
@@ -68,4 +68,9 @@ public class CacheTest {
     Assert.assertArrayEquals(
         Files.readAllBytes(resourceMetadataJsonPath), Files.readAllBytes(testMetadataJsonPath));
   }
+
+  @Test
+  public void test_saveMetadata_noDuplicates() {
+    // TODO: Implement
+  }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
@@ -16,11 +16,23 @@
 
 package com.google.cloud.tools.jib.cache;
 
+import com.google.cloud.tools.jib.blob.BlobDescriptor;
+import com.google.cloud.tools.jib.image.DescriptorDigest;
+import com.google.cloud.tools.jib.image.LayerEntry;
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.NotDirectoryException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.FileTime;
+import java.security.DigestException;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -70,7 +82,87 @@ public class CacheTest {
   }
 
   @Test
-  public void test_saveMetadata_noDuplicates() {
-    // TODO: Implement
+  public void test_saveMetadata_noDuplicates()
+      throws IOException, CacheMetadataCorruptedException, DigestException, URISyntaxException {
+    Path cacheDirectory = temporaryCacheDirectory.newFolder().toPath();
+
+    Path resourceMetadataJsonPath = PlatformSpecificMetadataJson.getMetadataJsonFile();
+    Path testMetadataJsonPath = cacheDirectory.resolve(CacheFiles.METADATA_FILENAME);
+    Files.copy(resourceMetadataJsonPath, testMetadataJsonPath);
+
+    DescriptorDigest descriptorDigest1 =
+        DescriptorDigest.fromHash(
+            "8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad");
+    DescriptorDigest descriptorDigest2 =
+        DescriptorDigest.fromHash(
+            "6f70bf18a086007016e948b04aed3b82103a36bea41755b6cddfaf10ace3c6ef");
+
+    LayerEntry layerEntry1 =
+        new LayerEntry(
+            ImmutableList.of(Paths.get("some", "file"), Paths.get("some", "other", "file")),
+            "extractionPath1");
+    LayerEntry layerEntry2 =
+        new LayerEntry(
+            ImmutableList.of(Paths.get("another", "file"), Paths.get("yet", "another", "file")),
+            "extractionPath2");
+
+    LayerMetadata layerMetadata1 =
+        LayerMetadata.from(
+            ImmutableList.of(layerEntry1, layerEntry2), FileTime.from(Instant.now()));
+    LayerMetadata layerMetadata2 =
+        LayerMetadata.from(ImmutableList.of(layerEntry2), FileTime.from(Instant.EPOCH));
+
+    DescriptorDigest mockDiffId =
+        DescriptorDigest.fromHash(
+            "91e0cae00b86c289b33fee303a807ae72dd9f0315c16b74e6ab0cdbe9d996c10");
+
+    // Layers ABA.
+    List<CachedLayerWithMetadata> cachedLayersWithMetadata =
+        Arrays.asList(
+            new CachedLayerWithMetadata(
+                new CachedLayer(
+                    Paths.get("nonexistent"), new BlobDescriptor(descriptorDigest1), mockDiffId),
+                layerMetadata1),
+            new CachedLayerWithMetadata(
+                new CachedLayer(
+                    Paths.get("nonexistent"), new BlobDescriptor(descriptorDigest2), mockDiffId),
+                layerMetadata2),
+            new CachedLayerWithMetadata(
+                new CachedLayer(
+                    Paths.get("nonexistent"), new BlobDescriptor(descriptorDigest1), mockDiffId),
+                layerMetadata2));
+
+    // Saves the new layers to the cache metadata.
+    try (Cache cache = Cache.init(cacheDirectory)) {
+      cache.addCachedLayersWithMetadataToMetadata(cachedLayersWithMetadata);
+    }
+
+    // Reload the cache and check that all digests are unique.
+    try (Cache cache = Cache.init(cacheDirectory)) {
+      Set<DescriptorDigest> encounteredDigests = new HashSet<>();
+      for (CachedLayerWithMetadata layer : cache.getMetadata().getLayers()) {
+        DescriptorDigest layerDigest = layer.getBlobDescriptor().getDigest();
+        Assert.assertFalse(encounteredDigests.contains(layerDigest));
+        encounteredDigests.add(layerDigest);
+      }
+
+      // The layer metadata for layer with digest descriptorDigest1 should be layerMetadata2.
+      CachedLayerWithMetadata descriptorDigest1Layer =
+          cache.getMetadata().getLayers().get(descriptorDigest1);
+      Assert.assertNotNull(descriptorDigest1Layer);
+      LayerMetadata layerMetadata = descriptorDigest1Layer.getMetadata();
+      Assert.assertNotNull(layerMetadata);
+      Assert.assertEquals(1, layerMetadata.getEntries().size());
+      Assert.assertEquals(FileTime.from(Instant.EPOCH), layerMetadata.getLastModifiedTime());
+      Assert.assertEquals(
+          layerEntry2
+              .getSourceFiles()
+              .stream()
+              .map(Path::toString)
+              .collect(ImmutableList.toImmutableList()),
+          layerMetadata.getEntries().get(0).getSourceFilesStrings());
+      Assert.assertEquals(
+          layerEntry2.getExtractionPath(), layerMetadata.getEntries().get(0).getExtractionPath());
+    }
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageLayersTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageLayersTest.java
@@ -76,7 +76,7 @@ public class ImageLayersTest {
   @Test
   public void testAddLayer_sameAsLastLayer() throws LayerPropertyNotFoundException {
     List<Layer> expectedLayers =
-        Arrays.asList(mockCachedLayer, mockReferenceLayer, mockDigestOnlyLayer, mockUnwrittenLayer);
+        Arrays.asList(mockReferenceLayer, mockDigestOnlyLayer, mockUnwrittenLayer, mockCachedLayer);
 
     ImageLayers<Layer> imageLayers =
         ImageLayers.builder()

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -13,8 +13,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed slow image reference parsing ([#680](https://github.com/GoogleContainerTools/jib/pull/680))
-- Only builds non-empty layers ([#516](https://github.com/GoogleContainerTools/jib/pull/516/files))
+- Slow image reference parsing ([#680](https://github.com/GoogleContainerTools/jib/pull/680))
+- Building empty layers ([#516](https://github.com/GoogleContainerTools/jib/pull/516/files))
+- Duplicate layer entries causing unbounded cache growth ([#721](https://github.com/GoogleContainerTools/jib/issues/721))
 
 ## 0.9.7
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -16,8 +16,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed slow image reference parsing ([#680](https://github.com/GoogleContainerTools/jib/pull/680))
-- Only builds non-empty layers ([#516](https://github.com/GoogleContainerTools/jib/pull/516/files))
+- Slow image reference parsing ([#680](https://github.com/GoogleContainerTools/jib/pull/680))
+- Building empty layers ([#516](https://github.com/GoogleContainerTools/jib/pull/516/files))
+- Duplicate layer entries causing unbounded cache growth ([#721](https://github.com/GoogleContainerTools/jib/issues/721))
 
 ## 0.9.7
 


### PR DESCRIPTION
Fixes #721 

The solution here is to, when adding a new layer, remove any prior layers with the same digest (essentially bumping layers to the top if re-added). This should work, for example, since applying layers A and B in order ABA should produce an identical filesystem as just BA.