### PR TITLE
Report registry and image on RegistryAuthenticationFailedException

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticationFailedException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticationFailedException.java
@@ -16,21 +16,23 @@
 
 package com.google.cloud.tools.jib.registry;
 
+import java.text.MessageFormat;
+
 /** Thrown because registry authentication failed. */
 public class RegistryAuthenticationFailedException extends Exception {
 
-  private static final String REASON_PREFIX = "Failed to authenticate with the registry because: ";
+  private static final String REASON = "Failed to authenticate with registry {0}/{1} because: {2}";
   private final String serverUrl;
   private final String imageName;
 
   RegistryAuthenticationFailedException(String serverUrl, String imageName, Throwable cause) {
-    super(REASON_PREFIX + cause.getMessage(), cause);
+    super(MessageFormat.format(REASON, serverUrl, imageName, cause.getMessage()), cause);
     this.serverUrl = serverUrl;
     this.imageName = imageName;
   }
 
   RegistryAuthenticationFailedException(String serverUrl, String imageName, String reason) {
-    super(REASON_PREFIX + reason);
+    super(MessageFormat.format(REASON, serverUrl, imageName, reason));
     this.serverUrl = serverUrl;
     this.imageName = imageName;
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticationFailedException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticationFailedException.java
@@ -20,12 +20,28 @@ package com.google.cloud.tools.jib.registry;
 public class RegistryAuthenticationFailedException extends Exception {
 
   private static final String REASON_PREFIX = "Failed to authenticate with the registry because: ";
+  private final String serverUrl;
+  private final String imageName;
 
-  RegistryAuthenticationFailedException(Throwable cause) {
+  RegistryAuthenticationFailedException(String serverUrl, String imageName, Throwable cause) {
     super(REASON_PREFIX + cause.getMessage(), cause);
+    this.serverUrl = serverUrl;
+    this.imageName = imageName;
   }
 
-  RegistryAuthenticationFailedException(String reason) {
+  RegistryAuthenticationFailedException(String serverUrl, String imageName, String reason) {
     super(REASON_PREFIX + reason);
+    this.serverUrl = serverUrl;
+    this.imageName = imageName;
+  }
+
+  /** @return the server being authenticated */
+  public String getServerUrl() {
+    return serverUrl;
+  }
+
+  /** @return the image being authenticated */
+  public String getImageName() {
+    return imageName;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
@@ -87,7 +87,7 @@ public class RegistryAuthenticator {
             .getRegistryAuthenticator();
 
       } catch (MalformedURLException ex) {
-        throw new RegistryAuthenticationFailedException(ex);
+        throw new RegistryAuthenticationFailedException(serverUrl, repository, ex);
 
       } catch (InsecureRegistryException ex) {
         // Cannot skip certificate validation or use HTTP, so just return null.
@@ -133,13 +133,21 @@ public class RegistryAuthenticator {
 
     // Checks that the authentication method starts with 'bearer ' (case insensitive).
     if (!authenticationMethod.matches("^(?i)(bearer) .*")) {
-      throw newRegistryAuthenticationFailedException(authenticationMethod, "Bearer");
+      throw newRegistryAuthenticationFailedException(
+          registryEndpointRequestProperties.getServerUrl(),
+          registryEndpointRequestProperties.getImageName(),
+          authenticationMethod,
+          "Bearer");
     }
 
     Pattern realmPattern = Pattern.compile("realm=\"(.*?)\"");
     Matcher realmMatcher = realmPattern.matcher(authenticationMethod);
     if (!realmMatcher.find()) {
-      throw newRegistryAuthenticationFailedException(authenticationMethod, "realm");
+      throw newRegistryAuthenticationFailedException(
+          registryEndpointRequestProperties.getServerUrl(),
+          registryEndpointRequestProperties.getImageName(),
+          authenticationMethod,
+          "realm");
     }
     String realm = realmMatcher.group(1);
 
@@ -151,13 +159,14 @@ public class RegistryAuthenticator {
             ? serviceMatcher.group(1)
             : registryEndpointRequestProperties.getServerUrl();
 
-    return new RegistryAuthenticator(
-        realm, service, registryEndpointRequestProperties.getImageName());
+    return new RegistryAuthenticator(realm, service, registryEndpointRequestProperties);
   }
 
   private static RegistryAuthenticationFailedException newRegistryAuthenticationFailedException(
-      String authenticationMethod, String authParam) {
+      String registry, String repository, String authenticationMethod, String authParam) {
     return new RegistryAuthenticationFailedException(
+        registry,
+        repository,
         "'"
             + authParam
             + "' was not found in the 'WWW-Authenticate' header, tried to parse: "
@@ -189,10 +198,21 @@ public class RegistryAuthenticator {
   }
 
   private final String authenticationUrlBase;
+  private final RegistryEndpointRequestProperties registryEndpointRequestProperties;
   @Nullable private Authorization authorization;
 
-  RegistryAuthenticator(String realm, String service, String repository) {
-    authenticationUrlBase = realm + "?service=" + service + "&scope=repository:" + repository + ":";
+  RegistryAuthenticator(
+      String realm,
+      String service,
+      RegistryEndpointRequestProperties registryEndpointRequestProperties) {
+    authenticationUrlBase =
+        realm
+            + "?service="
+            + service
+            + "&scope=repository:"
+            + registryEndpointRequestProperties.getImageName()
+            + ":";
+    this.registryEndpointRequestProperties = registryEndpointRequestProperties;
   }
 
   /**
@@ -257,13 +277,18 @@ public class RegistryAuthenticator {
             JsonTemplateMapper.readJson(responseString, AuthenticationResponseTemplate.class);
         if (responseJson.getToken() == null) {
           throw new RegistryAuthenticationFailedException(
+              registryEndpointRequestProperties.getServerUrl(),
+              registryEndpointRequestProperties.getImageName(),
               "Did not get token in authentication response from " + authenticationUrl);
         }
         return Authorizations.withBearerToken(responseJson.getToken());
       }
 
     } catch (IOException ex) {
-      throw new RegistryAuthenticationFailedException(ex);
+      throw new RegistryAuthenticationFailedException(
+          registryEndpointRequestProperties.getServerUrl(),
+          registryEndpointRequestProperties.getImageName(),
+          ex);
     }
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticationFailedExceptionTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticationFailedExceptionTest.java
@@ -29,7 +29,8 @@ public class RegistryAuthenticationFailedExceptionTest {
     Assert.assertEquals("serverUrl", exception.getServerUrl());
     Assert.assertEquals("imageName", exception.getImageName());
     Assert.assertEquals(
-        "Failed to authenticate with the registry because: message", exception.getMessage());
+        "Failed to authenticate with registry serverUrl/imageName because: message",
+        exception.getMessage());
   }
 
   @Test
@@ -41,6 +42,7 @@ public class RegistryAuthenticationFailedExceptionTest {
     Assert.assertEquals("imageName", exception.getImageName());
     Assert.assertSame(cause, exception.getCause());
     Assert.assertEquals(
-        "Failed to authenticate with the registry because: message", exception.getMessage());
+        "Failed to authenticate with registry serverUrl/imageName because: message",
+        exception.getMessage());
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticationFailedExceptionTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticationFailedExceptionTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.jib.registry;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for {@link RegistryAuthenticationFailedException}. */
+public class RegistryAuthenticationFailedExceptionTest {
+
+  @Test
+  public void testRegistryAuthenticationFailedException_message() {
+    RegistryAuthenticationFailedException exception =
+        new RegistryAuthenticationFailedException("serverUrl", "imageName", "message");
+    Assert.assertEquals("serverUrl", exception.getServerUrl());
+    Assert.assertEquals("imageName", exception.getImageName());
+    Assert.assertEquals(
+        "Failed to authenticate with the registry because: message", exception.getMessage());
+  }
+
+  @Test
+  public void testRegistryAuthenticationFailedException_exception() {
+    Throwable cause = new Throwable("message");
+    RegistryAuthenticationFailedException exception =
+        new RegistryAuthenticationFailedException("serverUrl", "imageName", cause);
+    Assert.assertEquals("serverUrl", exception.getServerUrl());
+    Assert.assertEquals("imageName", exception.getImageName());
+    Assert.assertSame(cause, exception.getCause());
+    Assert.assertEquals(
+        "Failed to authenticate with the registry because: message", exception.getMessage());
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
@@ -74,7 +74,7 @@ public class RegistryAuthenticatorTest {
 
     } catch (RegistryAuthenticationFailedException ex) {
       Assert.assertEquals(
-          "Failed to authenticate with the registry because: 'Bearer' was not found in the 'WWW-Authenticate' header, tried to parse: realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
+          "Failed to authenticate with registry someserver/someimage because: 'Bearer' was not found in the 'WWW-Authenticate' header, tried to parse: realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
           ex.getMessage());
     }
   }
@@ -88,7 +88,7 @@ public class RegistryAuthenticatorTest {
 
     } catch (RegistryAuthenticationFailedException ex) {
       Assert.assertEquals(
-          "Failed to authenticate with the registry because: 'realm' was not found in the 'WWW-Authenticate' header, tried to parse: Bearer scope=\"somescope\"",
+          "Failed to authenticate with registry someserver/someimage because: 'realm' was not found in the 'WWW-Authenticate' header, tried to parse: Bearer scope=\"somescope\"",
           ex.getMessage());
     }
   }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
@@ -199,10 +199,12 @@ public class BuildStepsRunner {
 
       } else if (exceptionDuringBuildSteps instanceof RegistryAuthenticationFailedException
           && exceptionDuringBuildSteps.getCause() instanceof HttpResponseException) {
+        RegistryAuthenticationFailedException failureException =
+            (RegistryAuthenticationFailedException) exceptionDuringBuildSteps;
         handleRegistryUnauthorizedException(
             new RegistryUnauthorizedException(
-                buildConfiguration.getTargetImageConfiguration().getImageRegistry(),
-                buildConfiguration.getTargetImageConfiguration().getImageRepository(),
+                failureException.getServerUrl(),
+                failureException.getImageName(),
                 (HttpResponseException) exceptionDuringBuildSteps.getCause()),
             helpfulSuggestions);
 


### PR DESCRIPTION
Changes `RegistryAuthenticationFailedException` to carry the registry and image name that was being authenticated.  Changes `BuildStepsRunner` to use this information.

Fixes #942 
