### PR TITLE
Add plugin configuration for environment variables

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -216,10 +216,10 @@ public class BuildStepsIntegrationTest {
                 + "                \"key1\": \"value1\",\n"
                 + "                \"key2\": \"value2\"\n"
                 + "            }"));
-    Assert.assertThat(
-        dockerContainerConfig,
-        CoreMatchers.containsString(
-            "                \"var1=value1\",\n                \"var2=value2\"\n"));
+
+    String dockerConfigEnv =
+        new Command("docker", "inspect", "-f", "{{.Config.Env}}", imageReference).run();
+    Assert.assertThat(dockerConfigEnv, CoreMatchers.containsString("var1=value1 var2=value2"));
     String history = new Command("docker", "history", imageReference).run();
     Assert.assertThat(history, CoreMatchers.containsString("jib-integration-test"));
     Assert.assertThat(history, CoreMatchers.containsString("bazel build ..."));

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -85,7 +85,7 @@ public class BuildStepsIntegrationTest {
                 + "            }"));
     String dockerConfigEnv =
         new Command("docker", "inspect", "-f", "{{.Config.Env}}", imageReference).run();
-    Assert.assertThat(dockerConfigEnv, CoreMatchers.containsString("var1=value1 var2=value2"));
+    Assert.assertThat(dockerConfigEnv, CoreMatchers.containsString("env1=value1 env2=value2"));
     String history = new Command("docker", "history", imageReference).run();
     Assert.assertThat(history, CoreMatchers.containsString("jib-integration-test"));
     Assert.assertThat(history, CoreMatchers.containsString("bazel build ..."));
@@ -210,7 +210,7 @@ public class BuildStepsIntegrationTest {
                 JavaEntrypointConstructor.makeDefaultEntrypoint(
                     Collections.emptyList(), "HelloWorld"))
             .setProgramArguments(Collections.singletonList("An argument."))
-            .setEnvironment(ImmutableMap.of("var1", "value1", "var2", "value2"))
+            .setEnvironment(ImmutableMap.of("env1", "value1", "env2", "value2"))
             .setExposedPorts(
                 ExposedPortsParser.parse(Arrays.asList("1000", "2000-2002/tcp", "3000/udp")))
             .setLabels(ImmutableMap.of("key1", "value1", "key2", "value2"))

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -85,7 +85,8 @@ public class BuildStepsIntegrationTest {
                 + "            }"));
     String dockerConfigEnv =
         new Command("docker", "inspect", "-f", "{{.Config.Env}}", imageReference).run();
-    Assert.assertThat(dockerConfigEnv, CoreMatchers.containsString("env1=value1 env2=value2"));
+    Assert.assertThat(
+        dockerConfigEnv, CoreMatchers.containsString("env1=envvalue1 env2=envvalue2"));
     String history = new Command("docker", "history", imageReference).run();
     Assert.assertThat(history, CoreMatchers.containsString("jib-integration-test"));
     Assert.assertThat(history, CoreMatchers.containsString("bazel build ..."));
@@ -210,7 +211,7 @@ public class BuildStepsIntegrationTest {
                 JavaEntrypointConstructor.makeDefaultEntrypoint(
                     Collections.emptyList(), "HelloWorld"))
             .setProgramArguments(Collections.singletonList("An argument."))
