### PR TITLE
Fix docker error output not being captured

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
@@ -108,7 +108,11 @@ public class DockerClient {
       String output = CharStreams.toString(stdout);
 
       if (dockerProcess.waitFor() != 0) {
-        throw new IOException("'docker load' command failed with output: " + output);
+        try (InputStreamReader stderr =
+            new InputStreamReader(dockerProcess.getErrorStream(), StandardCharsets.UTF_8)) {
+          throw new IOException(
+              "'docker load' command failed with output: " + CharStreams.toString(stderr));
+        }
       }
 
       return output;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
@@ -156,13 +156,15 @@ public class DockerClientTest {
     Mockito.when(mockProcess.getOutputStream()).thenReturn(ByteStreams.nullOutputStream());
     Mockito.when(mockProcess.getInputStream())
         .thenReturn(new ByteArrayInputStream("ignored".getBytes(StandardCharsets.UTF_8)));
+    Mockito.when(mockProcess.getErrorStream())
+        .thenReturn(new ByteArrayInputStream("error".getBytes(StandardCharsets.UTF_8)));
 
     try {
       testDockerClient.load(Blobs.from("jib"));
       Assert.fail("Process should have failed");
 
     } catch (IOException ex) {
-      Assert.assertEquals("'docker load' command failed with output: ignored", ex.getMessage());
+      Assert.assertEquals("'docker load' command failed with output: error", ex.getMessage());
     }
   }
 


### PR DESCRIPTION
Fixes #1013. Stole from #1047 + fixed a test.