### PR TITLE
Stores temporary cache files under cache directory.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/TemporaryDirectory.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/TemporaryDirectory.java
@@ -32,7 +32,7 @@ public class TemporaryDirectory implements Closeable {
   private final Path temporaryDirectory;
 
   /**
-   * Creates a new temporary directory under {@code parentDirectory}.
+   * Creates a new temporary directory under an existing {@code parentDirectory}.
    *
    * @param parentDirectory the directory to create the temporary directory within
    * @throws IOException if an I/O exception occurs

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/TemporaryDirectory.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/TemporaryDirectory.java
@@ -32,12 +32,13 @@ public class TemporaryDirectory implements Closeable {
   private final Path temporaryDirectory;
 
   /**
-   * Creates a new temporary directory.
+   * Creates a new temporary directory under {@code parentDirectory}.
    *
+   * @param parentDirectory the directory to create the temporary directory within
    * @throws IOException if an I/O exception occurs
    */
-  public TemporaryDirectory() throws IOException {
-    temporaryDirectory = Files.createTempDirectory(null);
+  public TemporaryDirectory(Path parentDirectory) throws IOException {
+    temporaryDirectory = Files.createTempDirectory(parentDirectory, null);
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageFiles.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageFiles.java
@@ -26,6 +26,7 @@ class DefaultCacheStorageFiles {
   private static final String LAYERS_DIRECTORY = "layers";
   private static final String METADATA_FILENAME = "metadata";
   private static final String SELECTORS_DIRECTORY = "selectors";
+  private static final String TEMPORARY_DIRECTORY = "tmp";
 
   /**
    * Returns whether or not {@code file} is a layer contents file.
@@ -139,5 +140,14 @@ class DefaultCacheStorageFiles {
    */
   Path getLayerDirectory(DescriptorDigest layerDigest) {
     return getLayersDirectory().resolve(layerDigest.getHash());
+  }
+
+  /**
+   * Gets the directory to store temporary files.
+   *
+   * @return the directory for temporary files
+   */
+  Path getTemporaryDirectory() {
+    return cacheDirectory.resolve(TEMPORARY_DIRECTORY);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageWriter.java
@@ -108,8 +108,11 @@ class DefaultCacheStorageWriter {
     // Creates the layers directory if it doesn't exist.
     Files.createDirectories(defaultCacheStorageFiles.getLayersDirectory());
 
-    // Creates the temporary directory.
-    try (TemporaryDirectory temporaryDirectory = new TemporaryDirectory()) {
+    // Creates the temporary directory. The temporary directory must be in the same FileStore as the
+    // final location for Files.move to work.
+    Files.createDirectories(defaultCacheStorageFiles.getTemporaryDirectory());
+    try (TemporaryDirectory temporaryDirectory =
+        new TemporaryDirectory(defaultCacheStorageFiles.getTemporaryDirectory())) {
       Path temporaryLayerDirectory = temporaryDirectory.getDirectory();
 
       // Writes the layer file to the temporary directory.

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/TemporaryDirectoryTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/TemporaryDirectoryTest.java
@@ -42,7 +42,8 @@ public class TemporaryDirectoryTest {
 
   @Test
   public void testClose_directoryDeleted() throws IOException, URISyntaxException {
-    try (TemporaryDirectory temporaryDirectory = new TemporaryDirectory()) {
+    try (TemporaryDirectory temporaryDirectory =
+        new TemporaryDirectory(temporaryFolder.newFolder().toPath())) {
       createFilesInDirectory(temporaryDirectory.getDirectory());
 
       temporaryDirectory.close();
@@ -54,7 +55,8 @@ public class TemporaryDirectoryTest {
   public void testClose_directoryNotDeletedIfMoved() throws IOException, URISyntaxException {
     Path destinationParent = temporaryFolder.newFolder().toPath();
 
-    try (TemporaryDirectory temporaryDirectory = new TemporaryDirectory()) {
+    try (TemporaryDirectory temporaryDirectory =
+        new TemporaryDirectory(temporaryFolder.newFolder().toPath())) {
       createFilesInDirectory(temporaryDirectory.getDirectory());
 
       Assert.assertFalse(Files.exists(destinationParent.resolve("destination")));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageFilesTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/ncache/DefaultCacheStorageFilesTest.java
@@ -178,4 +178,10 @@ public class DefaultCacheStorageFilesTest {
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
         testDefaultCacheStorageFiles.getLayerDirectory(layerDigest));
   }
+
+  @Test
+  public void testGetTemporaryDirectory() {
+    Assert.assertEquals(
+        Paths.get("cache/directory/tmp"), testDefaultCacheStorageFiles.getTemporaryDirectory());
+  }
 }


### PR DESCRIPTION
Fixes #1036 
Uses `[CACHE DIRECTORY]/tmp` as the temporary directory.