### PR TITLE
Delete containers after run in integration tests

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -138,7 +138,7 @@ public class BuildStepsIntegrationTest {
     localRegistry.pull(imageReference);
     assertDockerInspect(imageReference);
     Assert.assertEquals(
-        "Hello, world. An argument.\n", new Command("docker", "run", imageReference).run());
+        "Hello, world. An argument.\n", new Command("docker", "run", "--rm", imageReference).run());
   }
 
   @Test
@@ -164,19 +164,21 @@ public class BuildStepsIntegrationTest {
     localRegistry.pull(imageReference);
     assertDockerInspect(imageReference);
     Assert.assertEquals(
-        "Hello, world. An argument.\n", new Command("docker", "run", imageReference).run());
+        "Hello, world. An argument.\n", new Command("docker", "run", "--rm", imageReference).run());
 
     String imageReference2 = "localhost:5000/testimage:testtag2";
     localRegistry.pull(imageReference2);
     assertDockerInspect(imageReference2);
     Assert.assertEquals(
-        "Hello, world. An argument.\n", new Command("docker", "run", imageReference2).run());
+        "Hello, world. An argument.\n",
+        new Command("docker", "run", "--rm", imageReference2).run());
 
     String imageReference3 = "localhost:5000/testimage:testtag3";
     localRegistry.pull(imageReference3);
     assertDockerInspect(imageReference3);
     Assert.assertEquals(
-        "Hello, world. An argument.\n", new Command("docker", "run", imageReference3).run());
+        "Hello, world. An argument.\n",
+        new Command("docker", "run", "--rm", imageReference3).run());
   }
 
   @Test
@@ -194,7 +196,7 @@ public class BuildStepsIntegrationTest {
     String imageReference = "localhost:5000/testimage:testtag";
     new Command("docker", "pull", imageReference).run();
     Assert.assertEquals(
-        "Hello, world. An argument.\n", new Command("docker", "run", imageReference).run());
+        "Hello, world. An argument.\n", new Command("docker", "run", "--rm", imageReference).run());
   }
 
   @Test
@@ -215,7 +217,7 @@ public class BuildStepsIntegrationTest {
 
     assertDockerInspect(imageReference);
     Assert.assertEquals(
-        "Hello, world. An argument.\n", new Command("docker", "run", imageReference).run());
+        "Hello, world. An argument.\n", new Command("docker", "run", "--rm", imageReference).run());
   }
 
   @Test
@@ -237,15 +239,15 @@ public class BuildStepsIntegrationTest {
 
     assertDockerInspect(imageReference);
     Assert.assertEquals(
-        "Hello, world. An argument.\n", new Command("docker", "run", imageReference).run());
+        "Hello, world. An argument.\n", new Command("docker", "run", "--rm", imageReference).run());
     assertDockerInspect(imageReference + ":testtag2");
     Assert.assertEquals(
         "Hello, world. An argument.\n",
-        new Command("docker", "run", imageReference + ":testtag2").run());
+        new Command("docker", "run", "--rm", imageReference + ":testtag2").run());
     assertDockerInspect(imageReference + ":testtag3");
     Assert.assertEquals(
         "Hello, world. An argument.\n",
-        new Command("docker", "run", imageReference + ":testtag3").run());
+        new Command("docker", "run", "--rm", imageReference + ":testtag3").run());
   }
 
   @Test
