### PR TITLE
Renames NonexistentDockerCredentialHelperException to DockerCredentialHelperNotFoundException.

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperIntegrationTest.java
@@ -34,7 +34,7 @@ public class DockerCredentialHelperIntegrationTest {
   @Test
   public void testRetrieveGCR()
       throws IOException, NonexistentServerUrlDockerCredentialHelperException,
-          NonexistentDockerCredentialHelperException, URISyntaxException, InterruptedException {
+          DockerCredentialHelperNotFoundException, URISyntaxException, InterruptedException {
     new Command("docker-credential-gcr", "store")
         .run(Files.readAllBytes(Paths.get(Resources.getResource("credentials.json").toURI())));
 
@@ -57,7 +57,7 @@ public class DockerCredentialHelperIntegrationTest {
 
       Assert.fail("Retrieve should have failed for nonexistent credential helper");
 
-    } catch (NonexistentDockerCredentialHelperException ex) {
+    } catch (DockerCredentialHelperNotFoundException ex) {
       Assert.assertEquals(
           "The system does not have docker-credential-fake-cloud-provider CLI", ex.getMessage());
     }
@@ -65,7 +65,7 @@ public class DockerCredentialHelperIntegrationTest {
 
   @Test
   public void testRetrieve_nonexistentServerUrl()
-      throws IOException, NonexistentDockerCredentialHelperException {
+      throws IOException, DockerCredentialHelperNotFoundException {
     try {
       DockerCredentialHelper fakeDockerCredentialHelper =
           new DockerCredentialHelperFactory().newDockerCredentialHelper("fake.server.url", "gcr");

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactory.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactory.java
@@ -23,7 +23,7 @@ import com.google.cloud.tools.jib.configuration.credentials.CredentialRetriever.
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.registry.credentials.DockerConfigCredentialRetriever;
 import com.google.cloud.tools.jib.registry.credentials.DockerCredentialHelperFactory;
-import com.google.cloud.tools.jib.registry.credentials.NonexistentDockerCredentialHelperException;
+import com.google.cloud.tools.jib.registry.credentials.DockerCredentialHelperNotFoundException;
 import com.google.cloud.tools.jib.registry.credentials.NonexistentServerUrlDockerCredentialHelperException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
@@ -161,7 +161,7 @@ public class CredentialRetrieverFactory {
                       + inferredCredentialHelperSuffix),
               dockerCredentialHelperFactory);
 
-        } catch (NonexistentDockerCredentialHelperException ex) {
+        } catch (DockerCredentialHelperNotFoundException ex) {
           if (ex.getMessage() != null) {
             // Warns the user that the specified (or inferred) credential helper is not on the
             // system.
@@ -193,7 +193,7 @@ public class CredentialRetrieverFactory {
             "No credentials for " + imageReference.getRegistry() + " in " + credentialHelper);
         return null;
 
-      } catch (NonexistentDockerCredentialHelperException | IOException ex) {
+      } catch (DockerCredentialHelperNotFoundException | IOException ex) {
         throw new CredentialRetrievalException(ex);
       }
     };
@@ -220,7 +220,7 @@ public class CredentialRetrieverFactory {
   private Credential retrieveFromDockerCredentialHelper(
       Path credentialHelper, DockerCredentialHelperFactory dockerCredentialHelperFactory)
       throws NonexistentServerUrlDockerCredentialHelperException,
-          NonexistentDockerCredentialHelperException, IOException {
+          DockerCredentialHelperNotFoundException, IOException {
     Credential credentials =
         dockerCredentialHelperFactory
             .newDockerCredentialHelper(imageReference.getRegistry(), credentialHelper)

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
@@ -130,7 +130,7 @@ public class DockerConfigCredentialRetriever {
 
       } catch (IOException
           | NonexistentServerUrlDockerCredentialHelperException
-          | NonexistentDockerCredentialHelperException ex) {
+          | DockerCredentialHelperNotFoundException ex) {
         // Ignores credential helper retrieval exceptions.
       }
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
@@ -71,11 +71,11 @@ public class DockerCredentialHelper {
    * @return the Docker credentials by calling the corresponding CLI
    * @throws IOException if writing/reading process input/output fails.
    * @throws NonexistentServerUrlDockerCredentialHelperException if credentials are not found.
-   * @throws NonexistentDockerCredentialHelperException if the credential helper CLI doesn't exist.
+   * @throws DockerCredentialHelperNotFoundException if the credential helper CLI doesn't exist.
    */
   public Credential retrieve()
       throws IOException, NonexistentServerUrlDockerCredentialHelperException,
-          NonexistentDockerCredentialHelperException {
+          DockerCredentialHelperNotFoundException {
     try {
       String[] credentialHelperCommand = {credentialHelper.toString(), "get"};
 
@@ -127,7 +127,7 @@ public class DockerCredentialHelper {
       // Checks if the failure is due to a nonexistent credential helper CLI.
       if (ex.getMessage().contains("No such file or directory")
           || ex.getMessage().contains("cannot find the file")) {
-        throw new NonexistentDockerCredentialHelperException(credentialHelper, ex);
+        throw new DockerCredentialHelperNotFoundException(credentialHelper, ex);
       }
 
       throw ex;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperNotFoundException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperNotFoundException.java
@@ -19,9 +19,9 @@ package com.google.cloud.tools.jib.registry.credentials;
 import java.nio.file.Path;
 
 /** Thrown because the requested credential helper CLI does not exist. */
-public class NonexistentDockerCredentialHelperException extends Exception {
+public class DockerCredentialHelperNotFoundException extends Exception {
 
-  NonexistentDockerCredentialHelperException(Path credentialHelper, Throwable cause) {
+  DockerCredentialHelperNotFoundException(Path credentialHelper, Throwable cause) {
     super("The system does not have " + credentialHelper + " CLI", cause);
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactoryTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactoryTest.java
@@ -22,7 +22,7 @@ import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.registry.credentials.DockerConfigCredentialRetriever;
 import com.google.cloud.tools.jib.registry.credentials.DockerCredentialHelper;
 import com.google.cloud.tools.jib.registry.credentials.DockerCredentialHelperFactory;
-import com.google.cloud.tools.jib.registry.credentials.NonexistentDockerCredentialHelperException;
+import com.google.cloud.tools.jib.registry.credentials.DockerCredentialHelperNotFoundException;
 import com.google.cloud.tools.jib.registry.credentials.NonexistentServerUrlDockerCredentialHelperException;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -46,21 +46,19 @@ public class CredentialRetrieverFactoryTest {
   @Mock private DockerConfigCredentialRetriever mockDockerConfigCredentialRetriever;
 
   /**
-   * A {@link DockerCredentialHelper} that throws {@link
-   * NonexistentDockerCredentialHelperException}.
+   * A {@link DockerCredentialHelper} that throws {@link DockerCredentialHelperNotFoundException}.
    */
   @Mock private DockerCredentialHelper mockNonexistentDockerCredentialHelper;
 
-  @Mock
-  private NonexistentDockerCredentialHelperException mockNonexistentDockerCredentialHelperException;
+  @Mock private DockerCredentialHelperNotFoundException mockDockerCredentialHelperNotFoundException;
 
   @Before
   public void setUp()
       throws NonexistentServerUrlDockerCredentialHelperException,
-          NonexistentDockerCredentialHelperException, IOException {
+          DockerCredentialHelperNotFoundException, IOException {
     Mockito.when(mockDockerCredentialHelper.retrieve()).thenReturn(FAKE_CREDENTIALS);
     Mockito.when(mockNonexistentDockerCredentialHelper.retrieve())
-        .thenThrow(mockNonexistentDockerCredentialHelperException);
+        .thenThrow(mockDockerCredentialHelperNotFoundException);
   }
 
   @Test
@@ -105,8 +103,8 @@ public class CredentialRetrieverFactoryTest {
             .retrieve());
     Mockito.verify(mockJibLogger).info("Using docker-credential-gcr for something.gcr.io");
 
-    Mockito.when(mockNonexistentDockerCredentialHelperException.getMessage()).thenReturn("warning");
-    Mockito.when(mockNonexistentDockerCredentialHelperException.getCause())
+    Mockito.when(mockDockerCredentialHelperNotFoundException.getMessage()).thenReturn("warning");
+    Mockito.when(mockDockerCredentialHelperNotFoundException.getCause())
         .thenReturn(new IOException("the root cause"));
     Assert.assertNull(
         credentialRetrieverFactory

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
@@ -44,7 +44,7 @@ public class DockerConfigCredentialRetrieverTest {
   @Before
   public void setUp()
       throws URISyntaxException, NonexistentServerUrlDockerCredentialHelperException,
-          NonexistentDockerCredentialHelperException, IOException {
+          DockerCredentialHelperNotFoundException, IOException {
     dockerConfigFile = Paths.get(Resources.getResource("json/dockerconfig.json").toURI());
 
     Mockito.when(mockDockerCredentialHelper.retrieve()).thenReturn(FAKE_CREDENTIAL);


### PR DESCRIPTION
Part of #832.