### PR TITLE
Move getGeneratedTargetDockerTag to ConfigurationPropertyValidator

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/plugins/common/HelpfulSuggestions.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/plugins/common/HelpfulSuggestions.java
@@ -28,6 +28,9 @@ public class HelpfulSuggestions {
   private final Function<String, String> baseImageAuthConfiguration;
   private final String targetImageCredHelperConfiguration;
   private final Function<String, String> targetImageAuthConfiguration;
+  private final String toImageConfiguration;
+  private final String buildConfigurationFilename;
+  private final String toImageFlag;
 
   /**
    * Creates a new {@link HelpfulSuggestions} with frontend-specific texts.
@@ -42,6 +45,9 @@ public class HelpfulSuggestions {
    *     for the target image
    * @param targetImageAuthConfiguration the way to define raw credentials for the target image -
    *     takes the target image registry as an argument
+   * @param toImageConfiguration the configuration defining the target image
+   * @param toImageFlag the commandline flag used to set the target image
+   * @param buildConfigurationFilename the filename of the build configuration
    */
   public HelpfulSuggestions(
       String messagePrefix,
@@ -49,13 +55,19 @@ public class HelpfulSuggestions {
       String baseImageCredHelperConfiguration,
       Function<String, String> baseImageAuthConfiguration,
       String targetImageCredHelperConfiguration,
-      Function<String, String> targetImageAuthConfiguration) {
+      Function<String, String> targetImageAuthConfiguration,
+      String toImageConfiguration,
+      String toImageFlag,
+      String buildConfigurationFilename) {
     this.messagePrefix = messagePrefix;
     this.clearCacheCommand = clearCacheCommand;
     this.baseImageCredHelperConfiguration = baseImageCredHelperConfiguration;
     this.baseImageAuthConfiguration = baseImageAuthConfiguration;
     this.targetImageCredHelperConfiguration = targetImageCredHelperConfiguration;
     this.targetImageAuthConfiguration = targetImageAuthConfiguration;
+    this.toImageConfiguration = toImageConfiguration;
+    this.buildConfigurationFilename = buildConfigurationFilename;
+    this.toImageFlag = toImageFlag;
   }
 
   public String forHttpHostConnect() {
@@ -133,6 +145,20 @@ public class HelpfulSuggestions {
             + " or set the parameter via the commandline (e.g. '"
             + command
             + "').");
+  }
+
+  public String forGeneratedTag(String projectName, String projectVersion) {
+    return "Tagging image with generated image reference "
+        + projectName
+        + ":"
+        + projectVersion
+        + ". If you'd like to specify a different tag, you can set the "
+        + toImageConfiguration
+        + " parameter in your "
+        + buildConfigurationFilename
+        + ", or use the "
+        + toImageFlag
+        + "=<MY IMAGE> commandline flag.";
   }
 
   public String none() {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunnerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunnerTest.java
@@ -58,7 +58,10 @@ public class BuildStepsRunnerTest {
           "baseImageCredHelperConfiguration",
           registry -> "baseImageAuthConfiguration " + registry,
           "targetImageCredHelperConfiguration",
-          registry -> "targetImageAuthConfiguration " + registry);
+          registry -> "targetImageAuthConfiguration " + registry,
+          "toConfig",
+          "toFlag",
+          "buildFile");
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/plugins/common/HelpfulSuggestionsTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/plugins/common/HelpfulSuggestionsTest.java
@@ -30,7 +30,10 @@ public class HelpfulSuggestionsTest {
           "baseImageCredHelperConfiguration",
           registry -> "baseImageAuthConfiguration " + registry,
           "targetImageCredHelperConfiguration",
-          registry -> "targetImageAuthConfiguration " + registry);
+          registry -> "targetImageAuthConfiguration " + registry,
+          "toProperty",
+          "toFlag",
+          "buildFile");
 
   @Test
   public void testSuggestions_smoke() {
@@ -71,5 +74,8 @@ public class HelpfulSuggestionsTest {
     Assert.assertEquals(
         "messagePrefix, perhaps you should use a registry that supports HTTPS so credentials can be sent safely, or set the 'sendCredentialsOverHttp' system property to true",
         TEST_HELPFUL_SUGGESTIONS.forCredentialsNotSent());
+    Assert.assertEquals(
+        "Tagging image with generated image reference project-name:project-version. If you'd like to specify a different tag, you can set the toProperty parameter in your buildFile, or use the toFlag=<MY IMAGE> commandline flag.",
+        TEST_HELPFUL_SUGGESTIONS.forGeneratedTag("project-name", "project-version"));
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -24,6 +24,7 @@ import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
+import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
 import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
@@ -77,7 +78,12 @@ public class BuildDockerTask extends DefaultTask {
             getProject(), gradleJibLogger, jibExtension.getExtraDirectoryPath());
 
     ImageReference targetImage =
-        gradleProjectProperties.getGeneratedTargetDockerTag(jibExtension, gradleJibLogger);
+        ConfigurationPropertyValidator.getGeneratedTargetDockerTag(
+            jibExtension.getTargetImage(),
+            gradleJibLogger,
+            getProject().getName(),
+            getProject().getVersion().toString(),
+            HELPFUL_SUGGESTIONS);
 
     PluginConfigurationProcessor pluginConfigurationProcessor =
         PluginConfigurationProcessor.processCommonConfiguration(

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
+import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
 import com.google.common.base.Preconditions;
 import java.nio.file.Paths;
@@ -105,7 +106,12 @@ public class BuildTarTask extends DefaultTask {
             getProject(), gradleJibLogger, jibExtension.getExtraDirectoryPath());
 
     ImageReference targetImage =
-        gradleProjectProperties.getGeneratedTargetDockerTag(jibExtension, gradleJibLogger);
+        ConfigurationPropertyValidator.getGeneratedTargetDockerTag(
+            jibExtension.getTargetImage(),
+            gradleJibLogger,
+            getProject().getName(),
+            getProject().getVersion().toString(),
+            HELPFUL_SUGGESTIONS);
 
     PluginConfigurationProcessor pluginConfigurationProcessor =
         PluginConfigurationProcessor.processCommonConfiguration(

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -18,15 +18,11 @@ package com.google.cloud.tools.jib.gradle;
 
 import com.google.cloud.tools.jib.JibLogger;
 import com.google.cloud.tools.jib.frontend.JavaLayerConfigurations;
-import com.google.cloud.tools.jib.image.ImageReference;
-import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.MainClassResolver;
 import com.google.cloud.tools.jib.plugins.common.ProjectProperties;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -125,35 +121,6 @@ class GradleProjectProperties implements ProjectProperties {
       return MainClassResolver.resolveMainClass(jibExtension.getMainClass(), this);
     } catch (MainClassInferenceException ex) {
       throw new GradleException(ex.getMessage(), ex);
-    }
-  }
-
-  /**
-   * Returns an {@link ImageReference} parsed from the configured target image, or one of the form
-   * {@code project-name:project-version} if target image is not configured
-   *
-   * @param jibExtension the plugin configuration parameters to generate the name from
-   * @param gradleJibLogger the logger used to notify users of the target image parameter
-   * @return an {@link ImageReference} parsed from the configured target image, or one of the form
-   *     {@code project-name:project-version} if target image is not configured
-   */
-  ImageReference getGeneratedTargetDockerTag(
-      JibExtension jibExtension, GradleJibLogger gradleJibLogger)
-      throws InvalidImageReferenceException {
-    Preconditions.checkNotNull(jibExtension);
-    if (Strings.isNullOrEmpty(jibExtension.getTargetImage())) {
-      // TODO: Validate that project name and version are valid repository/tag
-      // TODO: Use HelpfulSuggestions
-      gradleJibLogger.lifecycle(
-          "Tagging image with generated image reference "
-              + project.getName()
-              + ":"
-              + project.getVersion().toString()
-              + ". If you'd like to specify a different tag, you can set the jib.to.image "
-              + "parameter in your build.gradle, or use the --image=<MY IMAGE> commandline flag.");
-      return ImageReference.of(null, project.getName(), project.getVersion().toString());
-    } else {
-      return ImageReference.parse(jibExtension.getTargetImage());
     }
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/HelpfulSuggestionsProvider.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/HelpfulSuggestionsProvider.java
@@ -32,7 +32,10 @@ class HelpfulSuggestionsProvider {
         "from.credHelper",
         ignored -> "from.auth",
         "to.credHelper",
-        ignored -> "to.auth");
+        ignored -> "to.auth",
+        "jib.to.image",
+        "--image",
+        "build.gradle");
   }
 
   private HelpfulSuggestionsProvider() {}

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -17,8 +17,6 @@
 package com.google.cloud.tools.jib.gradle;
 
 import com.google.cloud.tools.jib.frontend.JavaLayerConfigurations;
-import com.google.cloud.tools.jib.image.ImageReference;
-import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
@@ -44,7 +42,6 @@ public class GradleProjectPropertiesTest {
   @Mock private Jar mockJar2;
   @Mock private Project mockProject;
   @Mock private GradleJibLogger mockGradleJibLogger;
-  @Mock private JibExtension mockJibExtension;
   @Mock private JavaLayerConfigurations mockJavaLayerConfigurations;
 
   private Manifest manifest;
@@ -78,31 +75,5 @@ public class GradleProjectPropertiesTest {
     Mockito.when(mockProject.getTasksByName("jar", false))
         .thenReturn(ImmutableSet.of(mockJar, mockJar2));
     Assert.assertNull(gradleProjectProperties.getMainClassFromJar());
-  }
-
-  @Test
-  public void testGetDockerTag_configured() throws InvalidImageReferenceException {
-    Mockito.when(mockJibExtension.getTargetImage()).thenReturn("a/b:c");
-    ImageReference result =
-        gradleProjectProperties.getGeneratedTargetDockerTag(mockJibExtension, mockGradleJibLogger);
-    Assert.assertEquals("a/b", result.getRepository());
-    Assert.assertEquals("c", result.getTag());
-    Mockito.verify(mockGradleJibLogger, Mockito.never()).lifecycle(Mockito.any());
-  }
-
-  @Test
-  public void testGetDockerTag_notConfigured() throws InvalidImageReferenceException {
-    Mockito.when(mockProject.getName()).thenReturn("project-name");
-    Mockito.when(mockProject.getVersion()).thenReturn("project-version");
-    Mockito.when(mockJibExtension.getTargetImage()).thenReturn(null);
-    ImageReference result =
-        gradleProjectProperties.getGeneratedTargetDockerTag(mockJibExtension, mockGradleJibLogger);
-    Assert.assertEquals("project-name", result.getRepository());
-    Assert.assertEquals("project-version", result.getTag());
-    Mockito.verify(mockGradleJibLogger)
-        .lifecycle(
-            "Tagging image with generated image reference project-name:project-version. If you'd "
-                + "like to specify a different tag, you can set the jib.to.image parameter in your "
-                + "build.gradle, or use the --image=<MY IMAGE> commandline flag.");
   }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -20,8 +20,10 @@ import com.google.cloud.tools.jib.cache.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.image.ImageReference;
+import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
+import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
 import com.google.common.annotations.VisibleForTesting;
 import java.nio.file.Paths;
@@ -53,31 +55,38 @@ public class BuildTarMojo extends JibPluginConfiguration {
     MavenProjectProperties mavenProjectProperties =
         MavenProjectProperties.getForProject(getProject(), mavenJibLogger, getExtraDirectory());
 
-    ImageReference targetImage =
-        mavenProjectProperties.getGeneratedTargetDockerTag(getTargetImage(), mavenJibLogger);
-
-    PluginConfigurationProcessor pluginConfigurationProcessor =
-        PluginConfigurationProcessor.processCommonConfiguration(
-            mavenJibLogger, this, mavenProjectProperties);
-
-    BuildConfiguration buildConfiguration =
-        pluginConfigurationProcessor
-            .getBuildConfigurationBuilder()
-            .setBaseImageConfiguration(
-                pluginConfigurationProcessor.getBaseImageConfigurationBuilder().build())
-            .setTargetImageConfiguration(ImageConfiguration.builder(targetImage).build())
-            .setContainerConfiguration(
-                pluginConfigurationProcessor.getContainerConfigurationBuilder().build())
-            .build();
-
     try {
+      ImageReference targetImage =
+          ConfigurationPropertyValidator.getGeneratedTargetDockerTag(
+              getTargetImage(),
+              mavenJibLogger,
+              getProject().getName(),
+              getProject().getVersion(),
+              HELPFUL_SUGGESTIONS);
+
+      PluginConfigurationProcessor pluginConfigurationProcessor =
+          PluginConfigurationProcessor.processCommonConfiguration(
+              mavenJibLogger, this, mavenProjectProperties);
+
+      BuildConfiguration buildConfiguration =
+          pluginConfigurationProcessor
+              .getBuildConfigurationBuilder()
+              .setBaseImageConfiguration(
+                  pluginConfigurationProcessor.getBaseImageConfigurationBuilder().build())
+              .setTargetImageConfiguration(ImageConfiguration.builder(targetImage).build())
+              .setContainerConfiguration(
+                  pluginConfigurationProcessor.getContainerConfigurationBuilder().build())
+              .build();
+
       BuildStepsRunner.forBuildTar(
               Paths.get(getProject().getBuild().getDirectory()).resolve("jib-image.tar"),
               buildConfiguration)
           .build(HELPFUL_SUGGESTIONS);
       getLog().info("");
 
-    } catch (CacheDirectoryCreationException | BuildStepsExecutionException ex) {
+    } catch (CacheDirectoryCreationException
+        | BuildStepsExecutionException
+        | InvalidImageReferenceException ex) {
       throw new MojoExecutionException(ex.getMessage(), ex.getCause());
     }
   }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/HelpfulSuggestionsProvider.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/HelpfulSuggestionsProvider.java
@@ -36,7 +36,10 @@ class HelpfulSuggestionsProvider {
         "<from><credHelper>",
         AUTH_CONFIGURATION_SUGGESTION,
         "<to><credHelper>",
-        AUTH_CONFIGURATION_SUGGESTION);
+        AUTH_CONFIGURATION_SUGGESTION,
+        "<to><image>",
+        "-Dimage",
+        "pom.xml");
   }
 
   private HelpfulSuggestionsProvider() {}

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -18,13 +18,11 @@ package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.JibLogger;
 import com.google.cloud.tools.jib.frontend.JavaLayerConfigurations;
-import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.MainClassResolver;
 import com.google.cloud.tools.jib.plugins.common.ProjectProperties;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -144,33 +142,6 @@ class MavenProjectProperties implements ProjectProperties {
       return MainClassResolver.resolveMainClass(jibPluginConfiguration.getMainClass(), this);
     } catch (MainClassInferenceException ex) {
       throw new MojoExecutionException(ex.getMessage(), ex);
-    }
-  }
-
-  /**
-   * Returns an {@link ImageReference} parsed from the configured target image, or one of the form
-   * {@code project-name:project-version} if target image is not configured
-   *
-   * @param targetImage the configured target image reference (can be empty)
-   * @param mavenJibLogger the logger used to notify users of the target image parameter
-   * @return an {@link ImageReference} parsed from the configured target image, or one of the form
-   *     {@code project-name:project-version} if target image is not configured
-   */
-  ImageReference getGeneratedTargetDockerTag(
-      @Nullable String targetImage, MavenJibLogger mavenJibLogger) {
-    if (Strings.isNullOrEmpty(targetImage)) {
-      // TODO: Validate that project name and version are valid repository/tag
-      // TODO: Use HelpfulSuggestions
-      mavenJibLogger.lifecycle(
-          "Tagging image with generated image reference "
-              + project.getName()
-              + ":"
-              + project.getVersion()
-              + ". If you'd like to specify a different tag, you can set the <to><image> parameter "
-              + "in your pom.xml, or use the -Dimage=<MY IMAGE> commandline flag.");
-      return ImageReference.of(null, project.getName(), project.getVersion());
-    } else {
-      return PluginConfigurationProcessor.parseImageReference(targetImage, "to");
     }
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.frontend.JavaLayerConfigurations;
-import com.google.cloud.tools.jib.image.ImageReference;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
@@ -47,8 +46,6 @@ public class MavenProjectPropertiesTest {
 
   @Before
   public void setup() {
-    Mockito.when(mockMavenProject.getName()).thenReturn("project-name");
-    Mockito.when(mockMavenProject.getVersion()).thenReturn("project-version");
     mavenProjectProperties =
         new MavenProjectProperties(
             mockMavenProject, mockMavenJibLogger, mockJavaLayerConfigurations);
@@ -112,27 +109,5 @@ public class MavenProjectPropertiesTest {
   @Test
   public void testGetMainClassFromJar_missingPlugin() {
     Assert.assertNull(mavenProjectProperties.getMainClassFromJar());
-  }
-
-  @Test
-  public void testGetDockerTag_configured() {
-    ImageReference result =
-        mavenProjectProperties.getGeneratedTargetDockerTag("a/b:c", mockMavenJibLogger);
-    Assert.assertEquals("a/b", result.getRepository());
-    Assert.assertEquals("c", result.getTag());
-    Mockito.verify(mockMavenJibLogger, Mockito.never()).lifecycle(Mockito.any());
-  }
-
-  @Test
-  public void testGetDockerTag_notConfigured() {
-    ImageReference result =
-        mavenProjectProperties.getGeneratedTargetDockerTag(null, mockMavenJibLogger);
-    Assert.assertEquals("project-name", result.getRepository());
-    Assert.assertEquals("project-version", result.getTag());
-    Mockito.verify(mockMavenJibLogger)
-        .lifecycle(
-            "Tagging image with generated image reference project-name:project-version. If you'd "
-                + "like to specify a different tag, you can set the <to><image> parameter in your "
-                + "pom.xml, or use the -Dimage=<MY IMAGE> commandline flag.");
   }
 }


### PR DESCRIPTION
Part of #594. Also gets rid of a couple TODOs (using `HelpfulSuggestions` for the log message and validating the generated tag).