### PR TITLE
Has integration test check actual build time.

### DIFF
--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -93,14 +93,13 @@ public class BuildImageMojoIntegrationTest {
   }
 
   private static float getBuildTimeFromVerifierLog(Verifier verifier) throws IOException {
-    Pattern pattern = Pattern.compile("Building and pushing image : (.*) ms");
+    Pattern pattern = Pattern.compile("Building and pushing image : (?<time>.*) ms");
 
     for (String line :
         Files.readAllLines(Paths.get(verifier.getBasedir(), verifier.getLogFileName()))) {
       Matcher matcher = pattern.matcher(line);
       if (matcher.find()) {
-        String time = matcher.group();
-        return Float.parseFloat(time);
+        return Float.parseFloat(matcher.group("time"));
       }
     }
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -63,14 +63,20 @@ public class BuildImageMojoIntegrationTest {
 
     Logger logger = Logger.getLogger(String.valueOf(BuildImageMojoIntegrationTest.class));
     logger.info("BUILD OUTPUT 1: -------------------");
-    Files.readAllLines(Paths.get(verifier.getLogFileName())).forEach(logger::info);
+    for (String line : Files.readAllLines(Paths.get(verifier.getLogFileName()))) {
+      logger.info(line);
+    }
 
     if (runTwice) {
+      lastTime = System.nanoTime();
+      verifier.resetStreams();
       verifier.executeGoal("jib:" + BuildImageMojo.GOAL_NAME);
-      long timeTwo = System.nanoTime() - timeOne;
+      long timeTwo = System.nanoTime() - lastTime;
 
       logger.info("BUILD OUTPUT 2: -------------------");
-      Files.readAllLines(Paths.get(verifier.getLogFileName())).forEach(logger::info);
+      for (String line : Files.readAllLines(Paths.get(verifier.getLogFileName()))) {
+        logger.info(line);
+      }
       Assert.assertTrue(
           "First build time ("
               + timeOne

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -52,7 +52,8 @@ public class BuildImageMojoIntegrationTest {
    * Builds and runs jib:build on a project at {@code projectRoot} pushing to {@code
    * imageReference}.
    */
-  private static String buildAndRun(Path projectRoot, String imageReference, boolean runTwice)
+  private static String buildAndRun(
+      Path projectRoot, String imageReference, String worldString, boolean runTwice)
       throws VerificationException, IOException, InterruptedException {
     // The target registry these tests push to would already have all the layers cached from before,
     // causing this test to fail sometimes with the second build being a bit slower than the first
@@ -60,7 +61,7 @@ public class BuildImageMojoIntegrationTest {
     // this issue.
     Files.write(
         projectRoot.resolve("src").resolve("main").resolve("resources").resolve("world"),
-        Instant.now().toString().getBytes(StandardCharsets.UTF_8));
+        worldString.getBytes(StandardCharsets.UTF_8));
 
     Verifier verifier = new Verifier(projectRoot.toString());
     verifier.setAutoclean(false);
@@ -135,10 +136,11 @@ public class BuildImageMojoIntegrationTest {
 
     Instant before = Instant.now();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n",
+        "Hello, " + before + ". An argument.\nfoo\ncat\n",
         buildAndRun(
             simpleTestProject.getProjectRoot(),
             "gcr.io/jib-integration-testing/simpleimage:maven",
+            before.toString(),
             true));
 
     Instant buildTime =
@@ -161,6 +163,7 @@ public class BuildImageMojoIntegrationTest {
         buildAndRun(
             emptyTestProject.getProjectRoot(),
             "gcr.io/jib-integration-testing/emptyimage:maven",
+            Instant.now().toString(),
             false));
     Assert.assertEquals(
         "1970-01-01T00:00:00Z",

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.logging.Logger;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.hamcrest.CoreMatchers;
@@ -60,15 +61,16 @@ public class BuildImageMojoIntegrationTest {
     verifier.executeGoal("jib:" + BuildImageMojo.GOAL_NAME);
     long timeOne = System.nanoTime() - lastTime;
 
-    System.out.println("BUILD OUTPUT 1: -------------------");
-    Files.readAllLines(Paths.get(verifier.getLogFileName())).forEach(System.out::println);
+    Logger logger = Logger.getLogger(String.valueOf(BuildImageMojoIntegrationTest.class));
+    logger.info("BUILD OUTPUT 1: -------------------");
+    Files.readAllLines(Paths.get(verifier.getLogFileName())).forEach(logger::info);
 
     if (runTwice) {
       verifier.executeGoal("jib:" + BuildImageMojo.GOAL_NAME);
       long timeTwo = System.nanoTime() - timeOne;
 
-      System.out.println("BUILD OUTPUT 2: -------------------");
-      Files.readAllLines(Paths.get(verifier.getLogFileName())).forEach(System.out::println);
+      logger.info("BUILD OUTPUT 2: -------------------");
+      Files.readAllLines(Paths.get(verifier.getLogFileName())).forEach(logger::info);
       Assert.assertTrue(
           "First build time ("
               + timeOne

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -63,7 +63,8 @@ public class BuildImageMojoIntegrationTest {
 
     Logger logger = Logger.getLogger(String.valueOf(BuildImageMojoIntegrationTest.class));
     logger.info("BUILD OUTPUT 1: -------------------");
-    for (String line : Files.readAllLines(Paths.get(verifier.getLogFileName()))) {
+    for (String line :
+        Files.readAllLines(Paths.get(verifier.getBasedir(), verifier.getLogFileName()))) {
       logger.info(line);
     }
 
@@ -74,7 +75,8 @@ public class BuildImageMojoIntegrationTest {
       long timeTwo = System.nanoTime() - lastTime;
 
       logger.info("BUILD OUTPUT 2: -------------------");
-      for (String line : Files.readAllLines(Paths.get(verifier.getLogFileName()))) {
+      for (String line :
+          Files.readAllLines(Paths.get(verifier.getBasedir(), verifier.getLogFileName()))) {
         logger.info(line);
       }
       Assert.assertTrue(

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -51,7 +51,7 @@ public class BuildImageMojoIntegrationTest {
       throws VerificationException, IOException, InterruptedException {
     Verifier verifier = new Verifier(projectRoot.toString());
     verifier.setAutoclean(false);
-    verifier.executeGoal("package");
+    verifier.executeGoals(Arrays.asList("clean", "compile"));
 
     // Builds twice, and checks if the second build took less time.
     long lastTime = System.nanoTime();

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -52,7 +52,7 @@ public class BuildImageMojoIntegrationTest {
    * Builds and runs jib:build on a project at {@code projectRoot} pushing to {@code
    * imageReference}.
    */
-  private static String buildAndRun(Path projectRoot, String imageReference, boolean runTwice)
+  private static String buildAndRun(Path projectRoot, String imageReference)
       throws VerificationException, IOException, InterruptedException {
     Verifier verifier = new Verifier(projectRoot.toString());
     verifier.setAutoclean(false);
@@ -63,19 +63,17 @@ public class BuildImageMojoIntegrationTest {
     verifier.executeGoal("jib:" + BuildImageMojo.GOAL_NAME);
     float timeOne = getBuildTimeFromVerifierLog(verifier);
 
-    if (runTwice) {
-      verifier.resetStreams();
-      verifier.executeGoal("jib:" + BuildImageMojo.GOAL_NAME);
-      float timeTwo = getBuildTimeFromVerifierLog(verifier);
+    verifier.resetStreams();
+    verifier.executeGoal("jib:" + BuildImageMojo.GOAL_NAME);
+    float timeTwo = getBuildTimeFromVerifierLog(verifier);
 
-      Assert.assertTrue(
-          "First build time ("
-              + timeOne
-              + ") is not greater than second build time ("
-              + timeTwo
-              + ")",
-          timeOne > timeTwo);
-    }
+    Assert.assertTrue(
+        "First build time ("
+            + timeOne
+            + ") is not greater than second build time ("
+            + timeTwo
+            + ")",
+        timeOne > timeTwo);
 
     verifier.verifyErrorFreeLog();
 
@@ -130,8 +128,7 @@ public class BuildImageMojoIntegrationTest {
         "Hello, world. An argument.\nfoo\ncat\n",
         buildAndRun(
             simpleTestProject.getProjectRoot(),
-            "gcr.io/jib-integration-testing/simpleimage:maven",
-            true));
+            "gcr.io/jib-integration-testing/simpleimage:maven"));
 
     Instant buildTime =
         Instant.parse(
@@ -152,8 +149,7 @@ public class BuildImageMojoIntegrationTest {
         "",
         buildAndRun(
             emptyTestProject.getProjectRoot(),
-            "gcr.io/jib-integration-testing/emptyimage:maven",
-            false));
+            "gcr.io/jib-integration-testing/emptyimage:maven"));
     Assert.assertEquals(
         "1970-01-01T00:00:00Z",
         new Command(

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.maven.it.VerificationException;
@@ -55,6 +56,7 @@ public class BuildImageMojoIntegrationTest {
       throws VerificationException, IOException, InterruptedException {
     Verifier verifier = new Verifier(projectRoot.toString());
     verifier.setAutoclean(false);
+    verifier.setCliOptions(Collections.singletonList("-X"));
     verifier.executeGoals(Arrays.asList("clean", "compile"));
 
     // Builds twice, and checks if the second build took less time.

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.Command;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -53,6 +54,14 @@ public class BuildImageMojoIntegrationTest {
    */
   private static String buildAndRun(Path projectRoot, String imageReference, boolean runTwice)
       throws VerificationException, IOException, InterruptedException {
+    // The target registry these tests push to would already have all the layers cached from before,
+    // causing this test to fail sometimes with the second build being a bit slower than the first
+    // build. This file change makes sure that a new layer is always pushed the first time to solve
+    // this issue.
+    Files.write(
+        projectRoot.resolve("src").resolve("main").resolve("resources").resolve("world"),
+        Instant.now().toString().getBytes(StandardCharsets.UTF_8));
+
     Verifier verifier = new Verifier(projectRoot.toString());
     verifier.setAutoclean(false);
     verifier.addCliOption("-X");

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -18,7 +18,9 @@ package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.Command;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Arrays;
 import org.apache.maven.it.VerificationException;
@@ -57,12 +59,16 @@ public class BuildImageMojoIntegrationTest {
     long lastTime = System.nanoTime();
     verifier.executeGoal("jib:" + BuildImageMojo.GOAL_NAME);
     long timeOne = System.nanoTime() - lastTime;
-    lastTime = System.nanoTime();
+
+    System.out.println("BUILD OUTPUT 1: -------------------");
+    Files.readAllLines(Paths.get(verifier.getLogFileName())).forEach(System.out::println);
 
     if (runTwice) {
       verifier.executeGoal("jib:" + BuildImageMojo.GOAL_NAME);
-      long timeTwo = System.nanoTime() - lastTime;
+      long timeTwo = System.nanoTime() - timeOne;
 
+      System.out.println("BUILD OUTPUT 2: -------------------");
+      Files.readAllLines(Paths.get(verifier.getLogFileName())).forEach(System.out::println);
       Assert.assertTrue(
           "First build time ("
               + timeOne

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -127,8 +127,7 @@ public class BuildImageMojoIntegrationTest {
         "Hello, world. An argument.\nfoo\ncat\n",
         buildAndRun(
             simpleTestProject.getProjectRoot(),
-            "gcr.io/jib-integration-testing/simpleimage:maven",
-            true));
+            "gcr.io/jib-integration-testing/simpleimage:maven"));
 
     Instant buildTime =
         Instant.parse(

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -103,6 +103,8 @@ public class BuildImageMojoIntegrationTest {
     }
 
     Assert.fail("Could not find build execution time in logs");
+    // Should not reach here.
+    return -1;
   }
 
   @Test


### PR DESCRIPTION
https://github.com/GoogleContainerTools/jib/pull/749 did not seem to fix the issue completely (simple project still fails, although running the macOS integration tests locally does not fail). This PR runs clean before the first integration test run so that the first run always starts with a clean cache.

This PR also changes the time comparison to be the actual execution time of the `jib:build` goal rather than the time the `Verifier` took so that the comparison is more accurate - this is the main fix.