### PR TITLE
Fixes CacheStorage interface and renames CacheReadEntry/CacheWriteEntry to CacheEntry/CacheWrite.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheEntry.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheEntry.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  * Represents a cache entry for a layer stored in the cache. <b>Implementations must be
  * immutable.</b>
  */
-public interface CacheReadEntry {
+public interface CacheEntry {
 
   /**
    * Gets the digest of the layer.
@@ -58,7 +58,7 @@ public interface CacheReadEntry {
 
   /**
    * Gets the optional metadata blob for the layer. The metadata is in the same format as supplied
-   * when writing to the cache with {@link CacheWriteEntry}. This {@link Blob} should be able to be
+   * when writing to the cache with {@link CacheWrite}. This {@link Blob} should be able to be
    * used multiple times.
    *
    * @return the metadata {@link Blob}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheEntry.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheEntry.java
@@ -58,8 +58,8 @@ public interface CacheEntry {
 
   /**
    * Gets the optional metadata blob for the layer. The metadata is in the same format as supplied
-   * when writing to the cache with {@link CacheWrite}. This {@link Blob} should be able to be
-   * used multiple times.
+   * when writing to the cache with {@link CacheWrite}. This {@link Blob} should be able to be used
+   * multiple times.
    *
    * @return the metadata {@link Blob}
    */

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheStorage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheStorage.java
@@ -24,8 +24,8 @@ import java.util.Optional;
 /**
  * Interface for queries to a cache storage engine.
  *
- * <p>The cache storage engine stores layer data as {@link CacheWriteEntry}s. These entries are read
- * out as {@link CacheReadEntry}s. Cache entries can be retrieved by the layer digest.
+ * <p>The cache storage engine stores layer data as {@link CacheWrite}s. These entries are read
+ * out as {@link CacheEntry}s. Cache entries can be retrieved by the layer digest.
  *
  * <p>The cache entries can also be queried by an arbitrarily-defined selector (in digest format).
  * The selectors do not need to be unique. An example of a selector could be the digest of the list
@@ -36,13 +36,13 @@ import java.util.Optional;
 public interface CacheStorage {
 
   /**
-   * Saves the {@link CacheWriteEntry}.
+   * Saves the {@link CacheWrite}.
    *
-   * @param cacheWriteEntry the {@link CacheWriteEntry}
-   * @return the {@link CacheReadEntry} for the written {@link CacheWriteEntry}
+   * @param cacheWrite the {@link CacheWrite}
+   * @return the {@link CacheEntry} for the written {@link CacheWrite}
    * @throws IOException if an I/O exception occurs
    */
-  CacheReadEntry save(CacheWriteEntry cacheWriteEntry) throws IOException;
+  CacheEntry save(CacheWrite cacheWrite) throws IOException;
 
   /**
    * Lists all the layer digests stored.
@@ -53,20 +53,20 @@ public interface CacheStorage {
   List<DescriptorDigest> listDigests() throws IOException;
 
   /**
-   * Retrieves the {@link CacheReadEntry} for the layer with digest {@code layerDigest}.
+   * Retrieves the {@link CacheEntry} for the layer with digest {@code layerDigest}.
    *
    * @param layerDigest the layer digest
-   * @return the {@link CacheReadEntry} referenced by the layer digest
+   * @return the {@link CacheEntry} referenced by the layer digest
    * @throws IOException if an I/O exception occurs
    */
-  Optional<CacheReadEntry> retrieve(DescriptorDigest layerDigest) throws IOException;
+  Optional<CacheEntry> retrieve(DescriptorDigest layerDigest) throws IOException;
 
   /**
    * Queries for layer digests that can be selected with the {@code selector}.
    *
    * @param selector the selector to query with
-   * @return the list of layer digests selected
+   * @return the layer digest selected, or {@link Optional#empty} if none found
    * @throws IOException if an I/O exception occurs
    */
-  List<DescriptorDigest> listDigestsBySelector(DescriptorDigest selector) throws IOException;
+  Optional<DescriptorDigest> select(DescriptorDigest selector) throws IOException;
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheStorage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheStorage.java
@@ -24,8 +24,8 @@ import java.util.Optional;
 /**
  * Interface for queries to a cache storage engine.
  *
- * <p>The cache storage engine stores layer data as {@link CacheWrite}s. These entries are read
- * out as {@link CacheEntry}s. Cache entries can be retrieved by the layer digest.
+ * <p>The cache storage engine stores layer data as {@link CacheWrite}s. These entries are read out
+ * as {@link CacheEntry}s. Cache entries can be retrieved by the layer digest.
  *
  * <p>The cache entries can also be queried by an arbitrarily-defined selector (in digest format).
  * The selectors do not need to be unique. An example of a selector could be the digest of the list
@@ -42,7 +42,7 @@ public interface CacheStorage {
    * @return the {@link CacheEntry} for the written {@link CacheWrite}
    * @throws IOException if an I/O exception occurs
    */
-  CacheEntry save(CacheWrite cacheWrite) throws IOException;
+  CacheEntry write(CacheWrite cacheWrite) throws IOException;
 
   /**
    * Lists all the layer digests stored.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheWrite.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheWrite.java
@@ -21,7 +21,7 @@ import com.google.cloud.tools.jib.image.DescriptorDigest;
 import java.util.Optional;
 
 /** Represents layer data to write to the cache. <b>Implementations must be immutable.</b> */
-public interface CacheWriteEntry {
+public interface CacheWrite {
 
   /**
    * Gets the {@link Blob} to write as the layer contents.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheEntry.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheEntry.java
@@ -22,10 +22,10 @@ import com.google.common.base.Preconditions;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
-/** Default implementation of {@link CacheReadEntry}. */
-public class DefaultCacheReadEntry implements CacheReadEntry {
+/** Default implementation of {@link CacheEntry}. */
+public class DefaultCacheEntry implements CacheEntry {
 
-  /** Builds a {@link CacheReadEntry}. */
+  /** Builds a {@link CacheEntry}. */
   public static class Builder {
 
     @Nullable private DescriptorDigest layerDigest;
@@ -61,8 +61,8 @@ public class DefaultCacheReadEntry implements CacheReadEntry {
       return this;
     }
 
-    public CacheReadEntry build() {
-      return new DefaultCacheReadEntry(
+    public CacheEntry build() {
+      return new DefaultCacheEntry(
           Preconditions.checkNotNull(layerDigest, "layerDigest required"),
           Preconditions.checkNotNull(layerDiffId, "layerDiffId required"),
           layerSize,
@@ -72,7 +72,7 @@ public class DefaultCacheReadEntry implements CacheReadEntry {
   }
 
   /**
-   * Creates a new {@link Builder} for a {@link CacheReadEntry}.
+   * Creates a new {@link Builder} for a {@link CacheEntry}.
    *
    * @return the new {@link Builder}
    */
@@ -86,7 +86,7 @@ public class DefaultCacheReadEntry implements CacheReadEntry {
   private final Blob layerBlob;
   @Nullable private final Blob metadataBlob;
 
-  private DefaultCacheReadEntry(
+  private DefaultCacheEntry(
       DescriptorDigest layerDigest,
       DescriptorDigest layerDiffId,
       long layerSize,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheWrite.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheWrite.java
@@ -21,38 +21,38 @@ import com.google.cloud.tools.jib.image.DescriptorDigest;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
-/** A default implementation of {@link CacheWriteEntry}. */
-public class DefaultCacheWriteEntry implements CacheWriteEntry {
+/** A default implementation of {@link CacheWrite}. */
+public class DefaultCacheWrite implements CacheWrite {
 
   /**
-   * Constructs a {@link CacheWriteEntry} with only the layer {@link Blob}.
+   * Constructs a {@link CacheWrite} with only the layer {@link Blob}.
    *
    * @param layerBlob the layer {@link Blob}
-   * @return the new {@link CacheWriteEntry}
+   * @return the new {@link CacheWrite}
    */
-  public static CacheWriteEntry layerOnly(Blob layerBlob) {
-    return new DefaultCacheWriteEntry(layerBlob, null, null);
+  public static CacheWrite layerOnly(Blob layerBlob) {
+    return new DefaultCacheWrite(layerBlob, null, null);
   }
 
   /**
-   * Constructs a {@link CacheWriteEntry} with a layer {@link Blob}, an additional selector digest,
+   * Constructs a {@link CacheWrite} with a layer {@link Blob}, an additional selector digest,
    * and a metadata {@link Blob}.
    *
    * @param layerBlob the layer {@link Blob}
    * @param selector the selector digest
    * @param metadataBlob the metadata {@link Blob}
-   * @return the new {@link CacheWriteEntry}
+   * @return the new {@link CacheWrite}
    */
-  public static CacheWriteEntry withSelectorAndMetadata(
+  public static CacheWrite withSelectorAndMetadata(
       Blob layerBlob, DescriptorDigest selector, Blob metadataBlob) {
-    return new DefaultCacheWriteEntry(layerBlob, selector, metadataBlob);
+    return new DefaultCacheWrite(layerBlob, selector, metadataBlob);
   }
 
   private final Blob layerBlob;
   @Nullable private final DescriptorDigest selector;
   @Nullable private final Blob metadataBlob;
 
-  private DefaultCacheWriteEntry(
+  private DefaultCacheWrite(
       Blob layerBlob, @Nullable DescriptorDigest selector, @Nullable Blob metadataBlob) {
     this.layerBlob = layerBlob;
     this.selector = selector;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheWrite.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheWrite.java
@@ -35,8 +35,8 @@ public class DefaultCacheWrite implements CacheWrite {
   }
 
   /**
-   * Constructs a {@link CacheWrite} with a layer {@link Blob}, an additional selector digest,
-   * and a metadata {@link Blob}.
+   * Constructs a {@link CacheWrite} with a layer {@link Blob}, an additional selector digest, and a
+   * metadata {@link Blob}.
    *
    * @param layerBlob the layer {@link Blob}
    * @param selector the selector digest

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/ncache/DefaultCacheEntryTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/ncache/DefaultCacheEntryTest.java
@@ -26,9 +26,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/** Tests for {@link DefaultCacheReadEntry}. */
+/** Tests for {@link DefaultCacheEntry}. */
 @RunWith(MockitoJUnitRunner.class)
-public class DefaultCacheReadEntryTest {
+public class DefaultCacheEntryTest {
 
   @Mock private DescriptorDigest mockLayerDigest;
   @Mock private DescriptorDigest mockLayerDiffId;
@@ -36,7 +36,7 @@ public class DefaultCacheReadEntryTest {
   @Test
   public void testBuilder_fail() {
     try {
-      DefaultCacheReadEntry.builder().build();
+      DefaultCacheEntry.builder().build();
       Assert.fail("missing required");
 
     } catch (NullPointerException ex) {
@@ -44,7 +44,7 @@ public class DefaultCacheReadEntryTest {
     }
 
     try {
-      DefaultCacheReadEntry.builder().setLayerDigest(mockLayerDigest).build();
+      DefaultCacheEntry.builder().setLayerDigest(mockLayerDigest).build();
       Assert.fail("missing required");
 
     } catch (NullPointerException ex) {
@@ -52,7 +52,7 @@ public class DefaultCacheReadEntryTest {
     }
 
     try {
-      DefaultCacheReadEntry.builder()
+      DefaultCacheEntry.builder()
           .setLayerDigest(mockLayerDigest)
           .setLayerDiffId(mockLayerDiffId)
           .build();
@@ -65,35 +65,35 @@ public class DefaultCacheReadEntryTest {
 
   @Test
   public void testBuilder_noMetadataBlob() throws IOException {
-    CacheReadEntry cacheReadEntry =
-        DefaultCacheReadEntry.builder()
+    CacheEntry cacheEntry =
+        DefaultCacheEntry.builder()
             .setLayerDigest(mockLayerDigest)
             .setLayerDiffId(mockLayerDiffId)
             .setLayerSize(1337)
             .setLayerBlob(Blobs.from("layerBlob"))
             .build();
-    Assert.assertEquals(mockLayerDigest, cacheReadEntry.getLayerDigest());
-    Assert.assertEquals(mockLayerDiffId, cacheReadEntry.getLayerDiffId());
-    Assert.assertEquals(1337, cacheReadEntry.getLayerSize());
-    Assert.assertEquals("layerBlob", Blobs.writeToString(cacheReadEntry.getLayerBlob()));
-    Assert.assertFalse(cacheReadEntry.getMetadataBlob().isPresent());
+    Assert.assertEquals(mockLayerDigest, cacheEntry.getLayerDigest());
+    Assert.assertEquals(mockLayerDiffId, cacheEntry.getLayerDiffId());
+    Assert.assertEquals(1337, cacheEntry.getLayerSize());
+    Assert.assertEquals("layerBlob", Blobs.writeToString(cacheEntry.getLayerBlob()));
+    Assert.assertFalse(cacheEntry.getMetadataBlob().isPresent());
   }
 
   @Test
   public void testBuilder_withMetadataBlob() throws IOException {
-    CacheReadEntry cacheReadEntry =
-        DefaultCacheReadEntry.builder()
+    CacheEntry cacheEntry =
+        DefaultCacheEntry.builder()
             .setLayerDigest(mockLayerDigest)
             .setLayerDiffId(mockLayerDiffId)
             .setLayerSize(1337)
             .setLayerBlob(Blobs.from("layerBlob"))
             .setMetadataBlob(Blobs.from("metadataBlob"))
             .build();
-    Assert.assertEquals(mockLayerDigest, cacheReadEntry.getLayerDigest());
-    Assert.assertEquals(mockLayerDiffId, cacheReadEntry.getLayerDiffId());
-    Assert.assertEquals(1337, cacheReadEntry.getLayerSize());
-    Assert.assertEquals("layerBlob", Blobs.writeToString(cacheReadEntry.getLayerBlob()));
+    Assert.assertEquals(mockLayerDigest, cacheEntry.getLayerDigest());
+    Assert.assertEquals(mockLayerDiffId, cacheEntry.getLayerDiffId());
+    Assert.assertEquals(1337, cacheEntry.getLayerSize());
+    Assert.assertEquals("layerBlob", Blobs.writeToString(cacheEntry.getLayerBlob()));
     Assert.assertEquals(
-        "metadataBlob", Blobs.writeToString(cacheReadEntry.getMetadataBlob().orElse(null)));
+        "metadataBlob", Blobs.writeToString(cacheEntry.getMetadataBlob().orElse(null)));
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/ncache/DefaultCacheWriteTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/ncache/DefaultCacheWriteTest.java
@@ -25,28 +25,28 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/** Tests for {@link DefaultCacheWriteEntry}. */
+/** Tests for {@link DefaultCacheWrite}. */
 @RunWith(MockitoJUnitRunner.class)
-public class DefaultCacheWriteEntryTest {
+public class DefaultCacheWriteTest {
 
   @Mock private DescriptorDigest mockSelector;
 
   @Test
   public void testLayerOnly() throws IOException {
-    CacheWriteEntry cacheWriteEntry = DefaultCacheWriteEntry.layerOnly(Blobs.from("layerBlob"));
-    Assert.assertEquals("layerBlob", Blobs.writeToString(cacheWriteEntry.getLayerBlob()));
-    Assert.assertFalse(cacheWriteEntry.getSelector().isPresent());
-    Assert.assertFalse(cacheWriteEntry.getMetadataBlob().isPresent());
+    CacheWrite cacheWrite = DefaultCacheWrite.layerOnly(Blobs.from("layerBlob"));
+    Assert.assertEquals("layerBlob", Blobs.writeToString(cacheWrite.getLayerBlob()));
+    Assert.assertFalse(cacheWrite.getSelector().isPresent());
+    Assert.assertFalse(cacheWrite.getMetadataBlob().isPresent());
   }
 
   @Test
   public void testWithSelectorAndMetadata() throws IOException {
-    CacheWriteEntry cacheWriteEntry =
-        DefaultCacheWriteEntry.withSelectorAndMetadata(
+    CacheWrite cacheWrite =
+        DefaultCacheWrite.withSelectorAndMetadata(
             Blobs.from("layerBlob"), mockSelector, Blobs.from("metadataBlob"));
-    Assert.assertEquals("layerBlob", Blobs.writeToString(cacheWriteEntry.getLayerBlob()));
-    Assert.assertEquals(mockSelector, cacheWriteEntry.getSelector().orElse(null));
+    Assert.assertEquals("layerBlob", Blobs.writeToString(cacheWrite.getLayerBlob()));
+    Assert.assertEquals(mockSelector, cacheWrite.getSelector().orElse(null));
     Assert.assertEquals(
-        "metadataBlob", Blobs.writeToString(cacheWriteEntry.getMetadataBlob().orElse(null)));
+        "metadataBlob", Blobs.writeToString(cacheWrite.getMetadataBlob().orElse(null)));
   }
 }


### PR DESCRIPTION
Continuation of #874 - makes changes according to updated spec at #878 

- Changes selection by selector to only return single layer digest
- Renames CacheReadEntry to CacheEntry since it represents an entry in the cache
- Renames CacheWriteEntry to CacheWrite since it simply parameterizes a write