### PR TITLE
 Adds JibContainerBuilder#setUser.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -68,6 +68,7 @@ public class JibContainerBuilder {
   @Nullable private ImmutableList<String> programArguments;
   private ImageFormat imageFormat = ImageFormat.Docker;
   private Instant creationTime = Instant.EPOCH;
+  @Nullable private String user;
 
   /** Instantiate with {@link Jib#from}. */
   JibContainerBuilder(SourceImage baseImage) {
@@ -333,6 +334,28 @@ public class JibContainerBuilder {
   }
 
   /**
+   * Sets the user and group to run the container as. {@code user} can be a username or UID along with an optional groupname or GID.
+   *
+   * The following are valid formats for {@code user}
+   *
+   * <ul>
+   *   <li>{@code user}</li>
+   *   <li>{@code uid}</li>
+   *   <li>{@code user:group}</li>
+   *   <li>{@code uid:gid}</li>
+   *   <li>{@code uid:group}</li>
+   *   <li>{@code user:gid}</li>
+   * </ul>
+   *
+   * @param user the user to run the container as
+   * @return this
+   */
+  public JibContainerBuilder setUser(String user) {
+    this.user = user;
+    return this;
+  }
+
+  /**
    * Builds the container(s).
    *
    * @param containerizer the {@link Containerizer} that configures how to containerize
@@ -400,6 +423,7 @@ public class JibContainerBuilder {
         .setExposedPorts(ports)
         .setLabels(labels)
         .setCreationTime(creationTime)
+        .setUser(user)
         .build();
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -351,7 +351,7 @@ public class JibContainerBuilder {
    * @param user the user to run the container as
    * @return this
    */
-  public JibContainerBuilder setUser(String user) {
+  public JibContainerBuilder setUser(@Nullable String user) {
     this.user = user;
     return this;
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -334,17 +334,18 @@ public class JibContainerBuilder {
   }
 
   /**
-   * Sets the user and group to run the container as. {@code user} can be a username or UID along with an optional groupname or GID.
+   * Sets the user and group to run the container as. {@code user} can be a username or UID along
+   * with an optional groupname or GID.
    *
-   * The following are valid formats for {@code user}
+   * <p>The following are valid formats for {@code user}
    *
    * <ul>
-   *   <li>{@code user}</li>
-   *   <li>{@code uid}</li>
-   *   <li>{@code user:group}</li>
-   *   <li>{@code uid:gid}</li>
-   *   <li>{@code uid:group}</li>
-   *   <li>{@code user:gid}</li>
+   *   <li>{@code user}
+   *   <li>{@code uid}
+   *   <li>{@code user:group}
+   *   <li>{@code uid:gid}
+   *   <li>{@code uid:group}
+   *   <li>{@code user:gid}
    * </ul>
    *
    * @param user the user to run the container as

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
@@ -66,7 +66,8 @@ public class JibContainerBuilderTest {
             .setExposedPorts(Arrays.asList(Port.tcp(1234), Port.udp(5678)))
             .setLabels(ImmutableMap.of("key", "value"))
             .setProgramArguments(Arrays.asList("program", "arguments"))
-            .setCreationTime(Instant.ofEpochMilli(1000));
+            .setCreationTime(Instant.ofEpochMilli(1000))
+            .setUser("user");
 
     ContainerConfiguration containerConfiguration = jibContainerBuilder.toContainerConfiguration();
     Assert.assertEquals(Arrays.asList("entry", "point"), containerConfiguration.getEntrypoint());
@@ -78,6 +79,7 @@ public class JibContainerBuilderTest {
     Assert.assertEquals(
         Arrays.asList("program", "arguments"), containerConfiguration.getProgramArguments());
     Assert.assertEquals(Instant.ofEpochMilli(1000), containerConfiguration.getCreationTime());
+    Assert.assertEquals("user", containerConfiguration.getUser());
   }
 
   @Test

--- a/proposals/jib_core_library.md
+++ b/proposals/jib_core_library.md
@@ -28,6 +28,7 @@ Design for Jib Core as a Java library for building container images.
 - `JibContainerBuilder addLabel(String key, String value)`
 - `JibContainerBuilder setFormat(ImageFormat)`
 - `JibContainerBuilder setCreationTime(Instant creationTime)`
+- `JibContainerBuilder setUser(String user)`
 - `JibContainer containerize(Containerizer)`
 
 Three `TargetImage` types (`RegistryImage`, `DockerDaemonImage`, and `TarImage`) define the 3 different targets Jib can build to.


### PR DESCRIPTION
Brings `JibContainerBuilder` in sync with the new `container.user` configuration.