### PR TITLE
Gradle release v0.9.12

### DIFF
--- a/jib-gradle-plugin/gradle.properties
+++ b/jib-gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.9.12
+version = 0.9.13-SNAPSHOT

--- a/jib-gradle-plugin/gradle.properties
+++ b/jib-gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-version = 0.9.12-SNAPSHOT
+version = 0.9.12


### PR DESCRIPTION
Fixes #1110

This is releasing `v0.9.11` with just the #1061 fix. Note that branch `0.9.12` should NOT be merged into master.