### PR TITLE
Make createdBy in history configurable

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -114,7 +114,7 @@ public class BuildStepsIntegrationTest {
                 + "                \"2002/tcp\": {},\n"
                 + "                \"3000/udp\": {}"));
     String history = new Command("docker", "history", imageReference).run();
-    Assert.assertThat(history, CoreMatchers.containsString("jib"));
+    Assert.assertThat(history, CoreMatchers.containsString("jib-integration-test"));
     Assert.assertThat(history, CoreMatchers.containsString("bazel build ..."));
     Assert.assertEquals(
         "Hello, world. An argument.\n", new Command("docker", "run", imageReference).run());
@@ -170,7 +170,7 @@ public class BuildStepsIntegrationTest {
                 + "                \"key2\": \"value2\"\n"
                 + "            }"));
     String history = new Command("docker", "history", imageReference).run();
-    Assert.assertThat(history, CoreMatchers.containsString("jib"));
+    Assert.assertThat(history, CoreMatchers.containsString("jib-integration-test"));
     Assert.assertThat(history, CoreMatchers.containsString("bazel build ..."));
     Assert.assertEquals(
         "Hello, world. An argument.\n", new Command("docker", "run", imageReference).run());
@@ -223,6 +223,7 @@ public class BuildStepsIntegrationTest {
         .setContainerConfiguration(containerConfiguration)
         .setAllowInsecureRegistries(true)
         .setLayerConfigurations(fakeLayerConfigurations)
+        .setCreatedBy("jib-integration-test")
         .build();
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
@@ -137,7 +137,7 @@ class BuildImageStep
             HistoryEntry.builder()
                 .setCreationTimestamp(layerCreationTime)
                 .setAuthor("Jib")
-                .setCreatedBy("jib")
+                .setCreatedBy(buildConfiguration.getCreatedBy())
                 .build());
       }
       if (containerConfiguration != null) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
