### PR TITLE
Update credential retrieval order

### DIFF
--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -98,7 +98,7 @@ public class BuildImageMojo extends JibPluginConfiguration {
               .getMavenSettingsServerCredentials()
               .retrieve(targetImage.getRegistry());
       if (toCredential != null) {
-        defaultCredentialRetrievers.setInferredKnownCredential(
+        defaultCredentialRetrievers.setInferredCredential(
             toCredential, MavenSettingsServerCredentials.CREDENTIAL_SOURCE);
       }
     } else {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -98,7 +98,7 @@ public class BuildImageMojo extends JibPluginConfiguration {
               .getMavenSettingsServerCredentials()
               .retrieve(targetImage.getRegistry());
       if (toCredential != null) {
-        defaultCredentialRetrievers.setKnownCredential(
+        defaultCredentialRetrievers.setInferredKnownCredential(
             toCredential, MavenSettingsServerCredentials.CREDENTIAL_SOURCE);
       }
     } else {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
@@ -88,7 +88,7 @@ class PluginConfigurationProcessor {
     if (fromCredential == null) {
       fromCredential = mavenSettingsServerCredentials.retrieve(baseImage.getRegistry());
       if (fromCredential != null) {
-        defaultCredentialRetrievers.setKnownCredential(
+        defaultCredentialRetrievers.setInferredKnownCredential(
             fromCredential, MavenSettingsServerCredentials.CREDENTIAL_SOURCE);
       }
     } else {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
@@ -88,7 +88,7 @@ class PluginConfigurationProcessor {
     if (fromCredential == null) {
       fromCredential = mavenSettingsServerCredentials.retrieve(baseImage.getRegistry());
       if (fromCredential != null) {
-        defaultCredentialRetrievers.setInferredKnownCredential(
+        defaultCredentialRetrievers.setInferredCredential(
             fromCredential, MavenSettingsServerCredentials.CREDENTIAL_SOURCE);
       }
     } else {

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
@@ -55,7 +55,7 @@ public class DefaultCredentialRetrievers {
   private final CredentialRetrieverFactory credentialRetrieverFactory;
 
   @Nullable private CredentialRetriever knownCredentialRetriever;
-  @Nullable private CredentialRetriever inferredKnownCredentialRetriever;
+  @Nullable private CredentialRetriever inferredCredentialRetriever;
   @Nullable private String credentialHelperSuffix;
 
   private DefaultCredentialRetrievers(CredentialRetrieverFactory credentialRetrieverFactory) {
@@ -78,14 +78,14 @@ public class DefaultCredentialRetrievers {
   /**
    * Sets the inferred known {@link Credential} to use in the default credential retrievers.
    *
-   * @param inferredKnownCredential the known credential
+   * @param inferredCredential the known credential
    * @param credentialSource the source of the known credential (for logging)
    * @return this
    */
-  public DefaultCredentialRetrievers setInferredKnownCredential(
-      Credential inferredKnownCredential, String credentialSource) {
-    inferredKnownCredentialRetriever =
-        credentialRetrieverFactory.known(inferredKnownCredential, credentialSource);
+  public DefaultCredentialRetrievers setInferredCredential(
+      Credential inferredCredential, String credentialSource) {
+    inferredCredentialRetriever =
+        credentialRetrieverFactory.known(inferredCredential, credentialSource);
     return this;
   }
 
@@ -117,8 +117,8 @@ public class DefaultCredentialRetrievers {
           credentialRetrieverFactory.dockerCredentialHelper(
               DockerCredentialHelperFactory.CREDENTIAL_HELPER_PREFIX + credentialHelperSuffix));
     }
-    if (inferredKnownCredentialRetriever != null) {
-      credentialRetrievers.add(inferredKnownCredentialRetriever);
+    if (inferredCredentialRetriever != null) {
+      credentialRetrievers.add(inferredCredentialRetriever);
     }
     credentialRetrievers.add(credentialRetrieverFactory.inferCredentialHelper());
     credentialRetrievers.add(credentialRetrieverFactory.dockerConfig());

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
@@ -55,6 +55,7 @@ public class DefaultCredentialRetrievers {
   private final CredentialRetrieverFactory credentialRetrieverFactory;
 
   @Nullable private CredentialRetriever knownCredentialRetriever;
+  @Nullable private CredentialRetriever inferredKnownCredentialRetriever;
   @Nullable private String credentialHelperSuffix;
 
   private DefaultCredentialRetrievers(CredentialRetrieverFactory credentialRetrieverFactory) {
@@ -71,6 +72,20 @@ public class DefaultCredentialRetrievers {
   public DefaultCredentialRetrievers setKnownCredential(
       Credential knownCredential, String credentialSource) {
     knownCredentialRetriever = credentialRetrieverFactory.known(knownCredential, credentialSource);
+    return this;
+  }
+
+  /**
+   * Sets the inferred known {@link Credential} to use in the default credential retrievers.
+   *
+   * @param inferredKnownCredential the known credential
+   * @param credentialSource the source of the known credential (for logging)
+   * @return this
+   */
+  public DefaultCredentialRetrievers setInferredKnownCredential(
+      Credential inferredKnownCredential, String credentialSource) {
+    inferredKnownCredentialRetriever =
+        credentialRetrieverFactory.known(inferredKnownCredential, credentialSource);
     return this;
   }
 
@@ -94,13 +109,16 @@ public class DefaultCredentialRetrievers {
    */
   public List<CredentialRetriever> asList() {
     List<CredentialRetriever> credentialRetrievers = new ArrayList<>();
+    if (knownCredentialRetriever != null) {
+      credentialRetrievers.add(knownCredentialRetriever);
+    }
     if (credentialHelperSuffix != null) {
       credentialRetrievers.add(
           credentialRetrieverFactory.dockerCredentialHelper(
               DockerCredentialHelperFactory.CREDENTIAL_HELPER_PREFIX + credentialHelperSuffix));
     }
-    if (knownCredentialRetriever != null) {
-      credentialRetrievers.add(knownCredentialRetriever);
+    if (inferredKnownCredentialRetriever != null) {
+      credentialRetrievers.add(inferredKnownCredentialRetriever);
     }
     credentialRetrievers.add(credentialRetrieverFactory.inferCredentialHelper());
     credentialRetrievers.add(credentialRetrieverFactory.dockerConfig());

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
@@ -76,10 +76,10 @@ public class DefaultCredentialRetrievers {
   }
 
   /**
-   * Sets the inferred known {@link Credential} to use in the default credential retrievers.
+   * Sets the inferred {@link Credential} to use in the default credential retrievers.
    *
-   * @param inferredCredential the known credential
-   * @param credentialSource the source of the known credential (for logging)
+   * @param inferredCredential the inferred credential
+   * @param credentialSource the source of the inferred credential (for logging)
    * @return this
    */
   public DefaultCredentialRetrievers setInferredCredential(

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
@@ -36,12 +36,12 @@ public class DefaultCredentialRetrieversTest {
   @Mock private CredentialRetrieverFactory mockCredentialRetrieverFactory;
   @Mock private CredentialRetriever mockDockerCredentialHelperCredentialRetriever;
   @Mock private CredentialRetriever mockKnownCredentialRetriever;
-  @Mock private CredentialRetriever mockInferredKnownCredentialRetriever;
+  @Mock private CredentialRetriever mockInferredCredentialRetriever;
   @Mock private CredentialRetriever mockInferCredentialHelperCredentialRetriever;
   @Mock private CredentialRetriever mockDockerConfigCredentialRetriever;
 
   private final Credential knownCredential = new Credential("username", "password");
-  private final Credential inferredKnownCredential = new Credential("username2", "password2");
+  private final Credential inferredCredential = new Credential("username2", "password2");
 
   @Before
   public void setUp() {
@@ -50,9 +50,8 @@ public class DefaultCredentialRetrieversTest {
     Mockito.when(mockCredentialRetrieverFactory.known(knownCredential, "credentialSource"))
         .thenReturn(mockKnownCredentialRetriever);
     Mockito.when(
-            mockCredentialRetrieverFactory.known(
-                inferredKnownCredential, "inferredCredentialSource"))
-        .thenReturn(mockInferredKnownCredentialRetriever);
+            mockCredentialRetrieverFactory.known(inferredCredential, "inferredCredentialSource"))
+        .thenReturn(mockInferredCredentialRetriever);
     Mockito.when(mockCredentialRetrieverFactory.inferCredentialHelper())
         .thenReturn(mockInferCredentialHelperCredentialRetriever);
     Mockito.when(mockCredentialRetrieverFactory.dockerConfig())
@@ -74,21 +73,21 @@ public class DefaultCredentialRetrieversTest {
     List<CredentialRetriever> credentialRetrievers =
         DefaultCredentialRetrievers.init(mockCredentialRetrieverFactory)
             .setKnownCredential(knownCredential, "credentialSource")
-            .setInferredKnownCredential(inferredKnownCredential, "inferredCredentialSource")
+            .setInferredCredential(inferredCredential, "inferredCredentialSource")
             .setCredentialHelperSuffix("credentialHelperSuffix")
             .asList();
     Assert.assertEquals(
         Arrays.asList(
             mockKnownCredentialRetriever,
             mockDockerCredentialHelperCredentialRetriever,
-            mockInferredKnownCredentialRetriever,
+            mockInferredCredentialRetriever,
             mockInferCredentialHelperCredentialRetriever,
             mockDockerConfigCredentialRetriever),
         credentialRetrievers);
 
     Mockito.verify(mockCredentialRetrieverFactory).known(knownCredential, "credentialSource");
     Mockito.verify(mockCredentialRetrieverFactory)
-        .known(inferredKnownCredential, "inferredCredentialSource");
+        .known(inferredCredential, "inferredCredentialSource");
     Mockito.verify(mockCredentialRetrieverFactory)
         .dockerCredentialHelper("docker-credential-credentialHelperSuffix");
   }


### PR DESCRIPTION
Fixes #724. Now uses explicitly configured credentials over creds pulled from elsewhere (i.e. configured known credentials, configured cred helper, inferred known credentials (e.g. maven settings), inferred cred helpers, docker settings)