### PR TITLE
Fix missing env in maven docker context generator

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaDockerContextGenerator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaDockerContextGenerator.java
@@ -139,7 +139,7 @@ public class JavaDockerContextGenerator {
   @Nullable private String baseImage;
   private List<String> entrypoint = Collections.emptyList();
   private List<String> javaArguments = Collections.emptyList();
-  private Map<String, String> environment = Collections.emptyMap();
+  @Nullable private Map<String, String> environment;
   private List<String> exposedPorts = Collections.emptyList();
   private Map<String, String> labels = Collections.emptyMap();
 
@@ -226,7 +226,7 @@ public class JavaDockerContextGenerator {
    * @param environment map from the environment variable name to value
    * @return this
    */
-  public JavaDockerContextGenerator setEnvironment(Map<String, String> environment) {
+  public JavaDockerContextGenerator setEnvironment(@Nullable Map<String, String> environment) {
     this.environment = environment;
     return this;
   }
@@ -348,7 +348,9 @@ public class JavaDockerContextGenerator {
       dockerfile.append("\nEXPOSE ").append(port);
     }
 
-    dockerfile.append(mapToDockerfileString(environment, "ENV"));
+    if (environment != null) {
+      dockerfile.append(mapToDockerfileString(environment, "ENV"));
+    }
     dockerfile.append(mapToDockerfileString(labels, "LABEL"));
     dockerfile
         .append("\nENTRYPOINT ")

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -3,14 +3,20 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
+## 0.9.13
+
+### Fixed
+
+- Adds environment variable configuration to Docker context generator ([#890 (comment)](https://github.com/GoogleContainerTools/jib/issues/890#issuecomment-430227555))
+
+## 0.9.11
+
 ### Added
 
 - `<skip>` configuration parameter to skip Jib execution in multi-module projects (also settable via `jib.skip` property) ([#865](https://github.com/GoogleContainerTools/jib/issues/865))
 - `<container><environment>` configuration parameter to configure environment variables ([#890](https://github.com/GoogleContainerTools/jib/issues/890))
 - `container.appRoot` configuration parameter to configure app root in the image ([#984](https://github.com/GoogleContainerTools/jib/pull/984))
 - `<to><tags>` (list) defines additional tags to push to ([#1026](https://github.com/GoogleContainerTools/jib/pull/1026))
-
-### Changed
 
 ### Fixed
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/DockerContextMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/DockerContextMojo.java
@@ -94,6 +94,7 @@ public class DockerContextMojo extends JibPluginConfiguration {
           .setEntrypoint(entrypoint)
           .setJavaArguments(getArgs())
           .setExposedPorts(getExposedPorts())
+          .setEnvironment(getEnvironment())
           .setLabels(getLabels())
           .generate(Paths.get(targetDir));
 


### PR DESCRIPTION
Again, changes for Maven 0.9.13 patch (skipping 0.9.12 to stay even with the Gradle plugin). Will close and re-open with the release PR after approval.