### PR TITLE
Add auth integration tests with different from/to registries and credentials

### DIFF
--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/complex-build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/complex-build.gradle
@@ -25,8 +25,8 @@ jib {
     to {
         image = System.getProperty("_TARGET_IMAGE")
         auth {
-            username = 'testuser'
-            password = 'testpassword'
+            username = System.getProperty("_TARGET_USERNAME")
+            password = System.getProperty("_TARGET_PASSWORD")
         }
     }
     container {

--- a/jib-maven-plugin/src/test/resources/projects/simple/pom-complex.xml
+++ b/jib-maven-plugin/src/test/resources/projects/simple/pom-complex.xml
@@ -48,8 +48,8 @@
           <to>
             <image>${_TARGET_IMAGE}</image>
             <auth>
-              <username>testuser</username>
-              <password>testpassword</password>
+              <username>${_TARGET_USERNAME}</username>
+              <password>${_TARGET_PASSWORD}</password>
             </auth>
           </to>
           <container>


### PR DESCRIPTION
Added a test that pulls a base image from a local registry requiring credentials, and pushes the built image to a different local registry that requires different credentials. This would have caught the problem discovered in #801.

Fixes #803 