### PR TITLE
Do not put JIB_INTEGRATION_TESTING_KEY into environment variable

### DIFF
--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
 set -e
-
-echo ${JIB_INTEGRATION_TESTING_KEY} > ./keyfile.json
-
 set -x
 
 gcloud components install docker-credential-gcr
@@ -12,7 +9,7 @@ gcloud components install docker-credential-gcr
 export PATH=$PATH:/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/bin/
 
 # docker-credential-gcr uses GOOGLE_APPLICATION_CREDENTIALS as the credentials key file
-export GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/keyfile.json
+export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_KEYSTORE_DIR}/72743_jib_integration_testing_key
 docker-credential-gcr configure-docker
 
 # Stops any left-over containers.


### PR DESCRIPTION
I don't see a reason to put this in the environment variable. There is no code using this variable except `continuous.sh`.

With this, the key will no longer exposed in our continuous build log.