### PR TITLE
Make ImageParameters interface public

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ImageParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ImageParameters.java
@@ -29,7 +29,7 @@ import org.gradle.api.tasks.Optional;
  * <p>{@code image} (required) is the image reference and {@code credHelper} (optional) is the name
  * (after {@code docker-credential} of the credential helper for accessing the {@code image}.
  */
-interface ImageParameters {
+public interface ImageParameters {
 
   @Input
   @Nullable


### PR DESCRIPTION
<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->

`ImageParameters` is exposed through methods `from` and `to`, but if the interface isn't `public`, then consumers can't actually configure the parameters. This doesn't effect Groovy builds where visibility is ignored, but Java and Kotlin users can't configure image parameters right now.