### PR TITLE
Return concrete types in from and to

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -107,11 +107,11 @@ public class JibExtension {
     extraDirectory.set(resolveDefaultExtraDirectory(project.getProjectDir().toPath()));
   }
 
-  public void from(Action<? super ImageParameters> action) {
+  public void from(Action<BaseImageParameters> action) {
     action.execute(from);
   }
 
-  public void to(Action<? super ImageParameters> action) {
+  public void to(Action<TargetImageParameters> action) {
     action.execute(to);
   }
 


### PR DESCRIPTION
<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->

`from` and `to` currently return `ImageParameters` to consumers, but that is a private type and cannot be used in static-typed scripts (Java, Kotlin). Since `getFrom` and `getTo` return the concrete types, there doesn't seem to be a good reason not to do that in the action versions too.