### PR TITLE
Consolidate tool name usage

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -222,7 +222,7 @@ public class BuildStepsIntegrationTest {
         .setContainerConfiguration(containerConfiguration)
         .setAllowInsecureRegistries(true)
         .setLayerConfigurations(fakeLayerConfigurations)
-        .setCreatedBy("jib-integration-test")
+        .setToolName("jib-integration-test")
         .build();
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
@@ -138,7 +138,7 @@ class BuildImageStep
             HistoryEntry.builder()
                 .setCreationTimestamp(layerCreationTime)
                 .setAuthor("Jib")
-                .setCreatedBy(buildConfiguration.getCreatedBy())
+                .setCreatedBy(buildConfiguration.getToolName())
                 .build());
       }
       if (containerConfiguration != null) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
@@ -70,13 +70,9 @@ class PullAndCacheBaseImageLayerStep implements AsyncStep<CachedLayer>, Callable
     try (Timer ignored =
         new Timer(buildConfiguration.getBuildLogger(), String.format(DESCRIPTION, layerDigest))) {
       RegistryClient registryClient =
-          RegistryClient.factory(
-                  buildConfiguration.getBuildLogger(),
-                  buildConfiguration.getBaseImageConfiguration().getImageRegistry(),
-                  buildConfiguration.getBaseImageConfiguration().getImageRepository())
-              .setAllowInsecureRegistries(buildConfiguration.getAllowInsecureRegistries())
+          buildConfiguration
+              .newRegistryClientFactory(buildConfiguration.getBaseImageConfiguration())
               .setAuthorization(pullAuthorization)
-              .setUserAgentSuffix(buildConfiguration.getToolName())
               .newRegistryClient();
 
       // Checks if the layer already exists in the cache.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
@@ -76,6 +76,7 @@ class PullAndCacheBaseImageLayerStep implements AsyncStep<CachedLayer>, Callable
                   buildConfiguration.getBaseImageConfiguration().getImageRepository())
               .setAllowInsecureRegistries(buildConfiguration.getAllowInsecureRegistries())
               .setAuthorization(pullAuthorization)
+              .setUserAgentSuffix(buildConfiguration.getToolName())
               .newRegistryClient();
 
       // Checks if the layer already exists in the cache.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
