### PR TITLE
Sets the JIB_INTEGRATION_TESTING_PROJECT for Kokoro.

### DIFF
--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -9,6 +9,9 @@ cd github/jib
 REM Stops any left-over containers.
 REM FOR /f "tokens=*" %%i IN ('docker ps -aq') DO docker rm -vf %%i
 
+REM Sets the integration testing project.
+set JIB_INTEGRATION_TESTING_PROJECT=jib-integration-testing
+
 REM TODO: Enable integration tests once docker works (b/73345382).
 cd jib-core && call gradlew.bat clean build --info --stacktrace && ^
 cd ../jib-maven-plugin && call mvnw.cmd clean install -B -U -X && ^

--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -19,6 +19,9 @@ docker-credential-gcr configure-docker
 docker stop $(docker ps --all --quiet) || true
 docker kill $(docker ps --all --quiet) || true
 
+# Sets the integration testing project.
+export JIB_INTEGRATION_TESTING_PROJECT=jib-integration-testing
+
 (cd github/jib/jib-core; ./gradlew clean build integrationTest --info --stacktrace)
 (cd github/jib/jib-maven-plugin; ./mvnw clean install -P integration-tests -B -U -X)
 (cd github/jib/jib-gradle-plugin; ./gradlew clean build integrationTest --info --stacktrace)


### PR DESCRIPTION
This is necessary for Kokoro to use the right project. Note that only continuous tests run the integration tests.