### PR TITLE
Add skip parameter to base plugin configuration

### DIFF
--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -43,6 +43,10 @@ public class BuildDockerMojo extends JibPluginConfiguration {
 
   @Override
   public void execute() throws MojoExecutionException {
+    if (isSkipped()) {
+      getLog().info("Skipping containerizations because jib-maven-plugin: skip = true");
+      return;
+    }
     if ("pom".equals(getProject().getPackaging())) {
       getLog().info("Skipping containerization because packaging is 'pom'...");
       return;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -44,7 +44,7 @@ public class BuildDockerMojo extends JibPluginConfiguration {
   @Override
   public void execute() throws MojoExecutionException {
     if (isSkipped()) {
-      getLog().info("Skipping containerizations because jib-maven-plugin: skip = true");
+      getLog().info("Skipping containerization because jib-maven-plugin: skip = true");
       return;
     }
     if ("pom".equals(getProject().getPackaging())) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -48,6 +48,10 @@ public class BuildImageMojo extends JibPluginConfiguration {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
+    if (isSkipped()) {
+      getLog().info("Skipping containerization because jib-maven-plugin: skip = true");
+      return;
+    }
     if ("pom".equals(getProject().getPackaging())) {
       getLog().info("Skipping containerization because packaging is 'pom'...");
       return;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -45,6 +45,10 @@ public class BuildTarMojo extends JibPluginConfiguration {
 
   @Override
   public void execute() throws MojoExecutionException {
+    if (isSkipped()) {
+      getLog().info("Skipping containerization because jib-maven-plugin: skip = true");
+      return;
+    }
     if ("pom".equals(getProject().getPackaging())) {
       getLog().info("Skipping containerization because packaging is 'pom'...");
       return;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/DockerContextMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/DockerContextMojo.java
@@ -50,6 +50,10 @@ public class DockerContextMojo extends JibPluginConfiguration {
 
   @Override
   public void execute() throws MojoExecutionException {
+    if (isSkipped()) {
+      getLog().info("Skipping containerization because jib-maven-plugin: skip = true");
+      return;
+    }
     if ("pom".equals(getProject().getPackaging())) {
       getLog().info("Skipping containerization because packaging is 'pom'...");
       return;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -170,6 +170,9 @@ abstract class JibPluginConfiguration extends AbstractMojo {
   @Parameter(defaultValue = "${project.basedir}/src/main/jib", required = true)
   private String extraDirectory;
 
+  @Parameter(defaultValue = "false", property = "jib.skip")
+  private boolean skip;
+
   @Nullable @Component protected SettingsDecrypter settingsDecrypter;
 
   /** Default constructor handles setting up auth property descriptors. */
@@ -300,6 +303,10 @@ abstract class JibPluginConfiguration extends AbstractMojo {
   Path getExtraDirectory() {
     // TODO: Should inform user about nonexistent directory if using custom directory.
     return Paths.get(Preconditions.checkNotNull(extraDirectory));
+  }
+
+  boolean isSkipped() {
+    return skip;
   }
 
   SettingsDecrypter getSettingsDecrypter() {

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
@@ -18,10 +18,7 @@ package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.Command;
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
@@ -119,21 +116,6 @@ public class BuildDockerMojoIntegrationTest {
 
   @Test
   public void testExecute_skipJibGoal() throws VerificationException, IOException {
-    String targetImage = "neverbuilt:maven" + System.nanoTime();
-
-    Verifier verifier = new Verifier(skippedTestProject.getProjectRoot().toString());
-    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
-    verifier.setAutoclean(false);
-    verifier.setSystemProperty("jib.skip", "true");
-
-    verifier.executeGoal("jib:" + BuildDockerMojo.GOAL_NAME);
-
-    Path logFile = Paths.get(verifier.getBasedir(), verifier.getLogFileName());
-    Assert.assertThat(
-        new String(Files.readAllBytes(logFile), Charset.forName("UTF-8")),
-        CoreMatchers.containsString(
-            "[INFO] Skipping containerization because jib-maven-plugin: skip = true\n"
-                + "[INFO] ------------------------------------------------------------------------\n"
-                + "[INFO] BUILD SUCCESS"));
+    SkippedGoalVerifier.verifyGoalIsSkipped(skippedTestProject, BuildDockerMojo.GOAL_NAME);
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -20,7 +20,6 @@ import com.google.cloud.tools.jib.Command;
 import com.google.cloud.tools.jib.IntegrationTestingConfiguration;
 import com.google.cloud.tools.jib.registry.LocalRegistry;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -277,21 +276,6 @@ public class BuildImageMojoIntegrationTest {
 
   @Test
   public void testExecute_skipJibGoal() throws VerificationException, IOException {
-    String targetImage = "neverbuilt:maven" + System.nanoTime();
-
-    Verifier verifier = new Verifier(skippedTestProject.getProjectRoot().toString());
-    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
-    verifier.setAutoclean(false);
-    verifier.setSystemProperty("jib.skip", "true");
-
-    verifier.executeGoal("jib:" + BuildImageMojo.GOAL_NAME);
-
-    Path logFile = Paths.get(verifier.getBasedir(), verifier.getLogFileName());
-    Assert.assertThat(
-        new String(Files.readAllBytes(logFile), Charset.forName("UTF-8")),
-        CoreMatchers.containsString(
-            "[INFO] Skipping containerization because jib-maven-plugin: skip = true\n"
-                + "[INFO] ------------------------------------------------------------------------\n"
-                + "[INFO] BUILD SUCCESS"));
+    SkippedGoalVerifier.verifyGoalIsSkipped(skippedTestProject, BuildImageMojo.GOAL_NAME);
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
@@ -17,6 +17,9 @@
 package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.Command;
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import java.io.File;
 import java.io.IOException;
 import java.time.Instant;
 import org.apache.maven.it.VerificationException;
@@ -31,6 +34,9 @@ public class BuildTarMojoIntegrationTest {
 
   @ClassRule
   public static final TestProject simpleTestProject = new TestProject(testPlugin, "simple");
+
+  @ClassRule
+  public static final TestProject skippedTestProject = new TestProject(testPlugin, "empty");
 
   /**
    * Builds and runs jib:buildTar on a project at {@code projectRoot} pushing to {@code
@@ -66,5 +72,25 @@ public class BuildTarMojoIntegrationTest {
         Instant.parse(
             new Command("docker", "inspect", "-f", "{{.Created}}", targetImage).run().trim());
     Assert.assertTrue(buildTime.isAfter(before) || buildTime.equals(before));
+  }
+
+  @Test
+  public void testExecute_skipJibGoal() throws VerificationException, IOException {
+    String targetImage = "emptyimage:maven" + System.nanoTime();
+
+    Verifier verifier = new Verifier(skippedTestProject.getProjectRoot().toString());
+    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
+    verifier.setAutoclean(false);
+    verifier.setSystemProperty("jib.skip", "true");
+
+    verifier.executeGoal("jib:" + BuildTarMojo.GOAL_NAME);
+    File logFile = new File(verifier.getBasedir(), verifier.getLogFileName());
+    Assert.assertTrue(
+        Files.asCharSource(logFile, Charsets.UTF_8)
+            .read()
+            .contains(
+                "[INFO] Skipping containerizations because jib-maven-plugin: skip = true\n"
+                    + "[INFO] ------------------------------------------------------------------------\n"
+                    + "[INFO] BUILD SUCCESS"));
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
@@ -17,13 +17,15 @@
 package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.Command;
-import com.google.common.base.Charsets;
-import com.google.common.io.Files;
-import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -76,7 +78,7 @@ public class BuildTarMojoIntegrationTest {
 
   @Test
   public void testExecute_skipJibGoal() throws VerificationException, IOException {
-    String targetImage = "emptyimage:maven" + System.nanoTime();
+    String targetImage = "neverbuilt:maven" + System.nanoTime();
 
     Verifier verifier = new Verifier(skippedTestProject.getProjectRoot().toString());
     verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
@@ -84,13 +86,13 @@ public class BuildTarMojoIntegrationTest {
     verifier.setSystemProperty("jib.skip", "true");
 
     verifier.executeGoal("jib:" + BuildTarMojo.GOAL_NAME);
-    File logFile = new File(verifier.getBasedir(), verifier.getLogFileName());
-    Assert.assertTrue(
-        Files.asCharSource(logFile, Charsets.UTF_8)
-            .read()
-            .contains(
-                "[INFO] Skipping containerizations because jib-maven-plugin: skip = true\n"
-                    + "[INFO] ------------------------------------------------------------------------\n"
-                    + "[INFO] BUILD SUCCESS"));
+
+    Path logFile = Paths.get(verifier.getBasedir(), verifier.getLogFileName());
+    Assert.assertThat(
+        new String(Files.readAllBytes(logFile), Charset.forName("UTF-8")),
+        CoreMatchers.containsString(
+            "[INFO] Skipping containerization because jib-maven-plugin: skip = true\n"
+                + "[INFO] ------------------------------------------------------------------------\n"
+                + "[INFO] BUILD SUCCESS"));
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
@@ -18,14 +18,9 @@ package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.Command;
 import java.io.IOException;
-import java.nio.charset.Charset;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
-import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -78,21 +73,6 @@ public class BuildTarMojoIntegrationTest {
 
   @Test
   public void testExecute_skipJibGoal() throws VerificationException, IOException {
-    String targetImage = "neverbuilt:maven" + System.nanoTime();
-
-    Verifier verifier = new Verifier(skippedTestProject.getProjectRoot().toString());
-    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
-    verifier.setAutoclean(false);
-    verifier.setSystemProperty("jib.skip", "true");
-
-    verifier.executeGoal("jib:" + BuildTarMojo.GOAL_NAME);
-
-    Path logFile = Paths.get(verifier.getBasedir(), verifier.getLogFileName());
-    Assert.assertThat(
-        new String(Files.readAllBytes(logFile), Charset.forName("UTF-8")),
-        CoreMatchers.containsString(
-            "[INFO] Skipping containerization because jib-maven-plugin: skip = true\n"
-                + "[INFO] ------------------------------------------------------------------------\n"
-                + "[INFO] BUILD SUCCESS"));
+    SkippedGoalVerifier.verifyGoalIsSkipped(skippedTestProject, BuildTarMojo.GOAL_NAME);
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/DockerContextMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/DockerContextMojoIntegrationTest.java
@@ -18,10 +18,8 @@ package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.Command;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.hamcrest.CoreMatchers;
@@ -79,21 +77,6 @@ public class DockerContextMojoIntegrationTest {
   }
 
   public void testExecute_skipJibGoal() throws VerificationException, IOException {
-    String targetImage = "neverbuilt:maven" + System.nanoTime();
-
-    Verifier verifier = new Verifier(skippedTestProject.getProjectRoot().toString());
-    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
-    verifier.setAutoclean(false);
-    verifier.setSystemProperty("jib.skip", "true");
-
-    verifier.executeGoal("jib:" + BuildDockerMojo.GOAL_NAME);
-
-    Path logFile = Paths.get(verifier.getBasedir(), verifier.getLogFileName());
-    Assert.assertThat(
-        new String(Files.readAllBytes(logFile), Charset.forName("UTF-8")),
-        CoreMatchers.containsString(
-            "[INFO] Skipping containerization because jib-maven-plugin: skip = true\n"
-                + "[INFO] ------------------------------------------------------------------------\n"
-                + "[INFO] BUILD SUCCESS"));
+    SkippedGoalVerifier.verifyGoalIsSkipped(skippedTestProject, BuildDockerMojo.GOAL_NAME);
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/DockerContextMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/DockerContextMojoIntegrationTest.java
@@ -17,11 +17,11 @@
 package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.Command;
-import com.google.common.base.Charsets;
-import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.hamcrest.CoreMatchers;
@@ -79,7 +79,7 @@ public class DockerContextMojoIntegrationTest {
   }
 
   public void testExecute_skipJibGoal() throws VerificationException, IOException {
-    String targetImage = "emptyimage:maven" + System.nanoTime();
+    String targetImage = "neverbuilt:maven" + System.nanoTime();
 
     Verifier verifier = new Verifier(skippedTestProject.getProjectRoot().toString());
     verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
@@ -87,13 +87,13 @@ public class DockerContextMojoIntegrationTest {
     verifier.setSystemProperty("jib.skip", "true");
 
     verifier.executeGoal("jib:" + BuildDockerMojo.GOAL_NAME);
-    File logFile = new File(verifier.getBasedir(), verifier.getLogFileName());
-    Assert.assertTrue(
-        com.google.common.io.Files.asCharSource(logFile, Charsets.UTF_8)
-            .read()
-            .contains(
-                "[INFO] Skipping containerizations because jib-maven-plugin: skip = true\n"
-                    + "[INFO] ------------------------------------------------------------------------\n"
-                    + "[INFO] BUILD SUCCESS"));
+
+    Path logFile = Paths.get(verifier.getBasedir(), verifier.getLogFileName());
+    Assert.assertThat(
+        new String(Files.readAllBytes(logFile), Charset.forName("UTF-8")),
+        CoreMatchers.containsString(
+            "[INFO] Skipping containerization because jib-maven-plugin: skip = true\n"
+                + "[INFO] ------------------------------------------------------------------------\n"
+                + "[INFO] BUILD SUCCESS"));
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SkippedGoalVerifier.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SkippedGoalVerifier.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC. All rights reserved.
+ * Copyright 2018 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SkippedGoalVerifier.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SkippedGoalVerifier.java
@@ -1,0 +1,34 @@
+package com.google.cloud.tools.jib.maven;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+
+public class SkippedGoalVerifier {
+
+  public static void verifyGoalIsSkipped(TestProject testProject, String goal)
+      throws VerificationException, IOException {
+    String targetImage = "neverbuilt:maven" + System.nanoTime();
+
+    Verifier verifier = new Verifier(testProject.getProjectRoot().toString());
+    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
+    verifier.setAutoclean(false);
+    verifier.setSystemProperty("jib.skip", "true");
+
+    verifier.executeGoal("jib:" + goal);
+
+    Path logFile = Paths.get(verifier.getBasedir(), verifier.getLogFileName());
+    Assert.assertThat(
+        new String(Files.readAllBytes(logFile), Charset.forName("UTF-8")),
+        CoreMatchers.containsString(
+            "[INFO] Skipping containerization because jib-maven-plugin: skip = true\n"
+                + "[INFO] ------------------------------------------------------------------------\n"
+                + "[INFO] BUILD SUCCESS"));
+  }
+}

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SkippedGoalVerifier.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SkippedGoalVerifier.java
@@ -1,7 +1,23 @@
+/*
+ * Copyright 2018 Google LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.google.cloud.tools.jib.maven;
 
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -10,14 +26,16 @@ import org.apache.maven.it.Verifier;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 
-public class SkippedGoalVerifier {
+/** A simple verifier utility to test goal skipping accross all our jib goals. */
+class SkippedGoalVerifier {
 
-  public static void verifyGoalIsSkipped(TestProject testProject, String goal)
+  private SkippedGoalVerifier() {}
+
+  /** Verify that a jib goal is skipped */
+  static void verifyGoalIsSkipped(TestProject testProject, String goal)
       throws VerificationException, IOException {
-    String targetImage = "neverbuilt:maven" + System.nanoTime();
 
     Verifier verifier = new Verifier(testProject.getProjectRoot().toString());
-    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
     verifier.setAutoclean(false);
     verifier.setSystemProperty("jib.skip", "true");
 
@@ -25,7 +43,7 @@ public class SkippedGoalVerifier {
 
     Path logFile = Paths.get(verifier.getBasedir(), verifier.getLogFileName());
     Assert.assertThat(
-        new String(Files.readAllBytes(logFile), Charset.forName("UTF-8")),
+        new String(Files.readAllBytes(logFile), StandardCharsets.UTF_8),
         CoreMatchers.containsString(
             "[INFO] Skipping containerization because jib-maven-plugin: skip = true\n"
                 + "[INFO] ------------------------------------------------------------------------\n"

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SkippedGoalVerifier.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SkippedGoalVerifier.java
@@ -29,12 +29,9 @@ import org.junit.Assert;
 /** A simple verifier utility to test goal skipping accross all our jib goals. */
 class SkippedGoalVerifier {
 
-  private SkippedGoalVerifier() {}
-
   /** Verify that a jib goal is skipped */
   static void verifyGoalIsSkipped(TestProject testProject, String goal)
       throws VerificationException, IOException {
-
     Verifier verifier = new Verifier(testProject.getProjectRoot().toString());
     verifier.setAutoclean(false);
     verifier.setSystemProperty("jib.skip", "true");
@@ -49,4 +46,6 @@ class SkippedGoalVerifier {
                 + "[INFO] ------------------------------------------------------------------------\n"
                 + "[INFO] BUILD SUCCESS"));
   }
+
+  private SkippedGoalVerifier() {}
 }


### PR DESCRIPTION
- can use system property -Djib.skip=true to skip if part of
  lifecycle
- still requires "required parameters" on jib to be configured
  even if skipping, since maven doesn't provide a api for actual
  goal skipping

fixes #865 
