### PR TITLE
Adds EventEmitter.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/EventEmitter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/EventEmitter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.event;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
+import java.util.List;
+
+/** Emits {@link JibEvent}s to event handlers. */
+public class EventEmitter {
+
+  /** Maps from {@link JibEvent} class to handlers for that event type. */
+  private final ImmutableMap<Class<? extends JibEvent>, List<Handler<? extends JibEvent>>> handlers;
+
+  /**
+   * Creates from {@link Handler}s in an {@link EventHandlers}.
+   *
+   * @param eventHandlers the {@link EventHandlers} to get the {@link Handler}s from
+   */
+  public EventEmitter(EventHandlers eventHandlers) {
+    handlers = ImmutableMap.copyOf(eventHandlers.getHandlers());
+    System.out.println(handlers);
+  }
+
+  /**
+   * Emits {@code jibEvent} to all the handlers that can handle it.
+   *
+   * @param jibEvent the {@link JibEvent} to emit
+   */
+  public void emit(JibEvent jibEvent) {
+    for (Handler<? extends JibEvent> handler : getHandlersFor(JibEvent.class)) {
+      handler.handle(jibEvent);
+    }
+    for (Handler<? extends JibEvent> handler : getHandlersFor(jibEvent.getClass())) {
+      handler.handle(jibEvent);
+    }
+  }
+
+  private List<Handler<? extends JibEvent>> getHandlersFor(
+      Class<? extends JibEvent> jibEventClass) {
+    List<Handler<? extends JibEvent>> handlerList = handlers.get(jibEventClass);
+    if (handlerList == null) {
+      return Collections.emptyList();
+    }
+    return handlerList;
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/EventEmitter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/EventEmitter.java
@@ -33,7 +33,6 @@ public class EventEmitter {
    */
   public EventEmitter(EventHandlers eventHandlers) {
     handlers = ImmutableMap.copyOf(eventHandlers.getHandlers());
-    System.out.println(handlers);
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/EventEmitter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/EventEmitter.java
@@ -16,23 +16,21 @@
 
 package com.google.cloud.tools.jib.event;
 
-import com.google.common.collect.ImmutableMap;
-import java.util.Collections;
-import java.util.List;
+import com.google.common.collect.ImmutableMultimap;
 
 /** Emits {@link JibEvent}s to event handlers. */
 public class EventEmitter {
 
   /** Maps from {@link JibEvent} class to handlers for that event type. */
-  private final ImmutableMap<Class<? extends JibEvent>, List<Handler<? extends JibEvent>>> handlers;
+  private final ImmutableMultimap<Class<? extends JibEvent>, Handler<? extends JibEvent>> handlers;
 
   /**
-   * Creates from {@link Handler}s in an {@link EventHandlers}.
+   * Creates an instance from {@link Handler}s in an {@link EventHandlers}.
    *
    * @param eventHandlers the {@link EventHandlers} to get the {@link Handler}s from
    */
   public EventEmitter(EventHandlers eventHandlers) {
-    handlers = ImmutableMap.copyOf(eventHandlers.getHandlers());
+    handlers = eventHandlers.getHandlers();
   }
 
   /**
@@ -41,20 +39,7 @@ public class EventEmitter {
    * @param jibEvent the {@link JibEvent} to emit
    */
   public void emit(JibEvent jibEvent) {
-    for (Handler<? extends JibEvent> handler : getHandlersFor(JibEvent.class)) {
-      handler.handle(jibEvent);
-    }
-    for (Handler<? extends JibEvent> handler : getHandlersFor(jibEvent.getClass())) {
-      handler.handle(jibEvent);
-    }
-  }
-
-  private List<Handler<? extends JibEvent>> getHandlersFor(
-      Class<? extends JibEvent> jibEventClass) {
-    List<Handler<? extends JibEvent>> handlerList = handlers.get(jibEventClass);
-    if (handlerList == null) {
-      return Collections.emptyList();
-    }
-    return handlerList;
+    handlers.get(JibEvent.class).forEach(handler -> handler.handle(jibEvent));
+    handlers.get(jibEvent.getClass()).forEach(handler -> handler.handle(jibEvent));
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/EventHandlers.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/EventHandlers.java
@@ -26,34 +26,7 @@ import java.util.function.Consumer;
 /** Builds a set of event handlers to handle {@link JibEvent}s. */
 public class EventHandlers {
 
-  /** Handles an emitted {@link JibEvent}. */
-  public static class Handler<E extends JibEvent> {
-
-    private final Class<E> eventClass;
-    private final Consumer<E> eventConsumer;
-
-    private Handler(Class<E> eventClass, Consumer<E> eventConsumer) {
-      this.eventClass = eventClass;
-      this.eventConsumer = eventConsumer;
-    }
-
-    /**
-     * Handles a {@link JibEvent}.
-     *
-     * @param jibEvent the event to handle
-     * @return {@code true} if this {@link Handler} handled the event; {@code false} if this {@link
-     *     Handler} does not handle the event
-     */
-    public boolean handle(JibEvent jibEvent) {
-      if (eventClass.isInstance(jibEvent)) {
-        eventConsumer.accept(eventClass.cast(jibEvent));
-        return true;
-      }
-      return false;
-    }
-  }
-
-  // Maps from JibEvent class to handlers for that event type.
+  /** Maps from {@link JibEvent} class to handlers for that event type. */
   private final Map<Class<? extends JibEvent>, List<Handler<? extends JibEvent>>> handlers =
       new HashMap<>();
 
@@ -95,7 +68,7 @@ public class EventHandlers {
    *
    * @return the map from {@link JibEvent} type to a list of {@link Handler}s
    */
-  public Map<Class<? extends JibEvent>, List<Handler<? extends JibEvent>>> getHandlers() {
+  Map<Class<? extends JibEvent>, List<Handler<? extends JibEvent>>> getHandlers() {
     return Collections.unmodifiableMap(handlers);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/EventHandlers.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/EventHandlers.java
@@ -16,19 +16,17 @@
 
 package com.google.cloud.tools.jib.event;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
 import java.util.function.Consumer;
 
 /** Builds a set of event handlers to handle {@link JibEvent}s. */
 public class EventHandlers {
 
   /** Maps from {@link JibEvent} class to handlers for that event type. */
-  private final Map<Class<? extends JibEvent>, List<Handler<? extends JibEvent>>> handlers =
-      new HashMap<>();
+  private final Multimap<Class<? extends JibEvent>, Handler<? extends JibEvent>> handlers =
+      ArrayListMultimap.create();
 
   /**
    * Adds the {@code eventConsumer} to handle the {@link JibEvent} with class {@code eventClass}.
@@ -45,10 +43,7 @@ public class EventHandlers {
   public <E extends JibEvent> EventHandlers add(
       JibEventType<E> eventType, Consumer<E> eventConsumer) {
     Class<E> eventClass = eventType.getEventClass();
-    if (!handlers.containsKey(eventClass)) {
-      handlers.put(eventClass, new ArrayList<>());
-    }
-    handlers.get(eventClass).add(new Handler<>(eventClass, eventConsumer));
+    handlers.put(eventClass, new Handler<>(eventClass, eventConsumer));
     return this;
   }
 
@@ -68,7 +63,7 @@ public class EventHandlers {
    *
    * @return the map from {@link JibEvent} type to a list of {@link Handler}s
    */
-  Map<Class<? extends JibEvent>, List<Handler<? extends JibEvent>>> getHandlers() {
-    return Collections.unmodifiableMap(handlers);
+  ImmutableMultimap<Class<? extends JibEvent>, Handler<? extends JibEvent>> getHandlers() {
+    return ImmutableMultimap.copyOf(handlers);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/Handler.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/Handler.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.event;
 
+import com.google.common.base.Preconditions;
 import java.util.function.Consumer;
 
 /** Handles an emitted {@link JibEvent}. */
@@ -33,14 +34,9 @@ class Handler<E extends JibEvent> {
    * Handles a {@link JibEvent}.
    *
    * @param jibEvent the event to handle
-   * @return {@code true} if this {@link Handler} handled the event; {@code false} if this {@link
-   *     Handler} does not handle the event
    */
-  boolean handle(JibEvent jibEvent) {
-    if (eventClass.isInstance(jibEvent)) {
-      eventConsumer.accept(eventClass.cast(jibEvent));
-      return true;
-    }
-    return false;
+  void handle(JibEvent jibEvent) {
+    Preconditions.checkArgument(eventClass.isInstance(jibEvent));
+    eventConsumer.accept(eventClass.cast(jibEvent));
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/Handler.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/Handler.java
@@ -16,24 +16,31 @@
 
 package com.google.cloud.tools.jib.event;
 
-import com.google.common.annotations.VisibleForTesting;
+import java.util.function.Consumer;
 
-/** Holds references to all {@link JibEvent} types. */
-public class JibEventType<E extends JibEvent> {
-
-  /** All event types. Handlers for this will always be called first. */
-  public static final JibEventType<JibEvent> ALL = new JibEventType<>(JibEvent.class);
-
-  // TODO: Add entries for all JibEvent types.
+/** Handles an emitted {@link JibEvent}. */
+class Handler<E extends JibEvent> {
 
   private final Class<E> eventClass;
+  private final Consumer<E> eventConsumer;
 
-  @VisibleForTesting
-  JibEventType(Class<E> eventClass) {
+  Handler(Class<E> eventClass, Consumer<E> eventConsumer) {
     this.eventClass = eventClass;
+    this.eventConsumer = eventConsumer;
   }
 
-  Class<E> getEventClass() {
-    return eventClass;
+  /**
+   * Handles a {@link JibEvent}.
+   *
+   * @param jibEvent the event to handle
+   * @return {@code true} if this {@link Handler} handled the event; {@code false} if this {@link
+   *     Handler} does not handle the event
+   */
+  boolean handle(JibEvent jibEvent) {
+    if (eventClass.isInstance(jibEvent)) {
+      eventConsumer.accept(eventClass.cast(jibEvent));
+      return true;
+    }
+    return false;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/JibEvent.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/JibEvent.java
@@ -16,5 +16,8 @@
 
 package com.google.cloud.tools.jib.event;
 
-/** Type for events emitted by Jib Core. */
+/**
+ * Type for events emitted by Jib Core. Implementation classes should <b>not</b> inherit from each
+ * other.
+ */
 public interface JibEvent {}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/EventEmitterTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/EventEmitterTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.event;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for {@link EventEmitter}. */
+public class EventEmitterTest {
+
+  /** Test {@link JibEvent}. */
+  private static class TestJibEvent1 implements JibEvent {}
+
+  /** Test {@link JibEvent}. */
+  private static class TestJibEvent2 implements JibEvent {}
+
+  @Test
+  public void testEmit() {
+    List<String> emissions = new ArrayList<>();
+
+    EventHandlers eventHandlers =
+        new EventHandlers()
+            .add(
+                new JibEventType<>(TestJibEvent1.class),
+                testJibEvent1 -> emissions.add("handled 1 first"))
+            .add(
+                new JibEventType<>(TestJibEvent1.class),
+                testJibEvent1 -> emissions.add("handled 1 second"))
+            .add(
+                new JibEventType<>(TestJibEvent2.class),
+                testJibEvent2 -> emissions.add("handled 2"))
+            .add(jibEvent -> emissions.add("handled generic"));
+
+    TestJibEvent1 testJibEvent1 = new TestJibEvent1();
+    TestJibEvent2 testJibEvent2 = new TestJibEvent2();
+
+    EventEmitter eventEmitter = new EventEmitter(eventHandlers);
+    eventEmitter.emit(testJibEvent1);
+    eventEmitter.emit(testJibEvent2);
+
+    Assert.assertEquals(
+        Arrays.asList(
+            "handled generic",
+            "handled 1 first",
+            "handled 1 second",
+            "handled generic",
+            "handled 2"),
+        emissions);
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/EventHandlersTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/EventHandlersTest.java
@@ -52,9 +52,7 @@ public class EventHandlersTest {
         new EventHandlers()
             .add(
                 new JibEventType<>(TestJibEvent1.class),
-                testJibEvent1 -> {
-                  Assert.assertEquals("payload", testJibEvent1.getPayload());
-                })
+                testJibEvent1 -> Assert.assertEquals("payload", testJibEvent1.getPayload()))
             .add(
                 new JibEventType<>(TestJibEvent2.class),
                 testJibEvent2 -> testJibEvent2.sayHello("Jib"))

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/EventHandlersTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/EventHandlersTest.java
@@ -69,17 +69,10 @@ public class EventHandlersTest {
     TestJibEvent2 testJibEvent2 = new TestJibEvent2();
 
     // Checks that the handlers handled their respective event types.
-    Assert.assertTrue(
-        eventHandlers.getHandlers().get(JibEvent.class).get(0).handle(mockTestJibEvent1));
-    Assert.assertTrue(eventHandlers.getHandlers().get(JibEvent.class).get(0).handle(testJibEvent2));
-    Assert.assertTrue(
-        eventHandlers.getHandlers().get(TestJibEvent1.class).get(0).handle(mockTestJibEvent1));
-    Assert.assertTrue(
-        eventHandlers.getHandlers().get(TestJibEvent2.class).get(0).handle(testJibEvent2));
-    Assert.assertFalse(
-        eventHandlers.getHandlers().get(TestJibEvent1.class).get(0).handle(testJibEvent2));
-    Assert.assertFalse(
-        eventHandlers.getHandlers().get(TestJibEvent2.class).get(0).handle(mockTestJibEvent1));
+    eventHandlers.getHandlers().get(JibEvent.class).asList().get(0).handle(mockTestJibEvent1);
+    eventHandlers.getHandlers().get(JibEvent.class).asList().get(0).handle(testJibEvent2);
+    eventHandlers.getHandlers().get(TestJibEvent1.class).asList().get(0).handle(mockTestJibEvent1);
+    eventHandlers.getHandlers().get(TestJibEvent2.class).asList().get(0).handle(testJibEvent2);
 
     Assert.assertEquals(2, counter[0]);
     Mockito.verify(mockTestJibEvent1).getPayload();


### PR DESCRIPTION
Continuation of #921

Regards #909

`EventEmitter` will be used in the Jib execution to emit the actual events.