### PR TITLE
Auto build gradle lib-project dependencies

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Gradle project dependencies have their `assemble` task run before running a jib task ([#815](https://github.com/GoogleContainerTools/jib/issues/815))
+
 ## 0.9.8
 
 ### Added

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -40,6 +40,42 @@ public class JibPlugin implements Plugin<Project> {
   @VisibleForTesting static final String BUILD_DOCKER_TASK_NAME = "jibDockerBuild";
   @VisibleForTesting static final String DOCKER_CONTEXT_TASK_NAME = "jibExportDockerContext";
 
+  private static void checkGradleVersion() {
+    if (GRADLE_MIN_VERSION.compareTo(GradleVersion.current()) > 0) {
+      throw new GradleException(
+          "Detected "
+              + GradleVersion.current()
+              + ", but jib requires "
+              + GRADLE_MIN_VERSION
+              + " or higher. You can upgrade by running 'gradle wrapper --gradle-version="
+              + GRADLE_MIN_VERSION.getVersion()
+              + "'.");
+    }
+  }
+
+  /**
+   * Collects all assemble tasks for project dependencies of the style "compile project(':mylib')"
+   * for any kind of configuration [compile, runtime, etc]. It potentially will collect common test
+   * libraries in configs like [test, integrationTest, etc], but it's either that or filter based on
+   * a configuration containing the word "test" which feels dangerous.
+   *
+   * @param project this project we are containerizing
+   * @return a list of "assemble" tasks associated with projects that this project depends on.
+   */
+  @VisibleForTesting
+  static List<Task> getProjectDependencyAssembleTasks(Project project) {
+    return project
+        .getConfigurations()
+        .stream()
+        .map(Configuration::getDependencies)
+        .flatMap(DependencySet::stream)
+        .filter(ProjectDependency.class::isInstance)
+        .map(ProjectDependency.class::cast)
+        .map(ProjectDependency::getDependencyProject)
+        .map(subProject -> subProject.getTasks().getByPath(BasePlugin.ASSEMBLE_TASK_NAME))
+        .collect(Collectors.toList());
+  }
+
   @Override
   public void apply(Project project) {
     checkGradleVersion();
@@ -68,18 +104,23 @@ public class JibPlugin implements Plugin<Project> {
             .create(BUILD_TAR_TASK_NAME, BuildTarTask.class)
             .setJibExtension(jibExtension);
 
-    // Has all tasks depend on the 'classes' task.
     project.afterEvaluate(
         projectAfterEvaluation -> {
           try {
-            List<Task> taskDependencies = getProjectDependencyAssembleTasks(projectAfterEvaluation);
+            // Find project dependencies
+            List<Task> computedDependencies =
+                getProjectDependencyAssembleTasks(projectAfterEvaluation);
+            // Has all tasks depend on the 'classes' task.
             Task classesTask = projectAfterEvaluation.getTasks().getByPath("classes");
-            taskDependencies.add(classesTask);
+            computedDependencies.add(classesTask);
 
-            buildImageTask.dependsOn(taskDependencies.toArray());
-            dockerContextTask.dependsOn(taskDependencies.toArray());
-            buildDockerTask.dependsOn(taskDependencies.toArray());
-            buildTarTask.dependsOn(taskDependencies.toArray());
+            // dependsOn takes an Object... type
+            Object[] dependenciesArray = computedDependencies.toArray();
+
+            buildImageTask.dependsOn(dependenciesArray);
+            dockerContextTask.dependsOn(dependenciesArray);
+            buildDockerTask.dependsOn(dependenciesArray);
+            buildTarTask.dependsOn(dependenciesArray);
 
           } catch (UnknownTaskException ex) {
             throw new GradleException(
@@ -89,40 +130,5 @@ public class JibPlugin implements Plugin<Project> {
                 ex);
           }
         });
-  }
-
-  /**
-   * Collects all assemble tasks for project dependencies of the style "compile project(':mylib')"
-   * for any kind of configuration [compile, runtime, etc]. It potentially will collect common test
-   * libraries in configs like [test, integrationTest, etc], but it's either that or filter based on
-   * a configuration containing the word "test" which feels dangerous.
-   *
-   * @param project this project we are containerizing
-   * @return a list of "assemble" tasks associated with projects that this project depends on.
-   */
-  static List<Task> getProjectDependencyAssembleTasks(Project project) {
-    return project
-        .getConfigurations()
-        .stream()
-        .map(Configuration::getDependencies)
-        .flatMap(DependencySet::stream)
-        .filter(ProjectDependency.class::isInstance)
-        .map(ProjectDependency.class::cast)
-        .map(ProjectDependency::getDependencyProject)
-        .map(subProject -> subProject.getTasks().getByPath(BasePlugin.ASSEMBLE_TASK_NAME))
-        .collect(Collectors.toList());
-  }
-
-  private static void checkGradleVersion() {
-    if (GRADLE_MIN_VERSION.compareTo(GradleVersion.current()) > 0) {
-      throw new GradleException(
-          "Detected "
-              + GradleVersion.current()
-              + ", but jib requires "
-              + GRADLE_MIN_VERSION
-              + " or higher. You can upgrade by running 'gradle wrapper --gradle-version="
-              + GRADLE_MIN_VERSION.getVersion()
-              + "'.");
-    }
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -40,19 +40,6 @@ public class JibPlugin implements Plugin<Project> {
   @VisibleForTesting static final String BUILD_DOCKER_TASK_NAME = "jibDockerBuild";
   @VisibleForTesting static final String DOCKER_CONTEXT_TASK_NAME = "jibExportDockerContext";
 
-  private static void checkGradleVersion() {
-    if (GRADLE_MIN_VERSION.compareTo(GradleVersion.current()) > 0) {
-      throw new GradleException(
-          "Detected "
-              + GradleVersion.current()
-              + ", but jib requires "
-              + GRADLE_MIN_VERSION
-              + " or higher. You can upgrade by running 'gradle wrapper --gradle-version="
-              + GRADLE_MIN_VERSION.getVersion()
-              + "'.");
-    }
-  }
-
   /**
    * Collects all assemble tasks for project dependencies of the style "compile project(':mylib')"
    * for any kind of configuration [compile, runtime, etc]. It potentially will collect common test
@@ -74,6 +61,19 @@ public class JibPlugin implements Plugin<Project> {
         .map(ProjectDependency::getDependencyProject)
         .map(subProject -> subProject.getTasks().getByPath(BasePlugin.ASSEMBLE_TASK_NAME))
         .collect(Collectors.toList());
+  }
+
+  private static void checkGradleVersion() {
+    if (GRADLE_MIN_VERSION.compareTo(GradleVersion.current()) > 0) {
+      throw new GradleException(
+          "Detected "
+              + GradleVersion.current()
+              + ", but jib requires "
+              + GRADLE_MIN_VERSION
+              + " or higher. You can upgrade by running 'gradle wrapper --gradle-version="
+              + GRADLE_MIN_VERSION.getVersion()
+              + "'.");
+    }
   }
 
   @Override

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -24,7 +24,6 @@ import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.List;
 import java.util.stream.Collectors;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
@@ -40,7 +39,7 @@ import org.junit.rules.TemporaryFolder;
 /** Tests for {@link JibPlugin}. */
 public class JibPluginTest {
 
-  private static final List<String> KNOWN_JIB_TASKS =
+  private static final ImmutableList<String> KNOWN_JIB_TASKS =
       ImmutableList.of(
           JibPlugin.BUILD_IMAGE_TASK_NAME,
           JibPlugin.BUILD_DOCKER_TASK_NAME,
@@ -129,8 +128,7 @@ public class JibPluginTest {
     rootProject.getPluginManager().apply("com.google.cloud.tools.jib");
 
     // add a custom task that our jib tasks depend on to ensure we do not overwrite this dependsOn
-    Task dependencyTask =
-        rootProject.getTasks().create("myCustomTask", task -> System.out.println("test"));
+    Task dependencyTask = rootProject.getTasks().create("myCustomTask", task -> {});
     KNOWN_JIB_TASKS.forEach(
         taskName -> rootProject.getTasks().getByPath(taskName).dependsOn(dependencyTask));
 


### PR DESCRIPTION
Search through all configurations for dependencies of the style
'configurationName project(":path")' and have jib depend on the
'assemble' task of that project. This ensure jar dependencies
are built before jib starts to package the project.

Fixes #815 