-            .setEnvironment(ImmutableMap.of("env1", "value1", "env2", "value2"))
+            .setEnvironment(ImmutableMap.of("env1", "envvalue1", "env2", "envvalue2"))
             .setExposedPorts(
                 ExposedPortsParser.parse(Arrays.asList("1000", "2000-2002/tcp", "3000/udp")))
             .setLabels(ImmutableMap.of("key1", "value1", "key2", "value2"))

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaDockerContextGenerator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaDockerContextGenerator.java
@@ -103,6 +103,7 @@ public class JavaDockerContextGenerator {
   @Nullable private String baseImage;
   private List<String> entrypoint = Collections.emptyList();
   private List<String> javaArguments = Collections.emptyList();
+  private Map<String, String> environment = Collections.emptyMap();
   private List<String> exposedPorts = Collections.emptyList();
   private Map<String, String> labels = Collections.emptyMap();
 
@@ -167,6 +168,17 @@ public class JavaDockerContextGenerator {
    */
   public JavaDockerContextGenerator setJavaArguments(List<String> javaArguments) {
     this.javaArguments = javaArguments;
+    return this;
+  }
+
+  /**
+   * Sets the environment variables
+   *
+   * @param environment the environment variables
+   * @return this
+   */
+  public JavaDockerContextGenerator setEnvironment(Map<String, String> environment) {
+    this.environment = environment;
     return this;
   }
 
@@ -240,6 +252,9 @@ public class JavaDockerContextGenerator {
    *
    * EXPOSE [port]
    * [More EXPOSE instructions, if necessary]
+   * ENV [key1]="[value1]" \
+   *     [key2]="[value2]" \
+   *     [...]
    * LABEL [key1]="[value1]" \
    *       [key2]="[value2]" \
    *       [...]
@@ -267,14 +282,24 @@ public class JavaDockerContextGenerator {
       dockerfile.append("\nEXPOSE ").append(port);
     }
 
-    boolean firstLabel = true;
+    boolean firstElement = true;
+    for (Entry<String, String> env : environment.entrySet()) {
+      dockerfile
+          .append(firstElement ? "\nENV " : " \\\n    ")
+          .append(env.getKey())
+          .append("=")
+          .append(objectMapper.writeValueAsString(env.getValue()));
+      firstElement = false;
+    }
+
+    firstElement = true;
     for (Entry<String, String> label : labels.entrySet()) {
       dockerfile
-          .append(firstLabel ? "\nLABEL " : " \\\n      ")
+          .append(firstElement ? "\nLABEL " : " \\\n      ")
           .append(label.getKey())
           .append("=")
           .append(objectMapper.writeValueAsString(label.getValue()));
-      firstLabel = false;
+      firstElement = false;
     }
 
     dockerfile

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaDockerContextGenerator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaDockerContextGenerator.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
 /**
@@ -282,24 +283,20 @@ public class JavaDockerContextGenerator {
       dockerfile.append("\nEXPOSE ").append(port);
     }
 
-    boolean firstElement = true;
+    StringJoiner joiner = new StringJoiner(" \\\n    ", "\nENV ", "");
     for (Entry<String, String> env : environment.entrySet()) {
-      dockerfile
-          .append(firstElement ? "\nENV " : " \\\n    ")
-          .append(env.getKey())
-          .append("=")
-          .append(objectMapper.writeValueAsString(env.getValue()));
-      firstElement = false;
+      joiner.add(env.getKey() + "=" + objectMapper.writeValueAsString(env.getValue()));
+    }
+    if (environment.entrySet().size() > 0) {
+      dockerfile.append(joiner.toString());
     }
 
-    firstElement = true;
+    joiner = new StringJoiner(" \\\n      ", "\nLABEL ", "");
     for (Entry<String, String> label : labels.entrySet()) {
-      dockerfile
-          .append(firstElement ? "\nLABEL " : " \\\n      ")
-          .append(label.getKey())
-          .append("=")
-          .append(objectMapper.writeValueAsString(label.getValue()));
-      firstElement = false;
+      joiner.add(label.getKey() + "=" + objectMapper.writeValueAsString(label.getValue()));
+    }
+    if (labels.entrySet().size() > 0) {
+      dockerfile.append(joiner.toString());
     }
 
     dockerfile

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaDockerContextGenerator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaDockerContextGenerator.java
@@ -59,6 +59,8 @@ public class JavaDockerContextGenerator {
   private static final String CLASSES_LAYER_DIRECTORY = "classes";
   private static final String EXTRA_FILES_LAYER_DIRECTORY = "root";
 
+  private static final ObjectMapper objectMapper = new ObjectMapper();
+
   /** Represents a Dockerfile {@code COPY} directive. */
   private static class CopyDirective {
 
@@ -110,12 +112,10 @@ public class JavaDockerContextGenerator {
    *
    * @param map the map to convert
    * @param command the dockerfile command to prefix the map values with
-   * @param objectMapper used to json-ify map values
    * @return the new dockerfile command as a string
    * @throws JsonProcessingException if getting the json string of a map value fails
    */
-  private static String mapToDockerfileString(
-      Map<String, String> map, String command, ObjectMapper objectMapper)
+  private static String mapToDockerfileString(Map<String, String> map, String command)
       throws JsonProcessingException {
     if (map.isEmpty()) {
       return "";
@@ -296,7 +296,6 @@ public class JavaDockerContextGenerator {
    */
   @VisibleForTesting
   String makeDockerfile() throws JsonProcessingException {
-    ObjectMapper objectMapper = new ObjectMapper();
     StringBuilder dockerfile = new StringBuilder();
     dockerfile.append("FROM ").append(Preconditions.checkNotNull(baseImage)).append("\n");
     for (CopyDirective copyDirective : copyDirectives) {
@@ -312,8 +311,8 @@ public class JavaDockerContextGenerator {
       dockerfile.append("\nEXPOSE ").append(port);
     }
 
-    dockerfile.append(mapToDockerfileString(environment, "ENV", objectMapper));
-    dockerfile.append(mapToDockerfileString(labels, "LABEL", objectMapper));
+    dockerfile.append(mapToDockerfileString(environment, "ENV"));
+    dockerfile.append(mapToDockerfileString(labels, "LABEL"));
     dockerfile
         .append("\nENTRYPOINT ")
         .append(objectMapper.writeValueAsString(entrypoint))

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/JavaDockerContextGeneratorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/JavaDockerContextGeneratorTest.java
@@ -125,6 +125,7 @@ public class JavaDockerContextGeneratorTest {
     List<String> expectedJvmFlags = Arrays.asList("-flag", "another\"Flag");
     String expectedMainClass = "SomeMainClass";
     List<String> expectedJavaArguments = Arrays.asList("arg1", "arg2");
+    Map<String, String> expectedEnv = ImmutableMap.of("key1", "value1", "key2", "value2");
     List<String> exposedPorts = Arrays.asList("1000/tcp", "2000-2010/udp");
     Map<String, String> expectedLabels =
         ImmutableMap.of(
@@ -155,6 +156,7 @@ public class JavaDockerContextGeneratorTest {
                 JavaEntrypointConstructor.makeDefaultEntrypoint(
                     expectedJvmFlags, expectedMainClass))
             .setJavaArguments(expectedJavaArguments)
+            .setEnvironment(expectedEnv)
             .setExposedPorts(exposedPorts)
             .setLabels(expectedLabels)
             .makeDockerfile();

--- a/jib-core/src/test/resources/sampleDockerfile
+++ b/jib-core/src/test/resources/sampleDockerfile
@@ -11,7 +11,7 @@ EXPOSE 2000-2010/udp
 ENV key1="value1" \
     key2="value2"
 LABEL key1="value" \
-      key2="value with\\backslashes\"and\\\\\"\"quotes\"\\" \
-      key3="value3"
+    key2="value with\\backslashes\"and\\\\\"\"quotes\"\\" \
+    key3="value3"
 ENTRYPOINT ["java","-flag","another\"Flag","-cp","/app/resources/:/app/classes/:/app/libs/*","SomeMainClass"]
 CMD ["arg1","arg2"]

--- a/jib-core/src/test/resources/sampleDockerfile
+++ b/jib-core/src/test/resources/sampleDockerfile
@@ -8,6 +8,8 @@ COPY root /
 
 EXPOSE 1000/tcp
 EXPOSE 2000-2010/udp
+ENV key1="value1" \
+    key2="value2"
 LABEL key1="value" \
       key2="value with\\backslashes\"and\\\\\"\"quotes\"\\" \
       key3="value3"

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `container.environment` configuration parameter to configure environment variables ([#890](https://github.com/GoogleContainerTools/jib/issues/890))
+
 ### Changed
 
 ### Fixed

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibPluginIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibPluginIntegrationTest.java
@@ -238,7 +238,7 @@ public class JibPluginIntegrationTest {
     String targetImage = "localhost:6000/compleximage:gradle" + System.nanoTime();
     Instant beforeBuild = Instant.now();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nvalue1\nvalue2\n",
+        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nenvvalue1\nenvvalue2\n",
         buildAndRunComplex(targetImage, "testuser2", "testpassword2", localRegistry2));
     assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);
   }
@@ -248,7 +248,7 @@ public class JibPluginIntegrationTest {
     String targetImage = "localhost:5000/compleximage:gradle" + System.nanoTime();
     Instant beforeBuild = Instant.now();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nvalue1\nvalue2\n",
+        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nenvvalue1\nenvvalue2\n",
         buildAndRunComplex(targetImage, "testuser", "testpassword", localRegistry1));
     assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);
   }

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibPluginIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibPluginIntegrationTest.java
@@ -238,7 +238,7 @@ public class JibPluginIntegrationTest {
     String targetImage = "localhost:6000/compleximage:gradle" + System.nanoTime();
     Instant beforeBuild = Instant.now();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\n",
+        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nvalue1\nvalue2\n",
         buildAndRunComplex(targetImage, "testuser2", "testpassword2", localRegistry2));
     assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);
   }
@@ -248,7 +248,7 @@ public class JibPluginIntegrationTest {
     String targetImage = "localhost:5000/compleximage:gradle" + System.nanoTime();
     Instant beforeBuild = Instant.now();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\n",
+        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nvalue1\nvalue2\n",
         buildAndRunComplex(targetImage, "testuser", "testpassword", localRegistry1));
     assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);
   }

--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/complex-build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/complex-build.gradle
@@ -34,7 +34,7 @@ jib {
         args = ['An argument.']
         mainClass = 'com.test.HelloWorld'
         jvmFlags = ['-Xms512m', '-Xdebug']
-        environment = [env1:'value1', env2:'value2']
+        environment = [env1:'envvalue1', env2:'envvalue2']
         ports = ['1000/tcp', '2000-2003/udp']
         labels = [key1:'value1', key2:'value2']
     }

--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/complex-build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/complex-build.gradle
@@ -34,6 +34,7 @@ jib {
         args = ['An argument.']
         mainClass = 'com.test.HelloWorld'
         jvmFlags = ['-Xms512m', '-Xdebug']
+        environment = [var1:'value1', var2:'value2']
         ports = ['1000/tcp', '2000-2003/udp']
         labels = [key1:'value1', key2:'value2']
     }

--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/complex-build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/complex-build.gradle
@@ -34,7 +34,7 @@ jib {
         args = ['An argument.']
         mainClass = 'com.test.HelloWorld'
         jvmFlags = ['-Xms512m', '-Xdebug']
-        environment = [var1:'value1', var2:'value2']
+        environment = [env1:'value1', env2:'value2']
         ports = ['1000/tcp', '2000-2003/udp']
         labels = [key1:'value1', key2:'value2']
     }

--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/src/main/java/com/test/HelloWorld.java
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/src/main/java/com/test/HelloWorld.java
@@ -51,11 +51,11 @@ public class HelloWorld {
       System.out.println(jvmFlag);
     }
 
-    if (System.getenv("var1") != null) {
-      System.out.println(System.getenv("var1"));
+    if (System.getenv("env1") != null) {
+      System.out.println(System.getenv("env1"));
     }
-    if (System.getenv("var2") != null) {
-      System.out.println(System.getenv("var2"));
+    if (System.getenv("env2") != null) {
+      System.out.println(System.getenv("env2"));
     }
   }
 }

--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/src/main/java/com/test/HelloWorld.java
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/src/main/java/com/test/HelloWorld.java
@@ -50,5 +50,12 @@ public class HelloWorld {
     for (String jvmFlag : ManagementFactory.getRuntimeMXBean().getInputArguments()) {
       System.out.println(jvmFlag);
     }
+
+    if (System.getenv("var1") != null) {
+      System.out.println(System.getenv("var1"));
+    }
+    if (System.getenv("var2") != null) {
+      System.out.println(System.getenv("var2"));
+    }
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
@@ -34,6 +34,7 @@ public class ContainerParameters {
 
   private boolean useCurrentTimestamp = false;
   private List<String> jvmFlags = Collections.emptyList();
+  private Map<String, String> environment = Collections.emptyMap();
   private List<String> entrypoint = Collections.emptyList();
   @Nullable private String mainClass;
   private List<String> args = Collections.emptyList();
@@ -69,6 +70,16 @@ public class ContainerParameters {
 
   public void setJvmFlags(List<String> jvmFlags) {
     this.jvmFlags = jvmFlags;
+  }
+
+  @Input
+  @Optional
+  public Map<String, String> getEnvironment() {
+    return environment;
+  }
+
+  public void setEnvironment(Map<String, String> environment) {
+    this.environment = environment;
   }
 
   @Input

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -229,6 +229,12 @@ public class JibExtension {
     return container.getJvmFlags();
   }
 
+  @Internal
+  @Optional
+  Map<String, String> getEnvironment() {
+    return container.getEnvironment();
+  }
+
   // TODO: Make @Internal (deprecated)
   @Input
   @Nullable

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
@@ -97,6 +97,7 @@ class PluginConfigurationProcessor {
     ContainerConfiguration.Builder containerConfigurationBuilder =
         ContainerConfiguration.builder()
             .setEntrypoint(entrypoint)
+            .setEnvironment(jibExtension.getEnvironment())
             .setProgramArguments(jibExtension.getArgs())
             .setExposedPorts(ExposedPortsParser.parse(jibExtension.getExposedPorts()))
             .setLabels(jibExtension.getLabels());

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -95,14 +95,17 @@ public class JibExtensionTest {
   @Test
   public void testContainer() {
     Assert.assertEquals(Collections.emptyList(), testJibExtension.getContainer().getJvmFlags());
+    Assert.assertEquals(Collections.emptyMap(), testJibExtension.getContainer().getEnvironment());
     Assert.assertNull(testJibExtension.getContainer().getMainClass());
     Assert.assertEquals(Collections.emptyList(), testJibExtension.getContainer().getArgs());
     Assert.assertEquals(V22ManifestTemplate.class, testJibExtension.getContainer().getFormat());
     Assert.assertEquals(Collections.emptyList(), testJibExtension.getContainer().getPorts());
+    Assert.assertEquals(Collections.emptyMap(), testJibExtension.getContainer().getLabels());
 
     testJibExtension.container(
         container -> {
           container.setJvmFlags(Arrays.asList("jvmFlag1", "jvmFlag2"));
+          container.setEnvironment(ImmutableMap.of("var1", "value1", "var2", "value2"));
           container.setEntrypoint(Arrays.asList("foo", "bar", "baz"));
           container.setMainClass("mainClass");
           container.setArgs(Arrays.asList("arg1", "arg2", "arg3"));
@@ -114,6 +117,9 @@ public class JibExtensionTest {
         Arrays.asList("foo", "bar", "baz"), testJibExtension.getContainer().getEntrypoint());
     Assert.assertEquals(
         Arrays.asList("jvmFlag1", "jvmFlag2"), testJibExtension.getContainer().getJvmFlags());
+    Assert.assertEquals(
+        ImmutableMap.of("var1", "value1", "var2", "value2"),
+        testJibExtension.getContainer().getEnvironment());
     Assert.assertEquals("mainClass", testJibExtension.getContainer().getMainClass());
     Assert.assertEquals(
         Arrays.asList("arg1", "arg2", "arg3"), testJibExtension.getContainer().getArgs());

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `<skip>` configuration parameter to skip Jib execution in multi-module projects ([#865](https://github.com/GoogleContainerTools/jib/issues/865))
 - `<container><environment>` configuration parameter to configure environment variables ([#890](https://github.com/GoogleContainerTools/jib/issues/890))
 
 ### Changed

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `<skip>` configuration parameter to skip Jib execution in multi-module projects ([#865](https://github.com/GoogleContainerTools/jib/issues/865))
+- `<skip>` configuration parameter to skip Jib execution in multi-module projects (also settable via `jib.skip` property) ([#865](https://github.com/GoogleContainerTools/jib/issues/865))
 - `<container><environment>` configuration parameter to configure environment variables ([#890](https://github.com/GoogleContainerTools/jib/issues/890))
 
 ### Changed

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `<container><environment>` configuration parameter to configure environment variables ([#890](https://github.com/GoogleContainerTools/jib/issues/890))
+
 ### Changed
 
 ### Fixed

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -122,6 +122,8 @@ abstract class JibPluginConfiguration extends AbstractMojo {
 
     @Parameter private List<String> jvmFlags = Collections.emptyList();
 
+    @Parameter private Map<String, String> environment = Collections.emptyMap();
+
     @Nullable @Parameter private String mainClass;
 
     @Parameter private List<String> args = Collections.emptyList();
@@ -151,8 +153,6 @@ abstract class JibPluginConfiguration extends AbstractMojo {
   @Parameter private ContainerParameters container = new ContainerParameters();
 
   @Deprecated @Parameter private List<String> jvmFlags = Collections.emptyList();
-
-  @Nullable @Parameter private Map<String, String> environment;
 
   @Deprecated @Nullable @Parameter private String mainClass;
 
@@ -268,7 +268,7 @@ abstract class JibPluginConfiguration extends AbstractMojo {
 
   @Nullable
   Map<String, String> getEnvironment() {
-    return environment;
+    return container.environment;
   }
 
   @Nullable

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -261,7 +261,7 @@ public class BuildImageMojoIntegrationTest {
       throws IOException, InterruptedException, VerificationException {
     String targetImage = "localhost:6000/compleximage:maven" + System.nanoTime();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nvalue1\nvalue2\n",
+        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nenvvalue1\nenvvalue2\n",
         buildAndRunComplex(targetImage, "testuser2", "testpassword2", localRegistry2));
   }
 
@@ -270,7 +270,7 @@ public class BuildImageMojoIntegrationTest {
       throws IOException, InterruptedException, VerificationException {
     String targetImage = "localhost:5000/compleximage:maven" + System.nanoTime();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nvalue1\nvalue2\n",
+        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nenvvalue1\nenvvalue2\n",
         buildAndRunComplex(targetImage, "testuser", "testpassword", localRegistry1));
   }
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -261,7 +261,7 @@ public class BuildImageMojoIntegrationTest {
       throws IOException, InterruptedException, VerificationException {
     String targetImage = "localhost:6000/compleximage:maven" + System.nanoTime();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\n",
+        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nvalue1\nvalue2\n",
         buildAndRunComplex(targetImage, "testuser2", "testpassword2", localRegistry2));
   }
 
@@ -270,7 +270,7 @@ public class BuildImageMojoIntegrationTest {
       throws IOException, InterruptedException, VerificationException {
     String targetImage = "localhost:5000/compleximage:maven" + System.nanoTime();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\n",
+        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nvalue1\nvalue2\n",
         buildAndRunComplex(targetImage, "testuser", "testpassword", localRegistry1));
   }
 

--- a/jib-maven-plugin/src/test/resources/projects/simple/pom-complex.xml
+++ b/jib-maven-plugin/src/test/resources/projects/simple/pom-complex.xml
@@ -62,6 +62,10 @@
               <jvmFlag>-Xms512m</jvmFlag>
               <jvmFlag>-Xdebug</jvmFlag>
             </jvmFlags>
+            <environment>
+              <var1>value1</var1>
+              <var2>value2</var2>
+            </environment>
             <ports>
               <port>1000/tcp</port>
               <port>2000-2003/udp</port>

--- a/jib-maven-plugin/src/test/resources/projects/simple/pom-complex.xml
+++ b/jib-maven-plugin/src/test/resources/projects/simple/pom-complex.xml
@@ -63,8 +63,8 @@
               <jvmFlag>-Xdebug</jvmFlag>
             </jvmFlags>
             <environment>
-              <env1>value1</env1>
-              <env2>value2</env2>
+              <env1>envvalue1</env1>
+              <env2>envvalue2</env2>
             </environment>
             <ports>
               <port>1000/tcp</port>

--- a/jib-maven-plugin/src/test/resources/projects/simple/pom-complex.xml
+++ b/jib-maven-plugin/src/test/resources/projects/simple/pom-complex.xml
@@ -63,8 +63,8 @@
               <jvmFlag>-Xdebug</jvmFlag>
             </jvmFlags>
             <environment>
-              <var1>value1</var1>
-              <var2>value2</var2>
+              <env1>value1</env1>
+              <env2>value2</env2>
             </environment>
             <ports>
               <port>1000/tcp</port>

--- a/jib-maven-plugin/src/test/resources/projects/simple/src/main/java/com/test/HelloWorld.java
+++ b/jib-maven-plugin/src/test/resources/projects/simple/src/main/java/com/test/HelloWorld.java
@@ -51,11 +51,11 @@ public class HelloWorld {
       System.out.println(jvmFlag);
     }
 
-    if (System.getenv("var1") != null) {
-      System.out.println(System.getenv("var1"));
+    if (System.getenv("env1") != null) {
+      System.out.println(System.getenv("env1"));
     }
-    if (System.getenv("var2") != null) {
-      System.out.println(System.getenv("var2"));
+    if (System.getenv("env2") != null) {
+      System.out.println(System.getenv("env2"));
     }
   }
 }

--- a/jib-maven-plugin/src/test/resources/projects/simple/src/main/java/com/test/HelloWorld.java
+++ b/jib-maven-plugin/src/test/resources/projects/simple/src/main/java/com/test/HelloWorld.java
@@ -50,5 +50,12 @@ public class HelloWorld {
     for (String jvmFlag : ManagementFactory.getRuntimeMXBean().getInputArguments()) {
       System.out.println(jvmFlag);
     }
+
+    if (System.getenv("var1") != null) {
+      System.out.println(System.getenv("var1"));
+    }
+    if (System.getenv("var2") != null) {
+      System.out.println(System.getenv("var2"));
+    }
   }
 }


### PR DESCRIPTION
Fixes #890 

This adds a new `environment` configuration parameter to the maven and gradle plugins to set environment variables on the container image.

Maven:
```xml
<configuration>
  <container>
    <environment>
      <key1>value1</key1>
      <key2>value2</key2>
    </environment>
  </container>
</configuration>
```

Gradle:
```groovy
jib {
  container {
    environment = [key1:"value1", key2:"value2"]
  }
}
```

This PR also adds the corresponding "ENV" command to the docker context generator.

Also slipped `skip` into the changelog to fix #929 