### PR TITLE
Eliminate Maven build warnings for helloworld example

### DIFF
--- a/examples/helloworld/pom.xml
+++ b/examples/helloworld/pom.xml
@@ -6,7 +6,9 @@
   <version>1</version>
 
   <properties>
-    <jib-maven-plugin.version>0.9.7</jib-maven-plugin.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jib-maven-plugin.version>0.9.8</jib-maven-plugin.version>
+    <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
   </properties>
 
   <dependencies>
@@ -22,6 +24,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>


### PR DESCRIPTION
I just wanted to remove the warnings below, but feel free to reject if the intention was to have a minimal working example focusing only on Jib configurations.

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for example:helloworld:jar:1
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-compiler-plugin is missing. @ line 22, column 15
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING] 
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] Building helloworld 1
[INFO] ------------------------------------------------------------------------
...
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 1 resource
...
[INFO] --- maven-compiler-plugin:3.1:compile (default-compile) @ helloworld ---
...
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
```