### PR TITLE
List cached layer digests as Set

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheStorage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheStorage.java
@@ -18,8 +18,8 @@ package com.google.cloud.tools.jib.ncache;
 
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import java.io.IOException;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Interface for queries to a cache storage engine.
@@ -47,11 +47,11 @@ public interface CacheStorage {
   /**
    * Lists all the layer digests stored.
    *
-   * @return the list of layer digests (that can be retrieved via {@link #retrieve})
+   * @return the set of layer digests (that can be retrieved via {@link #retrieve})
    * @throws CacheCorruptedException if the cache was found to be corrupted
    * @throws IOException if an I/O exception occurs
    */
-  List<DescriptorDigest> listDigests() throws IOException, CacheCorruptedException;
+  Set<DescriptorDigest> listDigests() throws IOException, CacheCorruptedException;
 
   /**
    * Retrieves the {@link CacheEntry} for the layer with digest {@code layerDigest}.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheStorage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheStorage.java
@@ -45,7 +45,7 @@ public interface CacheStorage {
   CacheEntry write(CacheWrite cacheWrite) throws IOException;
 
   /**
-   * Fetch all the layer digests stored.
+   * Fetches all the layer digests stored.
    *
    * @return the set of layer digests (that can be retrieved via {@link #retrieve})
    * @throws CacheCorruptedException if the cache was found to be corrupted

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheStorage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/CacheStorage.java
@@ -45,13 +45,13 @@ public interface CacheStorage {
   CacheEntry write(CacheWrite cacheWrite) throws IOException;
 
   /**
-   * Lists all the layer digests stored.
+   * Fetch all the layer digests stored.
    *
    * @return the set of layer digests (that can be retrieved via {@link #retrieve})
    * @throws CacheCorruptedException if the cache was found to be corrupted
    * @throws IOException if an I/O exception occurs
    */
-  Set<DescriptorDigest> listDigests() throws IOException, CacheCorruptedException;
+  Set<DescriptorDigest> fetchDigests() throws IOException, CacheCorruptedException;
 
   /**
    * Retrieves the {@link CacheEntry} for the layer with digest {@code layerDigest}.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorage.java
@@ -19,8 +19,8 @@ package com.google.cloud.tools.jib.ncache;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Default implementation of {@link CacheStorage}. This storage engine stores cache entries in a
@@ -73,7 +73,7 @@ public class DefaultCacheStorage implements CacheStorage {
   }
 
   @Override
-  public List<DescriptorDigest> listDigests() throws IOException, CacheCorruptedException {
+  public Set<DescriptorDigest> listDigests() throws IOException, CacheCorruptedException {
     return defaultCacheStorageReader.listDigests();
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorage.java
@@ -73,8 +73,8 @@ public class DefaultCacheStorage implements CacheStorage {
   }
 
   @Override
-  public Set<DescriptorDigest> listDigests() throws IOException, CacheCorruptedException {
-    return defaultCacheStorageReader.listDigests();
+  public Set<DescriptorDigest> fetchDigests() throws IOException, CacheCorruptedException {
+    return defaultCacheStorageReader.fetchDigests();
   }
 
   @Override

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageReader.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageReader.java
@@ -45,7 +45,7 @@ class DefaultCacheStorageReader {
    * @throws CacheCorruptedException if the cache was found to be corrupted
    * @throws IOException if an I/O exception occurs
    */
-  Set<DescriptorDigest> listDigests() throws IOException, CacheCorruptedException {
+  Set<DescriptorDigest> fetchDigests() throws IOException, CacheCorruptedException {
     try (Stream<Path> layerDirectories =
         Files.list(defaultCacheStorageFiles.getLayersDirectory())) {
       List<Path> layerDirectoriesList = layerDirectories.collect(Collectors.toList());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageReader.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageReader.java
@@ -22,9 +22,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.DigestException;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -44,11 +45,11 @@ class DefaultCacheStorageReader {
    * @throws CacheCorruptedException if the cache was found to be corrupted
    * @throws IOException if an I/O exception occurs
    */
-  List<DescriptorDigest> listDigests() throws IOException, CacheCorruptedException {
+  Set<DescriptorDigest> listDigests() throws IOException, CacheCorruptedException {
     try (Stream<Path> layerDirectories =
         Files.list(defaultCacheStorageFiles.getLayersDirectory())) {
       List<Path> layerDirectoriesList = layerDirectories.collect(Collectors.toList());
-      List<DescriptorDigest> layerDigests = new ArrayList<>(layerDirectoriesList.size());
+      Set<DescriptorDigest> layerDigests = new HashSet<>(layerDirectoriesList.size());
       for (Path layerDirectory : layerDirectoriesList) {
         try {
           layerDigests.add(DescriptorDigest.fromHash(layerDirectory.getFileName().toString()));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageReaderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageReaderTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.security.DigestException;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Optional;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -65,7 +66,8 @@ public class DefaultCacheStorageReaderTest {
 
     // Checks that layer directories created are all listed.
     Assert.assertEquals(
-        Arrays.asList(layerDigest1, layerDigest2), defaultCacheStorageReader.listDigests());
+        new HashSet<>(Arrays.asList(layerDigest1, layerDigest2)),
+        defaultCacheStorageReader.listDigests());
 
     // Checks that non-digest directories means the cache is corrupted.
     Files.createDirectory(defaultCacheStorageFiles.getLayersDirectory().resolve("not a hash"));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageReaderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageReaderTest.java
@@ -67,12 +67,12 @@ public class DefaultCacheStorageReaderTest {
     // Checks that layer directories created are all listed.
     Assert.assertEquals(
         new HashSet<>(Arrays.asList(layerDigest1, layerDigest2)),
-        defaultCacheStorageReader.listDigests());
+        defaultCacheStorageReader.fetchDigests());
 
     // Checks that non-digest directories means the cache is corrupted.
     Files.createDirectory(defaultCacheStorageFiles.getLayersDirectory().resolve("not a hash"));
     try {
-      defaultCacheStorageReader.listDigests();
+      defaultCacheStorageReader.fetchDigests();
       Assert.fail("Listing digests should have failed");
 
     } catch (CacheCorruptedException ex) {


### PR DESCRIPTION
Fixes #985.

FYI, I noticed that no code in our repo calls `DefaultCacheStorage.listDigests()`, so this change should be pretty safe.