### PR TITLE
Improve the error message when pushing to a registry that does not support v2-2

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ManifestPusher.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ManifestPusher.java
@@ -17,14 +17,19 @@
 package com.google.cloud.tools.jib.registry;
 
 import com.google.api.client.http.HttpMethods;
+import com.google.api.client.http.HttpResponseException;
 import com.google.cloud.tools.jib.http.BlobHttpContent;
 import com.google.cloud.tools.jib.http.Response;
 import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
+import com.google.cloud.tools.jib.registry.json.ErrorEntryTemplate;
+import com.google.cloud.tools.jib.registry.json.ErrorResponseTemplate;
+import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
+import org.apache.http.HttpStatus;
 
 /** Pushes an image's manifest. */
 class ManifestPusher implements RegistryEndpointProvider<Void> {
@@ -51,6 +56,62 @@ class ManifestPusher implements RegistryEndpointProvider<Void> {
   @Override
   public List<String> getAccept() {
     return Collections.emptyList();
+  }
+
+  @Override
+  public Void handleHttpResponseException(HttpResponseException httpResponseException)
+      throws HttpResponseException, RegistryErrorException {
+    // docker registry 2.0 and 2.1 returns:
+    //   400 Bad Request
+    //   {"errors":[{"code":"TAG_INVALID","message":"manifest tag did not match URI"}]}
+    // docker registry:2.2 returns:
+    //   400 Bad Request
+    //   {"errors":[{"code":"MANIFEST_INVALID","message":"manifest invalid","detail":{}}]}
+    // quay.io returns:
+    //   415 UNSUPPORTED MEDIA TYPE
+    //   {"errors":[{"code":"MANIFEST_INVALID","detail":
+    //   {"message":"manifest schema version not supported"},"message":"manifest invalid"}]}
+
+    if (httpResponseException.getStatusCode() != HttpStatus.SC_BAD_REQUEST
+        && httpResponseException.getStatusCode() != HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE) {
+      throw httpResponseException;
+    }
+
+    // TODO turn deserializing the error-code into a library method
+
+    // Obtain the error response code.
+    String errorContent = httpResponseException.getContent();
+    if (errorContent == null) {
+      throw httpResponseException;
+    }
+
+    try {
+      ErrorResponseTemplate errorResponse =
+          JsonTemplateMapper.readJson(errorContent, ErrorResponseTemplate.class);
+      List<ErrorEntryTemplate> errors = errorResponse.getErrors();
+      if (errors.size() == 1) {
+        String errorCodeString = errors.get(0).getCode();
+        if (errorCodeString == null) {
+          // Did not get an error code back.
+          throw httpResponseException;
+        }
+        ErrorCodes errorCode = ErrorCodes.valueOf(errorCodeString);
+        if (errorCode.equals(ErrorCodes.MANIFEST_INVALID)
+            || errorCode.equals(ErrorCodes.TAG_INVALID)) {
+          throw new RegistryErrorExceptionBuilder(getActionDescription(), httpResponseException)
+              .addReason("Registry does not support Image Manifest Version 2, Schema 2")
+              .build();
+        }
+      }
+
+    } catch (IOException ex) {
+      throw new RegistryErrorExceptionBuilder(getActionDescription(), httpResponseException)
+          .addReason("Failed to parse registry error response body")
+          .build();
+    }
+
+    // unhandled error response code.
+    throw httpResponseException;
   }
 
   @Override

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ManifestPusher.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ManifestPusher.java
@@ -99,7 +99,7 @@ class ManifestPusher implements RegistryEndpointProvider<Void> {
         if (errorCode.equals(ErrorCodes.MANIFEST_INVALID)
             || errorCode.equals(ErrorCodes.TAG_INVALID)) {
           throw new RegistryErrorExceptionBuilder(getActionDescription(), httpResponseException)
-              .addReason("Registry does not support Image Manifest Version 2, Schema 2")
+              .addReason("Registry may not support Image Manifest Version 2, Schema 2")
               .build();
         }
       }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.jib.registry;
 
+import com.google.api.client.http.HttpHeaders;
+import com.google.api.client.http.HttpResponseException;
 import com.google.cloud.tools.jib.http.BlobHttpContent;
 import com.google.cloud.tools.jib.http.Response;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
@@ -30,6 +32,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import org.apache.http.HttpStatus;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -100,5 +104,97 @@ public class ManifestPusherTest {
   @Test
   public void testGetAccept() {
     Assert.assertEquals(0, testManifestPusher.getAccept().size());
+  }
+
+  /** Docker Registry 2.0 and 2.1 return 400 / TAG_INVALID. */
+  @Test
+  public void testHandleHttpResponseException_dockerRegistry_tagInvalid() {
+    HttpResponseException exception =
+        new HttpResponseException.Builder(
+                HttpStatus.SC_BAD_REQUEST, "Bad Request", new HttpHeaders())
+            .setContent(
+                "{\"errors\":[{\"code\":\"TAG_INVALID\",\"message\":\"manifest tag did not match URI\"}]}")
+            .build();
+    try {
+      testManifestPusher.handleHttpResponseException(exception);
+      Assert.fail();
+
+    } catch (RegistryErrorException ex) {
+      Assert.assertThat(
+          ex.getMessage(),
+          CoreMatchers.containsString(
+              "Registry does not support Image Manifest Version 2, Schema 2"));
+
+    } catch (HttpResponseException ex) {
+      Assert.fail("should have been a RegistryErrorException");
+    }
+  }
+
+  /** Docker Registry 2.2 returns a 400 / MANIFEST_INVALID. */
+  @Test
+  public void testHandleHttpResponseException_dockerRegistry_manifestInvalid() {
+    HttpResponseException exception =
+        new HttpResponseException.Builder(
+                HttpStatus.SC_BAD_REQUEST, "Bad Request", new HttpHeaders())
+            .setContent(
+                "{\"errors\":[{\"code\":\"MANIFEST_INVALID\",\"message\":\"manifest invalid\",\"detail\":{}}]}")
+            .build();
+    try {
+      testManifestPusher.handleHttpResponseException(exception);
+      Assert.fail();
+
+    } catch (RegistryErrorException ex) {
+      Assert.assertThat(
+          ex.getMessage(),
+          CoreMatchers.containsString(
+              "Registry does not support Image Manifest Version 2, Schema 2"));
+
+    } catch (HttpResponseException ex) {
+      Assert.fail("should have been a RegistryErrorException");
+    }
+  }
+
+  /** Quay.io returns an undocumented 415 / MANIFEST_INVALID. */
+  @Test
+  public void testHandleHttpResponseException_quayIo() {
+    HttpResponseException exception =
+        new HttpResponseException.Builder(
+                HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE, "UNSUPPORTED MEDIA TYPE", new HttpHeaders())
+            .setContent(
+                "{\"errors\":[{\"code\":\"MANIFEST_INVALID\",\"detail\":"
+                    + "{\"message\":\"manifest schema version not supported\"},\"message\":\"manifest invalid\"}]}")
+            .build();
+    try {
+      testManifestPusher.handleHttpResponseException(exception);
+      Assert.fail();
+
+    } catch (RegistryErrorException ex) {
+      Assert.assertThat(
+          ex.getMessage(),
+          CoreMatchers.containsString(
+              "Registry does not support Image Manifest Version 2, Schema 2"));
+
+    } catch (HttpResponseException ex) {
+      Assert.fail("should have been a RegistryErrorException");
+    }
+  }
+
+  @Test
+  public void testHandleHttpResponseException_otherError() {
+    HttpResponseException exception =
+        new HttpResponseException.Builder(
+                HttpStatus.SC_UNAUTHORIZED, "Unauthorized", new HttpHeaders())
+            .setContent("{\"errors\":[{\"code\":\"UNAUTHORIZED\",\"message\":\"Unauthorized\"]}}")
+            .build();
+    try {
+      testManifestPusher.handleHttpResponseException(exception);
+      Assert.fail();
+
+    } catch (RegistryErrorException ex) {
+      Assert.fail("should have been a HttpResponseException");
+
+    } catch (HttpResponseException ex) {
+      Assert.assertSame(exception, ex);
+    }
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java
@@ -123,7 +123,7 @@ public class ManifestPusherTest {
       Assert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
-              "Registry does not support Image Manifest Version 2, Schema 2"));
+              "Registry may not support Image Manifest Version 2, Schema 2"));
 
     } catch (HttpResponseException ex) {
       Assert.fail("should have been a RegistryErrorException");
@@ -147,7 +147,7 @@ public class ManifestPusherTest {
       Assert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
-              "Registry does not support Image Manifest Version 2, Schema 2"));
+              "Registry may not support Image Manifest Version 2, Schema 2"));
 
     } catch (HttpResponseException ex) {
       Assert.fail("should have been a RegistryErrorException");
@@ -172,7 +172,7 @@ public class ManifestPusherTest {
       Assert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
-              "Registry does not support Image Manifest Version 2, Schema 2"));
+              "Registry may not support Image Manifest Version 2, Schema 2"));
 
     } catch (HttpResponseException ex) {
       Assert.fail("should have been a RegistryErrorException");


### PR DESCRIPTION
Turns `MANIFEST_INVALID` / `TAG_INVALID` errors into slightly more helpful error messages:

>  _Tried to push image manifest for localhost:5000/foo:bar but failed because: Registry does not support Image Manifest Version 2, Schema 2_

Docker Registry 2.1, which returns a `400` / `TAG_INVALID`:
```
[ERROR] Failed to execute goal com.google.cloud.tools:jib-maven-plugin:0.9.11-SNAPSHOT:build (default-cli) on project first: Tried to push image manifest for localhost:5000/foo:bar but failed because: Registry does not support Image Manifest Version 2, Schema 2 | If this is a bug, please file an issue at https://github.com/GoogleContainerTools/jib/issues/new: 400 Bad Request
[ERROR] {"errors":[{"code":"TAG_INVALID","message":"manifest tag did not match URI"}]}
[ERROR] -> [Help 1]
```

Docker Registry 2.2, which returns a `400` / `MANIFEST_INVALID`:
```
[ERROR] Failed to execute goal com.google.cloud.tools:jib-maven-plugin:0.9.11-SNAPSHOT:build (default-cli) on project first: Tried to push image manifest for localhost:5000/foo:bar but failed because: Registry does not support Image Manifest Version 2, Schema 2 | If this is a bug, please file an issue at https://github.com/GoogleContainerTools/jib/issues/new: 400 Bad Request
[ERROR] {"errors":[{"code":"MANIFEST_INVALID","message":"manifest invalid","detail":{}}]}
[ERROR] -> [Help 1]
```

Pushing to quay.io, which returns a `415` / `MANIFEST_INVALID` (doesn't adhere to spec):
```
[ERROR] Failed to execute goal com.google.cloud.tools:jib-maven-plugin:0.9.11-SNAPSHOT:build (default-cli) on project first: Tried to push image manifest for quay.io/briandealwis/foo:popo but failed because: Registry does not support Image Manifest Version 2, Schema 2 | If this is a bug, please file an issue at https://github.com/GoogleContainerTools/jib/issues/new: 415 UNSUPPORTED MEDIA TYPE
[ERROR] {"errors":[{"code":"MANIFEST_INVALID","detail":{"message":"manifest schema version not supported"},"message":"manifest invalid"}]}
[ERROR] -> [Help 1]
```

Fixes #601