### PR TITLE
Builds to Docker daemon with additional tags.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
@@ -96,9 +96,9 @@ class LoadDockerStep implements AsyncStep<Void>, Callable<Void> {
 
     // Tags the image with all the tags. This only needs to be done for additional tags, so this can
     // be skipped if there is only one tag - the load above already loads that tag.
-    if (buildConfiguration.getAllTargetImageTags().size() > 0) {
+    if (buildConfiguration.getAllTargetImageTags().size() > 1) {
       for (String tag : buildConfiguration.getAllTargetImageTags()) {
-        dockerClient.tag(targetImageReference, targetImageReference.retag(tag));
+        dockerClient.tag(targetImageReference, targetImageReference.withTag(tag));
       }
     }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
@@ -94,12 +94,13 @@ class LoadDockerStep implements AsyncStep<Void>, Callable<Void> {
     DockerClient dockerClient = new DockerClient();
     dockerClient.load(new ImageToTarballTranslator(image).toTarballBlob(targetImageReference));
 
-    // Tags the image with all the tags. This only needs to be done for additional tags, so this can
-    // be skipped if there is only one tag - the load above already loads that tag.
-    if (buildConfiguration.getAllTargetImageTags().size() > 1) {
-      for (String tag : buildConfiguration.getAllTargetImageTags()) {
-        dockerClient.tag(targetImageReference, targetImageReference.withTag(tag));
+    // Tags the image with all the additional tags, skipping the one 'docker load' already loaded.
+    for (String tag : buildConfiguration.getAllTargetImageTags()) {
+      if (tag.equals(targetImageReference.getTag())) {
+        continue;
       }
+
+      dockerClient.tag(targetImageReference, targetImageReference.withTag(tag));
     }
 
     return null;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.docker;
 
 import com.google.cloud.tools.jib.blob.Blob;
+import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.CharStreams;
 import java.io.IOException;
@@ -111,6 +112,32 @@ public class DockerClient {
       }
 
       return output;
+    }
+  }
+
+  /**
+   * Tags the image referenced by {@code originalImageReference} with a new image reference {@code
+   * newImageReference}.
+   *
+   * @param originalImageReference the existing image reference on the Docker daemon
+   * @param newImageReference the new image reference
+   * @see <a
+   *     href="https://docs.docker.com/engine/reference/commandline/tag/">https://docs.docker.com/engine/reference/commandline/tag/</a>
+   * @throws InterruptedException if the 'docker tag' process is interrupted.
+   * @throws IOException if an I/O exception occurs or {@code docker tag} failed
+   */
+  public void tag(ImageReference originalImageReference, ImageReference newImageReference)
+      throws IOException, InterruptedException {
+    // Runs 'docker tag'.
+    Process dockerProcess =
+        docker("tag", originalImageReference.toString(), newImageReference.toString());
+
+    if (dockerProcess.waitFor() != 0) {
+      try (InputStreamReader stderr =
+          new InputStreamReader(dockerProcess.getErrorStream(), StandardCharsets.UTF_8)) {
+        throw new IOException(
+            "'docker tag' command failed with error: " + CharStreams.toString(stderr));
+      }
     }
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
@@ -204,11 +204,11 @@ public class ImageReference {
   /**
    * Gets an {@link ImageReference} with the same registry and repository, but a different tag.
    *
-   * @param tag the new tag
+   * @param newTag the new tag
    * @return an {@link ImageReference} with the same registry/repository and the new tag
    */
-  public ImageReference retag(String tag) {
-    return ImageReference.of(registry, repository, tag);
+  public ImageReference withTag(String newTag) {
+    return ImageReference.of(registry, repository, newTag);
   }
 
   /** @return the image reference in Docker-readable format (inverse of {@link #parse}) */

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
@@ -201,6 +201,16 @@ public class ImageReference {
     return DEFAULT_TAG.equals(tag);
   }
 
+  /**
+   * Gets an {@link ImageReference} with the same registry and repository, but a different tag.
+   *
+   * @param tag the new tag
+   * @return an {@link ImageReference} with the same registry/repository and the new tag
+   */
+  public ImageReference retag(String tag) {
+    return ImageReference.of(registry, repository, tag);
+  }
+
   /** @return the image reference in Docker-readable format (inverse of {@link #parse}) */
   @Override
   public String toString() {


### PR DESCRIPTION
For https://github.com/GoogleContainerTools/jib/issues/802#issuecomment-418423375

Now, build to Docker daemon first loads the tarball, and then does `docker tag` to tag with the additional tags.