@@ -38,6 +38,7 @@ public class BuildConfiguration {
     private boolean allowInsecureRegistries = false;
     private ImmutableList<LayerConfiguration> layerConfigurations = ImmutableList.of();
     private Class<? extends BuildableManifestTemplate> targetFormat = V22ManifestTemplate.class;
+    private String createdBy = "jib";
 
     private JibLogger buildLogger;
 
@@ -136,6 +137,18 @@ public class BuildConfiguration {
     }
 
     /**
+     * Sets the command that created the image layers (for the "Created By" field in the container's
+     * history).
+     *
+     * @param createdBy the field value
+     * @return this
+     */
+    public Builder setCreatedBy(String createdBy) {
+      this.createdBy = createdBy;
+      return this;
+    }
+
+    /**
      * Builds a new {@link BuildConfiguration} using the parameters passed into the builder.
      *
      * @return the corresponding build configuration
@@ -171,7 +184,8 @@ public class BuildConfiguration {
               baseImageLayersCacheConfiguration,
               targetFormat,
               allowInsecureRegistries,
-              layerConfigurations);
+              layerConfigurations,
+              createdBy);
 
         case 1:
           throw new IllegalStateException(errorMessages.get(0));
@@ -199,6 +213,7 @@ public class BuildConfiguration {
   private Class<? extends BuildableManifestTemplate> targetFormat;
   private final boolean allowInsecureRegistries;
   private final ImmutableList<LayerConfiguration> layerConfigurations;
+  private final String createdBy;
 
   /** Instantiate with {@link Builder#build}. */
   private BuildConfiguration(
@@ -210,7 +225,8 @@ public class BuildConfiguration {
       @Nullable CacheConfiguration baseImageLayersCacheConfiguration,
       Class<? extends BuildableManifestTemplate> targetFormat,
       boolean allowInsecureRegistries,
-      ImmutableList<LayerConfiguration> layerConfigurations) {
+      ImmutableList<LayerConfiguration> layerConfigurations,
+      String createdBy) {
     this.buildLogger = buildLogger;
     this.baseImageConfiguration = baseImageConfiguration;
     this.targetImageConfiguration = targetImageConfiguration;
@@ -220,6 +236,7 @@ public class BuildConfiguration {
     this.targetFormat = targetFormat;
     this.allowInsecureRegistries = allowInsecureRegistries;
     this.layerConfigurations = layerConfigurations;
+    this.createdBy = createdBy;
   }
 
   public JibLogger getBuildLogger() {
@@ -241,6 +258,10 @@ public class BuildConfiguration {
 
   public Class<? extends BuildableManifestTemplate> getTargetFormat() {
     return targetFormat;
+  }
+
+  public String getCreatedBy() {
+    return createdBy;
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/HistoryEntry.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/HistoryEntry.java
@@ -160,4 +160,9 @@ public class HistoryEntry implements JsonTemplate {
   public int hashCode() {
     return Objects.hash(author, creationTimestamp, createdBy, comment, emptyLayer);
   }
+
+  @Override
+  public String toString() {
+    return createdBy == null ? "" : createdBy;
+  }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
@@ -73,6 +73,7 @@ public class BuildImageStepTest {
     Mockito.when(mockBuildConfiguration.getBuildLogger()).thenReturn(mockBuildLogger);
     Mockito.when(mockBuildConfiguration.getContainerConfiguration())
         .thenReturn(mockContainerConfiguration);
+    Mockito.when(mockBuildConfiguration.getCreatedBy()).thenReturn("jib");
     Mockito.when(mockContainerConfiguration.getCreationTime()).thenReturn(Instant.EPOCH);
     Mockito.when(mockContainerConfiguration.getEnvironmentMap()).thenReturn(ImmutableMap.of());
     Mockito.when(mockContainerConfiguration.getProgramArguments()).thenReturn(ImmutableList.of());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
@@ -64,6 +64,7 @@ public class BuildConfigurationTest {
     List<LayerConfiguration> expectedLayerConfigurations =
         Collections.singletonList(
             LayerConfiguration.builder().addEntry(Collections.emptyList(), "destination").build());
+    String expectedCreatedBy = "createdBy";
 
     ImageConfiguration baseImageConfiguration =
         ImageConfiguration.builder(
@@ -94,7 +95,8 @@ public class BuildConfigurationTest {
             .setBaseImageLayersCacheConfiguration(expectedBaseImageLayersCacheConfiguration)
             .setTargetFormat(OCIManifestTemplate.class)
             .setAllowInsecureRegistries(true)
-            .setLayerConfigurations(expectedLayerConfigurations);
+            .setLayerConfigurations(expectedLayerConfigurations)
+            .setCreatedBy(expectedCreatedBy);
     BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();
 
     Assert.assertNotNull(buildConfiguration.getContainerConfiguration());
@@ -141,6 +143,7 @@ public class BuildConfigurationTest {
     Assert.assertEquals(expectedLayerConfigurations, buildConfiguration.getLayerConfigurations());
     Assert.assertEquals(
         expectedEntrypoint, buildConfiguration.getContainerConfiguration().getEntrypoint());
+    Assert.assertEquals(expectedCreatedBy, buildConfiguration.getCreatedBy());
   }
 
   @Test
@@ -176,6 +179,7 @@ public class BuildConfigurationTest {
     Assert.assertEquals(buildConfiguration.getTargetFormat(), V22ManifestTemplate.class);
     Assert.assertFalse(buildConfiguration.getAllowInsecureRegistries());
     Assert.assertEquals(Collections.emptyList(), buildConfiguration.getLayerConfigurations());
+    Assert.assertEquals("jib", buildConfiguration.getCreatedBy());
   }
 
   @Test

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibPluginIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibPluginIntegrationTest.java
@@ -63,6 +63,8 @@ public class JibPluginIntegrationTest {
 
     new Command("docker", "pull", imageReference).run();
     assertDockerInspect(imageReference);
+    String history = new Command("docker", "history", imageReference).run();
+    Assert.assertThat(history, CoreMatchers.containsString("jib-gradle-plugin"));
     return new Command("docker", "run", imageReference).run();
   }
 
@@ -84,6 +86,8 @@ public class JibPluginIntegrationTest {
 
     targetRegistry.pull(imageReference);
     assertDockerInspect(imageReference);
+    String history = new Command("docker", "history", imageReference).run();
+    Assert.assertThat(history, CoreMatchers.containsString("jib-gradle-plugin"));
     return new Command("docker", "run", imageReference).run();
   }
 
@@ -97,6 +101,8 @@ public class JibPluginIntegrationTest {
     Assert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(imageReference));
 
     assertDockerInspect(imageReference);
+    String history = new Command("docker", "history", imageReference).run();
+    Assert.assertThat(history, CoreMatchers.containsString("jib-gradle-plugin"));
     return new Command("docker", "run", imageReference).run();
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
@@ -102,6 +102,7 @@ class PluginConfigurationProcessor {
 
     BuildConfiguration.Builder buildConfigurationBuilder =
         BuildConfiguration.builder(logger)
+            .setCreatedBy("jib-gradle-plugin")
             .setAllowInsecureRegistries(jibExtension.getAllowInsecureRegistries())
             .setLayerConfigurations(
                 projectProperties.getJavaLayerConfigurations().getLayerConfigurations());

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
@@ -120,6 +120,7 @@ class PluginConfigurationProcessor {
 
     BuildConfiguration.Builder buildConfigurationBuilder =
         BuildConfiguration.builder(logger)
+            .setCreatedBy("jib-maven-plugin")
             .setAllowInsecureRegistries(jibPluginConfiguration.getAllowInsecureRegistries())
             .setLayerConfigurations(
                 projectProperties.getJavaLayerConfigurations().getLayerConfigurations());

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -144,6 +144,8 @@ public class BuildImageMojoIntegrationTest {
                 + "                \"key1\": \"value1\",\n"
                 + "                \"key2\": \"value2\"\n"
                 + "            }"));
+    String history = new Command("docker", "history", imageReference).run();
+    Assert.assertThat(history, CoreMatchers.containsString("jib-maven-plugin"));
   }
 
   private static float getBuildTimeFromVerifierLog(Verifier verifier) throws IOException {


### PR DESCRIPTION
Fixes #875 

`created_by` is now `jib-gradle-plugin` for gradle and `jib-maven-plugin` for maven