### PR TITLE
Adds AbsoluteUnixPath to represent Unix paths in absolute form.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPath.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPath.java
@@ -62,7 +62,10 @@ public class AbsoluteUnixPath {
     return new AbsoluteUnixPath(pathJoiner.toString());
   }
 
-  /** Unix-style path, in absolute form. Does not end with trailing slash. */
+  /**
+   * Unix-style path, in absolute form. Does not end with trailing slash, except for the file system
+   * root ({@code /}).
+   */
   private final String unixPath;
 
   private AbsoluteUnixPath(String unixPath) {
@@ -76,8 +79,11 @@ public class AbsoluteUnixPath {
    * @return a new {@link AbsoluteUnixPath} representing the resolved path
    */
   public AbsoluteUnixPath resolve(RelativeUnixPath relativeUnixPath) {
-    return AbsoluteUnixPath.fromPath(
-        Paths.get(unixPath).resolve(relativeUnixPath.getRelativePath()));
+    StringJoiner pathJoiner = new StringJoiner("/", unixPath + '/', "");
+    for (String pathComponent : relativeUnixPath.getRelativePathComponents()) {
+      pathJoiner.add(pathComponent);
+    }
+    return AbsoluteUnixPath.get(pathJoiner.toString());
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPath.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPath.java
@@ -52,7 +52,7 @@ public class AbsoluteUnixPath {
    * @param path the absolute {@link Path} to convert to an {@link AbsoluteUnixPath}.
    * @return a new {@link AbsoluteUnixPath}
    */
-  private static AbsoluteUnixPath fromPath(Path path) {
+  public static AbsoluteUnixPath fromPath(Path path) {
     Preconditions.checkArgument(
         path.getRoot() != null, "Cannot create AbsoluteUnixPath from non-absolute Path: " + path);
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPath.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPath.java
@@ -32,24 +32,6 @@ import javax.annotation.concurrent.Immutable;
 public class AbsoluteUnixPath {
 
   /**
-   * Gets a new {@link AbsoluteUnixPath} from a {@link Path}. The {@code path} must be absolute
-   * (indicated by a non-null {@link Path#getRoot}).
-   *
-   * @param path the absolute {@link Path} to convert to an {@link AbsoluteUnixPath}.
-   * @return a new {@link AbsoluteUnixPath}
-   */
-  public static AbsoluteUnixPath fromPath(Path path) {
-    Preconditions.checkArgument(
-        path.getRoot() != null, "Cannot create AbsoluteUnixPath from non-absolute Path: " + path);
-
-    StringJoiner pathJoiner = new StringJoiner("/", "/", "");
-    for (Path pathComponent : path) {
-      pathJoiner.add(pathComponent.getFileName().toString());
-    }
-    return new AbsoluteUnixPath(pathJoiner.toString());
-  }
-
-  /**
    * Gets a new {@link AbsoluteUnixPath} from a Unix-style path string. The path must begin with a
    * forward slash ({@code /}).
    *
@@ -62,6 +44,24 @@ public class AbsoluteUnixPath {
     return fromPath(Paths.get(path));
   }
 
+  /**
+   * Gets a new {@link AbsoluteUnixPath} from a {@link Path}. The {@code path} must be absolute
+   * (indicated by a non-null {@link Path#getRoot}).
+   *
+   * @param path the absolute {@link Path} to convert to an {@link AbsoluteUnixPath}.
+   * @return a new {@link AbsoluteUnixPath}
+   */
+  private static AbsoluteUnixPath fromPath(Path path) {
+    Preconditions.checkArgument(
+        path.getRoot() != null, "Cannot create AbsoluteUnixPath from non-absolute Path: " + path);
+
+    StringJoiner pathJoiner = new StringJoiner("/", "/", "");
+    for (Path pathComponent : path) {
+      pathJoiner.add(pathComponent.getFileName().toString());
+    }
+    return new AbsoluteUnixPath(pathJoiner.toString());
+  }
+
   /** Unix-style path, in absolute form. Does not end with trailing slash. */
   private final String unixPath;
 
@@ -72,13 +72,12 @@ public class AbsoluteUnixPath {
   /**
    * Resolves this path against another relative path.
    *
-   * @param path the relative path to resolve against
+   * @param relativeUnixPath the relative path to resolve against
    * @return a new {@link AbsoluteUnixPath} representing the resolved path
    */
-  public AbsoluteUnixPath resolve(Path path) {
-    Preconditions.checkArgument(
-        path.getRoot() == null, "Cannot resolve AbsoluteUnixPath against absolute Path: " + path);
-    return AbsoluteUnixPath.fromPath(Paths.get(unixPath).resolve(path));
+  public AbsoluteUnixPath resolve(RelativeUnixPath relativeUnixPath) {
+    return AbsoluteUnixPath.fromPath(
+        Paths.get(unixPath).resolve(relativeUnixPath.getRelativePath()));
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPath.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPath.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.filesystem;
+
+import com.google.common.base.Preconditions;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.StringJoiner;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Represents a Unix-style path in absolute form (containing all path components relative to the
+ * file system root {@code /}).
+ *
+ * <p>This class is immutable and thread-safe.
+ */
+@Immutable
+public class AbsoluteUnixPath {
+
+  /**
+   * Gets a new {@link AbsoluteUnixPath} from a {@link Path}. The {@code path} must be absolute
+   * (indicated by a non-null {@link Path#getRoot}).
+   *
+   * @param path the absolute {@link Path} to convert to an {@link AbsoluteUnixPath}.
+   * @return a new {@link AbsoluteUnixPath}
+   */
+  public static AbsoluteUnixPath fromPath(Path path) {
+    Preconditions.checkArgument(
+        path.getRoot() != null, "Cannot create AbsoluteUnixPath from non-absolute Path: " + path);
+
+    StringJoiner pathJoiner = new StringJoiner("/", "/", "");
+    for (Path pathComponent : path) {
+      pathJoiner.add(pathComponent.getFileName().toString());
+    }
+    return new AbsoluteUnixPath(pathJoiner.toString());
+  }
+
+  /**
+   * Gets a new {@link AbsoluteUnixPath} from a Unix-style path string. The path must begin with a
+   * forward slash ({@code /}).
+   *
+   * @param path the Unix-style path string in absolute form
+   * @return a new {@link AbsoluteUnixPath}
+   */
+  public static AbsoluteUnixPath get(String path) {
+    Preconditions.checkArgument(
+        path.startsWith("/"), "Path does not start with forward slash (/): " + path);
+    return fromPath(Paths.get(path));
+  }
+
+  /** Unix-style path, in absolute form. Does not end with trailing slash. */
+  private final String unixPath;
+
+  private AbsoluteUnixPath(String unixPath) {
+    this.unixPath = unixPath;
+  }
+
+  /**
+   * Resolves this path against another relative path.
+   *
+   * @param path the relative path to resolve against
+   * @return a new {@link AbsoluteUnixPath} representing the resolved path
+   */
+  public AbsoluteUnixPath resolve(Path path) {
+    Preconditions.checkArgument(
+        path.getRoot() == null, "Cannot resolve AbsoluteUnixPath against absolute Path: " + path);
+    return AbsoluteUnixPath.fromPath(Paths.get(unixPath).resolve(path));
+  }
+
+  /**
+   * Returns the string form of the absolute Unix-style path.
+   *
+   * @return the string form
+   */
+  @Override
+  public String toString() {
+    return unixPath;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof AbsoluteUnixPath)) {
+      return false;
+    }
+    AbsoluteUnixPath otherAbsoluteUnixPath = (AbsoluteUnixPath) other;
+    return unixPath.equals(otherAbsoluteUnixPath.unixPath);
+  }
+
+  @Override
+  public int hashCode() {
+    return unixPath.hashCode();
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/RelativeUnixPath.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/RelativeUnixPath.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.jib.filesystem;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import javax.annotation.concurrent.Immutable;
 
@@ -40,16 +39,7 @@ public class RelativeUnixPath {
     Preconditions.checkArgument(
         !relativePath.startsWith("/"), "Path starts with forward slash (/): " + relativePath);
 
-    ImmutableList.Builder<String> pathComponents = ImmutableList.builder();
-    for (String pathComponent : Splitter.on('/').split(relativePath)) {
-      if (pathComponent.isEmpty()) {
-        // Skips empty components.
-        continue;
-      }
-      pathComponents.add(pathComponent);
-    }
-
-    return new RelativeUnixPath(pathComponents.build());
+    return new RelativeUnixPath(UnixPathParser.parse(relativePath));
   }
 
   private final ImmutableList<String> pathComponents;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/RelativeUnixPath.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/RelativeUnixPath.java
@@ -17,12 +17,16 @@
 package com.google.cloud.tools.jib.filesystem;
 
 import com.google.common.base.Preconditions;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import javax.annotation.concurrent.Immutable;
 
 /**
  * Represents a Unix-style path in relative form (does not start at the file system root {@code /}).
+ *
+ * <p>This class is immutable and thread-safe.
  */
+@Immutable
 public class RelativeUnixPath {
 
   /**
@@ -36,22 +40,31 @@ public class RelativeUnixPath {
     Preconditions.checkArgument(
         !relativePath.startsWith("/"), "Path starts with forward slash (/): " + relativePath);
 
-    return new RelativeUnixPath(Paths.get(relativePath));
+    ImmutableList.Builder<String> pathComponents = ImmutableList.builder();
+    for (String pathComponent : Splitter.on('/').split(relativePath)) {
+      if (pathComponent.isEmpty()) {
+        // Skips empty components.
+        continue;
+      }
+      pathComponents.add(pathComponent);
+    }
+
+    return new RelativeUnixPath(pathComponents.build());
   }
 
-  private final Path relativePath;
+  private final ImmutableList<String> pathComponents;
 
   /** Instantiate with {@link #get}. */
-  private RelativeUnixPath(Path relativePath) {
-    this.relativePath = relativePath;
+  private RelativeUnixPath(ImmutableList<String> pathComponents) {
+    this.pathComponents = pathComponents;
   }
 
   /**
-   * Gets the path this represents.
+   * Gets the relative Unix path this represents, in a list of components.
    *
-   * @return the relative path this represents
+   * @return the relative path this represents, in a list of components
    */
-  Path getRelativePath() {
-    return relativePath;
+  ImmutableList<String> getRelativePathComponents() {
+    return pathComponents;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/RelativeUnixPath.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/RelativeUnixPath.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.filesystem;
+
+import com.google.common.base.Preconditions;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Represents a Unix-style path in relative form (does not start at the file system root {@code /}).
+ */
+public class RelativeUnixPath {
+
+  /**
+   * Gets a new {@link RelativeUnixPath} from a Unix-style path in relative form. The {@code path}
+   * must be relative (does not begin with a leading slash {@code /}).
+   *
+   * @param relativePath the relative path
+   * @return a new {@link RelativeUnixPath}
+   */
+  public static RelativeUnixPath get(String relativePath) {
+    Preconditions.checkArgument(
+        !relativePath.startsWith("/"), "Path starts with forward slash (/): " + relativePath);
+
+    return new RelativeUnixPath(Paths.get(relativePath));
+  }
+
+  private final Path relativePath;
+
+  /** Instantiate with {@link #get}. */
+  private RelativeUnixPath(Path relativePath) {
+    this.relativePath = relativePath;
+  }
+
+  /**
+   * Gets the path this represents.
+   *
+   * @return the relative path this represents
+   */
+  Path getRelativePath() {
+    return relativePath;
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/UnixPathParser.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/UnixPathParser.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.filesystem;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+
+/** Parses Unix-style paths. */
+class UnixPathParser {
+
+  /**
+   * Parses a Unix-style path into a list of path components.
+   *
+   * @param unixPath the Unix-style path
+   * @return a list of path components
+   */
+  static ImmutableList<String> parse(String unixPath) {
+    ImmutableList.Builder<String> pathComponents = ImmutableList.builder();
+    for (String pathComponent : Splitter.on('/').split(unixPath)) {
+      if (pathComponent.isEmpty()) {
+        // Skips empty components.
+        continue;
+      }
+      pathComponents.add(pathComponent);
+    }
+    return pathComponents.build();
+  }
+
+  private UnixPathParser() {}
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPathTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPathTest.java
@@ -16,7 +16,9 @@
 
 package com.google.cloud.tools.jib.filesystem;
 
+import java.nio.file.Paths;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Test;
 
 /** Test for {@link AbsoluteUnixPath}. */
@@ -32,6 +34,20 @@ public class AbsoluteUnixPathTest {
       Assert.assertEquals(
           "Path does not start with forward slash (/): not/absolute", ex.getMessage());
     }
+  }
+
+  @Test
+  public void testFromPath() {
+    Assert.assertEquals(
+        "/absolute/path", AbsoluteUnixPath.fromPath(Paths.get("/absolute/path")).toString());
+  }
+
+  @Test
+  public void testFromPath_windows() {
+    Assume.assumeTrue(System.getProperty("os.name").startsWith("Windows"));
+
+    Assert.assertEquals(
+        "/absolute/path", AbsoluteUnixPath.fromPath(Paths.get("T:\\absolute\\path")).toString());
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPathTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPathTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.filesystem;
+
+import java.nio.file.Paths;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Test for {@link AbsoluteUnixPath}. */
+public class AbsoluteUnixPathTest {
+
+  @Test
+  public void testFromPath_notAbsolute() {
+    try {
+      AbsoluteUnixPath.fromPath(Paths.get("not", "absolute"));
+      Assert.fail();
+
+    } catch (IllegalArgumentException ex) {
+      Assert.assertEquals(
+          "Cannot create AbsoluteUnixPath from non-absolute Path: " + Paths.get("not", "absolute"),
+          ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testGet_notAbsolute() {
+    try {
+      AbsoluteUnixPath.get("not/absolute");
+      Assert.fail();
+
+    } catch (IllegalArgumentException ex) {
+      Assert.assertEquals(
+          "Path does not start with forward slash (/): not/absolute", ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testEquals() {
+    AbsoluteUnixPath absoluteUnixPath1 = AbsoluteUnixPath.fromPath(Paths.get("/absolute/path"));
+    AbsoluteUnixPath absoluteUnixPath2 = AbsoluteUnixPath.fromPath(Paths.get("/absolute/path/"));
+    AbsoluteUnixPath absoluteUnixPath3 = AbsoluteUnixPath.get("/absolute/path");
+    AbsoluteUnixPath absoluteUnixPath4 = AbsoluteUnixPath.get("/absolute/path/");
+    AbsoluteUnixPath absoluteUnixPath5 = AbsoluteUnixPath.fromPath(Paths.get("/another/path"));
+    AbsoluteUnixPath absoluteUnixPath6 = AbsoluteUnixPath.get("/another/path");
+    Assert.assertEquals(absoluteUnixPath1, absoluteUnixPath2);
+    Assert.assertEquals(absoluteUnixPath1, absoluteUnixPath3);
+    Assert.assertEquals(absoluteUnixPath1, absoluteUnixPath4);
+    Assert.assertNotEquals(absoluteUnixPath1, absoluteUnixPath5);
+    Assert.assertNotEquals(absoluteUnixPath1, absoluteUnixPath6);
+  }
+
+  @Test
+  public void testResolve_absolute() {
+    try {
+      AbsoluteUnixPath.fromPath(Paths.get("/some/path")).resolve(Paths.get("/"));
+      Assert.fail();
+
+    } catch (IllegalArgumentException ex) {
+      Assert.assertEquals(
+          "Cannot resolve AbsoluteUnixPath against absolute Path: " + Paths.get("/"),
+          ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testResolve() {
+    AbsoluteUnixPath absoluteUnixPath1 = AbsoluteUnixPath.get("/");
+    Assert.assertEquals(absoluteUnixPath1, absoluteUnixPath1.resolve(Paths.get("")));
+    Assert.assertEquals("/file", absoluteUnixPath1.resolve(Paths.get("file")).toString());
+    Assert.assertEquals(
+        "/relative/path", absoluteUnixPath1.resolve(Paths.get("relative/path")).toString());
+
+    AbsoluteUnixPath absoluteUnixPath2 = AbsoluteUnixPath.get("/some/path");
+    Assert.assertEquals(absoluteUnixPath2, absoluteUnixPath2.resolve(Paths.get("")));
+    Assert.assertEquals("/some/path/file", absoluteUnixPath2.resolve(Paths.get("file")).toString());
+    Assert.assertEquals(
+        "/some/path/relative/path",
+        absoluteUnixPath2.resolve(Paths.get("relative/path")).toString());
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPathTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPathTest.java
@@ -44,17 +44,6 @@ public class AbsoluteUnixPathTest {
   }
 
   @Test
-  public void testResolve_absolute() {
-    try {
-      AbsoluteUnixPath.get("/some/path").resolve(RelativeUnixPath.get("/absolute"));
-      Assert.fail();
-
-    } catch (IllegalArgumentException ex) {
-      Assert.assertEquals("Path starts with forward slash (/): /absolute", ex.getMessage());
-    }
-  }
-
-  @Test
   public void testResolve() {
     AbsoluteUnixPath absoluteUnixPath1 = AbsoluteUnixPath.get("/");
     Assert.assertEquals(absoluteUnixPath1, absoluteUnixPath1.resolve(RelativeUnixPath.get("")));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPathTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/AbsoluteUnixPathTest.java
@@ -16,25 +16,11 @@
 
 package com.google.cloud.tools.jib.filesystem;
 
-import java.nio.file.Paths;
 import org.junit.Assert;
 import org.junit.Test;
 
 /** Test for {@link AbsoluteUnixPath}. */
 public class AbsoluteUnixPathTest {
-
-  @Test
-  public void testFromPath_notAbsolute() {
-    try {
-      AbsoluteUnixPath.fromPath(Paths.get("not", "absolute"));
-      Assert.fail();
-
-    } catch (IllegalArgumentException ex) {
-      Assert.assertEquals(
-          "Cannot create AbsoluteUnixPath from non-absolute Path: " + Paths.get("not", "absolute"),
-          ex.getMessage());
-    }
-  }
 
   @Test
   public void testGet_notAbsolute() {
@@ -50,45 +36,40 @@ public class AbsoluteUnixPathTest {
 
   @Test
   public void testEquals() {
-    AbsoluteUnixPath absoluteUnixPath1 = AbsoluteUnixPath.fromPath(Paths.get("/absolute/path"));
-    AbsoluteUnixPath absoluteUnixPath2 = AbsoluteUnixPath.fromPath(Paths.get("/absolute/path/"));
-    AbsoluteUnixPath absoluteUnixPath3 = AbsoluteUnixPath.get("/absolute/path");
-    AbsoluteUnixPath absoluteUnixPath4 = AbsoluteUnixPath.get("/absolute/path/");
-    AbsoluteUnixPath absoluteUnixPath5 = AbsoluteUnixPath.fromPath(Paths.get("/another/path"));
-    AbsoluteUnixPath absoluteUnixPath6 = AbsoluteUnixPath.get("/another/path");
+    AbsoluteUnixPath absoluteUnixPath1 = AbsoluteUnixPath.get("/absolute/path");
+    AbsoluteUnixPath absoluteUnixPath2 = AbsoluteUnixPath.get("/absolute/path/");
+    AbsoluteUnixPath absoluteUnixPath3 = AbsoluteUnixPath.get("/another/path");
     Assert.assertEquals(absoluteUnixPath1, absoluteUnixPath2);
-    Assert.assertEquals(absoluteUnixPath1, absoluteUnixPath3);
-    Assert.assertEquals(absoluteUnixPath1, absoluteUnixPath4);
-    Assert.assertNotEquals(absoluteUnixPath1, absoluteUnixPath5);
-    Assert.assertNotEquals(absoluteUnixPath1, absoluteUnixPath6);
+    Assert.assertNotEquals(absoluteUnixPath1, absoluteUnixPath3);
   }
 
   @Test
   public void testResolve_absolute() {
     try {
-      AbsoluteUnixPath.fromPath(Paths.get("/some/path")).resolve(Paths.get("/"));
+      AbsoluteUnixPath.get("/some/path").resolve(RelativeUnixPath.get("/absolute"));
       Assert.fail();
 
     } catch (IllegalArgumentException ex) {
-      Assert.assertEquals(
-          "Cannot resolve AbsoluteUnixPath against absolute Path: " + Paths.get("/"),
-          ex.getMessage());
+      Assert.assertEquals("Path starts with forward slash (/): /absolute", ex.getMessage());
     }
   }
 
   @Test
   public void testResolve() {
     AbsoluteUnixPath absoluteUnixPath1 = AbsoluteUnixPath.get("/");
-    Assert.assertEquals(absoluteUnixPath1, absoluteUnixPath1.resolve(Paths.get("")));
-    Assert.assertEquals("/file", absoluteUnixPath1.resolve(Paths.get("file")).toString());
+    Assert.assertEquals(absoluteUnixPath1, absoluteUnixPath1.resolve(RelativeUnixPath.get("")));
     Assert.assertEquals(
-        "/relative/path", absoluteUnixPath1.resolve(Paths.get("relative/path")).toString());
+        "/file", absoluteUnixPath1.resolve(RelativeUnixPath.get("file")).toString());
+    Assert.assertEquals(
+        "/relative/path",
+        absoluteUnixPath1.resolve(RelativeUnixPath.get("relative/path")).toString());
 
     AbsoluteUnixPath absoluteUnixPath2 = AbsoluteUnixPath.get("/some/path");
-    Assert.assertEquals(absoluteUnixPath2, absoluteUnixPath2.resolve(Paths.get("")));
-    Assert.assertEquals("/some/path/file", absoluteUnixPath2.resolve(Paths.get("file")).toString());
+    Assert.assertEquals(absoluteUnixPath2, absoluteUnixPath2.resolve(RelativeUnixPath.get("")));
+    Assert.assertEquals(
+        "/some/path/file", absoluteUnixPath2.resolve(RelativeUnixPath.get("file")).toString());
     Assert.assertEquals(
         "/some/path/relative/path",
-        absoluteUnixPath2.resolve(Paths.get("relative/path")).toString());
+        absoluteUnixPath2.resolve(RelativeUnixPath.get("relative/path")).toString());
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/RelativeUnixPathTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/RelativeUnixPathTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.filesystem;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for {@link RelativeUnixPath}. */
+public class RelativeUnixPathTest {
+
+  @Test
+  public void testGet_absolute() {
+    try {
+      RelativeUnixPath.get("/absolute");
+      Assert.fail();
+
+    } catch (IllegalArgumentException ex) {
+      Assert.assertEquals("Path starts with forward slash (/): /absolute", ex.getMessage());
+    }
+  }
+
+  @Test
+  public void testGet() {
+    Assert.assertEquals(
+        ImmutableList.of("some", "relative", "path"),
+        RelativeUnixPath.get("some/relative///path").getRelativePathComponents());
+  }
+
+  @Test
+  public void testGet_windowsStyle() {
+    // Windows-style paths are resolved in Unix semantics.
+    Assert.assertEquals(
+        ImmutableList.of("T:\\windows\\path"),
+        RelativeUnixPath.get("T:\\windows\\path").getRelativePathComponents());
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/UnixPathParserTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/UnixPathParserTest.java
@@ -20,24 +20,19 @@ import com.google.common.collect.ImmutableList;
 import org.junit.Assert;
 import org.junit.Test;
 
-/** Tests for {@link RelativeUnixPath}. */
-public class RelativeUnixPathTest {
+/** Tests for {@link UnixPathParser}. */
+public class UnixPathParserTest {
 
   @Test
-  public void testGet_absolute() {
-    try {
-      RelativeUnixPath.get("/absolute");
-      Assert.fail();
-
-    } catch (IllegalArgumentException ex) {
-      Assert.assertEquals("Path starts with forward slash (/): /absolute", ex.getMessage());
-    }
-  }
-
-  @Test
-  public void testGet() {
+  public void testParse() {
+    Assert.assertEquals(ImmutableList.of("some", "path"), UnixPathParser.parse("/some/path"));
+    Assert.assertEquals(ImmutableList.of("some", "path"), UnixPathParser.parse("some/path/"));
+    Assert.assertEquals(ImmutableList.of("some", "path"), UnixPathParser.parse("some///path///"));
+    // Windows-style paths are resolved in Unix semantics.
     Assert.assertEquals(
-        ImmutableList.of("some", "relative", "path"),
-        RelativeUnixPath.get("some/relative///path").getRelativePathComponents());
+        ImmutableList.of("\\windows\\path"), UnixPathParser.parse("\\windows\\path"));
+    Assert.assertEquals(ImmutableList.of("T:\\dir"), UnixPathParser.parse("T:\\dir"));
+    Assert.assertEquals(
+        ImmutableList.of("T:\\dir", "real", "path"), UnixPathParser.parse("T:\\dir/real/path"));
   }
 }


### PR DESCRIPTION
Part of #992.

Followup PR will change `LayerEntry#extractionPath` to use this new `AbsoluteUnixPath`.