@@ -267,7 +269,7 @@ public class BuildStepsIntegrationTest {
 
     new Command("docker", "load", "--input", outputPath.toString()).run();
     Assert.assertEquals(
-        "Hello, world. An argument.\n", new Command("docker", "run", "testtar").run());
+        "Hello, world. An argument.\n", new Command("docker", "run", "--rm", "testtar").run());
   }
 
   private BuildSteps getBuildSteps(BuildConfiguration buildConfiguration) throws IOException {

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibPluginIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibPluginIntegrationTest.java
@@ -65,7 +65,7 @@ public class JibPluginIntegrationTest {
     assertDockerInspect(imageReference);
     String history = new Command("docker", "history", imageReference).run();
     Assert.assertThat(history, CoreMatchers.containsString("jib-gradle-plugin"));
-    return new Command("docker", "run", imageReference).run();
+    return new Command("docker", "run", "--rm", imageReference).run();
   }
 
   private static String buildAndRunComplex(
@@ -88,7 +88,7 @@ public class JibPluginIntegrationTest {
     assertDockerInspect(imageReference);
     String history = new Command("docker", "history", imageReference).run();
     Assert.assertThat(history, CoreMatchers.containsString("jib-gradle-plugin"));
-    return new Command("docker", "run", imageReference).run();
+    return new Command("docker", "run", "--rm", imageReference).run();
   }
 
   private static String buildToDockerDaemonAndRun(TestProject testProject, String imageReference)
@@ -103,7 +103,7 @@ public class JibPluginIntegrationTest {
     assertDockerInspect(imageReference);
     String history = new Command("docker", "history", imageReference).run();
     Assert.assertThat(history, CoreMatchers.containsString("jib-gradle-plugin"));
-    return new Command("docker", "run", imageReference).run();
+    return new Command("docker", "run", "--rm", imageReference).run();
   }
 
   /**
@@ -296,7 +296,8 @@ public class JibPluginIntegrationTest {
 
     new Command("docker", "load", "--input", outputPath).run();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n", new Command("docker", "run", targetImage).run());
+        "Hello, world. An argument.\nfoo\ncat\n",
+        new Command("docker", "run", "--rm", targetImage).run());
     assertDockerInspect(targetImage);
     assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);
   }
@@ -324,7 +325,8 @@ public class JibPluginIntegrationTest {
 
     assertDockerInspect(imageName);
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n", new Command("docker", "run", imageName).run());
+        "Hello, world. An argument.\nfoo\ncat\n",
+        new Command("docker", "run", "--rm", imageName).run());
 
     // Checks that generating the Docker context again is skipped.
     BuildTask upToDateJibDockerContextTask =

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
@@ -76,7 +76,7 @@ public class BuildDockerMojoIntegrationTest {
                 + "                \"key1\": \"value1\",\n"
                 + "                \"key2\": \"value2\"\n"
                 + "            }"));
-    return new Command("docker", "run", imageReference).run();
+    return new Command("docker", "run", "--rm", imageReference).run();
   }
 
   @Test

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -100,7 +100,7 @@ public class BuildImageMojoIntegrationTest {
 
     new Command("docker", "pull", imageReference).run();
     assertDockerInspectParameters(imageReference);
-    return new Command("docker", "run", imageReference).run();
+    return new Command("docker", "run", "--rm", imageReference).run();
   }
 
   private static String buildAndRunComplex(
@@ -125,7 +125,7 @@ public class BuildImageMojoIntegrationTest {
         Instant.parse(
             new Command("docker", "inspect", "-f", "{{.Created}}", imageReference).run().trim());
     Assert.assertTrue(buildTime.isAfter(before) || buildTime.equals(before));
-    return new Command("docker", "run", imageReference).run();
+    return new Command("docker", "run", "--rm", imageReference).run();
   }
 
   private static void assertDockerInspectParameters(String imageReference)

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
@@ -63,7 +63,8 @@ public class BuildTarMojoIntegrationTest {
                 .toString())
         .run();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n", new Command("docker", "run", targetImage).run());
+        "Hello, world. An argument.\nfoo\ncat\n",
+        new Command("docker", "run", "--rm", targetImage).run());
 
     Instant buildTime =
         Instant.parse(

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/DockerContextMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/DockerContextMojoIntegrationTest.java
@@ -73,7 +73,8 @@ public class DockerContextMojoIntegrationTest {
                 + "            }"));
 
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n", new Command("docker", "run", imageName).run());
+        "Hello, world. An argument.\nfoo\ncat\n",
+        new Command("docker", "run", "--rm", imageName).run());
   }
 
   public void testExecute_skipJibGoal() throws VerificationException, IOException {


### PR DESCRIPTION
Running integration tests pollute my local docker container space, so I decided to auto-remove the test containers.