@@ -71,7 +71,7 @@ class PullAndCacheBaseImageLayerStep implements AsyncStep<CachedLayer>, Callable
         new Timer(buildConfiguration.getBuildLogger(), String.format(DESCRIPTION, layerDigest))) {
       RegistryClient registryClient =
           buildConfiguration
-              .newRegistryClientFactory(buildConfiguration.getBaseImageConfiguration())
+              .newBaseImageRegistryClientFactory()
               .setAuthorization(pullAuthorization)
               .newRegistryClient();
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -186,7 +186,7 @@ class PullBaseImageStep
           LayerCountMismatchException, BadContainerConfigurationFormatException {
     RegistryClient registryClient =
         buildConfiguration
-            .newRegistryClientFactory(buildConfiguration.getBaseImageConfiguration())
+            .newBaseImageRegistryClientFactory()
             .setAuthorization(registryAuthorization)
             .newRegistryClient();
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -191,6 +191,7 @@ class PullBaseImageStep
                 buildConfiguration.getBaseImageConfiguration().getImageRepository())
             .setAllowInsecureRegistries(buildConfiguration.getAllowInsecureRegistries())
             .setAuthorization(registryAuthorization)
+            .setUserAgentSuffix(buildConfiguration.getToolName())
             .newRegistryClient();
 
     ManifestTemplate manifestTemplate =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -185,13 +185,9 @@ class PullBaseImageStep
       throws IOException, RegistryException, LayerPropertyNotFoundException,
           LayerCountMismatchException, BadContainerConfigurationFormatException {
     RegistryClient registryClient =
-        RegistryClient.factory(
-                buildConfiguration.getBuildLogger(),
-                buildConfiguration.getBaseImageConfiguration().getImageRegistry(),
-                buildConfiguration.getBaseImageConfiguration().getImageRepository())
-            .setAllowInsecureRegistries(buildConfiguration.getAllowInsecureRegistries())
+        buildConfiguration
+            .newRegistryClientFactory(buildConfiguration.getBaseImageConfiguration())
             .setAuthorization(registryAuthorization)
-            .setUserAgentSuffix(buildConfiguration.getToolName())
             .newRegistryClient();
 
     ManifestTemplate manifestTemplate =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -70,7 +70,7 @@ class PushBlobStep implements AsyncStep<BlobDescriptor>, Callable<BlobDescriptor
         new Timer(buildConfiguration.getBuildLogger(), DESCRIPTION + blobDescriptor)) {
       RegistryClient registryClient =
           buildConfiguration
-              .newRegistryClientFactory(buildConfiguration.getTargetImageConfiguration())
+              .newTargetImageRegistryClientFactory()
               .setAuthorization(NonBlockingSteps.get(authenticatePushStep))
               .newRegistryClient();
       registryClient.setTimer(timer);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -75,6 +75,7 @@ class PushBlobStep implements AsyncStep<BlobDescriptor>, Callable<BlobDescriptor
                   buildConfiguration.getTargetImageConfiguration().getImageRepository())
               .setAllowInsecureRegistries(buildConfiguration.getAllowInsecureRegistries())
               .setAuthorization(NonBlockingSteps.get(authenticatePushStep))
+              .setUserAgentSuffix(buildConfiguration.getToolName())
               .newRegistryClient();
       registryClient.setTimer(timer);
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -69,13 +69,9 @@ class PushBlobStep implements AsyncStep<BlobDescriptor>, Callable<BlobDescriptor
     try (Timer timer =
         new Timer(buildConfiguration.getBuildLogger(), DESCRIPTION + blobDescriptor)) {
       RegistryClient registryClient =
-          RegistryClient.factory(
-                  buildConfiguration.getBuildLogger(),
-                  buildConfiguration.getTargetImageConfiguration().getImageRegistry(),
-                  buildConfiguration.getTargetImageConfiguration().getImageRepository())
-              .setAllowInsecureRegistries(buildConfiguration.getAllowInsecureRegistries())
+          buildConfiguration
+              .newRegistryClientFactory(buildConfiguration.getTargetImageConfiguration())
               .setAuthorization(NonBlockingSteps.get(authenticatePushStep))
-              .setUserAgentSuffix(buildConfiguration.getToolName())
               .newRegistryClient();
       registryClient.setTimer(timer);
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -118,7 +118,7 @@ class PushImageStep implements AsyncStep<Void>, Callable<Void> {
     try (Timer ignored = new Timer(buildConfiguration.getBuildLogger(), DESCRIPTION)) {
       RegistryClient registryClient =
           buildConfiguration
-              .newRegistryClientFactory(buildConfiguration.getTargetImageConfiguration())
+              .newTargetImageRegistryClientFactory()
               .setAuthorization(NonBlockingSteps.get(authenticatePushStep))
               .newRegistryClient();
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -117,13 +117,9 @@ class PushImageStep implements AsyncStep<Void>, Callable<Void> {
   private Void afterAllPushed() throws IOException, RegistryException, ExecutionException {
     try (Timer ignored = new Timer(buildConfiguration.getBuildLogger(), DESCRIPTION)) {
       RegistryClient registryClient =
-          RegistryClient.factory(
-                  buildConfiguration.getBuildLogger(),
-                  buildConfiguration.getTargetImageConfiguration().getImageRegistry(),
-                  buildConfiguration.getTargetImageConfiguration().getImageRepository())
-              .setAllowInsecureRegistries(buildConfiguration.getAllowInsecureRegistries())
+          buildConfiguration
+              .newRegistryClientFactory(buildConfiguration.getTargetImageConfiguration())
               .setAuthorization(NonBlockingSteps.get(authenticatePushStep))
-              .setUserAgentSuffix(buildConfiguration.getToolName())
               .newRegistryClient();
 
       // Constructs the image.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -123,6 +123,7 @@ class PushImageStep implements AsyncStep<Void>, Callable<Void> {
                   buildConfiguration.getTargetImageConfiguration().getImageRepository())
               .setAllowInsecureRegistries(buildConfiguration.getAllowInsecureRegistries())
               .setAuthorization(NonBlockingSteps.get(authenticatePushStep))
+              .setUserAgentSuffix(buildConfiguration.getToolName())
               .newRegistryClient();
 
       // Constructs the image.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
@@ -304,7 +304,7 @@ public class BuildConfiguration {
   }
 
   /**
-   * Creates a new {@link RegistryClient.Factory} for the target image with fields from the build
+   * Creates a new {@link RegistryClient.Factory} for the base image with fields from the build
    * configuration.
    *
    * @return a new {@link RegistryClient.Factory}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.configuration;
 import com.google.cloud.tools.jib.JibLogger;
 import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
+import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
@@ -300,5 +301,21 @@ public class BuildConfiguration {
    */
   public ImmutableList<LayerConfiguration> getLayerConfigurations() {
     return layerConfigurations;
+  }
+
+  /**
+   * Creates a new {@link RegistryClient.Factory} and sets fields from the build configuration.
+   *
+   * @param imageConfiguration the {@link ImageConfiguration} to use for the server URL and image
+   *     name
+   * @return a new {@link RegistryClient.Factory}
+   */
+  public RegistryClient.Factory newRegistryClientFactory(ImageConfiguration imageConfiguration) {
+    return RegistryClient.factory(
+            getBuildLogger(),
+            imageConfiguration.getImageRegistry(),
+            imageConfiguration.getImageRepository())
+        .setAllowInsecureRegistries(getAllowInsecureRegistries())
+        .setUserAgentSuffix(getToolName());
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
@@ -304,13 +304,26 @@ public class BuildConfiguration {
   }
 
   /**
-   * Creates a new {@link RegistryClient.Factory} and sets fields from the build configuration.
+   * Creates a new {@link RegistryClient.Factory} for the target image with fields from the build
+   * configuration.
    *
-   * @param imageConfiguration the {@link ImageConfiguration} to use for the server URL and image
-   *     name
    * @return a new {@link RegistryClient.Factory}
    */
-  public RegistryClient.Factory newRegistryClientFactory(ImageConfiguration imageConfiguration) {
+  public RegistryClient.Factory newBaseImageRegistryClientFactory() {
+    return newRegistryClientFactory(baseImageConfiguration);
+  }
+
+  /**
+   * Creates a new {@link RegistryClient.Factory} for the target image with fields from the build
+   * configuration.
+   *
+   * @return a new {@link RegistryClient.Factory}
+   */
+  public RegistryClient.Factory newTargetImageRegistryClientFactory() {
+    return newRegistryClientFactory(targetImageConfiguration);
+  }
+
+  private RegistryClient.Factory newRegistryClientFactory(ImageConfiguration imageConfiguration) {
     return RegistryClient.factory(
             getBuildLogger(),
             imageConfiguration.getImageRegistry(),

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
@@ -38,7 +38,7 @@ public class BuildConfiguration {
     private boolean allowInsecureRegistries = false;
     private ImmutableList<LayerConfiguration> layerConfigurations = ImmutableList.of();
     private Class<? extends BuildableManifestTemplate> targetFormat = V22ManifestTemplate.class;
-    private String createdBy = "jib";
+    private String toolName = "jib";
 
     private JibLogger buildLogger;
 
@@ -137,14 +137,13 @@ public class BuildConfiguration {
     }
 
     /**
-     * Sets the command that created the image layers (for the "Created By" field in the container's
-     * history).
+     * Sets the name of the tool that is executing the build.
      *
-     * @param createdBy the field value
+     * @param toolName the tool name
      * @return this
      */
-    public Builder setCreatedBy(String createdBy) {
-      this.createdBy = createdBy;
+    public Builder setToolName(String toolName) {
+      this.toolName = toolName;
       return this;
     }
 
@@ -185,7 +184,7 @@ public class BuildConfiguration {
               targetFormat,
               allowInsecureRegistries,
               layerConfigurations,
-              createdBy);
+              toolName);
 
         case 1:
           throw new IllegalStateException(errorMessages.get(0));
@@ -213,7 +212,7 @@ public class BuildConfiguration {
   private Class<? extends BuildableManifestTemplate> targetFormat;
   private final boolean allowInsecureRegistries;
   private final ImmutableList<LayerConfiguration> layerConfigurations;
-  private final String createdBy;
+  private final String toolName;
 
   /** Instantiate with {@link Builder#build}. */
   private BuildConfiguration(
@@ -226,7 +225,7 @@ public class BuildConfiguration {
       Class<? extends BuildableManifestTemplate> targetFormat,
       boolean allowInsecureRegistries,
       ImmutableList<LayerConfiguration> layerConfigurations,
-      String createdBy) {
+      String toolName) {
     this.buildLogger = buildLogger;
     this.baseImageConfiguration = baseImageConfiguration;
     this.targetImageConfiguration = targetImageConfiguration;
@@ -236,7 +235,7 @@ public class BuildConfiguration {
     this.targetFormat = targetFormat;
     this.allowInsecureRegistries = allowInsecureRegistries;
     this.layerConfigurations = layerConfigurations;
-    this.createdBy = createdBy;
+    this.toolName = toolName;
   }
 
   public JibLogger getBuildLogger() {
@@ -260,8 +259,8 @@ public class BuildConfiguration {
     return targetFormat;
   }
 
-  public String getCreatedBy() {
-    return createdBy;
+  public String getToolName() {
+    return toolName;
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -70,6 +70,7 @@ public class RegistryClient {
     private final RegistryEndpointRequestProperties registryEndpointRequestProperties;
 
     private boolean allowInsecureRegistries = false;
+    @Nullable private String userAgentSuffix;
     @Nullable private Authorization authorization;
 
     private Factory(
@@ -103,6 +104,17 @@ public class RegistryClient {
     }
 
     /**
+     * Sets a suffix to append to {@code User-Agent} headers.
+     *
+     * @param userAgentSuffix the suffix to append
+     * @return this
+     */
+    public Factory setUserAgentSuffix(@Nullable String userAgentSuffix) {
+      this.userAgentSuffix = userAgentSuffix;
+      return this;
+    }
+
+    /**
      * Creates a new {@link RegistryClient}.
      *
      * @return the new {@link RegistryClient}
@@ -115,9 +127,32 @@ public class RegistryClient {
           allowInsecureRegistries,
           makeUserAgent());
     }
-  }
 
-  @Nullable private static String userAgentSuffix;
+    /**
+     * The {@code User-Agent} is in the form of {@code jib <version> <type>}. For example: {@code
+     * jib 0.9.0 jib-maven-plugin}.
+     *
+     * @return the {@code User-Agent} header to send. The {@code User-Agent} can be disabled by
+     *     setting the system property variable {@code _JIB_DISABLE_USER_AGENT} to any non-empty
+     *     string.
+     */
+    private String makeUserAgent() {
+      if (!Strings.isNullOrEmpty(System.getProperty("_JIB_DISABLE_USER_AGENT"))) {
+        return "";
+      }
+
+      String version = RegistryClient.class.getPackage().getImplementationVersion();
+      StringBuilder userAgentBuilder = new StringBuilder();
+      userAgentBuilder.append("jib");
+      if (version != null) {
+        userAgentBuilder.append(" ").append(version);
+      }
+      if (userAgentSuffix != null) {
+        userAgentBuilder.append(" ").append(userAgentSuffix);
+      }
+      return userAgentBuilder.toString();
+    }
+  }
 
   /**
    * Creates a new {@link Factory} for building a {@link RegistryClient}.
@@ -129,42 +164,6 @@ public class RegistryClient {
    */
   public static Factory factory(JibLogger buildLogger, String serverUrl, String imageName) {
     return new Factory(buildLogger, new RegistryEndpointRequestProperties(serverUrl, imageName));
-  }
-
-  // TODO: Inject via a RegistryClient.Factory.
-  /**
-   * Sets a suffix to append to {@code User-Agent} headers.
-   *
-   * @param userAgentSuffix the suffix to append
-   */
-  public static void setUserAgentSuffix(@Nullable String userAgentSuffix) {
-    RegistryClient.userAgentSuffix = userAgentSuffix;
-  }
-
-  /**
-   * The {@code User-Agent} is in the form of {@code jib <version> <type>}. For example: {@code jib
-   * 0.9.0 jib-maven-plugin}.
-   *
-   * @return the {@code User-Agent} header to send. The {@code User-Agent} can be disabled by
-   *     setting the system property variable {@code _JIB_DISABLE_USER_AGENT} to any non-empty
-   *     string.
-   */
-  @VisibleForTesting
-  static String makeUserAgent() {
-    if (!Strings.isNullOrEmpty(System.getProperty("_JIB_DISABLE_USER_AGENT"))) {
-      return "";
-    }
-
-    String version = RegistryClient.class.getPackage().getImplementationVersion();
-    StringBuilder userAgentBuilder = new StringBuilder();
-    userAgentBuilder.append("jib");
-    if (version != null) {
-      userAgentBuilder.append(" ").append(version);
-    }
-    if (userAgentSuffix != null) {
-      userAgentBuilder.append(" ").append(userAgentSuffix);
-    }
-    return userAgentBuilder.toString();
   }
 
   private final JibLogger buildLogger;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
@@ -73,7 +73,7 @@ public class BuildImageStepTest {
     Mockito.when(mockBuildConfiguration.getBuildLogger()).thenReturn(mockBuildLogger);
     Mockito.when(mockBuildConfiguration.getContainerConfiguration())
         .thenReturn(mockContainerConfiguration);
-    Mockito.when(mockBuildConfiguration.getCreatedBy()).thenReturn("jib");
+    Mockito.when(mockBuildConfiguration.getToolName()).thenReturn("jib");
     Mockito.when(mockContainerConfiguration.getCreationTime()).thenReturn(Instant.EPOCH);
     Mockito.when(mockContainerConfiguration.getEnvironmentMap()).thenReturn(ImmutableMap.of());
     Mockito.when(mockContainerConfiguration.getProgramArguments()).thenReturn(ImmutableList.of());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
@@ -96,7 +96,7 @@ public class BuildConfigurationTest {
             .setTargetFormat(OCIManifestTemplate.class)
             .setAllowInsecureRegistries(true)
             .setLayerConfigurations(expectedLayerConfigurations)
-            .setCreatedBy(expectedCreatedBy);
+            .setToolName(expectedCreatedBy);
     BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();
 
     Assert.assertNotNull(buildConfiguration.getContainerConfiguration());
@@ -143,7 +143,7 @@ public class BuildConfigurationTest {
     Assert.assertEquals(expectedLayerConfigurations, buildConfiguration.getLayerConfigurations());
     Assert.assertEquals(
         expectedEntrypoint, buildConfiguration.getContainerConfiguration().getEntrypoint());
-    Assert.assertEquals(expectedCreatedBy, buildConfiguration.getCreatedBy());
+    Assert.assertEquals(expectedCreatedBy, buildConfiguration.getToolName());
   }
 
   @Test
@@ -179,7 +179,7 @@ public class BuildConfigurationTest {
     Assert.assertEquals(buildConfiguration.getTargetFormat(), V22ManifestTemplate.class);
     Assert.assertFalse(buildConfiguration.getAllowInsecureRegistries());
     Assert.assertEquals(Collections.emptyList(), buildConfiguration.getLayerConfigurations());
-    Assert.assertEquals("jib", buildConfiguration.getCreatedBy());
+    Assert.assertEquals("jib", buildConfiguration.getToolName());
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
@@ -51,10 +51,10 @@ public class RegistryClientTest {
             .getUserAgent()
             .startsWith("jib"));
 
-    RegistryClient.setUserAgentSuffix(null);
     Assert.assertTrue(
         testRegistryClientFactory
             .setAuthorization(mockAuthorization)
+            .setUserAgentSuffix(null)
             .newRegistryClient()
             .getUserAgent()
             .startsWith("jib"));
@@ -62,20 +62,14 @@ public class RegistryClientTest {
 
   @Test
   public void testGetUserAgent() {
-    RegistryClient.setUserAgentSuffix("some user agent suffix");
+    RegistryClient registryClient =
+        testRegistryClientFactory
+            .setAllowInsecureRegistries(true)
+            .setUserAgentSuffix("some user agent suffix")
+            .newRegistryClient();
 
-    Assert.assertTrue(
-        testRegistryClientFactory
-            .setAllowInsecureRegistries(true)
-            .newRegistryClient()
-            .getUserAgent()
-            .startsWith("jib "));
-    Assert.assertTrue(
-        testRegistryClientFactory
-            .setAllowInsecureRegistries(true)
-            .newRegistryClient()
-            .getUserAgent()
-            .endsWith(" some user agent suffix"));
+    Assert.assertTrue(registryClient.getUserAgent().startsWith("jib "));
+    Assert.assertTrue(registryClient.getUserAgent().endsWith(" some user agent suffix"));
   }
 
   @Test

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -39,6 +39,7 @@ import org.gradle.jvm.tasks.Jar;
 /** Obtains information about a Gradle {@link Project} that uses Jib. */
 class GradleProjectProperties implements ProjectProperties {
 
+  public static final String TOOL_NAME = "jib-gradle-plugin";
   private static final String PLUGIN_NAME = "jib";
   private static final String JAR_PLUGIN_NAME = "'jar' task";
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -39,8 +39,13 @@ import org.gradle.jvm.tasks.Jar;
 /** Obtains information about a Gradle {@link Project} that uses Jib. */
 class GradleProjectProperties implements ProjectProperties {
 
-  public static final String TOOL_NAME = "jib-gradle-plugin";
+  /** Used to generate the User-Agent header and history metadata. */
+  static final String TOOL_NAME = "jib-gradle-plugin";
+
+  /** Used for logging during main class inference. */
   private static final String PLUGIN_NAME = "jib";
+
+  /** Used for logging during main class inference. */
   private static final String JAR_PLUGIN_NAME = "'jar' task";
 
   /** @return a GradleProjectProperties from the given project and logger. */

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
@@ -37,6 +37,8 @@ import org.gradle.api.GradleException;
 /** Configures and provides builders for the image building tasks. */
 class PluginConfigurationProcessor {
 
+  private static final String TOOL_NAME = "jib-gradle-plugin";
+
   /**
    * Sets up {@link BuildConfiguration} that is common among the image building tasks. This includes
    * setting up the base image reference/authorization, container configuration, cache
@@ -104,7 +106,7 @@ class PluginConfigurationProcessor {
 
     BuildConfiguration.Builder buildConfigurationBuilder =
         BuildConfiguration.builder(logger)
-            .setToolName("jib-gradle-plugin")
+            .setToolName(TOOL_NAME)
             .setAllowInsecureRegistries(jibExtension.getAllowInsecureRegistries())
             .setLayerConfigurations(
                 projectProperties.getJavaLayerConfigurations().getLayerConfigurations());

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
@@ -37,8 +37,6 @@ import org.gradle.api.GradleException;
 /** Configures and provides builders for the image building tasks. */
 class PluginConfigurationProcessor {
 
-  private static final String TOOL_NAME = "jib-gradle-plugin";
-
   /**
    * Sets up {@link BuildConfiguration} that is common among the image building tasks. This includes
    * setting up the base image reference/authorization, container configuration, cache
@@ -106,7 +104,7 @@ class PluginConfigurationProcessor {
 
     BuildConfiguration.Builder buildConfigurationBuilder =
         BuildConfiguration.builder(logger)
-            .setToolName(TOOL_NAME)
+            .setToolName(GradleProjectProperties.TOOL_NAME)
             .setAllowInsecureRegistries(jibExtension.getAllowInsecureRegistries())
             .setLayerConfigurations(
                 projectProperties.getJavaLayerConfigurations().getLayerConfigurations());

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
@@ -29,7 +29,6 @@ import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.DefaultCredentialRetrievers;
-import com.google.cloud.tools.jib.registry.RegistryClient;
 import java.time.Instant;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -37,9 +36,6 @@ import org.gradle.api.GradleException;
 
 /** Configures and provides builders for the image building tasks. */
 class PluginConfigurationProcessor {
-
-  /** {@code User-Agent} header suffix to send to the registry. */
-  private static final String USER_AGENT_SUFFIX = "jib-gradle-plugin";
 
   /**
    * Sets up {@link BuildConfiguration} that is common among the image building tasks. This includes
@@ -60,7 +56,6 @@ class PluginConfigurationProcessor {
 
     // TODO: Instead of disabling logging, have authentication credentials be provided
     GradleJibLogger.disableHttpLogging();
-    RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
 
     ImageReference baseImage = ImageReference.parse(jibExtension.getBaseImage());
 
@@ -109,7 +104,7 @@ class PluginConfigurationProcessor {
 
     BuildConfiguration.Builder buildConfigurationBuilder =
         BuildConfiguration.builder(logger)
-            .setCreatedBy("jib-gradle-plugin")
+            .setToolName("jib-gradle-plugin")
             .setAllowInsecureRegistries(jibExtension.getAllowInsecureRegistries())
             .setLayerConfigurations(
                 projectProperties.getJavaLayerConfigurations().getLayerConfigurations());

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -34,8 +34,13 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 /** Obtains information about a {@link MavenProject}. */
 class MavenProjectProperties implements ProjectProperties {
 
-  public static final String TOOL_NAME = "jib-maven-plugin";
+  /** Used to generate the User-Agent header and history metadata. */
+  static final String TOOL_NAME = "jib-maven-plugin";
+
+  /** Used for logging during main class inference. */
   private static final String PLUGIN_NAME = "jib-maven-plugin";
+
+  /** Used for logging during main class inference. */
   private static final String JAR_PLUGIN_NAME = "'maven-jar-plugin'";
 
   /**

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -34,6 +34,7 @@ import org.codehaus.plexus.util.xml.Xpp3Dom;
 /** Obtains information about a {@link MavenProject}. */
 class MavenProjectProperties implements ProjectProperties {
 
+  public static final String TOOL_NAME = "jib-maven-plugin";
   private static final String PLUGIN_NAME = "jib-maven-plugin";
   private static final String JAR_PLUGIN_NAME = "'maven-jar-plugin'";
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
@@ -37,6 +37,8 @@ import org.apache.maven.plugin.MojoExecutionException;
 /** Configures and provides builders for the image building goals. */
 class PluginConfigurationProcessor {
 
+  private static final String TOOL_NAME = "jib-maven-plugin";
+
   /**
    * Sets up {@link BuildConfiguration} that is common among the image building goals. This includes
    * setting up the base image reference/authorization, container configuration, cache
@@ -123,7 +125,7 @@ class PluginConfigurationProcessor {
 
     BuildConfiguration.Builder buildConfigurationBuilder =
         BuildConfiguration.builder(logger)
-            .setToolName("jib-maven-plugin")
+            .setToolName(TOOL_NAME)
             .setAllowInsecureRegistries(jibPluginConfiguration.getAllowInsecureRegistries())
             .setLayerConfigurations(
                 projectProperties.getJavaLayerConfigurations().getLayerConfigurations());

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
@@ -28,7 +28,6 @@ import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.DefaultCredentialRetrievers;
-import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.common.base.Preconditions;
 import java.time.Instant;
 import java.util.List;
@@ -37,9 +36,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 
 /** Configures and provides builders for the image building goals. */
 class PluginConfigurationProcessor {
-
-  /** {@code User-Agent} header suffix to send to the registry. */
-  private static final String USER_AGENT_SUFFIX = "jib-maven-plugin";
 
   /**
    * Sets up {@link BuildConfiguration} that is common among the image building goals. This includes
@@ -63,7 +59,6 @@ class PluginConfigurationProcessor {
 
     // TODO: Instead of disabling logging, have authentication credentials be provided
     MavenJibLogger.disableHttpLogging();
-    RegistryClient.setUserAgentSuffix(USER_AGENT_SUFFIX);
 
     ImageReference baseImage = parseImageReference(jibPluginConfiguration.getBaseImage(), "from");
 
@@ -128,7 +123,7 @@ class PluginConfigurationProcessor {
 
     BuildConfiguration.Builder buildConfigurationBuilder =
         BuildConfiguration.builder(logger)
-            .setCreatedBy("jib-maven-plugin")
+            .setToolName("jib-maven-plugin")
             .setAllowInsecureRegistries(jibPluginConfiguration.getAllowInsecureRegistries())
             .setLayerConfigurations(
                 projectProperties.getJavaLayerConfigurations().getLayerConfigurations());

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
@@ -37,8 +37,6 @@ import org.apache.maven.plugin.MojoExecutionException;
 /** Configures and provides builders for the image building goals. */
 class PluginConfigurationProcessor {
 
-  private static final String TOOL_NAME = "jib-maven-plugin";
-
   /**
    * Sets up {@link BuildConfiguration} that is common among the image building goals. This includes
    * setting up the base image reference/authorization, container configuration, cache
@@ -125,7 +123,7 @@ class PluginConfigurationProcessor {
 
     BuildConfiguration.Builder buildConfigurationBuilder =
         BuildConfiguration.builder(logger)
-            .setToolName(TOOL_NAME)
+            .setToolName(MavenProjectProperties.TOOL_NAME)
             .setAllowInsecureRegistries(jibPluginConfiguration.getAllowInsecureRegistries())
             .setLayerConfigurations(
                 projectProperties.getJavaLayerConfigurations().getLayerConfigurations());


### PR DESCRIPTION
Fixes #900 
Also fixes #33 

Replaces `setCreatedBy` on `BuildConfiguration` with `setToolName`, which can also be used to set the user agent suffix in `RegistryClient`.