### PR TITLE
Wait until local registry is ready when setting it up in integration tests

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
@@ -152,7 +152,7 @@ public class LocalRegistry extends ExternalResource {
   private void waitUntilReady() throws InterruptedException, MalformedURLException {
     URL queryUrl = new URL("http://localhost:" + port + "/v2/_catalog");
 
-    for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < 40; i++) {
       try {
         HttpURLConnection connection = (HttpURLConnection) queryUrl.openConnection();
         int code = connection.getResponseCode();
@@ -160,8 +160,8 @@ public class LocalRegistry extends ExternalResource {
           return;
         }
       } catch (IOException ex) {
-        Thread.sleep(1000);
       }
+      Thread.sleep(250);
     }
   }
 }

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
@@ -157,7 +157,6 @@ public class LocalRegistry extends ExternalResource {
         HttpURLConnection connection = (HttpURLConnection) queryUrl.openConnection();
         int code = connection.getResponseCode();
         if (code == HttpURLConnection.HTTP_OK || code == HttpURLConnection.HTTP_UNAUTHORIZED) {
-          System.out.println("Code: " + code);
           return;
         }
       } catch (IOException ex) {

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
@@ -56,14 +56,7 @@ public class LocalRegistry extends ExternalResource {
     ArrayList<String> dockerTokens =
         new ArrayList<>(
             Arrays.asList(
-                "docker",
-                "run",
-                "--rm",
-                "-d",
-                "-p",
-                port + ":5000",
-                "--name",
-                containerName));
+                "docker", "run", "--rm", "-d", "-p", port + ":5000", "--name", containerName));
     if (username != null && password != null) {
       // Generate the htpasswd file to store credentials
       String credentialString =


### PR DESCRIPTION
Fixes #965.

Waits for up to 20 seconds.

- I don't think `--restart=always` is ever needed. What the flag would do is that the container will automatically start up if the Docker daemon restarts.
- No need to explicitly call `docker rm <container>` when giving `--rm` for `docker run`.