### PR TITLE
Makes Docker executable configurable.

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
 import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.configuration.LayerConfiguration;
+import com.google.cloud.tools.jib.docker.DockerClient;
 import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.frontend.ExposedPortsParser;
 import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
@@ -205,7 +206,7 @@ public class BuildStepsIntegrationTest {
                 ImageReference.of("gcr.io", "distroless/java", "latest"),
                 ImageReference.of(null, imageReference, null))
             .build();
-    BuildSteps.forBuildToDockerDaemon(buildConfiguration).run();
+    BuildSteps.forBuildToDockerDaemon(DockerClient.newClient(), buildConfiguration).run();
 
     assertDockerInspect(imageReference);
     Assert.assertEquals(
@@ -222,7 +223,7 @@ public class BuildStepsIntegrationTest {
                 ImageReference.of(null, imageReference, null))
             .setAdditionalTargetImageTags(ImmutableSet.of("testtag2", "testtag3"))
             .build();
-    BuildSteps.forBuildToDockerDaemon(buildConfiguration).run();
+    BuildSteps.forBuildToDockerDaemon(DockerClient.newClient(), buildConfiguration).run();
 
     assertDockerInspect(imageReference);
     Assert.assertEquals(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildSteps.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.builder;
 
 import com.google.cloud.tools.jib.builder.steps.StepsRunner;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
+import com.google.cloud.tools.jib.docker.DockerClient;
 import com.google.cloud.tools.jib.event.events.LogEvent;
 import java.nio.file.Path;
 import java.util.concurrent.ExecutionException;
@@ -65,10 +66,12 @@ public class BuildSteps {
   /**
    * All the steps to build to Docker daemon
    *
+   * @param dockerClient the {@link DockerClient} for running {@code docker} commands
    * @param buildConfiguration the configuration parameters for the build
    * @return a new {@link BuildSteps} for building to a Docker daemon
    */
-  public static BuildSteps forBuildToDockerDaemon(BuildConfiguration buildConfiguration) {
+  public static BuildSteps forBuildToDockerDaemon(
+      DockerClient dockerClient, BuildConfiguration buildConfiguration) {
     return new BuildSteps(
         DESCRIPTION_FOR_DOCKER_DAEMON,
         buildConfiguration,
@@ -79,7 +82,7 @@ public class BuildSteps {
                 .runBuildAndCacheApplicationLayerSteps()
                 .runBuildImageStep()
                 .runFinalizingBuildStep()
-                .runLoadDockerStep()
+                .runLoadDockerStep(dockerClient)
                 .waitOnLoadDockerStep());
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
@@ -36,6 +36,7 @@ import java.util.concurrent.ExecutionException;
 /** Adds image layers to a tarball and loads into Docker daemon. */
 class LoadDockerStep implements AsyncStep<Void>, Callable<Void> {
 
+  private final DockerClient dockerClient;
   private final BuildConfiguration buildConfiguration;
   private final PullAndCacheBaseImageLayersStep pullAndCacheBaseImageLayersStep;
   private final ImmutableList<BuildAndCacheApplicationLayerStep> buildAndCacheApplicationLayerSteps;
@@ -46,11 +47,13 @@ class LoadDockerStep implements AsyncStep<Void>, Callable<Void> {
 
   LoadDockerStep(
       ListeningExecutorService listeningExecutorService,
+      DockerClient dockerClient,
       BuildConfiguration buildConfiguration,
       PullAndCacheBaseImageLayersStep pullAndCacheBaseImageLayersStep,
       ImmutableList<BuildAndCacheApplicationLayerStep> buildAndCacheApplicationLayerSteps,
       BuildImageStep buildImageStep) {
     this.listeningExecutorService = listeningExecutorService;
+    this.dockerClient = dockerClient;
     this.buildConfiguration = buildConfiguration;
     this.pullAndCacheBaseImageLayersStep = pullAndCacheBaseImageLayersStep;
     this.buildAndCacheApplicationLayerSteps = buildAndCacheApplicationLayerSteps;
@@ -94,7 +97,6 @@ class LoadDockerStep implements AsyncStep<Void>, Callable<Void> {
     buildConfiguration
         .getEventDispatcher()
         .dispatch(LogEvent.lifecycle("Loading to Docker daemon..."));
-    DockerClient dockerClient = new DockerClient();
     dockerClient.load(new ImageToTarballTranslator(image).toTarballBlob(targetImageReference));
 
     // Tags the image with all the additional tags, skipping the one 'docker load' already loaded.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.async.AsyncSteps;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
+import com.google.cloud.tools.jib.docker.DockerClient;
 import com.google.cloud.tools.jib.global.JibSystemProperties;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
@@ -178,10 +179,11 @@ public class StepsRunner {
     return this;
   }
 
-  public StepsRunner runLoadDockerStep() {
+  public StepsRunner runLoadDockerStep(DockerClient dockerClient) {
     loadDockerStep =
         new LoadDockerStep(
             listeningExecutorService,
+            dockerClient,
             buildConfiguration,
             Preconditions.checkNotNull(pullAndCacheBaseImageLayersStep),
             Preconditions.checkNotNull(buildAndCacheApplicationLayerSteps),

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
@@ -41,7 +41,7 @@ public class DockerClient {
    * @return a new {@link DockerClient}
    */
   public static DockerClient newClient() {
-    return new DockerClient(defaultProcessBuilder(DEFAULT_DOCKER_CLIENT));
+    return new DockerClient(defaultProcessBuilderFactory(DEFAULT_DOCKER_CLIENT));
   }
 
   /**
@@ -51,7 +51,7 @@ public class DockerClient {
    * @return a new {@link DockerClient}
    */
   public static DockerClient newClient(Path dockerExecutable) {
-    return new DockerClient(defaultProcessBuilder(dockerExecutable.toString()));
+    return new DockerClient(defaultProcessBuilderFactory(dockerExecutable.toString()));
   }
 
   /**
@@ -61,7 +61,7 @@ public class DockerClient {
    * @param dockerExecutable path to {@code docker}
    * @return the default {@link ProcessBuilder} factory for running a {@code docker} subcommand
    */
-  private static Function<List<String>, ProcessBuilder> defaultProcessBuilder(
+  private static Function<List<String>, ProcessBuilder> defaultProcessBuilderFactory(
       String dockerExecutable) {
     return dockerSubCommand -> {
       List<String> dockerCommand = new ArrayList<>(1 + dockerSubCommand.size());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -32,23 +33,46 @@ import java.util.function.Function;
 /** Calls out to the {@code docker} CLI. */
 public class DockerClient {
 
+  private static final String DEFAULT_DOCKER_CLIENT = "docker";
+
   /**
-   * @param dockerSubCommand the subcommand to run after {@code docker}
+   * Instantiates with the default {@code docker} executable.
+   *
+   * @return a new {@link DockerClient}
+   */
+  public static DockerClient newClient() {
+    return new DockerClient(defaultProcessBuilder(DEFAULT_DOCKER_CLIENT));
+  }
+
+  /**
+   * Instantiates with a custom {@code docker} executable.
+   *
+   * @param dockerExecutable path to {@code docker}
+   * @return a new {@link DockerClient}
+   */
+  public static DockerClient newClient(Path dockerExecutable) {
+    return new DockerClient(defaultProcessBuilder(dockerExecutable.toString()));
+  }
+
+  /**
+   * Gets a function that takes a {@code docker} subcommand and gives back a {@link ProcessBuilder}
+   * for that {@code docker} command.
+   *
+   * @param dockerExecutable path to {@code docker}
    * @return the default {@link ProcessBuilder} factory for running a {@code docker} subcommand
    */
-  private static ProcessBuilder defaultProcessBuilder(List<String> dockerSubCommand) {
-    List<String> dockerCommand = new ArrayList<>(1 + dockerSubCommand.size());
-    dockerCommand.add("docker");
-    dockerCommand.addAll(dockerSubCommand);
-    return new ProcessBuilder(dockerCommand);
+  private static Function<List<String>, ProcessBuilder> defaultProcessBuilder(
+      String dockerExecutable) {
+    return dockerSubCommand -> {
+      List<String> dockerCommand = new ArrayList<>(1 + dockerSubCommand.size());
+      dockerCommand.add(dockerExecutable);
+      dockerCommand.addAll(dockerSubCommand);
+      return new ProcessBuilder(dockerCommand);
+    };
   }
 
   /** Factory for generating the {@link ProcessBuilder} for running {@code docker} commands. */
   private final Function<List<String>, ProcessBuilder> processBuilderFactory;
-
-  public DockerClient() {
-    this(DockerClient::defaultProcessBuilder);
-  }
 
   @VisibleForTesting
   DockerClient(Function<List<String>, ProcessBuilder> processBuilderFactory) {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -40,6 +40,8 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
 
   private static final String HELPFUL_SUGGESTIONS_PREFIX = "Build to Docker daemon failed";
 
+  private static final DockerClient DOCKER_CLIENT = DockerClient.newClient();
+
   @Nullable private JibExtension jibExtension;
 
   /**
@@ -67,7 +69,7 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
   @TaskAction
   public void buildDocker()
       throws InvalidImageReferenceException, IOException, BuildStepsExecutionException {
-    if (!new DockerClient().isDockerInstalled()) {
+    if (!DOCKER_CLIENT.isDockerInstalled()) {
       throw new GradleException(
           HelpfulSuggestions.forDockerNotInstalled(HELPFUL_SUGGESTIONS_PREFIX));
     }
@@ -113,7 +115,7 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
             .setTargetImageReference(buildConfiguration.getTargetImageConfiguration().getImage())
             .build();
 
-    BuildStepsRunner.forBuildToDockerDaemon(buildConfiguration).build(helpfulSuggestions);
+    BuildStepsRunner.forBuildToDockerDaemon(DOCKER_CLIENT, buildConfiguration).build(helpfulSuggestions);
   }
 
   @Override

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -115,7 +115,8 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
             .setTargetImageReference(buildConfiguration.getTargetImageConfiguration().getImage())
             .build();
 
-    BuildStepsRunner.forBuildToDockerDaemon(DOCKER_CLIENT, buildConfiguration).build(helpfulSuggestions);
+    BuildStepsRunner.forBuildToDockerDaemon(DOCKER_CLIENT, buildConfiguration)
+        .build(helpfulSuggestions);
   }
 
   @Override

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -99,7 +99,8 @@ public class BuildDockerMojo extends JibPluginConfiguration {
               .setTargetImageReference(buildConfiguration.getTargetImageConfiguration().getImage())
               .build();
 
-      BuildStepsRunner.forBuildToDockerDaemon(DOCKER_CLIENT, buildConfiguration).build(helpfulSuggestions);
+      BuildStepsRunner.forBuildToDockerDaemon(DOCKER_CLIENT, buildConfiguration)
+          .build(helpfulSuggestions);
       getLog().info("");
 
     } catch (InvalidImageReferenceException | IOException ex) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -42,6 +42,8 @@ public class BuildDockerMojo extends JibPluginConfiguration {
 
   private static final String HELPFUL_SUGGESTIONS_PREFIX = "Build to Docker daemon failed";
 
+  private static final DockerClient DOCKER_CLIENT = DockerClient.newClient();
+
   @Override
   public void execute() throws MojoExecutionException {
     if (isSkipped()) {
@@ -53,7 +55,7 @@ public class BuildDockerMojo extends JibPluginConfiguration {
       return;
     }
 
-    if (!new DockerClient().isDockerInstalled()) {
+    if (!DOCKER_CLIENT.isDockerInstalled()) {
       throw new MojoExecutionException(
           HelpfulSuggestions.forDockerNotInstalled(HELPFUL_SUGGESTIONS_PREFIX));
     }
@@ -97,7 +99,7 @@ public class BuildDockerMojo extends JibPluginConfiguration {
               .setTargetImageReference(buildConfiguration.getTargetImageConfiguration().getImage())
               .build();
 
-      BuildStepsRunner.forBuildToDockerDaemon(buildConfiguration).build(helpfulSuggestions);
+      BuildStepsRunner.forBuildToDockerDaemon(DOCKER_CLIENT, buildConfiguration).build(helpfulSuggestions);
       getLog().info("");
 
     } catch (InvalidImageReferenceException | IOException ex) {

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
@@ -21,6 +21,7 @@ import com.google.api.client.http.HttpStatusCodes;
 import com.google.cloud.tools.jib.builder.BuildSteps;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.configuration.LayerConfiguration;
+import com.google.cloud.tools.jib.docker.DockerClient;
 import com.google.cloud.tools.jib.event.EventDispatcher;
 import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.image.ImageReference;
@@ -91,12 +92,13 @@ public class BuildStepsRunner {
   /**
    * Creates a runner to build to the Docker daemon. Creates a directory for the cache, if needed.
    *
+   * @param dockerClient the {@link DockerClient} for running {@code docker} commands
    * @param buildConfiguration the configuration parameters for the build
    * @return a {@link BuildStepsRunner} for building to a Docker daemon
    */
-  public static BuildStepsRunner forBuildToDockerDaemon(BuildConfiguration buildConfiguration) {
+  public static BuildStepsRunner forBuildToDockerDaemon(DockerClient dockerClient, BuildConfiguration buildConfiguration) {
     return new BuildStepsRunner(
-        BuildSteps.forBuildToDockerDaemon(buildConfiguration),
+        BuildSteps.forBuildToDockerDaemon(dockerClient, buildConfiguration),
         buildMessageWithTargetImageReferences(
             buildConfiguration, STARTUP_MESSAGE_PREFIX_FOR_DOCKER_DAEMON, "..."),
         buildMessageWithTargetImageReferences(

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
@@ -96,7 +96,8 @@ public class BuildStepsRunner {
    * @param buildConfiguration the configuration parameters for the build
    * @return a {@link BuildStepsRunner} for building to a Docker daemon
    */
-  public static BuildStepsRunner forBuildToDockerDaemon(DockerClient dockerClient, BuildConfiguration buildConfiguration) {
+  public static BuildStepsRunner forBuildToDockerDaemon(
+      DockerClient dockerClient, BuildConfiguration buildConfiguration) {
     return new BuildStepsRunner(
         BuildSteps.forBuildToDockerDaemon(dockerClient, buildConfiguration),
         buildMessageWithTargetImageReferences(


### PR DESCRIPTION
This is useful for `JibContainerBuilder#containerize` #1076 to pass the `Docker` executable path configured on `DockerDaemonImage`.