### PR TITLE
Apply allowInsecureRegistries to RegistryAuthenticator too

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverIntegrationTest.java
@@ -29,7 +29,7 @@ public class AuthenticationMethodRetrieverIntegrationTest {
 
   @Test
   public void testGetRegistryAuthenticator()
-      throws RegistryAuthenticationFailedException, IOException, RegistryException {
+      throws RegistryAuthenticationFailedException, IOException, EndpointException {
     RegistryClient registryClient =
         RegistryClient.factory(BUILD_LOGGER, "registry.hub.docker.com", "library/busybox")
             .newRegistryClient();

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
@@ -32,7 +32,7 @@ public class BlobCheckerIntegrationTest {
   private static final EmptyJibLogger buildLogger = new EmptyJibLogger();
 
   @Test
-  public void testCheck_exists() throws IOException, RegistryException {
+  public void testCheck_exists() throws IOException, EndpointException {
     RegistryClient registryClient =
         RegistryClient.factory(buildLogger, "localhost:5000", "busybox")
             .setAllowInsecureRegistries(true)
@@ -45,7 +45,7 @@ public class BlobCheckerIntegrationTest {
   }
 
   @Test
-  public void testCheck_doesNotExist() throws IOException, RegistryException, DigestException {
+  public void testCheck_doesNotExist() throws IOException, EndpointException, DigestException {
     RegistryClient registryClient =
         RegistryClient.factory(buildLogger, "localhost:5000", "busybox")
             .setAllowInsecureRegistries(true)

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
@@ -41,7 +41,7 @@ public class BlobPullerIntegrationTest {
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
-  public void testPull() throws IOException, RegistryException {
+  public void testPull() throws IOException, EndpointException {
     // Pulls the busybox image.
     RegistryClient registryClient =
         RegistryClient.factory(BUILD_LOGGER, "localhost:5000", "busybox")
@@ -61,7 +61,7 @@ public class BlobPullerIntegrationTest {
   }
 
   @Test
-  public void testPull_unknownBlob() throws RegistryException, IOException, DigestException {
+  public void testPull_unknownBlob() throws EndpointException, IOException, DigestException {
     DescriptorDigest nonexistentDigest =
         DescriptorDigest.fromHash(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPusherIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPusherIntegrationTest.java
@@ -33,7 +33,7 @@ public class BlobPusherIntegrationTest {
   private static final EmptyJibLogger BUILD_LOGGER = new EmptyJibLogger();
 
   @Test
-  public void testPush() throws DigestException, IOException, RegistryException {
+  public void testPush() throws DigestException, IOException, EndpointException {
     Blob testBlob = Blobs.from("crepecake");
     // Known digest for 'crepecake'
     DescriptorDigest testBlobDigest =

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -33,7 +33,7 @@ public class ManifestPullerIntegrationTest {
   private static final EmptyJibLogger BUILD_LOGGER = new EmptyJibLogger();
 
   @Test
-  public void testPull_v21() throws IOException, RegistryException {
+  public void testPull_v21() throws IOException, EndpointException {
     RegistryClient registryClient =
         RegistryClient.factory(BUILD_LOGGER, "localhost:5000", "busybox")
             .setAllowInsecureRegistries(true)
@@ -46,7 +46,7 @@ public class ManifestPullerIntegrationTest {
   }
 
   @Test
-  public void testPull_v22() throws IOException, RegistryException {
+  public void testPull_v22() throws IOException, EndpointException {
     RegistryClient registryClient =
         RegistryClient.factory(BUILD_LOGGER, "gcr.io", "distroless/java").newRegistryClient();
     ManifestTemplate manifestTemplate = registryClient.pullManifest("latest");
@@ -57,7 +57,7 @@ public class ManifestPullerIntegrationTest {
   }
 
   @Test
-  public void testPull_unknownManifest() throws RegistryException, IOException {
+  public void testPull_unknownManifest() throws EndpointException, IOException {
     try {
       RegistryClient registryClient =
           RegistryClient.factory(BUILD_LOGGER, "localhost:5000", "busybox")

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPusherIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPusherIntegrationTest.java
@@ -37,7 +37,7 @@ public class ManifestPusherIntegrationTest {
   private static final EmptyJibLogger BUILD_LOGGER = new EmptyJibLogger();
 
   @Test
-  public void testPush_missingBlobs() throws IOException, RegistryException {
+  public void testPush_missingBlobs() throws IOException, EndpointException {
     RegistryClient registryClient =
         RegistryClient.factory(BUILD_LOGGER, "gcr.io", "distroless/java").newRegistryClient();
     ManifestTemplate manifestTemplate = registryClient.pullManifest("latest");
@@ -59,7 +59,7 @@ public class ManifestPusherIntegrationTest {
 
   /** Tests manifest pushing. This test is a comprehensive test of push and pull. */
   @Test
-  public void testPush() throws DigestException, IOException, RegistryException {
+  public void testPush() throws DigestException, IOException, EndpointException {
     Blob testLayerBlob = Blobs.from("crepecake");
     // Known digest for 'crepecake'
     DescriptorDigest testLayerBlobDigest =

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorIntegrationTest.java
@@ -32,7 +32,7 @@ public class RegistryAuthenticatorIntegrationTest {
   @Test
   public void testAuthenticate()
       throws RegistryAuthenticationFailedException, InvalidImageReferenceException, IOException,
-          RegistryException {
+          EndpointException {
     ImageReference dockerHubImageReference = ImageReference.parse("library/busybox");
     RegistryAuthenticator registryAuthenticator =
         RegistryAuthenticator.initializer(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
@@ -21,9 +21,9 @@ import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.NonBlockingSteps;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.http.Authorization;
+import com.google.cloud.tools.jib.registry.EndpointException;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticationFailedException;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticator;
-import com.google.cloud.tools.jib.registry.RegistryException;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -69,7 +69,7 @@ class AuthenticatePushStep implements AsyncStep<Authorization>, Callable<Authori
   @Nullable
   public Authorization call()
       throws ExecutionException, RegistryAuthenticationFailedException, IOException,
-          RegistryException {
+          EndpointException {
     try (Timer ignored =
         new Timer(
             buildConfiguration.getBuildLogger(),

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
@@ -25,8 +25,8 @@ import com.google.cloud.tools.jib.cache.CachedLayer;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
+import com.google.cloud.tools.jib.registry.EndpointException;
 import com.google.cloud.tools.jib.registry.RegistryClient;
-import com.google.cloud.tools.jib.registry.RegistryException;
 import com.google.common.io.CountingOutputStream;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -66,7 +66,7 @@ class PullAndCacheBaseImageLayerStep implements AsyncStep<CachedLayer>, Callable
   }
 
   @Override
-  public CachedLayer call() throws IOException, RegistryException {
+  public CachedLayer call() throws IOException, EndpointException {
     try (Timer ignored =
         new Timer(buildConfiguration.getBuildLogger(), String.format(DESCRIPTION, layerDigest))) {
       RegistryClient registryClient =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -35,10 +35,10 @@ import com.google.cloud.tools.jib.image.json.UnknownManifestFormatException;
 import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
+import com.google.cloud.tools.jib.registry.EndpointException;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticationFailedException;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticator;
 import com.google.cloud.tools.jib.registry.RegistryClient;
-import com.google.cloud.tools.jib.registry.RegistryException;
 import com.google.cloud.tools.jib.registry.RegistryUnauthorizedException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -98,7 +98,7 @@ class PullBaseImageStep
 
   @Override
   public BaseImageWithAuthorization call()
-      throws IOException, RegistryException, LayerPropertyNotFoundException,
+      throws IOException, EndpointException, LayerPropertyNotFoundException,
           LayerCountMismatchException, ExecutionException, BadContainerConfigurationFormatException,
           RegistryAuthenticationFailedException {
     buildConfiguration
@@ -168,7 +168,7 @@ class PullBaseImageStep
    * @param registryCredentials authentication credentials to possibly use
    * @return the pulled image
    * @throws IOException when an I/O exception occurs during the pulling
-   * @throws RegistryException if communicating with the registry caused a known error
+   * @throws EndpointException if communicating with the registry caused a known error
    * @throws LayerCountMismatchException if the manifest and configuration contain conflicting layer
    *     information
    * @throws LayerPropertyNotFoundException if adding image layers fails
@@ -176,7 +176,7 @@ class PullBaseImageStep
    *     format
    */
   private Image<Layer> pullBaseImage(@Nullable Authorization registryCredentials)
-      throws IOException, RegistryException, LayerPropertyNotFoundException,
+      throws IOException, EndpointException, LayerPropertyNotFoundException,
           LayerCountMismatchException, BadContainerConfigurationFormatException {
     RegistryClient registryClient =
         RegistryClient.factory(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -22,8 +22,8 @@ import com.google.cloud.tools.jib.async.NonBlockingSteps;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
+import com.google.cloud.tools.jib.registry.EndpointException;
 import com.google.cloud.tools.jib.registry.RegistryClient;
-import com.google.cloud.tools.jib.registry.RegistryException;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -65,7 +65,7 @@ class PushBlobStep implements AsyncStep<BlobDescriptor>, Callable<BlobDescriptor
   }
 
   @Override
-  public BlobDescriptor call() throws IOException, RegistryException, ExecutionException {
+  public BlobDescriptor call() throws IOException, EndpointException, ExecutionException {
     try (Timer timer =
         new Timer(buildConfiguration.getBuildLogger(), DESCRIPTION + blobDescriptor)) {
       RegistryClient registryClient =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -22,8 +22,8 @@ import com.google.cloud.tools.jib.async.NonBlockingSteps;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ImageToJsonTranslator;
+import com.google.cloud.tools.jib.registry.EndpointException;
 import com.google.cloud.tools.jib.registry.RegistryClient;
-import com.google.cloud.tools.jib.registry.RegistryException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -114,7 +114,7 @@ class PushImageStep implements AsyncStep<Void>, Callable<Void> {
         .call(this::afterAllPushed, listeningExecutorService);
   }
 
-  private Void afterAllPushed() throws IOException, RegistryException, ExecutionException {
+  private Void afterAllPushed() throws IOException, EndpointException, ExecutionException {
     try (Timer ignored = new Timer(buildConfiguration.getBuildLogger(), DESCRIPTION)) {
       RegistryClient registryClient =
           RegistryClient.factory(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/UnknownManifestFormatException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/UnknownManifestFormatException.java
@@ -16,10 +16,10 @@
 
 package com.google.cloud.tools.jib.image.json;
 
-import com.google.cloud.tools.jib.registry.RegistryException;
+import com.google.cloud.tools.jib.registry.EndpointException;
 
 /** Exception thrown when trying to parse an unknown image manifest format. */
-public class UnknownManifestFormatException extends RegistryException {
+public class UnknownManifestFormatException extends EndpointException {
 
   public UnknownManifestFormatException(String message) {
     super(message);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
@@ -29,7 +29,7 @@ import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.configuration.CacheConfiguration;
 import com.google.cloud.tools.jib.configuration.LayerConfiguration;
 import com.google.cloud.tools.jib.image.LayerEntry;
-import com.google.cloud.tools.jib.registry.InsecureRegistryException;
+import com.google.cloud.tools.jib.registry.InsecureEndpointException;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticationFailedException;
 import com.google.cloud.tools.jib.registry.RegistryCredentialsNotSentException;
 import com.google.cloud.tools.jib.registry.RegistryErrorException;
@@ -251,7 +251,7 @@ public class BuildStepsRunner {
         throw new BuildStepsExecutionException(
             helpfulSuggestions.forUnknownHost(), exceptionDuringBuildSteps);
 
-      } else if (exceptionDuringBuildSteps instanceof InsecureRegistryException) {
+      } else if (exceptionDuringBuildSteps instanceof InsecureEndpointException) {
         throw new BuildStepsExecutionException(
             helpfulSuggestions.forInsecureRegistry(), exceptionDuringBuildSteps);
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetriever.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.registry;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpStatusCodes;
+import com.google.cloud.tools.jib.JibLogger;
 import com.google.cloud.tools.jib.http.BlobHttpContent;
 import com.google.cloud.tools.jib.http.Response;
 import java.net.MalformedURLException;
@@ -31,9 +32,11 @@ import javax.annotation.Nullable;
 class AuthenticationMethodRetriever implements RegistryEndpointProvider<RegistryAuthenticator> {
 
   private final RegistryEndpointRequestProperties registryEndpointRequestProperties;
+  private final JibLogger jibLogger;
 
   AuthenticationMethodRetriever(
-      RegistryEndpointRequestProperties registryEndpointRequestProperties) {
+      JibLogger jibLogger, RegistryEndpointRequestProperties registryEndpointRequestProperties) {
+    this.jibLogger = jibLogger;
     this.registryEndpointRequestProperties = registryEndpointRequestProperties;
   }
 
@@ -96,7 +99,7 @@ class AuthenticationMethodRetriever implements RegistryEndpointProvider<Registry
     // Parses the header to retrieve the components.
     try {
       return RegistryAuthenticator.fromAuthenticationMethod(
-          authenticationMethod, registryEndpointRequestProperties);
+          jibLogger, authenticationMethod, registryEndpointRequestProperties);
 
     } catch (RegistryAuthenticationFailedException ex) {
       throw new RegistryErrorExceptionBuilder(getActionDescription(), ex)

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetriever.java
@@ -32,11 +32,11 @@ import javax.annotation.Nullable;
 class AuthenticationMethodRetriever implements RegistryEndpointProvider<RegistryAuthenticator> {
 
   private final RegistryEndpointRequestProperties registryEndpointRequestProperties;
-  private final JibLogger jibLogger;
+  private final JibLogger logger;
 
   AuthenticationMethodRetriever(
       JibLogger jibLogger, RegistryEndpointRequestProperties registryEndpointRequestProperties) {
-    this.jibLogger = jibLogger;
+    this.logger = jibLogger;
     this.registryEndpointRequestProperties = registryEndpointRequestProperties;
   }
 
@@ -99,7 +99,7 @@ class AuthenticationMethodRetriever implements RegistryEndpointProvider<Registry
     // Parses the header to retrieve the components.
     try {
       return RegistryAuthenticator.fromAuthenticationMethod(
-          jibLogger, authenticationMethod, registryEndpointRequestProperties);
+          logger, authenticationMethod, registryEndpointRequestProperties);
 
     } catch (RegistryAuthenticationFailedException ex) {
       throw new RegistryErrorExceptionBuilder(getActionDescription(), ex)

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/BlobPusher.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/BlobPusher.java
@@ -125,7 +125,7 @@ class BlobPusher {
 
     /** @return a URL to continue pushing the BLOB to */
     @Override
-    public URL handleResponse(Response response) throws RegistryException {
+    public URL handleResponse(Response response) throws EndpointException {
       // TODO: Handle 204 No Content
       return getRedirectLocation(response);
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/EndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/EndpointCaller.java
@@ -42,7 +42,7 @@ class EndpointCaller {
   private final Function<URL, Connection> connectionFactory;
   @Nullable private Function<URL, Connection> insecureConnectionFactory;
 
-  public EndpointCaller(JibLogger logger, boolean allowInsecureEndpoints) {
+  EndpointCaller(JibLogger logger, boolean allowInsecureEndpoints) {
     this(
         logger,
         allowInsecureEndpoints,
@@ -71,7 +71,7 @@ class EndpointCaller {
     }
 
     try {
-      return call(url, httpMethod, request, connectionFactory);
+      return sendRequest(url, httpMethod, request, connectionFactory);
 
     } catch (SSLPeerUnverifiedException ex) {
       return handleUnverifiableServerException(url, httpMethod, request);
@@ -95,7 +95,7 @@ class EndpointCaller {
     try {
       logger.warn(
           "Cannot verify server at " + url + ". Attempting again with no TLS verification.");
-      return call(url, httpMethod, request, getInsecureConnectionFactory());
+      return sendRequest(url, httpMethod, request, getInsecureConnectionFactory());
 
     } catch (SSLPeerUnverifiedException ex) {
       return fallBackToHttp(url, httpMethod, request);
@@ -108,7 +108,7 @@ class EndpointCaller {
     httpUrl.setScheme("http");
     logger.warn(
         "Failed to connect to " + url + " over HTTPS. Attempting again with HTTP: " + httpUrl);
-    return call(httpUrl.toURL(), httpMethod, request, connectionFactory);
+    return sendRequest(httpUrl.toURL(), httpMethod, request, connectionFactory);
   }
 
   private Function<URL, Connection> getInsecureConnectionFactory() throws EndpointException {
@@ -123,7 +123,7 @@ class EndpointCaller {
     }
   }
 
-  private Response call(
+  private Response sendRequest(
       URL url, String httpMethod, Request request, Function<URL, Connection> connectionFactory)
       throws IOException {
     try (Connection connection = connectionFactory.apply(url)) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/EndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/EndpointCaller.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2018 Google LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.registry;
+
+import com.google.api.client.http.GenericUrl;
+import com.google.cloud.tools.jib.JibLogger;
+import com.google.cloud.tools.jib.http.Connection;
+import com.google.cloud.tools.jib.http.Request;
+import com.google.cloud.tools.jib.http.Response;
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.net.URL;
+import java.security.GeneralSecurityException;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLPeerUnverifiedException;
+import org.apache.http.conn.HttpHostConnectException;
+
+class EndpointCaller {
+
+  private static boolean isHttpsProtocol(URL url) {
+    return "https".equals(url.getProtocol());
+  }
+
+  private final JibLogger logger;
+  private final boolean allowInsecureEndoints;
+
+  private final Function<URL, Connection> connectionFactory;
+  @Nullable private Function<URL, Connection> insecureConnectionFactory;
+
+  public EndpointCaller(JibLogger logger, boolean allowInsecureEndpoints) {
+    this(
+        logger,
+        allowInsecureEndpoints,
+        Connection.getConnectionFactory(),
+        null /* might never be used, so create lazily to delay throwing potential GeneralSecurityException */);
+  }
+
+  @VisibleForTesting
+  EndpointCaller(
+      JibLogger logger,
+      boolean allowInsecureEndpoints,
+      Function<URL, Connection> connectionFactory,
+      @Nullable Function<URL, Connection> insecureConnectionFactory) {
+    this.logger = logger;
+    allowInsecureEndoints = allowInsecureEndpoints;
+    this.connectionFactory = connectionFactory;
+    this.insecureConnectionFactory = insecureConnectionFactory;
+  }
+
+  // TODO: maybe "url" and "httpMethod" should be part of "request" (the pattern of the Google HTTP
+  // Client Library)?
+  public Response call(URL url, String httpMethod, Request request)
+      throws IOException, EndpointException {
+    if (!isHttpsProtocol(url) && !allowInsecureEndoints) {
+      throw new InsecureEndpointException(url);
+    }
+
+    try {
+      return call(url, httpMethod, request, connectionFactory);
+
+    } catch (SSLPeerUnverifiedException ex) {
+      return handleUnverifiableServerException(url, httpMethod, request);
+
+    } catch (HttpHostConnectException ex) {
+      if (allowInsecureEndoints && isHttpsProtocol(url) && url.getPort() == -1) {
+        // Fall back to HTTP only if "url" had no port specified (i.e., we tried the default HTTPS
+        // port 443) and we could not connect to 443. It's worth trying port 80.
+        return fallBackToHttp(url, httpMethod, request);
+      }
+      throw ex;
+    }
+  }
+
+  private Response handleUnverifiableServerException(URL url, String httpMethod, Request request)
+      throws IOException, EndpointException {
+    if (!allowInsecureEndoints) {
+      throw new InsecureEndpointException(url);
+    }
+
+    try {
+      logger.warn(
+          "Cannot verify server at " + url + ". Attempting again with no TLS verification.");
+      return call(url, httpMethod, request, getInsecureConnectionFactory());
+
+    } catch (SSLPeerUnverifiedException ex) {
+      return fallBackToHttp(url, httpMethod, request);
+    }
+  }
+
+  private Response fallBackToHttp(URL url, String httpMethod, Request request)
+      throws IOException, EndpointException {
+    GenericUrl httpUrl = new GenericUrl(url);
+    httpUrl.setScheme("http");
+    logger.warn(
+        "Failed to connect to " + url + " over HTTPS. Attempting again with HTTP: " + httpUrl);
+    return call(httpUrl.toURL(), httpMethod, request, connectionFactory);
+  }
+
+  private Function<URL, Connection> getInsecureConnectionFactory() throws EndpointException {
+    try {
+      if (insecureConnectionFactory == null) {
+        insecureConnectionFactory = Connection.getInsecureConnectionFactory();
+      }
+      return insecureConnectionFactory;
+
+    } catch (GeneralSecurityException ex) {
+      throw new EndpointException("cannot turn off TLS peer verification", ex);
+    }
+  }
+
+  private Response call(
+      URL url, String httpMethod, Request request, Function<URL, Connection> connectionFactory)
+      throws IOException {
+    try (Connection connection = connectionFactory.apply(url)) {
+      return connection.send(httpMethod, request);
+    }
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/EndpointException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/EndpointException.java
@@ -16,17 +16,20 @@
 
 package com.google.cloud.tools.jib.registry;
 
-import java.net.URL;
+import javax.annotation.Nullable;
 
-/**
- * Throw when attempting to access an insecure registry when only secure connections are allowed.
- */
-public class InsecureRegistryException extends RegistryException {
+/** Thrown when interacting with an endpoint. */
+public class EndpointException extends Exception {
 
-  InsecureRegistryException(URL insecureUrl) {
-    super(
-        "Failed to verify the server at "
-            + insecureUrl
-            + " because only secure connections are allowed.");
+  public EndpointException(String message, @Nullable Throwable cause) {
+    super(message, cause);
+  }
+
+  public EndpointException(String message) {
+    super(message);
+  }
+
+  public EndpointException(Throwable cause) {
+    super(cause);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/InsecureEndpointException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/InsecureEndpointException.java
@@ -16,20 +16,17 @@
 
 package com.google.cloud.tools.jib.registry;
 
-import javax.annotation.Nullable;
+import java.net.URL;
 
-/** Thrown when interacting with a registry. */
-public class RegistryException extends Exception {
+/**
+ * Throw when attempting to access an insecure registry when only secure connections are allowed.
+ */
+public class InsecureEndpointException extends EndpointException {
 
-  public RegistryException(String message, @Nullable Throwable cause) {
-    super(message, cause);
-  }
-
-  public RegistryException(String message) {
-    super(message);
-  }
-
-  public RegistryException(Throwable cause) {
-    super(cause);
+  InsecureEndpointException(URL insecureUrl) {
+    super(
+        "Failed to verify the server at "
+            + insecureUrl
+            + " because only secure connections are allowed.");
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -198,14 +198,14 @@ public class RegistryClient {
    * @return the {@link RegistryAuthenticator} to authenticate pulls/pushes with the registry, or
    *     {@code null} if no token authentication is necessary
    * @throws IOException if communicating with the endpoint fails
-   * @throws RegistryException if communicating with the endpoint fails
+   * @throws EndpointException if communicating with the endpoint fails
    */
   @Nullable
-  public RegistryAuthenticator getRegistryAuthenticator() throws IOException, RegistryException {
+  public RegistryAuthenticator getRegistryAuthenticator() throws IOException, EndpointException {
     // Gets the WWW-Authenticate header (eg. 'WWW-Authenticate: Bearer
     // realm="https://gcr.io/v2/token",service="gcr.io"')
     return callRegistryEndpoint(
-        new AuthenticationMethodRetriever(registryEndpointRequestProperties));
+        new AuthenticationMethodRetriever(buildLogger, registryEndpointRequestProperties));
   }
 
   /**
@@ -217,10 +217,10 @@ public class RegistryClient {
    *     ManifestTemplate} to pull either {@link V22ManifestTemplate} or {@link V21ManifestTemplate}
    * @return the manifest template
    * @throws IOException if communicating with the endpoint fails
-   * @throws RegistryException if communicating with the endpoint fails
+   * @throws EndpointException if communicating with the endpoint fails
    */
   public <T extends ManifestTemplate> T pullManifest(
-      String imageTag, Class<T> manifestTemplateClass) throws IOException, RegistryException {
+      String imageTag, Class<T> manifestTemplateClass) throws IOException, EndpointException {
     ManifestPuller<T> manifestPuller =
         new ManifestPuller<>(registryEndpointRequestProperties, imageTag, manifestTemplateClass);
     T manifestTemplate = callRegistryEndpoint(manifestPuller);
@@ -230,7 +230,7 @@ public class RegistryClient {
     return manifestTemplate;
   }
 
-  public ManifestTemplate pullManifest(String imageTag) throws IOException, RegistryException {
+  public ManifestTemplate pullManifest(String imageTag) throws IOException, EndpointException {
     return pullManifest(imageTag, ManifestTemplate.class);
   }
 
@@ -240,10 +240,10 @@ public class RegistryClient {
    * @param manifestTemplate the image manifest
    * @param imageTag the tag to push on
    * @throws IOException if communicating with the endpoint fails
-   * @throws RegistryException if communicating with the endpoint fails
+   * @throws EndpointException if communicating with the endpoint fails
    */
   public void pushManifest(BuildableManifestTemplate manifestTemplate, String imageTag)
-      throws IOException, RegistryException {
+      throws IOException, EndpointException {
     callRegistryEndpoint(
         new ManifestPusher(registryEndpointRequestProperties, manifestTemplate, imageTag));
   }
@@ -253,11 +253,11 @@ public class RegistryClient {
    * @return the BLOB's {@link BlobDescriptor} if the BLOB exists on the registry, or {@code null}
    *     if it doesn't
    * @throws IOException if communicating with the endpoint fails
-   * @throws RegistryException if communicating with the endpoint fails
+   * @throws EndpointException if communicating with the endpoint fails
    */
   @Nullable
   public BlobDescriptor checkBlob(DescriptorDigest blobDigest)
-      throws IOException, RegistryException {
+      throws IOException, EndpointException {
     BlobChecker blobChecker = new BlobChecker(registryEndpointRequestProperties, blobDigest);
     return callRegistryEndpoint(blobChecker);
   }
@@ -270,10 +270,10 @@ public class RegistryClient {
    * @return a {@link Blob} backed by the file at {@code destPath}. The file at {@code destPath}
    *     must exist for {@link Blob} to be valid.
    * @throws IOException if communicating with the endpoint fails
-   * @throws RegistryException if communicating with the endpoint fails
+   * @throws EndpointException if communicating with the endpoint fails
    */
   public Void pullBlob(DescriptorDigest blobDigest, OutputStream destinationOutputStream)
-      throws RegistryException, IOException {
+      throws EndpointException, IOException {
     BlobPuller blobPuller =
         new BlobPuller(registryEndpointRequestProperties, blobDigest, destinationOutputStream);
     return callRegistryEndpoint(blobPuller);
@@ -290,10 +290,10 @@ public class RegistryClient {
    * @return {@code true} if the BLOB already exists on the registry and pushing was skipped; false
    *     if the BLOB was pushed
    * @throws IOException if communicating with the endpoint fails
-   * @throws RegistryException if communicating with the endpoint fails
+   * @throws EndpointException if communicating with the endpoint fails
    */
   public boolean pushBlob(DescriptorDigest blobDigest, Blob blob, @Nullable String sourceRepository)
-      throws IOException, RegistryException {
+      throws IOException, EndpointException {
     BlobPusher blobPusher =
         new BlobPusher(registryEndpointRequestProperties, blobDigest, blob, sourceRepository);
 
@@ -340,11 +340,11 @@ public class RegistryClient {
    *
    * @param registryEndpointProvider the {@link RegistryEndpointProvider} to the endpoint
    * @throws IOException if communicating with the endpoint fails
-   * @throws RegistryException if communicating with the endpoint fails
+   * @throws EndpointException if communicating with the endpoint fails
    */
   @Nullable
   private <T> T callRegistryEndpoint(RegistryEndpointProvider<T> registryEndpointProvider)
-      throws IOException, RegistryException {
+      throws IOException, EndpointException {
     return new RegistryEndpointCaller<>(
             buildLogger,
             userAgent,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryCredentialsNotSentException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryCredentialsNotSentException.java
@@ -17,7 +17,7 @@
 package com.google.cloud.tools.jib.registry;
 
 /** Thrown when registry request was unauthorized because credentials weren't sent. */
-public class RegistryCredentialsNotSentException extends RegistryException {
+public class RegistryCredentialsNotSentException extends EndpointException {
 
   /**
    * Identifies the image registry and repository that denied access.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointProvider.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointProvider.java
@@ -50,7 +50,7 @@ interface RegistryEndpointProvider<T> {
 
   /** Handles the response specific to the registry action. */
   @Nullable
-  T handleResponse(Response response) throws IOException, RegistryException;
+  T handleResponse(Response response) throws IOException, EndpointException;
 
   /**
    * Handles an {@link HttpResponseException} that occurs.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryErrorException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryErrorException.java
@@ -22,7 +22,7 @@ import javax.annotation.Nullable;
  * Thrown when an HTTP request to a registry endpoint failed with errors as defined in {@link
  * ErrorCodes}.
  */
-public class RegistryErrorException extends RegistryException {
+public class RegistryErrorException extends EndpointException {
 
   RegistryErrorException(String message, @Nullable Throwable cause) {
     super(message, cause);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryNoResponseException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryNoResponseException.java
@@ -17,7 +17,7 @@
 package com.google.cloud.tools.jib.registry;
 
 /** Thrown when a registry did not respond. */
-public class RegistryNoResponseException extends RegistryException {
+public class RegistryNoResponseException extends EndpointException {
 
   RegistryNoResponseException(Throwable cause) {
     super(cause);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryUnauthorizedException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryUnauthorizedException.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.jib.registry;
 import com.google.api.client.http.HttpResponseException;
 
 /** Thrown when a registry request was unauthorized and therefore authentication is needed. */
-public class RegistryUnauthorizedException extends RegistryException {
+public class RegistryUnauthorizedException extends EndpointException {
 
   private final String registry;
   private final String repository;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/UnexpectedBlobDigestException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/UnexpectedBlobDigestException.java
@@ -17,7 +17,7 @@
 package com.google.cloud.tools.jib.registry;
 
 /** Thrown when a pulled BLOB did not have the same digest as requested. */
-public class UnexpectedBlobDigestException extends RegistryException {
+public class UnexpectedBlobDigestException extends EndpointException {
 
   UnexpectedBlobDigestException(String message) {
     super(message);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunnerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunnerTest.java
@@ -27,7 +27,7 @@ import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.configuration.CacheConfiguration;
 import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.configuration.LayerConfiguration;
-import com.google.cloud.tools.jib.registry.InsecureRegistryException;
+import com.google.cloud.tools.jib.registry.InsecureEndpointException;
 import com.google.cloud.tools.jib.registry.RegistryCredentialsNotSentException;
 import com.google.cloud.tools.jib.registry.RegistryUnauthorizedException;
 import com.google.common.collect.ImmutableList;
@@ -156,8 +156,8 @@ public class BuildStepsRunnerTest {
   public void testBuildImage_executionException_insecureRegistryException()
       throws InterruptedException, ExecutionException, CacheDirectoryNotOwnedException,
           CacheMetadataCorruptedException, IOException, CacheDirectoryCreationException {
-    InsecureRegistryException mockInsecureRegistryException =
-        Mockito.mock(InsecureRegistryException.class);
+    InsecureEndpointException mockInsecureRegistryException =
+        Mockito.mock(InsecureEndpointException.class);
     Mockito.when(mockExecutionException.getCause()).thenReturn(mockInsecureRegistryException);
     Mockito.doThrow(mockExecutionException).when(mockBuildSteps).run();
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverTest.java
@@ -20,6 +20,7 @@ import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpStatusCodes;
+import com.google.cloud.tools.jib.JibLogger;
 import com.google.cloud.tools.jib.http.Response;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -35,13 +36,14 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class AuthenticationMethodRetrieverTest {
 
+  @Mock private JibLogger logger;
   @Mock private HttpResponseException mockHttpResponseException;
   @Mock private HttpHeaders mockHeaders;
 
   private final RegistryEndpointRequestProperties fakeRegistryEndpointRequestProperties =
       new RegistryEndpointRequestProperties("someServerUrl", "someImageName");
   private final AuthenticationMethodRetriever testAuthenticationMethodRetriever =
-      new AuthenticationMethodRetriever(fakeRegistryEndpointRequestProperties);
+      new AuthenticationMethodRetriever(logger, fakeRegistryEndpointRequestProperties);
 
   @Test
   public void testGetContent() {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobPusherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobPusherTest.java
@@ -72,13 +72,13 @@ public class BlobPusherTest {
   }
 
   @Test
-  public void testInitializer_handleResponse_created() throws IOException, RegistryException {
+  public void testInitializer_handleResponse_created() throws IOException, EndpointException {
     Mockito.when(mockResponse.getStatusCode()).thenReturn(201); // Created
     Assert.assertNull(testBlobPusher.initializer().handleResponse(mockResponse));
   }
 
   @Test
-  public void testInitializer_handleResponse_accepted() throws IOException, RegistryException {
+  public void testInitializer_handleResponse_accepted() throws IOException, EndpointException {
     Mockito.when(mockResponse.getStatusCode()).thenReturn(202); // Accepted
     Mockito.when(mockResponse.getHeader("Location"))
         .thenReturn(Collections.singletonList("location"));
@@ -91,7 +91,7 @@ public class BlobPusherTest {
 
   @Test
   public void testInitializer_handleResponse_accepted_multipleLocations()
-      throws IOException, RegistryException {
+      throws IOException, EndpointException {
     Mockito.when(mockResponse.getStatusCode()).thenReturn(202); // Accepted
     Mockito.when(mockResponse.getHeader("Location"))
         .thenReturn(Arrays.asList("location1", "location2"));
@@ -107,7 +107,7 @@ public class BlobPusherTest {
   }
 
   @Test
-  public void testInitializer_handleResponse_unrecognized() throws IOException, RegistryException {
+  public void testInitializer_handleResponse_unrecognized() throws IOException, EndpointException {
     Mockito.when(mockResponse.getStatusCode()).thenReturn(-1); // Unrecognized
     try {
       testBlobPusher.initializer().handleResponse(mockResponse);
@@ -172,7 +172,7 @@ public class BlobPusherTest {
   }
 
   @Test
-  public void testWriter_handleResponse() throws IOException, RegistryException {
+  public void testWriter_handleResponse() throws IOException, EndpointException {
     Mockito.when(mockResponse.getHeader("Location"))
         .thenReturn(Collections.singletonList("https://somenewurl/location"));
     GenericUrl requestUrl = new GenericUrl("https://someurl");
@@ -211,7 +211,7 @@ public class BlobPusherTest {
   }
 
   @Test
-  public void testCommitter_handleResponse() throws IOException, RegistryException {
+  public void testCommitter_handleResponse() throws IOException, EndpointException {
     Assert.assertNull(
         testBlobPusher.committer(mockURL).handleResponse(Mockito.mock(Response.class)));
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
@@ -16,13 +16,21 @@
 
 package com.google.cloud.tools.jib.registry;
 
+import com.google.cloud.tools.jib.JibLogger;
 import java.net.MalformedURLException;
 import java.net.URL;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /** Tests for {@link RegistryAuthenticator}. */
+@RunWith(MockitoJUnitRunner.class)
 public class RegistryAuthenticatorTest {
+
+  @Mock private JibLogger logger;
+
   private final RegistryEndpointRequestProperties registryEndpointRequestProperties =
       new RegistryEndpointRequestProperties("someserver", "someimage");
 
@@ -31,6 +39,7 @@ public class RegistryAuthenticatorTest {
       throws MalformedURLException, RegistryAuthenticationFailedException {
     RegistryAuthenticator registryAuthenticator =
         RegistryAuthenticator.fromAuthenticationMethod(
+            logger,
             "Bearer realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
             registryEndpointRequestProperties);
     Assert.assertEquals(
@@ -39,6 +48,7 @@ public class RegistryAuthenticatorTest {
 
     registryAuthenticator =
         RegistryAuthenticator.fromAuthenticationMethod(
+            logger,
             "bEaReR realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
             registryEndpointRequestProperties);
     Assert.assertEquals(
@@ -50,16 +60,19 @@ public class RegistryAuthenticatorTest {
   public void testFromAuthenticationMethod_basic() throws RegistryAuthenticationFailedException {
     Assert.assertNull(
         RegistryAuthenticator.fromAuthenticationMethod(
+            logger,
             "Basic realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
             registryEndpointRequestProperties));
 
     Assert.assertNull(
         RegistryAuthenticator.fromAuthenticationMethod(
+            logger,
             "BASIC realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
             registryEndpointRequestProperties));
 
     Assert.assertNull(
         RegistryAuthenticator.fromAuthenticationMethod(
+            logger,
             "bASIC realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
             registryEndpointRequestProperties));
   }
@@ -68,6 +81,7 @@ public class RegistryAuthenticatorTest {
   public void testFromAuthenticationMethod_noBearer() {
     try {
       RegistryAuthenticator.fromAuthenticationMethod(
+          logger,
           "realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
           registryEndpointRequestProperties);
       Assert.fail("Authentication method without 'Bearer ' or 'Basic ' should fail");
@@ -83,7 +97,7 @@ public class RegistryAuthenticatorTest {
   public void testFromAuthenticationMethod_noRealm() {
     try {
       RegistryAuthenticator.fromAuthenticationMethod(
-          "Bearer scope=\"somescope\"", registryEndpointRequestProperties);
+          logger, "Bearer scope=\"somescope\"", registryEndpointRequestProperties);
       Assert.fail("Authentication method without 'realm' should fail");
 
     } catch (RegistryAuthenticationFailedException ex) {
@@ -98,7 +112,7 @@ public class RegistryAuthenticatorTest {
       throws MalformedURLException, RegistryAuthenticationFailedException {
     RegistryAuthenticator registryAuthenticator =
         RegistryAuthenticator.fromAuthenticationMethod(
-            "Bearer realm=\"https://somerealm\"", registryEndpointRequestProperties);
+            logger, "Bearer realm=\"https://somerealm\"", registryEndpointRequestProperties);
 
     Assert.assertEquals(
         new URL("https://somerealm?service=someserver&scope=repository:someimage:scope"),

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
@@ -128,14 +128,14 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testCall_secureCallerOnUnverifiableServer() throws IOException, RegistryException {
+  public void testCall_secureCallerOnUnverifiableServer() throws IOException, EndpointException {
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
         .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class)); // unverifiable HTTPS server
 
     try {
       secureEndpointCaller.call();
       Assert.fail("Secure caller should fail if cannot verify server");
-    } catch (InsecureRegistryException ex) {
+    } catch (InsecureEndpointException ex) {
       Assert.assertEquals(
           "Failed to verify the server at https://apiRouteBase/api because only secure connections are allowed.",
           ex.getMessage());
@@ -143,7 +143,7 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testCall_insecureCallerOnUnverifiableServer() throws IOException, RegistryException {
+  public void testCall_insecureCallerOnUnverifiableServer() throws IOException, EndpointException {
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
         .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class)); // unverifiable HTTPS server
     Mockito.when(mockInsecureConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
@@ -168,7 +168,7 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testCall_insecureCallerOnHttpServer() throws IOException, RegistryException {
+  public void testCall_insecureCallerOnHttpServer() throws IOException, EndpointException {
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
         .thenThrow(Mockito.mock(SSLPeerUnverifiedException.class)) // server is not HTTPS
         .thenReturn(mockResponse);
@@ -199,7 +199,7 @@ public class RegistryEndpointCallerTest {
 
   @Test
   public void testCall_insecureCallerOnHttpServerAndNoPortSpecified()
-      throws IOException, RegistryException {
+      throws IOException, EndpointException {
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
         .thenThrow(Mockito.mock(HttpHostConnectException.class)) // server is not listening on 443
         .thenReturn(mockResponse); // respond when connected through 80
@@ -222,7 +222,7 @@ public class RegistryEndpointCallerTest {
 
   @Test
   public void testCall_secureCallerOnNonListeningServerAndNoPortSpecified()
-      throws IOException, RegistryException {
+      throws IOException, EndpointException {
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
         .thenThrow(Mockito.mock(HttpHostConnectException.class)); // server is not listening on 443
 
@@ -243,7 +243,7 @@ public class RegistryEndpointCallerTest {
 
   @Test
   public void testCall_insecureCallerOnNonListeningServerAndPortSpecified()
-      throws IOException, RegistryException {
+      throws IOException, EndpointException {
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
         .thenThrow(Mockito.mock(HttpHostConnectException.class)); // server is not listening on 5000
 
@@ -265,7 +265,7 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testCall_noHttpResponse() throws IOException, RegistryException {
+  public void testCall_noHttpResponse() throws IOException, EndpointException {
     NoHttpResponseException mockNoHttpResponseException =
         Mockito.mock(NoHttpResponseException.class);
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
@@ -281,12 +281,12 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testCall_unauthorized() throws IOException, RegistryException {
+  public void testCall_unauthorized() throws IOException, EndpointException {
     verifyThrowsRegistryUnauthorizedException(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
   }
 
   @Test
-  public void testCall_credentialsNotSentOverHttp() throws IOException, RegistryException {
+  public void testCall_credentialsNotSentOverHttp() throws IOException, EndpointException {
     HttpResponse redirectResponse = mockRedirectHttpResponse("http://newlocation");
     HttpResponse unauthroizedResponse =
         mockHttpResponse(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED, null);
@@ -311,7 +311,7 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testCall_credentialsForcedOverHttp() throws IOException, RegistryException {
+  public void testCall_credentialsForcedOverHttp() throws IOException, EndpointException {
     HttpResponse redirectResponse = mockRedirectHttpResponse("http://newlocation");
 
     Mockito.when(mockConnection.send(Mockito.eq("httpMethod"), Mockito.any()))
@@ -346,27 +346,27 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testCall_forbidden() throws IOException, RegistryException {
+  public void testCall_forbidden() throws IOException, EndpointException {
     verifyThrowsRegistryUnauthorizedException(HttpStatusCodes.STATUS_CODE_FORBIDDEN);
   }
 
   @Test
-  public void testCall_badRequest() throws IOException, RegistryException {
+  public void testCall_badRequest() throws IOException, EndpointException {
     verifyThrowsRegistryErrorException(HttpStatusCodes.STATUS_CODE_BAD_REQUEST);
   }
 
   @Test
-  public void testCall_notFound() throws IOException, RegistryException {
+  public void testCall_notFound() throws IOException, EndpointException {
     verifyThrowsRegistryErrorException(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
   }
 
   @Test
-  public void testCall_methodNotAllowed() throws IOException, RegistryException {
+  public void testCall_methodNotAllowed() throws IOException, EndpointException {
     verifyThrowsRegistryErrorException(HttpStatusCodes.STATUS_CODE_METHOD_NOT_ALLOWED);
   }
 
   @Test
-  public void testCall_unknown() throws IOException, RegistryException {
+  public void testCall_unknown() throws IOException, EndpointException {
     HttpResponse mockHttpResponse =
         mockHttpResponse(HttpStatusCodes.STATUS_CODE_SERVER_ERROR, null);
     HttpResponseException httpResponseException = new HttpResponseException(mockHttpResponse);
@@ -384,22 +384,22 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testCall_temporaryRedirect() throws IOException, RegistryException {
+  public void testCall_temporaryRedirect() throws IOException, EndpointException {
     verifyRetriesWithNewLocation(HttpStatusCodes.STATUS_CODE_TEMPORARY_REDIRECT);
   }
 
   @Test
-  public void testCall_movedPermanently() throws IOException, RegistryException {
+  public void testCall_movedPermanently() throws IOException, EndpointException {
     verifyRetriesWithNewLocation(HttpStatusCodes.STATUS_CODE_MOVED_PERMANENTLY);
   }
 
   @Test
-  public void testCall_permanentRedirect() throws IOException, RegistryException {
+  public void testCall_permanentRedirect() throws IOException, EndpointException {
     verifyRetriesWithNewLocation(RegistryEndpointCaller.STATUS_CODE_PERMANENT_REDIRECT);
   }
 
   @Test
-  public void testCall_disallowInsecure() throws IOException, RegistryException {
+  public void testCall_disallowInsecure() throws IOException, EndpointException {
     // Mocks a response for temporary redirect to a new location.
     HttpResponse redirectResponse = mockRedirectHttpResponse("http://newlocation");
 
@@ -411,13 +411,13 @@ public class RegistryEndpointCallerTest {
       secureEndpointCaller.call();
       Assert.fail("Call should have failed");
 
-    } catch (InsecureRegistryException ex) {
+    } catch (InsecureEndpointException ex) {
       // pass
     }
   }
 
   @Test
-  public void testHttpTimeout_propertyNotSet() throws IOException, RegistryException {
+  public void testHttpTimeout_propertyNotSet() throws IOException, EndpointException {
     MockConnection mockConnection = new MockConnection((httpMethod, request) -> mockResponse);
     Mockito.when(mockConnectionFactory.apply(Mockito.any())).thenReturn(mockConnection);
 
@@ -430,7 +430,7 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testHttpTimeout_stringValue() throws IOException, RegistryException {
+  public void testHttpTimeout_stringValue() throws IOException, EndpointException {
     MockConnection mockConnection = new MockConnection((httpMethod, request) -> mockResponse);
     Mockito.when(mockConnectionFactory.apply(Mockito.any())).thenReturn(mockConnection);
 
@@ -441,7 +441,7 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testHttpTimeout_negativeValue() throws IOException, RegistryException {
+  public void testHttpTimeout_negativeValue() throws IOException, EndpointException {
     MockConnection mockConnection = new MockConnection((httpMethod, request) -> mockResponse);
     Mockito.when(mockConnectionFactory.apply(Mockito.any())).thenReturn(mockConnection);
 
@@ -454,7 +454,7 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testHttpTimeout_0accepted() throws IOException, RegistryException {
+  public void testHttpTimeout_0accepted() throws IOException, EndpointException {
     System.setProperty("jib.httpTimeout", "0");
 
     MockConnection mockConnection = new MockConnection((httpMethod, request) -> mockResponse);
@@ -466,7 +466,7 @@ public class RegistryEndpointCallerTest {
   }
 
   @Test
-  public void testHttpTimeout() throws IOException, RegistryException {
+  public void testHttpTimeout() throws IOException, EndpointException {
     System.setProperty("jib.httpTimeout", "7593");
 
     MockConnection mockConnection = new MockConnection((httpMethod, request) -> mockResponse);
@@ -482,7 +482,7 @@ public class RegistryEndpointCallerTest {
    * RegistryUnauthorizedException}.
    */
   private void verifyThrowsRegistryUnauthorizedException(int httpStatusCode)
-      throws IOException, RegistryException {
+      throws IOException, EndpointException {
     HttpResponse mockHttpResponse = mockHttpResponse(httpStatusCode, null);
     HttpResponseException httpResponseException = new HttpResponseException(mockHttpResponse);
 
@@ -505,7 +505,7 @@ public class RegistryEndpointCallerTest {
    * RegistryUnauthorizedException}.
    */
   private void verifyThrowsRegistryErrorException(int httpStatusCode)
-      throws IOException, RegistryException {
+      throws IOException, EndpointException {
     HttpResponse errorResponse = mockHttpResponse(httpStatusCode, null);
     Mockito.when(errorResponse.parseAsString())
         .thenReturn("{\"errors\":[{\"code\":\"code\",\"message\":\"message\"}]}");
@@ -531,7 +531,7 @@ public class RegistryEndpointCallerTest {
    * Location} header.
    */
   private void verifyRetriesWithNewLocation(int httpStatusCode)
-      throws IOException, RegistryException {
+      throws IOException, EndpointException {
     // Mocks a response for temporary redirect to a new location.
     HttpResponse redirectResponse =
         mockHttpResponse(httpStatusCode, new HttpHeaders().setLocation("https://newlocation"));
@@ -564,8 +564,6 @@ public class RegistryEndpointCallerTest {
         new TestRegistryEndpointProvider(),
         Authorizations.withBasicToken("token"),
         new RegistryEndpointRequestProperties("serverUrl", "imageName"),
-        allowInsecure,
-        mockConnectionFactory,
-        mockInsecureConnectionFactory);
+        allowInsecure);
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -16,28 +16,16 @@
 
 package com.google.cloud.tools.jib.gradle;
 
-import com.google.cloud.tools.jib.JibLogger;
 import com.google.cloud.tools.jib.cache.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
-import com.google.cloud.tools.jib.configuration.CacheConfiguration;
-import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
 import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.docker.DockerClient;
-import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
-import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
-import com.google.cloud.tools.jib.http.Authorization;
-import com.google.cloud.tools.jib.http.Authorizations;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
-import com.google.cloud.tools.jib.plugins.common.SystemPropertyValidator;
-import com.google.cloud.tools.jib.registry.RegistryClient;
-import com.google.cloud.tools.jib.registry.credentials.RegistryCredentials;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import java.time.Instant;
 import javax.annotation.Nullable;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -47,9 +35,6 @@ import org.gradle.api.tasks.options.Option;
 
 /** Builds a container image and exports to the default Docker daemon. */
 public class BuildDockerTask extends DefaultTask {
-
-  /** {@code User-Agent} header suffix to send to the registry. */
-  private static final String USER_AGENT_SUFFIX = "jib-gradle-plugin";
 
   private static final HelpfulSuggestions HELPFUL_SUGGESTIONS =
       HelpfulSuggestionsProvider.get("Build to Docker daemon failed");
@@ -87,73 +72,26 @@ public class BuildDockerTask extends DefaultTask {
     // Asserts required @Input parameters are not null.
     Preconditions.checkNotNull(jibExtension);
     GradleJibLogger gradleJibLogger = new GradleJibLogger(getLogger());
-    jibExtension.handleDeprecatedParameters(gradleJibLogger);
-    SystemPropertyValidator.checkHttpTimeoutProperty(GradleException::new);
-
-    if (Boolean.getBoolean("sendCredentialsOverHttp")) {
-      gradleJibLogger.warn(
-          "Authentication over HTTP is enabled. It is strongly recommended that you do not enable "
-              + "this on a public network!");
-    }
-    RegistryCredentials knownBaseRegistryCredentials = null;
-    Authorization fromAuthorization =
-        getImageAuthorization(gradleJibLogger, "from", jibExtension.getFrom().getAuth());
-    if (fromAuthorization != null) {
-      knownBaseRegistryCredentials = new RegistryCredentials("jib.from.auth", fromAuthorization);
-    }
-
     GradleProjectProperties gradleProjectProperties =
         GradleProjectProperties.getForProject(
             getProject(), gradleJibLogger, jibExtension.getExtraDirectoryPath());
-    String mainClass = gradleProjectProperties.getMainClass(jibExtension);
+
     ImageReference targetImage =
         gradleProjectProperties.getGeneratedTargetDockerTag(jibExtension, gradleJibLogger);
 
-    // Builds the BuildConfiguration.
-    // TODO: Consolidate with BuildImageTask.
-    ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder(ImageReference.parse(jibExtension.getBaseImage()))
-            .setCredentialHelper(jibExtension.getFrom().getCredHelper())
-            .setKnownRegistryCredentials(knownBaseRegistryCredentials)
+    PluginConfigurationProcessor pluginConfigurationProcessor =
+        PluginConfigurationProcessor.processCommonConfiguration(
+            gradleJibLogger, jibExtension, gradleProjectProperties);
+
+    BuildConfiguration buildConfiguration =
+        pluginConfigurationProcessor
+            .getBuildConfigurationBuilder()
+            .setBaseImageConfiguration(
+                pluginConfigurationProcessor.getBaseImageConfigurationBuilder().build())
+            .setTargetImageConfiguration(ImageConfiguration.builder(targetImage).build())
+            .setContainerConfiguration(
+                pluginConfigurationProcessor.getContainerConfigurationBuilder().build())
             .build();
-
-    ImageConfiguration targetImageConfiguration = ImageConfiguration.builder(targetImage).build();
-
-    ContainerConfiguration.Builder containerConfigurationBuilder =
-        ContainerConfiguration.builder()
-            .setEntrypoint(
-                JavaEntrypointConstructor.makeDefaultEntrypoint(
-                    jibExtension.getJvmFlags(), mainClass))
-            .setProgramArguments(jibExtension.getArgs())
-            .setExposedPorts(ExposedPortsParser.parse(jibExtension.getExposedPorts()));
-    if (jibExtension.getUseCurrentTimestamp()) {
-      gradleJibLogger.warn(
-          "Setting image creation time to current time; your image may not be reproducible.");
-      containerConfigurationBuilder.setCreationTime(Instant.now());
-    }
-
-    BuildConfiguration.Builder buildConfigurationBuilder =
-        BuildConfiguration.builder(gradleJibLogger)
-            .setBaseImageConfiguration(baseImageConfiguration)
-            .setTargetImageConfiguration(targetImageConfiguration)
-            .setContainerConfiguration(containerConfigurationBuilder.build())
-            .setAllowInsecureRegistries(jibExtension.getAllowInsecureRegistries())
-            .setLayerConfigurations(gradleProjectProperties.getLayerConfigurations());
-    CacheConfiguration applicationLayersCacheConfiguration =
-        CacheConfiguration.forPath(gradleProjectProperties.getCacheDirectory());
-    buildConfigurationBuilder.setApplicationLayersCacheConfiguration(
-        applicationLayersCacheConfiguration);
-    if (jibExtension.getUseOnlyProjectCache()) {
-      buildConfigurationBuilder.setBaseImageLayersCacheConfiguration(
-          applicationLayersCacheConfiguration);
-    }
-
-    BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();
-
-    // TODO: Instead of disabling logging, have authentication credentials be provided
-    GradleJibLogger.disableHttpLogging();
-
-    RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
 
     // Uses a directory in the Gradle build cache as the Jib cache.
     try {
@@ -167,42 +105,5 @@ public class BuildDockerTask extends DefaultTask {
   BuildDockerTask setJibExtension(JibExtension jibExtension) {
     this.jibExtension = jibExtension;
     return this;
-  }
-
-  /**
-   * Validates and returns an {@link Authorization} from a configured {@link AuthParameters}.
-   *
-   * <p>TODO: Consolidate with other tasks.
-   *
-   * @param logger the {@link JibLogger} used to print warnings
-   * @param imageProperty the image configuration's name (i.e. "from" or "to")
-   * @param auth the auth configuration to get the {@link Authorization} from
-   * @return the {@link Authorization}, or null if the username and password aren't both configured
-   */
-  @Nullable
-  private static Authorization getImageAuthorization(
-      JibLogger logger, String imageProperty, AuthParameters auth) {
-    if (Strings.isNullOrEmpty(auth.getUsername()) && Strings.isNullOrEmpty(auth.getPassword())) {
-      return null;
-    }
-    if (Strings.isNullOrEmpty(auth.getUsername())) {
-      logger.warn(
-          "jib."
-              + imageProperty
-              + ".auth.username is null; ignoring jib."
-              + imageProperty
-              + ".auth section.");
-      return null;
-    }
-    if (Strings.isNullOrEmpty(auth.getPassword())) {
-      logger.warn(
-          "jib."
-              + imageProperty
-              + ".auth.password is null; ignoring jib."
-              + imageProperty
-              + ".auth section.");
-      return null;
-    }
-    return Authorizations.withBasicCredentials(auth.getUsername(), auth.getPassword());
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -16,28 +16,18 @@
 
 package com.google.cloud.tools.jib.gradle;
 
-import com.google.cloud.tools.jib.JibLogger;
 import com.google.cloud.tools.jib.cache.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
-import com.google.cloud.tools.jib.configuration.CacheConfiguration;
-import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
 import com.google.cloud.tools.jib.configuration.ImageConfiguration;
-import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
-import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
 import com.google.cloud.tools.jib.http.Authorization;
-import com.google.cloud.tools.jib.http.Authorizations;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
-import com.google.cloud.tools.jib.plugins.common.SystemPropertyValidator;
-import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.cloud.tools.jib.registry.credentials.RegistryCredentials;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import java.time.Instant;
 import javax.annotation.Nullable;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -47,9 +37,6 @@ import org.gradle.api.tasks.options.Option;
 
 /** Builds a container image. */
 public class BuildImageTask extends DefaultTask {
-
-  /** {@code User-Agent} header suffix to send to the registry. */
-  private static final String USER_AGENT_SUFFIX = "jib-gradle-plugin";
 
   private static final HelpfulSuggestions HELPFUL_SUGGESTIONS =
       HelpfulSuggestionsProvider.get("Build image failed");
@@ -83,8 +70,9 @@ public class BuildImageTask extends DefaultTask {
     // Asserts required @Input parameters are not null.
     Preconditions.checkNotNull(jibExtension);
     GradleJibLogger gradleJibLogger = new GradleJibLogger(getLogger());
-    jibExtension.handleDeprecatedParameters(gradleJibLogger);
-    SystemPropertyValidator.checkHttpTimeoutProperty(GradleException::new);
+    GradleProjectProperties gradleProjectProperties =
+        GradleProjectProperties.getForProject(
+            getProject(), gradleJibLogger, jibExtension.getExtraDirectoryPath());
 
     if (Strings.isNullOrEmpty(jibExtension.getTargetImage())) {
       throw new GradleException(
@@ -92,80 +80,33 @@ public class BuildImageTask extends DefaultTask {
               .forToNotConfigured(
                   "'jib.to.image'", "build.gradle", "gradle jib --image <your image name>"));
     }
-
-    if (Boolean.getBoolean("sendCredentialsOverHttp")) {
-      gradleJibLogger.warn(
-          "Authentication over HTTP is enabled. It is strongly recommended that you do not enable "
-              + "this on a public network!");
-    }
-    RegistryCredentials knownBaseRegistryCredentials = null;
     RegistryCredentials knownTargetRegistryCredentials = null;
-    Authorization fromAuthorization =
-        getImageAuthorization(gradleJibLogger, "from", jibExtension.getFrom().getAuth());
-    if (fromAuthorization != null) {
-      knownBaseRegistryCredentials = new RegistryCredentials("jib.from.auth", fromAuthorization);
-    }
     Authorization toAuthorization =
-        getImageAuthorization(gradleJibLogger, "to", jibExtension.getFrom().getAuth());
+        PluginConfigurationProcessor.getImageAuthorization(
+            gradleJibLogger, "to", jibExtension.getFrom().getAuth());
     if (toAuthorization != null) {
       knownTargetRegistryCredentials = new RegistryCredentials("jib.to.auth", toAuthorization);
     }
-
-    GradleProjectProperties gradleProjectProperties =
-        GradleProjectProperties.getForProject(
-            getProject(), gradleJibLogger, jibExtension.getExtraDirectoryPath());
-    String mainClass = gradleProjectProperties.getMainClass(jibExtension);
-
-    // Builds the BuildConfiguration.
-    ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder(ImageReference.parse(jibExtension.getBaseImage()))
-            .setCredentialHelper(jibExtension.getFrom().getCredHelper())
-            .setKnownRegistryCredentials(knownBaseRegistryCredentials)
-            .build();
-
     ImageConfiguration targetImageConfiguration =
         ImageConfiguration.builder(ImageReference.parse(jibExtension.getTargetImage()))
             .setCredentialHelper(jibExtension.getTo().getCredHelper())
             .setKnownRegistryCredentials(knownTargetRegistryCredentials)
             .build();
 
-    ContainerConfiguration.Builder containerConfigurationBuilder =
-        ContainerConfiguration.builder()
-            .setEntrypoint(
-                JavaEntrypointConstructor.makeDefaultEntrypoint(
-                    jibExtension.getJvmFlags(), mainClass))
-            .setProgramArguments(jibExtension.getArgs())
-            .setExposedPorts(ExposedPortsParser.parse(jibExtension.getExposedPorts()));
-    if (jibExtension.getUseCurrentTimestamp()) {
-      gradleJibLogger.warn(
-          "Setting image creation time to current time; your image may not be reproducible.");
-      containerConfigurationBuilder.setCreationTime(Instant.now());
-    }
+    PluginConfigurationProcessor pluginConfigurationProcessor =
+        PluginConfigurationProcessor.processCommonConfiguration(
+            gradleJibLogger, jibExtension, gradleProjectProperties);
 
-    BuildConfiguration.Builder buildConfigurationBuilder =
-        BuildConfiguration.builder(gradleJibLogger)
-            .setBaseImageConfiguration(baseImageConfiguration)
+    BuildConfiguration buildConfiguration =
+        pluginConfigurationProcessor
+            .getBuildConfigurationBuilder()
+            .setBaseImageConfiguration(
+                pluginConfigurationProcessor.getBaseImageConfigurationBuilder().build())
             .setTargetImageConfiguration(targetImageConfiguration)
-            .setContainerConfiguration(containerConfigurationBuilder.build())
+            .setContainerConfiguration(
+                pluginConfigurationProcessor.getContainerConfigurationBuilder().build())
             .setTargetFormat(jibExtension.getFormat())
-            .setAllowInsecureRegistries(jibExtension.getAllowInsecureRegistries())
-            .setLayerConfigurations(gradleProjectProperties.getLayerConfigurations());
-
-    CacheConfiguration applicationLayersCacheConfiguration =
-        CacheConfiguration.forPath(gradleProjectProperties.getCacheDirectory());
-    buildConfigurationBuilder.setApplicationLayersCacheConfiguration(
-        applicationLayersCacheConfiguration);
-    if (jibExtension.getUseOnlyProjectCache()) {
-      buildConfigurationBuilder.setBaseImageLayersCacheConfiguration(
-          applicationLayersCacheConfiguration);
-    }
-
-    BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();
-
-    // TODO: Instead of disabling logging, have authentication credentials be provided
-    GradleJibLogger.disableHttpLogging();
-
-    RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
+            .build();
 
     try {
       BuildStepsRunner.forBuildImage(buildConfiguration).build(HELPFUL_SUGGESTIONS);
@@ -178,43 +119,5 @@ public class BuildImageTask extends DefaultTask {
   BuildImageTask setJibExtension(JibExtension jibExtension) {
     this.jibExtension = jibExtension;
     return this;
-  }
-
-  /**
-   * Validates and returns an {@link Authorization} from a configured {@link AuthParameters}.
-   *
-   * <p>TODO: Consolidate with other tasks.
-   *
-   * @param logger the {@link JibLogger} used to print warnings
-   * @param imageProperty the image configuration's name (i.e. "from" or "to")
-   * @param auth the auth configuration to get the {@link Authorization} from
-   * @return the {@link Authorization}, or null if the username and password aren't both configured
-   */
-  @VisibleForTesting
-  @Nullable
-  static Authorization getImageAuthorization(
-      JibLogger logger, String imageProperty, AuthParameters auth) {
-    if (Strings.isNullOrEmpty(auth.getUsername()) && Strings.isNullOrEmpty(auth.getPassword())) {
-      return null;
-    }
-    if (Strings.isNullOrEmpty(auth.getUsername())) {
-      logger.warn(
-          "jib."
-              + imageProperty
-              + ".auth.username is null; ignoring jib."
-              + imageProperty
-              + ".auth section.");
-      return null;
-    }
-    if (Strings.isNullOrEmpty(auth.getPassword())) {
-      logger.warn(
-          "jib."
-              + imageProperty
-              + ".auth.password is null; ignoring jib."
-              + imageProperty
-              + ".auth section.");
-      return null;
-    }
-    return Authorizations.withBasicCredentials(auth.getUsername(), auth.getPassword());
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -16,28 +16,16 @@
 
 package com.google.cloud.tools.jib.gradle;
 
-import com.google.cloud.tools.jib.JibLogger;
 import com.google.cloud.tools.jib.cache.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
-import com.google.cloud.tools.jib.configuration.CacheConfiguration;
-import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
 import com.google.cloud.tools.jib.configuration.ImageConfiguration;
-import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
-import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
-import com.google.cloud.tools.jib.http.Authorization;
-import com.google.cloud.tools.jib.http.Authorizations;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
-import com.google.cloud.tools.jib.plugins.common.SystemPropertyValidator;
-import com.google.cloud.tools.jib.registry.RegistryClient;
-import com.google.cloud.tools.jib.registry.credentials.RegistryCredentials;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import java.nio.file.Paths;
-import java.time.Instant;
 import javax.annotation.Nullable;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -50,9 +38,6 @@ import org.gradle.api.tasks.options.Option;
 
 /** Builds a container image to a tarball. */
 public class BuildTarTask extends DefaultTask {
-
-  /** {@code User-Agent} header suffix to send to the registry. */
-  private static final String USER_AGENT_SUFFIX = "jib-gradle-plugin";
 
   private static final HelpfulSuggestions HELPFUL_SUGGESTIONS =
       HelpfulSuggestionsProvider.get("Building image tarball failed");
@@ -115,73 +100,26 @@ public class BuildTarTask extends DefaultTask {
     // Asserts required @Input parameters are not null.
     Preconditions.checkNotNull(jibExtension);
     GradleJibLogger gradleJibLogger = new GradleJibLogger(getLogger());
-    jibExtension.handleDeprecatedParameters(gradleJibLogger);
-    SystemPropertyValidator.checkHttpTimeoutProperty(GradleException::new);
-
-    if (Boolean.getBoolean("sendCredentialsOverHttp")) {
-      gradleJibLogger.warn(
-          "Authentication over HTTP is enabled. It is strongly recommended that you do not enable "
-              + "this on a public network!");
-    }
-    RegistryCredentials knownBaseRegistryCredentials = null;
-    Authorization fromAuthorization =
-        getImageAuthorization(gradleJibLogger, "from", jibExtension.getFrom().getAuth());
-    if (fromAuthorization != null) {
-      knownBaseRegistryCredentials = new RegistryCredentials("jib.from.auth", fromAuthorization);
-    }
-
     GradleProjectProperties gradleProjectProperties =
         GradleProjectProperties.getForProject(
             getProject(), gradleJibLogger, jibExtension.getExtraDirectoryPath());
-    String mainClass = gradleProjectProperties.getMainClass(jibExtension);
+
     ImageReference targetImage =
         gradleProjectProperties.getGeneratedTargetDockerTag(jibExtension, gradleJibLogger);
 
-    // Builds the BuildConfiguration.
-    // TODO: Consolidate with BuildImageTask/BuildDockerTask.
-    ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder(ImageReference.parse(jibExtension.getBaseImage()))
-            .setCredentialHelper(jibExtension.getFrom().getCredHelper())
-            .setKnownRegistryCredentials(knownBaseRegistryCredentials)
+    PluginConfigurationProcessor pluginConfigurationProcessor =
+        PluginConfigurationProcessor.processCommonConfiguration(
+            gradleJibLogger, jibExtension, gradleProjectProperties);
+
+    BuildConfiguration buildConfiguration =
+        pluginConfigurationProcessor
+            .getBuildConfigurationBuilder()
+            .setBaseImageConfiguration(
+                pluginConfigurationProcessor.getBaseImageConfigurationBuilder().build())
+            .setTargetImageConfiguration(ImageConfiguration.builder(targetImage).build())
+            .setContainerConfiguration(
+                pluginConfigurationProcessor.getContainerConfigurationBuilder().build())
             .build();
-
-    ImageConfiguration targetImageConfiguration = ImageConfiguration.builder(targetImage).build();
-
-    ContainerConfiguration.Builder containerConfigurationBuilder =
-        ContainerConfiguration.builder()
-            .setEntrypoint(
-                JavaEntrypointConstructor.makeDefaultEntrypoint(
-                    jibExtension.getJvmFlags(), mainClass))
-            .setProgramArguments(jibExtension.getArgs())
-            .setExposedPorts(ExposedPortsParser.parse(jibExtension.getExposedPorts()));
-    if (jibExtension.getUseCurrentTimestamp()) {
-      gradleJibLogger.warn(
-          "Setting image creation time to current time; your image may not be reproducible.");
-      containerConfigurationBuilder.setCreationTime(Instant.now());
-    }
-
-    BuildConfiguration.Builder buildConfigurationBuilder =
-        BuildConfiguration.builder(gradleJibLogger)
-            .setBaseImageConfiguration(baseImageConfiguration)
-            .setTargetImageConfiguration(targetImageConfiguration)
-            .setContainerConfiguration(containerConfigurationBuilder.build())
-            .setAllowInsecureRegistries(jibExtension.getAllowInsecureRegistries())
-            .setLayerConfigurations(gradleProjectProperties.getLayerConfigurations());
-    CacheConfiguration applicationLayersCacheConfiguration =
-        CacheConfiguration.forPath(gradleProjectProperties.getCacheDirectory());
-    buildConfigurationBuilder.setApplicationLayersCacheConfiguration(
-        applicationLayersCacheConfiguration);
-    if (jibExtension.getUseOnlyProjectCache()) {
-      buildConfigurationBuilder.setBaseImageLayersCacheConfiguration(
-          applicationLayersCacheConfiguration);
-    }
-
-    BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();
-
-    // TODO: Instead of disabling logging, have authentication credentials be provided
-    GradleJibLogger.disableHttpLogging();
-
-    RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
 
     // Uses a directory in the Gradle build cache as the Jib cache.
     try {
@@ -196,42 +134,5 @@ public class BuildTarTask extends DefaultTask {
   BuildTarTask setJibExtension(JibExtension jibExtension) {
     this.jibExtension = jibExtension;
     return this;
-  }
-
-  /**
-   * Validates and returns an {@link Authorization} from a configured {@link AuthParameters}.
-   *
-   * <p>TODO: Consolidate with other tasks.
-   *
-   * @param logger the {@link JibLogger} used to print warnings
-   * @param imageProperty the image configuration's name (i.e. "from" or "to")
-   * @param auth the auth configuration to get the {@link Authorization} from
-   * @return the {@link Authorization}, or null if the username and password aren't both configured
-   */
-  @Nullable
-  private static Authorization getImageAuthorization(
-      JibLogger logger, String imageProperty, AuthParameters auth) {
-    if (Strings.isNullOrEmpty(auth.getUsername()) && Strings.isNullOrEmpty(auth.getPassword())) {
-      return null;
-    }
-    if (Strings.isNullOrEmpty(auth.getUsername())) {
-      logger.warn(
-          "jib."
-              + imageProperty
-              + ".auth.username is null; ignoring jib."
-              + imageProperty
-              + ".auth section.");
-      return null;
-    }
-    if (Strings.isNullOrEmpty(auth.getPassword())) {
-      logger.warn(
-          "jib."
-              + imageProperty
-              + ".auth.password is null; ignoring jib."
-              + imageProperty
-              + ".auth section.");
-      return null;
-    }
-    return Authorizations.withBasicCredentials(auth.getUsername(), auth.getPassword());
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2018 Google LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.gradle;
+
+import com.google.cloud.tools.jib.JibLogger;
+import com.google.cloud.tools.jib.configuration.BuildConfiguration;
+import com.google.cloud.tools.jib.configuration.CacheConfiguration;
+import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
+import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
+import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
+import com.google.cloud.tools.jib.http.Authorization;
+import com.google.cloud.tools.jib.http.Authorizations;
+import com.google.cloud.tools.jib.image.ImageReference;
+import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
+import com.google.cloud.tools.jib.plugins.common.SystemPropertyValidator;
+import com.google.cloud.tools.jib.registry.RegistryClient;
+import com.google.cloud.tools.jib.registry.credentials.RegistryCredentials;
+import com.google.common.base.Strings;
+import java.time.Instant;
+import javax.annotation.Nullable;
+import org.gradle.api.GradleException;
+
+/** Configures and provides builders for the image building tasks. */
+class PluginConfigurationProcessor {
+
+  /** {@code User-Agent} header suffix to send to the registry. */
+  private static final String USER_AGENT_SUFFIX = "jib-gradle-plugin";
+
+  /**
+   * Sets up {@link BuildConfiguration} that is common among the image building tasks. This includes
+   * setting up the base image reference/authorization, container configuration, cache
+   * configuration, and layer configuration.
+   *
+   * @param logger the logger used to display messages.
+   * @param jibExtension the {@link JibExtension} providing the configuration data
+   * @param projectProperties used for providing additional information
+   * @return a new {@link PluginConfigurationProcessor} containing pre-configured builders
+   * @throws InvalidImageReferenceException if parsing the base image configuration fails
+   */
+  static PluginConfigurationProcessor processCommonConfiguration(
+      JibLogger logger, JibExtension jibExtension, GradleProjectProperties projectProperties)
+      throws InvalidImageReferenceException {
+    jibExtension.handleDeprecatedParameters(logger);
+    SystemPropertyValidator.checkHttpTimeoutProperty(GradleException::new);
+
+    // TODO: Instead of disabling logging, have authentication credentials be provided
+    GradleJibLogger.disableHttpLogging();
+    RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
+
+    if (Boolean.getBoolean("sendCredentialsOverHttp")) {
+      logger.warn(
+          "Authentication over HTTP is enabled. It is strongly recommended that you do not enable "
+              + "this on a public network!");
+    }
+    RegistryCredentials knownBaseRegistryCredentials = null;
+    Authorization fromAuthorization =
+        getImageAuthorization(logger, "from", jibExtension.getFrom().getAuth());
+    if (fromAuthorization != null) {
+      knownBaseRegistryCredentials = new RegistryCredentials("jib.from.auth", fromAuthorization);
+    }
+
+    ImageConfiguration.Builder baseImageConfigurationBuilder =
+        ImageConfiguration.builder(ImageReference.parse(jibExtension.getBaseImage()))
+            .setCredentialHelper(jibExtension.getFrom().getCredHelper())
+            .setKnownRegistryCredentials(knownBaseRegistryCredentials);
+
+    String mainClass = projectProperties.getMainClass(jibExtension);
+    ContainerConfiguration.Builder containerConfigurationBuilder =
+        ContainerConfiguration.builder()
+            .setEntrypoint(
+                JavaEntrypointConstructor.makeDefaultEntrypoint(
+                    jibExtension.getJvmFlags(), mainClass))
+            .setProgramArguments(jibExtension.getArgs())
+            .setExposedPorts(ExposedPortsParser.parse(jibExtension.getExposedPorts()));
+    if (jibExtension.getUseCurrentTimestamp()) {
+      logger.warn(
+          "Setting image creation time to current time; your image may not be reproducible.");
+      containerConfigurationBuilder.setCreationTime(Instant.now());
+    }
+
+    BuildConfiguration.Builder buildConfigurationBuilder =
+        BuildConfiguration.builder(logger)
+            .setAllowInsecureRegistries(jibExtension.getAllowInsecureRegistries())
+            .setLayerConfigurations(projectProperties.getLayerConfigurations());
+    CacheConfiguration applicationLayersCacheConfiguration =
+        CacheConfiguration.forPath(projectProperties.getCacheDirectory());
+    buildConfigurationBuilder.setApplicationLayersCacheConfiguration(
+        applicationLayersCacheConfiguration);
+    if (jibExtension.getUseOnlyProjectCache()) {
+      buildConfigurationBuilder.setBaseImageLayersCacheConfiguration(
+          applicationLayersCacheConfiguration);
+    }
+
+    return new PluginConfigurationProcessor(
+        buildConfigurationBuilder, baseImageConfigurationBuilder, containerConfigurationBuilder);
+  }
+
+  /**
+   * Validates and returns an {@link Authorization} from a configured {@link AuthParameters}.
+   *
+   * @param logger the {@link JibLogger} used to print warnings
+   * @param imageProperty the image configuration's name (i.e. "from" or "to")
+   * @param auth the auth configuration to get the {@link Authorization} from
+   * @return the {@link Authorization}, or null if the username and password aren't both configured
+   */
+  @Nullable
+  static Authorization getImageAuthorization(
+      JibLogger logger, String imageProperty, AuthParameters auth) {
+    if (Strings.isNullOrEmpty(auth.getUsername()) && Strings.isNullOrEmpty(auth.getPassword())) {
+      return null;
+    }
+    if (Strings.isNullOrEmpty(auth.getUsername())) {
+      logger.warn(
+          "jib."
+              + imageProperty
+              + ".auth.username is null; ignoring jib."
+              + imageProperty
+              + ".auth section.");
+      return null;
+    }
+    if (Strings.isNullOrEmpty(auth.getPassword())) {
+      logger.warn(
+          "jib."
+              + imageProperty
+              + ".auth.password is null; ignoring jib."
+              + imageProperty
+              + ".auth section.");
+      return null;
+    }
+    return Authorizations.withBasicCredentials(auth.getUsername(), auth.getPassword());
+  }
+
+  private final BuildConfiguration.Builder buildConfigurationBuilder;
+  private final ImageConfiguration.Builder baseImageConfigurationBuilder;
+  private final ContainerConfiguration.Builder containerConfigurationBuilder;
+
+  private PluginConfigurationProcessor(
+      BuildConfiguration.Builder buildConfigurationBuilder,
+      ImageConfiguration.Builder baseImageConfigurationBuilder,
+      ContainerConfiguration.Builder containerConfigurationBuilder) {
+    this.buildConfigurationBuilder = buildConfigurationBuilder;
+    this.baseImageConfigurationBuilder = baseImageConfigurationBuilder;
+    this.containerConfigurationBuilder = containerConfigurationBuilder;
+  }
+
+  BuildConfiguration.Builder getBuildConfigurationBuilder() {
+    return buildConfigurationBuilder;
+  }
+
+  ImageConfiguration.Builder getBaseImageConfigurationBuilder() {
+    return baseImageConfigurationBuilder;
+  }
+
+  ContainerConfiguration.Builder getContainerConfigurationBuilder() {
+    return containerConfigurationBuilder;
+  }
+}

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessorTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessorTest.java
@@ -26,15 +26,9 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/**
- * Test for {@link BuildImageTask}.
- *
- * <p>TODO: This only tests the {@link BuildImageTask#getImageAuthorization(JibLogger, String,
- * AuthParameters)} method, which is copy-pasted between the 3 build tasks. When we refactor, we'll
- * need to move this test.
- */
+/** Test for {@link PluginConfigurationProcessor}. */
 @RunWith(MockitoJUnitRunner.class)
-public class BuildImageTaskTest {
+public class PluginConfigurationProcessorTest {
 
   @Mock private JibLogger mockLogger;
 
@@ -46,27 +40,28 @@ public class BuildImageTaskTest {
     auth.setUsername("vwxyz");
     auth.setPassword("98765");
     Authorization expected = Authorizations.withBasicCredentials("vwxyz", "98765");
-    Authorization actual = BuildImageTask.getImageAuthorization(mockLogger, "to", auth);
+    Authorization actual =
+        PluginConfigurationProcessor.getImageAuthorization(mockLogger, "to", auth);
     Assert.assertNotNull(actual);
     Assert.assertEquals(expected.toString(), actual.toString());
     Mockito.verify(mockLogger, Mockito.never()).warn(Mockito.any());
 
     // Auth completely missing
     auth = new AuthParameters();
-    actual = BuildImageTask.getImageAuthorization(mockLogger, "to", auth);
+    actual = PluginConfigurationProcessor.getImageAuthorization(mockLogger, "to", auth);
     Assert.assertNull(actual);
 
     // Password missing
     auth = new AuthParameters();
     auth.setUsername("vwxyz");
-    actual = BuildImageTask.getImageAuthorization(mockLogger, "to", auth);
+    actual = PluginConfigurationProcessor.getImageAuthorization(mockLogger, "to", auth);
     Assert.assertNull(actual);
     Mockito.verify(mockLogger).warn("jib.to.auth.password is null; ignoring jib.to.auth section.");
 
     // Username missing
     auth = new AuthParameters();
     auth.setPassword("98765");
-    actual = BuildImageTask.getImageAuthorization(mockLogger, "to", auth);
+    actual = PluginConfigurationProcessor.getImageAuthorization(mockLogger, "to", auth);
     Assert.assertNull(actual);
     Mockito.verify(mockLogger).warn("jib.to.auth.username is null; ignoring jib.to.auth section.");
   }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -16,29 +16,15 @@
 
 package com.google.cloud.tools.jib.maven;
 
-import com.google.cloud.tools.jib.JibLogger;
 import com.google.cloud.tools.jib.cache.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
-import com.google.cloud.tools.jib.configuration.CacheConfiguration;
-import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
 import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.docker.DockerClient;
-import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
-import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
-import com.google.cloud.tools.jib.http.Authorization;
-import com.google.cloud.tools.jib.http.Authorizations;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
-import com.google.cloud.tools.jib.plugins.common.SystemPropertyValidator;
-import com.google.cloud.tools.jib.registry.RegistryClient;
-import com.google.cloud.tools.jib.registry.credentials.RegistryCredentials;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import java.time.Instant;
-import javax.annotation.Nullable;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -51,9 +37,6 @@ public class BuildDockerMojo extends JibPluginConfiguration {
 
   @VisibleForTesting static final String GOAL_NAME = "dockerBuild";
 
-  /** {@code User-Agent} header suffix to send to the registry. */
-  private static final String USER_AGENT_SUFFIX = "jib-maven-plugin";
-
   private static final HelpfulSuggestions HELPFUL_SUGGESTIONS =
       HelpfulSuggestionsProvider.get("Build to Docker daemon failed");
 
@@ -64,90 +47,30 @@ public class BuildDockerMojo extends JibPluginConfiguration {
       return;
     }
 
-    MavenJibLogger mavenJibLogger = new MavenJibLogger(getLog());
-    handleDeprecatedParameters(mavenJibLogger);
-    SystemPropertyValidator.checkHttpTimeoutProperty(MojoExecutionException::new);
-
     if (!new DockerClient().isDockerInstalled()) {
       throw new MojoExecutionException(HELPFUL_SUGGESTIONS.forDockerNotInstalled());
     }
 
-    // Parses 'from' and 'to' into image reference.
+    MavenJibLogger mavenJibLogger = new MavenJibLogger(getLog());
     MavenProjectProperties mavenProjectProperties =
         MavenProjectProperties.getForProject(getProject(), mavenJibLogger, getExtraDirectory());
-    ImageReference baseImage = parseImageReference(getBaseImage(), "from");
+
     ImageReference targetImage =
         mavenProjectProperties.getGeneratedTargetDockerTag(getTargetImage(), mavenJibLogger);
 
-    // Checks Maven settings for registry credentials.
-    if (Boolean.getBoolean("sendCredentialsOverHttp")) {
-      mavenJibLogger.warn(
-          "Authentication over HTTP is enabled. It is strongly recommended that you do not enable "
-              + "this on a public network!");
-    }
-    MavenSettingsServerCredentials mavenSettingsServerCredentials =
-        new MavenSettingsServerCredentials(
-            Preconditions.checkNotNull(session).getSettings(), settingsDecrypter, mavenJibLogger);
-    Authorization fromAuthorization =
-        getImageAuth(
-            mavenJibLogger,
-            "from",
-            "jib.from.auth.username",
-            "jib.from.auth.password",
-            getBaseImageAuth());
-    RegistryCredentials knownBaseRegistryCredentials =
-        fromAuthorization != null
-            ? new RegistryCredentials(
-                "jib-maven-plugin <from><auth> configuration", fromAuthorization)
-            : mavenSettingsServerCredentials.retrieve(baseImage.getRegistry());
+    PluginConfigurationProcessor pluginConfigurationProcessor =
+        PluginConfigurationProcessor.processCommonConfiguration(
+            mavenJibLogger, this, mavenProjectProperties);
 
-    String mainClass = mavenProjectProperties.getMainClass(this);
-
-    // Builds the BuildConfiguration.
-    // TODO: Consolidate with BuildImageMojo.
-    ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder(baseImage)
-            .setCredentialHelper(getBaseImageCredentialHelperName())
-            .setKnownRegistryCredentials(knownBaseRegistryCredentials)
+    BuildConfiguration buildConfiguration =
+        pluginConfigurationProcessor
+            .getBuildConfigurationBuilder()
+            .setBaseImageConfiguration(
+                pluginConfigurationProcessor.getBaseImageConfigurationBuilder().build())
+            .setTargetImageConfiguration(ImageConfiguration.builder(targetImage).build())
+            .setContainerConfiguration(
+                pluginConfigurationProcessor.getContainerConfigurationBuilder().build())
             .build();
-
-    ImageConfiguration targetImageConfiguration = ImageConfiguration.builder(targetImage).build();
-
-    ContainerConfiguration.Builder containerConfigurationBuilder =
-        ContainerConfiguration.builder()
-            .setEntrypoint(
-                JavaEntrypointConstructor.makeDefaultEntrypoint(getJvmFlags(), mainClass))
-            .setProgramArguments(getArgs())
-            .setEnvironment(getEnvironment())
-            .setExposedPorts(ExposedPortsParser.parse(getExposedPorts()));
-    if (getUseCurrentTimestamp()) {
-      mavenJibLogger.warn(
-          "Setting image creation time to current time; your image may not be reproducible.");
-      containerConfigurationBuilder.setCreationTime(Instant.now());
-    }
-
-    BuildConfiguration.Builder buildConfigurationBuilder =
-        BuildConfiguration.builder(mavenJibLogger)
-            .setBaseImageConfiguration(baseImageConfiguration)
-            .setTargetImageConfiguration(targetImageConfiguration)
-            .setContainerConfiguration(containerConfigurationBuilder.build())
-            .setAllowInsecureRegistries(getAllowInsecureRegistries())
-            .setLayerConfigurations(mavenProjectProperties.getLayerConfigurations());
-    CacheConfiguration applicationLayersCacheConfiguration =
-        CacheConfiguration.forPath(mavenProjectProperties.getCacheDirectory());
-    buildConfigurationBuilder.setApplicationLayersCacheConfiguration(
-        applicationLayersCacheConfiguration);
-    if (getUseOnlyProjectCache()) {
-      buildConfigurationBuilder.setBaseImageLayersCacheConfiguration(
-          applicationLayersCacheConfiguration);
-    }
-
-    BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();
-
-    // TODO: Instead of disabling logging, have authentication credentials be provided
-    MavenJibLogger.disableHttpLogging();
-
-    RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
 
     try {
       BuildStepsRunner.forBuildToDockerDaemon(buildConfiguration).build(HELPFUL_SUGGESTIONS);
@@ -156,76 +79,5 @@ public class BuildDockerMojo extends JibPluginConfiguration {
     } catch (CacheDirectoryCreationException | BuildStepsExecutionException ex) {
       throw new MojoExecutionException(ex.getMessage(), ex.getCause());
     }
-  }
-
-  /**
-   * Gets an {@link Authorization} from a username and password. First tries system properties, then
-   * tries build configuration, otherwise returns null.
-   *
-   * <p>TODO: Consolidate with the other mojos.
-   *
-   * @param logger the {@link JibLogger} used to print warnings messages
-   * @param imageProperty the image configuration's name (i.e. "from" or "to")
-   * @param usernameProperty the name of the username system property
-   * @param passwordProperty the name of the password system property
-   * @param auth the configured credentials
-   * @return a new {@link Authorization} from the system properties or build configuration, or
-   *     {@code null} if neither is configured.
-   */
-  @Nullable
-  private static Authorization getImageAuth(
-      JibLogger logger,
-      String imageProperty,
-      String usernameProperty,
-      String passwordProperty,
-      AuthConfiguration auth) {
-    // System property takes priority over build configuration
-    String commandlineUsername = System.getProperty(usernameProperty);
-    String commandlinePassword = System.getProperty(passwordProperty);
-    if (!Strings.isNullOrEmpty(commandlineUsername)
-        && !Strings.isNullOrEmpty(commandlinePassword)) {
-      return Authorizations.withBasicCredentials(commandlineUsername, commandlinePassword);
-    }
-
-    // Warn if a system property is missing
-    if (!Strings.isNullOrEmpty(commandlinePassword) && Strings.isNullOrEmpty(commandlineUsername)) {
-      logger.warn(
-          passwordProperty
-              + " system property is set, but "
-              + usernameProperty
-              + " is not; attempting other authentication methods.");
-    }
-    if (!Strings.isNullOrEmpty(commandlineUsername) && Strings.isNullOrEmpty(commandlinePassword)) {
-      logger.warn(
-          usernameProperty
-              + " system property is set, but "
-              + passwordProperty
-              + " is not; attempting other authentication methods.");
-    }
-
-    // Check auth configuration next; warn if they aren't both set
-    if (Strings.isNullOrEmpty(auth.getUsername()) && Strings.isNullOrEmpty(auth.getPassword())) {
-      return null;
-    }
-    if (Strings.isNullOrEmpty(auth.getUsername())) {
-      logger.warn(
-          "<"
-              + imageProperty
-              + "><auth><username> is missing from maven configuration; ignoring <"
-              + imageProperty
-              + "><auth> section.");
-      return null;
-    }
-    if (Strings.isNullOrEmpty(auth.getPassword())) {
-      logger.warn(
-          "<"
-              + imageProperty
-              + "><auth><password> is missing from maven configuration; ignoring <"
-              + imageProperty
-              + "><auth> section.");
-      return null;
-    }
-
-    return Authorizations.withBasicCredentials(auth.getUsername(), auth.getPassword());
   }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -16,30 +16,19 @@
 
 package com.google.cloud.tools.jib.maven;
 
-import com.google.cloud.tools.jib.JibLogger;
 import com.google.cloud.tools.jib.cache.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
-import com.google.cloud.tools.jib.configuration.CacheConfiguration;
-import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
 import com.google.cloud.tools.jib.configuration.ImageConfiguration;
-import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
-import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
 import com.google.cloud.tools.jib.http.Authorization;
-import com.google.cloud.tools.jib.http.Authorizations;
 import com.google.cloud.tools.jib.image.ImageFormat;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
-import com.google.cloud.tools.jib.plugins.common.SystemPropertyValidator;
-import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.cloud.tools.jib.registry.credentials.RegistryCredentials;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import java.time.Instant;
 import java.util.Arrays;
-import javax.annotation.Nullable;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -53,23 +42,15 @@ public class BuildImageMojo extends JibPluginConfiguration {
 
   @VisibleForTesting static final String GOAL_NAME = "build";
 
-  /** {@code User-Agent} header suffix to send to the registry. */
-  private static final String USER_AGENT_SUFFIX = "jib-maven-plugin";
-
   private static final HelpfulSuggestions HELPFUL_SUGGESTIONS =
       HelpfulSuggestionsProvider.get("Build image failed");
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
-    // TODO: Consolidate all of these checks.
     if ("pom".equals(getProject().getPackaging())) {
       getLog().info("Skipping containerization because packaging is 'pom'...");
       return;
     }
-
-    MavenJibLogger mavenJibLogger = new MavenJibLogger(getLog());
-    handleDeprecatedParameters(mavenJibLogger);
-    SystemPropertyValidator.checkHttpTimeoutProperty(MojoExecutionException::new);
 
     // Validates 'format'.
     if (Arrays.stream(ImageFormat.values()).noneMatch(value -> value.name().equals(getFormat()))) {
@@ -83,9 +64,6 @@ public class BuildImageMojo extends JibPluginConfiguration {
               + "'.");
     }
 
-    // Parses 'from' into image reference.
-    ImageReference baseImage = parseImageReference(getBaseImage(), "from");
-
     // Parses 'to' into image reference.
     if (Strings.isNullOrEmpty(getTargetImage())) {
       throw new MojoFailureException(
@@ -93,32 +71,19 @@ public class BuildImageMojo extends JibPluginConfiguration {
               .forToNotConfigured(
                   "<to><image>", "pom.xml", "mvn compile jib:build -Dimage=<your image name>"));
     }
-    ImageReference targetImage = parseImageReference(getTargetImage(), "to");
 
-    // Checks Maven settings for registry credentials.
-    if (Boolean.getBoolean("sendCredentialsOverHttp")) {
-      mavenJibLogger.warn(
-          "Authentication over HTTP is enabled. It is strongly recommended that you do not enable "
-              + "this on a public network!");
-    }
+    MavenJibLogger mavenJibLogger = new MavenJibLogger(getLog());
+    MavenProjectProperties mavenProjectProperties =
+        MavenProjectProperties.getForProject(getProject(), mavenJibLogger, getExtraDirectory());
 
-    MavenSettingsServerCredentials mavenSettingsServerCredentials =
-        new MavenSettingsServerCredentials(
-            Preconditions.checkNotNull(session).getSettings(), settingsDecrypter, mavenJibLogger);
-    Authorization fromAuthorization =
-        getImageAuth(
-            mavenJibLogger,
-            "from",
-            "jib.from.auth.username",
-            "jib.from.auth.password",
-            getBaseImageAuth());
-    RegistryCredentials knownBaseRegistryCredentials =
-        fromAuthorization != null
-            ? new RegistryCredentials(
-                "jib-maven-plugin <from><auth> configuration", fromAuthorization)
-            : mavenSettingsServerCredentials.retrieve(baseImage.getRegistry());
+    PluginConfigurationProcessor pluginConfigurationProcessor =
+        PluginConfigurationProcessor.processCommonConfiguration(
+            mavenJibLogger, this, mavenProjectProperties);
+
+    ImageReference targetImage =
+        PluginConfigurationProcessor.parseImageReference(getTargetImage(), "to");
     Authorization toAuthorization =
-        getImageAuth(
+        PluginConfigurationProcessor.getImageAuth(
             mavenJibLogger,
             "to",
             "jib.to.auth.username",
@@ -127,62 +92,25 @@ public class BuildImageMojo extends JibPluginConfiguration {
     RegistryCredentials knownTargetRegistryCredentials =
         toAuthorization != null
             ? new RegistryCredentials("jib-maven-plugin <to><auth> configuration", toAuthorization)
-            : mavenSettingsServerCredentials.retrieve(targetImage.getRegistry());
-
-    MavenProjectProperties mavenProjectProperties =
-        MavenProjectProperties.getForProject(getProject(), mavenJibLogger, getExtraDirectory());
-    String mainClass = mavenProjectProperties.getMainClass(this);
-
-    // Builds the BuildConfiguration.
-    ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder(baseImage)
-            .setCredentialHelper(getBaseImageCredentialHelperName())
-            .setKnownRegistryCredentials(knownBaseRegistryCredentials)
-            .build();
-
+            : pluginConfigurationProcessor
+                .getMavenSettingsServerCredentials()
+                .retrieve(targetImage.getRegistry());
     ImageConfiguration targetImageConfiguration =
         ImageConfiguration.builder(targetImage)
             .setCredentialHelper(getTargetImageCredentialHelperName())
             .setKnownRegistryCredentials(knownTargetRegistryCredentials)
             .build();
 
-    ContainerConfiguration.Builder containerConfigurationBuilder =
-        ContainerConfiguration.builder()
-            .setEntrypoint(
-                JavaEntrypointConstructor.makeDefaultEntrypoint(getJvmFlags(), mainClass))
-            .setProgramArguments(getArgs())
-            .setEnvironment(getEnvironment())
-            .setExposedPorts(ExposedPortsParser.parse(getExposedPorts()));
-    if (getUseCurrentTimestamp()) {
-      mavenJibLogger.warn(
-          "Setting image creation time to current time; your image may not be reproducible.");
-      containerConfigurationBuilder.setCreationTime(Instant.now());
-    }
-
-    BuildConfiguration.Builder buildConfigurationBuilder =
-        BuildConfiguration.builder(mavenJibLogger)
-            .setBaseImageConfiguration(baseImageConfiguration)
+    BuildConfiguration buildConfiguration =
+        pluginConfigurationProcessor
+            .getBuildConfigurationBuilder()
+            .setBaseImageConfiguration(
+                pluginConfigurationProcessor.getBaseImageConfigurationBuilder().build())
             .setTargetImageConfiguration(targetImageConfiguration)
-            .setContainerConfiguration(containerConfigurationBuilder.build())
+            .setContainerConfiguration(
+                pluginConfigurationProcessor.getContainerConfigurationBuilder().build())
             .setTargetFormat(ImageFormat.valueOf(getFormat()).getManifestTemplateClass())
-            .setAllowInsecureRegistries(getAllowInsecureRegistries())
-            .setLayerConfigurations(mavenProjectProperties.getLayerConfigurations());
-
-    CacheConfiguration applicationLayersCacheConfiguration =
-        CacheConfiguration.forPath(mavenProjectProperties.getCacheDirectory());
-    buildConfigurationBuilder.setApplicationLayersCacheConfiguration(
-        applicationLayersCacheConfiguration);
-    if (getUseOnlyProjectCache()) {
-      buildConfigurationBuilder.setBaseImageLayersCacheConfiguration(
-          applicationLayersCacheConfiguration);
-    }
-
-    BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();
-
-    // TODO: Instead of disabling logging, have authentication credentials be provided
-    MavenJibLogger.disableHttpLogging();
-
-    RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
+            .build();
 
     try {
       BuildStepsRunner.forBuildImage(buildConfiguration).build(HELPFUL_SUGGESTIONS);
@@ -191,77 +119,5 @@ public class BuildImageMojo extends JibPluginConfiguration {
     } catch (CacheDirectoryCreationException | BuildStepsExecutionException ex) {
       throw new MojoExecutionException(ex.getMessage(), ex.getCause());
     }
-  }
-
-  /**
-   * Gets an {@link Authorization} from a username and password. First tries system properties, then
-   * tries build configuration, otherwise returns null.
-   *
-   * <p>TODO: Consolidate with the other mojos.
-   *
-   * @param logger the {@link JibLogger} used to print warnings messages
-   * @param imageProperty the image configuration's name (i.e. "from" or "to")
-   * @param usernameProperty the name of the username system property
-   * @param passwordProperty the name of the password system property
-   * @param auth the configured credentials
-   * @return a new {@link Authorization} from the system properties or build configuration, or
-   *     {@code null} if neither is configured.
-   */
-  @VisibleForTesting
-  @Nullable
-  static Authorization getImageAuth(
-      JibLogger logger,
-      String imageProperty,
-      String usernameProperty,
-      String passwordProperty,
-      AuthConfiguration auth) {
-    // System property takes priority over build configuration
-    String commandlineUsername = System.getProperty(usernameProperty);
-    String commandlinePassword = System.getProperty(passwordProperty);
-    if (!Strings.isNullOrEmpty(commandlineUsername)
-        && !Strings.isNullOrEmpty(commandlinePassword)) {
-      return Authorizations.withBasicCredentials(commandlineUsername, commandlinePassword);
-    }
-
-    // Warn if a system property is missing
-    if (!Strings.isNullOrEmpty(commandlinePassword) && Strings.isNullOrEmpty(commandlineUsername)) {
-      logger.warn(
-          passwordProperty
-              + " system property is set, but "
-              + usernameProperty
-              + " is not; attempting other authentication methods.");
-    }
-    if (!Strings.isNullOrEmpty(commandlineUsername) && Strings.isNullOrEmpty(commandlinePassword)) {
-      logger.warn(
-          usernameProperty
-              + " system property is set, but "
-              + passwordProperty
-              + " is not; attempting other authentication methods.");
-    }
-
-    // Check auth configuration next; warn if they aren't both set
-    if (Strings.isNullOrEmpty(auth.getUsername()) && Strings.isNullOrEmpty(auth.getPassword())) {
-      return null;
-    }
-    if (Strings.isNullOrEmpty(auth.getUsername())) {
-      logger.warn(
-          "<"
-              + imageProperty
-              + "><auth><username> is missing from maven configuration; ignoring <"
-              + imageProperty
-              + "><auth> section.");
-      return null;
-    }
-    if (Strings.isNullOrEmpty(auth.getPassword())) {
-      logger.warn(
-          "<"
-              + imageProperty
-              + "><auth><password> is missing from maven configuration; ignoring <"
-              + imageProperty
-              + "><auth> section.");
-      return null;
-    }
-
-    return Authorizations.withBasicCredentials(auth.getUsername(), auth.getPassword());
   }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -16,29 +16,15 @@
 
 package com.google.cloud.tools.jib.maven;
 
-import com.google.cloud.tools.jib.JibLogger;
 import com.google.cloud.tools.jib.cache.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
-import com.google.cloud.tools.jib.configuration.CacheConfiguration;
-import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
 import com.google.cloud.tools.jib.configuration.ImageConfiguration;
-import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
-import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
-import com.google.cloud.tools.jib.http.Authorization;
-import com.google.cloud.tools.jib.http.Authorizations;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
-import com.google.cloud.tools.jib.plugins.common.SystemPropertyValidator;
-import com.google.cloud.tools.jib.registry.RegistryClient;
-import com.google.cloud.tools.jib.registry.credentials.RegistryCredentials;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import java.nio.file.Paths;
-import java.time.Instant;
-import javax.annotation.Nullable;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -53,9 +39,6 @@ public class BuildTarMojo extends JibPluginConfiguration {
 
   @VisibleForTesting static final String GOAL_NAME = "buildTar";
 
-  /** {@code User-Agent} header suffix to send to the registry. */
-  private static final String USER_AGENT_SUFFIX = "jib-maven-plugin";
-
   private static final HelpfulSuggestions HELPFUL_SUGGESTIONS =
       HelpfulSuggestionsProvider.get("Building image tarball failed");
 
@@ -67,85 +50,25 @@ public class BuildTarMojo extends JibPluginConfiguration {
     }
 
     MavenJibLogger mavenJibLogger = new MavenJibLogger(getLog());
-    handleDeprecatedParameters(mavenJibLogger);
-    SystemPropertyValidator.checkHttpTimeoutProperty(MojoExecutionException::new);
-
-    // Parses 'from' and 'to' into image reference.
     MavenProjectProperties mavenProjectProperties =
         MavenProjectProperties.getForProject(getProject(), mavenJibLogger, getExtraDirectory());
-    ImageReference baseImage = parseImageReference(getBaseImage(), "from");
+
     ImageReference targetImage =
         mavenProjectProperties.getGeneratedTargetDockerTag(getTargetImage(), mavenJibLogger);
 
-    // Checks Maven settings for registry credentials.
-    if (Boolean.getBoolean("sendCredentialsOverHttp")) {
-      mavenJibLogger.warn(
-          "Authentication over HTTP is enabled. It is strongly recommended that you do not enable "
-              + "this on a public network!");
-    }
-    MavenSettingsServerCredentials mavenSettingsServerCredentials =
-        new MavenSettingsServerCredentials(
-            Preconditions.checkNotNull(session).getSettings(), settingsDecrypter, mavenJibLogger);
-    Authorization fromAuthorization =
-        getImageAuth(
-            mavenJibLogger,
-            "from",
-            "jib.from.auth.username",
-            "jib.from.auth.password",
-            getBaseImageAuth());
-    RegistryCredentials knownBaseRegistryCredentials =
-        fromAuthorization != null
-            ? new RegistryCredentials(
-                "jib-maven-plugin <from><auth> configuration", fromAuthorization)
-            : mavenSettingsServerCredentials.retrieve(baseImage.getRegistry());
+    PluginConfigurationProcessor pluginConfigurationProcessor =
+        PluginConfigurationProcessor.processCommonConfiguration(
+            mavenJibLogger, this, mavenProjectProperties);
 
-    String mainClass = mavenProjectProperties.getMainClass(this);
-
-    // Builds the BuildConfiguration.
-    // TODO: Consolidate with BuildImageMojo.
-    ImageConfiguration baseImageConfiguration =
-        ImageConfiguration.builder(baseImage)
-            .setCredentialHelper(getBaseImageCredentialHelperName())
-            .setKnownRegistryCredentials(knownBaseRegistryCredentials)
+    BuildConfiguration buildConfiguration =
+        pluginConfigurationProcessor
+            .getBuildConfigurationBuilder()
+            .setBaseImageConfiguration(
+                pluginConfigurationProcessor.getBaseImageConfigurationBuilder().build())
+            .setTargetImageConfiguration(ImageConfiguration.builder(targetImage).build())
+            .setContainerConfiguration(
+                pluginConfigurationProcessor.getContainerConfigurationBuilder().build())
             .build();
-
-    ImageConfiguration targetImageConfiguration = ImageConfiguration.builder(targetImage).build();
-
-    ContainerConfiguration.Builder containerConfigurationBuilder =
-        ContainerConfiguration.builder()
-            .setEntrypoint(
-                JavaEntrypointConstructor.makeDefaultEntrypoint(getJvmFlags(), mainClass))
-            .setProgramArguments(getArgs())
-            .setEnvironment(getEnvironment())
-            .setExposedPorts(ExposedPortsParser.parse(getExposedPorts()));
-    if (getUseCurrentTimestamp()) {
-      mavenJibLogger.warn(
-          "Setting image creation time to current time; your image may not be reproducible.");
-      containerConfigurationBuilder.setCreationTime(Instant.now());
-    }
-
-    BuildConfiguration.Builder buildConfigurationBuilder =
-        BuildConfiguration.builder(mavenJibLogger)
-            .setBaseImageConfiguration(baseImageConfiguration)
-            .setTargetImageConfiguration(targetImageConfiguration)
-            .setContainerConfiguration(containerConfigurationBuilder.build())
-            .setAllowInsecureRegistries(getAllowInsecureRegistries())
-            .setLayerConfigurations(mavenProjectProperties.getLayerConfigurations());
-    CacheConfiguration applicationLayersCacheConfiguration =
-        CacheConfiguration.forPath(mavenProjectProperties.getCacheDirectory());
-    buildConfigurationBuilder.setApplicationLayersCacheConfiguration(
-        applicationLayersCacheConfiguration);
-    if (getUseOnlyProjectCache()) {
-      buildConfigurationBuilder.setBaseImageLayersCacheConfiguration(
-          applicationLayersCacheConfiguration);
-    }
-
-    BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();
-
-    // TODO: Instead of disabling logging, have authentication credentials be provided
-    MavenJibLogger.disableHttpLogging();
-
-    RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
 
     try {
       BuildStepsRunner.forBuildTar(
@@ -157,76 +80,5 @@ public class BuildTarMojo extends JibPluginConfiguration {
     } catch (CacheDirectoryCreationException | BuildStepsExecutionException ex) {
       throw new MojoExecutionException(ex.getMessage(), ex.getCause());
     }
-  }
-
-  /**
-   * Gets an {@link Authorization} from a username and password. First tries system properties, then
-   * tries build configuration, otherwise returns null.
-   *
-   * <p>TODO: Consolidate with the other mojos.
-   *
-   * @param logger the {@link JibLogger} used to print warnings messages
-   * @param imageProperty the image configuration's name (i.e. "from" or "to")
-   * @param usernameProperty the name of the username system property
-   * @param passwordProperty the name of the password system property
-   * @param auth the configured credentials
-   * @return a new {@link Authorization} from the system properties or build configuration, or
-   *     {@code null} if neither is configured.
-   */
-  @Nullable
-  private static Authorization getImageAuth(
-      JibLogger logger,
-      String imageProperty,
-      String usernameProperty,
-      String passwordProperty,
-      AuthConfiguration auth) {
-    // System property takes priority over build configuration
-    String commandlineUsername = System.getProperty(usernameProperty);
-    String commandlinePassword = System.getProperty(passwordProperty);
-    if (!Strings.isNullOrEmpty(commandlineUsername)
-        && !Strings.isNullOrEmpty(commandlinePassword)) {
-      return Authorizations.withBasicCredentials(commandlineUsername, commandlinePassword);
-    }
-
-    // Warn if a system property is missing
-    if (!Strings.isNullOrEmpty(commandlinePassword) && Strings.isNullOrEmpty(commandlineUsername)) {
-      logger.warn(
-          passwordProperty
-              + " system property is set, but "
-              + usernameProperty
-              + " is not; attempting other authentication methods.");
-    }
-    if (!Strings.isNullOrEmpty(commandlineUsername) && Strings.isNullOrEmpty(commandlinePassword)) {
-      logger.warn(
-          usernameProperty
-              + " system property is set, but "
-              + passwordProperty
-              + " is not; attempting other authentication methods.");
-    }
-
-    // Check auth configuration next; warn if they aren't both set
-    if (Strings.isNullOrEmpty(auth.getUsername()) && Strings.isNullOrEmpty(auth.getPassword())) {
-      return null;
-    }
-    if (Strings.isNullOrEmpty(auth.getUsername())) {
-      logger.warn(
-          "<"
-              + imageProperty
-              + "><auth><username> is missing from maven configuration; ignoring <"
-              + imageProperty
-              + "><auth> section.");
-      return null;
-    }
-    if (Strings.isNullOrEmpty(auth.getPassword())) {
-      logger.warn(
-          "<"
-              + imageProperty
-              + "><auth><password> is missing from maven configuration; ignoring <"
-              + imageProperty
-              + "><auth> section.");
-      return null;
-    }
-
-    return Authorizations.withBasicCredentials(auth.getUsername(), auth.getPassword());
   }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -17,8 +17,6 @@
 package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.JibLogger;
-import com.google.cloud.tools.jib.image.ImageReference;
-import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -114,19 +112,6 @@ abstract class JibPluginConfiguration extends AbstractMojo {
     @Parameter private List<String> ports = Collections.emptyList();
   }
 
-  /**
-   * @param image the image reference string to parse.
-   * @param type name of the parameter being parsed (e.g. "to" or "from").
-   * @return the {@link ImageReference} parsed from {@code from}.
-   */
-  static ImageReference parseImageReference(String image, String type) {
-    try {
-      return ImageReference.parse(image);
-    } catch (InvalidImageReferenceException ex) {
-      throw new IllegalStateException("Parameter '" + type + "' is invalid", ex);
-    }
-  }
-
   @Nullable
   @Parameter(defaultValue = "${session}", readonly = true)
   MavenSession session;
@@ -202,6 +187,10 @@ abstract class JibPluginConfiguration extends AbstractMojo {
     }
   }
 
+  MavenSession getSession() {
+    return Preconditions.checkNotNull(session);
+  }
+
   MavenProject getProject() {
     return Preconditions.checkNotNull(project);
   }
@@ -274,6 +263,10 @@ abstract class JibPluginConfiguration extends AbstractMojo {
   Path getExtraDirectory() {
     // TODO: Should inform user about nonexistent directory if using custom directory.
     return Paths.get(Preconditions.checkNotNull(extraDirectory));
+  }
+
+  SettingsDecrypter getSettingsDecrypter() {
+    return Preconditions.checkNotNull(settingsDecrypter);
   }
 
   @VisibleForTesting

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -197,7 +197,7 @@ class MavenProjectProperties implements ProjectProperties {
               + "in your pom.xml, or use the -Dimage=<MY IMAGE> commandline flag.");
       return ImageReference.of(null, project.getName(), project.getVersion());
     } else {
-      return JibPluginConfiguration.parseImageReference(targetImage, "to");
+      return PluginConfigurationProcessor.parseImageReference(targetImage, "to");
     }
   }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2018 Google LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven;
+
+import com.google.cloud.tools.jib.JibLogger;
+import com.google.cloud.tools.jib.configuration.BuildConfiguration;
+import com.google.cloud.tools.jib.configuration.CacheConfiguration;
+import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
+import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
+import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
+import com.google.cloud.tools.jib.http.Authorization;
+import com.google.cloud.tools.jib.http.Authorizations;
+import com.google.cloud.tools.jib.image.ImageReference;
+import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
+import com.google.cloud.tools.jib.maven.JibPluginConfiguration.AuthConfiguration;
+import com.google.cloud.tools.jib.plugins.common.SystemPropertyValidator;
+import com.google.cloud.tools.jib.registry.RegistryClient;
+import com.google.cloud.tools.jib.registry.credentials.RegistryCredentials;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import java.time.Instant;
+import javax.annotation.Nullable;
+import org.apache.maven.plugin.MojoExecutionException;
+
+/** Configures and provides builders for the image building goals. */
+class PluginConfigurationProcessor {
+
+  /** {@code User-Agent} header suffix to send to the registry. */
+  private static final String USER_AGENT_SUFFIX = "jib-maven-plugin";
+
+  /**
+   * Sets up {@link BuildConfiguration} that is common among the image building goals. This includes
+   * setting up the base image reference/authorization, container configuration, cache
+   * configuration, and layer configuration.
+   *
+   * @param logger the logger used to display messages
+   * @param jibPluginConfiguration the {@link JibPluginConfiguration} providing the configuration
+   *     data
+   * @param projectProperties used for providing additional information
+   * @return a new {@link PluginConfigurationProcessor} containing pre-configured builders
+   * @throws MojoExecutionException if the http timeout system property is misconfigured
+   */
+  static PluginConfigurationProcessor processCommonConfiguration(
+      MavenJibLogger logger,
+      JibPluginConfiguration jibPluginConfiguration,
+      MavenProjectProperties projectProperties)
+      throws MojoExecutionException {
+    jibPluginConfiguration.handleDeprecatedParameters(logger);
+    SystemPropertyValidator.checkHttpTimeoutProperty(MojoExecutionException::new);
+
+    // TODO: Instead of disabling logging, have authentication credentials be provided
+    MavenJibLogger.disableHttpLogging();
+    RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
+
+    ImageReference baseImage = parseImageReference(jibPluginConfiguration.getBaseImage(), "from");
+
+    // Checks Maven settings for registry credentials.
+    if (Boolean.getBoolean("sendCredentialsOverHttp")) {
+      logger.warn(
+          "Authentication over HTTP is enabled. It is strongly recommended that you do not enable "
+              + "this on a public network!");
+    }
+    MavenSettingsServerCredentials mavenSettingsServerCredentials =
+        new MavenSettingsServerCredentials(
+            Preconditions.checkNotNull(jibPluginConfiguration.getSession()).getSettings(),
+            jibPluginConfiguration.getSettingsDecrypter(),
+            logger);
+    Authorization fromAuthorization =
+        getImageAuth(
+            logger,
+            "from",
+            "jib.from.auth.username",
+            "jib.from.auth.password",
+            jibPluginConfiguration.getBaseImageAuth());
+    RegistryCredentials knownBaseRegistryCredentials =
+        fromAuthorization != null
+            ? new RegistryCredentials(
+                "jib-maven-plugin <from><auth> configuration", fromAuthorization)
+            : mavenSettingsServerCredentials.retrieve(baseImage.getRegistry());
+    ImageConfiguration.Builder baseImageConfiguration =
+        ImageConfiguration.builder(baseImage)
+            .setCredentialHelper(jibPluginConfiguration.getBaseImageCredentialHelperName())
+            .setKnownRegistryCredentials(knownBaseRegistryCredentials);
+
+    String mainClass = projectProperties.getMainClass(jibPluginConfiguration);
+    ContainerConfiguration.Builder containerConfigurationBuilder =
+        ContainerConfiguration.builder()
+            .setEntrypoint(
+                JavaEntrypointConstructor.makeDefaultEntrypoint(
+                    jibPluginConfiguration.getJvmFlags(), mainClass))
+            .setProgramArguments(jibPluginConfiguration.getArgs())
+            .setEnvironment(jibPluginConfiguration.getEnvironment())
+            .setExposedPorts(ExposedPortsParser.parse(jibPluginConfiguration.getExposedPorts()));
+    if (jibPluginConfiguration.getUseCurrentTimestamp()) {
+      logger.warn(
+          "Setting image creation time to current time; your image may not be reproducible.");
+      containerConfigurationBuilder.setCreationTime(Instant.now());
+    }
+
+    BuildConfiguration.Builder buildConfigurationBuilder =
+        BuildConfiguration.builder(logger)
+            .setAllowInsecureRegistries(jibPluginConfiguration.getAllowInsecureRegistries())
+            .setLayerConfigurations(projectProperties.getLayerConfigurations());
+    CacheConfiguration applicationLayersCacheConfiguration =
+        CacheConfiguration.forPath(projectProperties.getCacheDirectory());
+    buildConfigurationBuilder.setApplicationLayersCacheConfiguration(
+        applicationLayersCacheConfiguration);
+    if (jibPluginConfiguration.getUseOnlyProjectCache()) {
+      buildConfigurationBuilder.setBaseImageLayersCacheConfiguration(
+          applicationLayersCacheConfiguration);
+    }
+
+    return new PluginConfigurationProcessor(
+        buildConfigurationBuilder,
+        baseImageConfiguration,
+        containerConfigurationBuilder,
+        mavenSettingsServerCredentials);
+  }
+
+  /**
+   * @param image the image reference string to parse.
+   * @param type name of the parameter being parsed (e.g. "to" or "from").
+   * @return the {@link ImageReference} parsed from {@code from}.
+   */
+  static ImageReference parseImageReference(String image, String type) {
+    try {
+      return ImageReference.parse(image);
+    } catch (InvalidImageReferenceException ex) {
+      throw new IllegalStateException("Parameter '" + type + "' is invalid", ex);
+    }
+  }
+
+  /**
+   * Gets an {@link Authorization} from a username and password. First tries system properties, then
+   * tries build configuration, otherwise returns null.
+   *
+   * @param logger the {@link JibLogger} used to print warnings messages
+   * @param imageProperty the image configuration's name (i.e. "from" or "to")
+   * @param usernameProperty the name of the username system property
+   * @param passwordProperty the name of the password system property
+   * @param auth the configured credentials
+   * @return a new {@link Authorization} from the system properties or build configuration, or
+   *     {@code null} if neither is configured.
+   */
+  @Nullable
+  static Authorization getImageAuth(
+      JibLogger logger,
+      String imageProperty,
+      String usernameProperty,
+      String passwordProperty,
+      AuthConfiguration auth) {
+    // System property takes priority over build configuration
+    String commandlineUsername = System.getProperty(usernameProperty);
+    String commandlinePassword = System.getProperty(passwordProperty);
+    if (!Strings.isNullOrEmpty(commandlineUsername)
+        && !Strings.isNullOrEmpty(commandlinePassword)) {
+      return Authorizations.withBasicCredentials(commandlineUsername, commandlinePassword);
+    }
+
+    // Warn if a system property is missing
+    if (!Strings.isNullOrEmpty(commandlinePassword) && Strings.isNullOrEmpty(commandlineUsername)) {
+      logger.warn(
+          passwordProperty
+              + " system property is set, but "
+              + usernameProperty
+              + " is not; attempting other authentication methods.");
+    }
+    if (!Strings.isNullOrEmpty(commandlineUsername) && Strings.isNullOrEmpty(commandlinePassword)) {
+      logger.warn(
+          usernameProperty
+              + " system property is set, but "
+              + passwordProperty
+              + " is not; attempting other authentication methods.");
+    }
+
+    // Check auth configuration next; warn if they aren't both set
+    if (Strings.isNullOrEmpty(auth.getUsername()) && Strings.isNullOrEmpty(auth.getPassword())) {
+      return null;
+    }
+    if (Strings.isNullOrEmpty(auth.getUsername())) {
+      logger.warn(
+          "<"
+              + imageProperty
+              + "><auth><username> is missing from maven configuration; ignoring <"
+              + imageProperty
+              + "><auth> section.");
+      return null;
+    }
+    if (Strings.isNullOrEmpty(auth.getPassword())) {
+      logger.warn(
+          "<"
+              + imageProperty
+              + "><auth><password> is missing from maven configuration; ignoring <"
+              + imageProperty
+              + "><auth> section.");
+      return null;
+    }
+
+    return Authorizations.withBasicCredentials(auth.getUsername(), auth.getPassword());
+  }
+
+  private final BuildConfiguration.Builder buildConfigurationBuilder;
+  private final ImageConfiguration.Builder baseImageConfigurationBuilder;
+  private final ContainerConfiguration.Builder containerConfigurationBuilder;
+  private final MavenSettingsServerCredentials mavenSettingsServerCredentials;
+
+  private PluginConfigurationProcessor(
+      BuildConfiguration.Builder buildConfigurationBuilder,
+      ImageConfiguration.Builder baseImageConfigurationBuilder,
+      ContainerConfiguration.Builder containerConfigurationBuilder,
+      MavenSettingsServerCredentials mavenSettingsServerCredentials) {
+    this.buildConfigurationBuilder = buildConfigurationBuilder;
+    this.baseImageConfigurationBuilder = baseImageConfigurationBuilder;
+    this.containerConfigurationBuilder = containerConfigurationBuilder;
+    this.mavenSettingsServerCredentials = mavenSettingsServerCredentials;
+  }
+
+  BuildConfiguration.Builder getBuildConfigurationBuilder() {
+    return buildConfigurationBuilder;
+  }
+
+  ImageConfiguration.Builder getBaseImageConfigurationBuilder() {
+    return baseImageConfigurationBuilder;
+  }
+
+  ContainerConfiguration.Builder getContainerConfigurationBuilder() {
+    return containerConfigurationBuilder;
+  }
+
+  MavenSettingsServerCredentials getMavenSettingsServerCredentials() {
+    return mavenSettingsServerCredentials;
+  }
+}

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessorTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessorTest.java
@@ -27,15 +27,9 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/**
- * Test for {@link BuildImageMojo}.
- *
- * <p>TODO: This only tests the {@link BuildImageMojo#getImageAuth(JibLogger, String, String,
- * String, AuthConfiguration)} method, which is copy-pasted between the 3 build mojos. When we
- * refactor, we'll need to move this test.
- */
+/** Test for {@link PluginConfigurationProcessor}. */
 @RunWith(MockitoJUnitRunner.class)
-public class BuildImageMojoTest {
+public class PluginConfigurationProcessorTest {
 
   @Mock private JibLogger mockLogger;
 
@@ -50,7 +44,7 @@ public class BuildImageMojoTest {
     System.setProperty("jib.test.auth.pass", "12345");
     Authorization expected = Authorizations.withBasicCredentials("abcde", "12345");
     Authorization actual =
-        BuildImageMojo.getImageAuth(
+        PluginConfigurationProcessor.getImageAuth(
             mockLogger, "to", "jib.test.auth.user", "jib.test.auth.pass", auth);
     Assert.assertNotNull(actual);
     Assert.assertEquals(expected.toString(), actual.toString());
@@ -60,7 +54,7 @@ public class BuildImageMojoTest {
     System.clearProperty("jib.test.auth.pass");
     expected = Authorizations.withBasicCredentials("vwxyz", "98765");
     actual =
-        BuildImageMojo.getImageAuth(
+        PluginConfigurationProcessor.getImageAuth(
             mockLogger, "to", "jib.test.auth.user", "jib.test.auth.pass", auth);
     Assert.assertNotNull(actual);
     Assert.assertEquals(expected.toString(), actual.toString());
@@ -69,7 +63,7 @@ public class BuildImageMojoTest {
     // Auth completely missing
     auth = new AuthConfiguration();
     actual =
-        BuildImageMojo.getImageAuth(
+        PluginConfigurationProcessor.getImageAuth(
             mockLogger, "to", "jib.test.auth.user", "jib.test.auth.pass", auth);
     Assert.assertNull(actual);
 
@@ -77,7 +71,7 @@ public class BuildImageMojoTest {
     auth = new AuthConfiguration();
     auth.setUsername("vwxyz");
     actual =
-        BuildImageMojo.getImageAuth(
+        PluginConfigurationProcessor.getImageAuth(
             mockLogger, "to", "jib.test.auth.user", "jib.test.auth.pass", auth);
     Assert.assertNull(actual);
     Mockito.verify(mockLogger)
@@ -88,7 +82,7 @@ public class BuildImageMojoTest {
     auth = new AuthConfiguration();
     auth.setPassword("98765");
     actual =
-        BuildImageMojo.getImageAuth(
+        PluginConfigurationProcessor.getImageAuth(
             mockLogger, "to", "jib.test.auth.user", "jib.test.auth.pass", auth);
     Assert.assertNull(actual);
     Mockito.verify(mockLogger)


### PR DESCRIPTION
Tests are completely broken. This is for early discussion. Please review the general approach, not details.

This is about the second part in #720, the issue that `allowInsecureRegistries` has no effect on `RegistryAuthenticator`. My approach here is

- Refactor the `allowInsecureRegistries` logic into a lower-level utility-like class, `EndpoinCaller`.
- Both `RegistryEndpointCaller` and `RegistryAuthenticator` uses `EndpointCaller` for handling `allowInsecureRegistries`.
- Rename `RegistryException` to `EndpointException`, because it's common that the auth server is different from a registry server.
