### PR TITLE
Make Entrypoint parameter nullable

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -163,9 +163,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setEntrypoint(@Nullable List<String> entrypoint) {
-    if (entrypoint != null) {
-      this.entrypoint = ImmutableList.copyOf(entrypoint);
-    }
+    this.entrypoint = entrypoint == null ? null : ImmutableList.copyOf(entrypoint);
     return this;
   }
 
@@ -197,9 +195,8 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setProgramArguments(@Nullable List<String> programArguments) {
-    if (programArguments != null) {
-      this.programArguments = ImmutableList.copyOf(programArguments);
-    }
+    this.programArguments =
+        programArguments == null ? null : ImmutableList.copyOf(programArguments);
     return this;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaDockerContextGenerator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaDockerContextGenerator.java
@@ -131,8 +131,8 @@ public class JavaDockerContextGenerator {
   private final ImmutableList<CopyDirective> copyDirectives;
 
   @Nullable private String baseImage;
-  @Nullable private List<String> entrypoint = Collections.emptyList();
-  @Nullable private List<String> programArguments = Collections.emptyList();
+  @Nullable private List<String> entrypoint;
+  @Nullable private List<String> programArguments;
   @Nullable private String user;
   private Map<String, String> environment = Collections.emptyMap();
   private List<String> exposedPorts = Collections.emptyList();

--- a/jib-core/src/test/resources/webAppSampleDockerfile
+++ b/jib-core/src/test/resources/webAppSampleDockerfile
@@ -7,4 +7,3 @@ COPY classes /
 COPY root /
 
 ENTRYPOINT ["catalina.sh","run"]
-CMD []

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
@@ -36,7 +36,7 @@ public class ContainerParameters {
   private boolean useCurrentTimestamp = false;
   private List<String> jvmFlags = Collections.emptyList();
   private Map<String, String> environment = Collections.emptyMap();
-  private List<String> entrypoint = Collections.emptyList();
+  @Nullable private List<String> entrypoint;
   @Nullable private String mainClass;
   @Nullable private List<String> args;
   private ImageFormat format = ImageFormat.Docker;
@@ -59,6 +59,7 @@ public class ContainerParameters {
   }
 
   @Input
+  @Nullable
   @Optional
   public List<String> getEntrypoint() {
     if (System.getProperty(PropertyNames.CONTAINER_ENTRYPOINT) != null) {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PluginConfigurationProcessor.java
@@ -139,10 +139,9 @@ class PluginConfigurationProcessor {
         Jib.from(baseImage)
             .setLayers(projectProperties.getJavaLayerConfigurations().getLayerConfigurations())
             .setEntrypoint(entrypoint)
+            .setProgramArguments(jibExtension.getContainer().getArgs())
             .setEnvironment(jibExtension.getContainer().getEnvironment())
-            .setProgramArguments(jibExtension.getContainer().getArgs())
             .setExposedPorts(ExposedPortsParser.parse(jibExtension.getContainer().getPorts()))
-            .setProgramArguments(jibExtension.getContainer().getArgs())
             .setLabels(jibExtension.getContainer().getLabels())
             .setUser(jibExtension.getContainer().getUser());
     if (jibExtension.getContainer().getUseCurrentTimestamp()) {
@@ -189,7 +188,7 @@ class PluginConfigurationProcessor {
   static List<String> computeEntrypoint(
       Logger logger, JibExtension jibExtension, GradleProjectProperties projectProperties) {
     ContainerParameters parameters = jibExtension.getContainer();
-    if (!parameters.getEntrypoint().isEmpty()) {
+    if (parameters.getEntrypoint() != null && !parameters.getEntrypoint().isEmpty()) {
       if (parameters.getMainClass() != null || !parameters.getJvmFlags().isEmpty()) {
         logger.warn("mainClass and jvmFlags are ignored when entrypoint is specified");
       }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -120,7 +120,7 @@ abstract class JibPluginConfiguration extends AbstractMojo {
 
     @Parameter private boolean useCurrentTimestamp = false;
 
-    @Parameter private List<String> entrypoint = Collections.emptyList();
+    @Nullable @Parameter private List<String> entrypoint;
 
     @Parameter private List<String> jvmFlags = Collections.emptyList();
 
@@ -292,6 +292,7 @@ abstract class JibPluginConfiguration extends AbstractMojo {
    *
    * @return the configured entrypoint
    */
+  @Nullable
   List<String> getEntrypoint() {
     if (System.getProperty(PropertyNames.CONTAINER_ENTRYPOINT) != null) {
       return ConfigurationPropertyValidator.parseListProperty(

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/PluginConfigurationProcessor.java
@@ -282,12 +282,13 @@ class PluginConfigurationProcessor {
       JibPluginConfiguration jibPluginConfiguration,
       MavenProjectProperties projectProperties)
       throws MojoExecutionException {
-    if (!jibPluginConfiguration.getEntrypoint().isEmpty()) {
+    List<String> entrypointParameter = jibPluginConfiguration.getEntrypoint();
+    if (entrypointParameter != null && !entrypointParameter.isEmpty()) {
       if (jibPluginConfiguration.getMainClass() != null
           || !jibPluginConfiguration.getJvmFlags().isEmpty()) {
         logger.warn("<mainClass> and <jvmFlags> are ignored when <entrypoint> is specified");
       }
-      return jibPluginConfiguration.getEntrypoint();
+      return entrypointParameter;
     }
 
     if (isWarPackaging(jibPluginConfiguration)) {


### PR DESCRIPTION
Fixes #1142. As stated in #1142, this is mostly for consistency with `programArguments` being `@Nullable`.

 This doesn't change the current behavior because `JibContainerBuilder.entrypoint` will be set to a proper value computed by `PluginConfigurationProcessor.computeEntry()`.