### PR TITLE
Fix ManifestPusherTest warnings

### DIFF
--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java
@@ -108,7 +108,8 @@ public class ManifestPusherTest {
 
   /** Docker Registry 2.0 and 2.1 return 400 / TAG_INVALID. */
   @Test
-  public void testHandleHttpResponseException_dockerRegistry_tagInvalid() {
+  public void testHandleHttpResponseException_dockerRegistry_tagInvalid()
+      throws HttpResponseException {
     HttpResponseException exception =
         new HttpResponseException.Builder(
                 HttpStatus.SC_BAD_REQUEST, "Bad Request", new HttpHeaders())
@@ -124,15 +125,13 @@ public class ManifestPusherTest {
           ex.getMessage(),
           CoreMatchers.containsString(
               "Registry may not support Image Manifest Version 2, Schema 2"));
-
-    } catch (HttpResponseException ex) {
-      Assert.fail("should have been a RegistryErrorException");
     }
   }
 
   /** Docker Registry 2.2 returns a 400 / MANIFEST_INVALID. */
   @Test
-  public void testHandleHttpResponseException_dockerRegistry_manifestInvalid() {
+  public void testHandleHttpResponseException_dockerRegistry_manifestInvalid()
+      throws HttpResponseException {
     HttpResponseException exception =
         new HttpResponseException.Builder(
                 HttpStatus.SC_BAD_REQUEST, "Bad Request", new HttpHeaders())
@@ -148,15 +147,12 @@ public class ManifestPusherTest {
           ex.getMessage(),
           CoreMatchers.containsString(
               "Registry may not support Image Manifest Version 2, Schema 2"));
-
-    } catch (HttpResponseException ex) {
-      Assert.fail("should have been a RegistryErrorException");
     }
   }
 
   /** Quay.io returns an undocumented 415 / MANIFEST_INVALID. */
   @Test
-  public void testHandleHttpResponseException_quayIo() {
+  public void testHandleHttpResponseException_quayIo() throws HttpResponseException {
     HttpResponseException exception =
         new HttpResponseException.Builder(
                 HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE, "UNSUPPORTED MEDIA TYPE", new HttpHeaders())
@@ -173,14 +169,11 @@ public class ManifestPusherTest {
           ex.getMessage(),
           CoreMatchers.containsString(
               "Registry may not support Image Manifest Version 2, Schema 2"));
-
-    } catch (HttpResponseException ex) {
-      Assert.fail("should have been a RegistryErrorException");
     }
   }
 
   @Test
-  public void testHandleHttpResponseException_otherError() {
+  public void testHandleHttpResponseException_otherError() throws RegistryErrorException {
     HttpResponseException exception =
         new HttpResponseException.Builder(
                 HttpStatus.SC_UNAUTHORIZED, "Unauthorized", new HttpHeaders())
@@ -189,9 +182,6 @@ public class ManifestPusherTest {
     try {
       testManifestPusher.handleHttpResponseException(exception);
       Assert.fail();
-
-    } catch (RegistryErrorException ex) {
-      Assert.fail("should have been a HttpResponseException");
 
     } catch (HttpResponseException ex) {
       Assert.assertSame(exception, ex);


### PR DESCRIPTION
Was getting

```
/usr/local/google/home/tcordle/IdeaProjects/jib/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java:118: warning: [CatchFail] Ignoring exceptions and calling fail() is unnecessary, and makes test output less useful
    try {
    ^
    (see http://errorprone.info/bugpattern/CatchFail)
  Did you mean 'throw new AssertionError("should have been a RegistryErrorException", ex);' or 'public void testHandleHttpResponseException_dockerRegistry_tagInvalid() throws HttpResponseException{'?
/usr/local/google/home/tcordle/IdeaProjects/jib/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java:142: warning: [CatchFail] Ignoring exceptions and calling fail() is unnecessary, and makes test output less useful
    try {
    ^
    (see http://errorprone.info/bugpattern/CatchFail)
  Did you mean 'throw new AssertionError("should have been a RegistryErrorException", ex);' or 'public void testHandleHttpResponseException_dockerRegistry_manifestInvalid() throws HttpResponseException{'?
/usr/local/google/home/tcordle/IdeaProjects/jib/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java:167: warning: [CatchFail] Ignoring exceptions and calling fail() is unnecessary, and makes test output less useful
    try {
    ^
    (see http://errorprone.info/bugpattern/CatchFail)
  Did you mean 'throw new AssertionError("should have been a RegistryErrorException", ex);' or 'public void testHandleHttpResponseException_quayIo() throws HttpResponseException{'?
/usr/local/google/home/tcordle/IdeaProjects/jib/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java:189: warning: [CatchFail] Ignoring exceptions and calling fail() is unnecessary, and makes test output less useful
    try {
    ^
    (see http://errorprone.info/bugpattern/CatchFail)
  Did you mean 'throw new AssertionError("should have been a HttpResponseException", ex);' or 'public void testHandleHttpResponseException_otherError() throws RegistryErrorException{'?
```

The fix was to remove the sections that were catching exceptions and immediately failing with an assertion.