### PR TITLE
Adds README for Jib Core.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@
 Jib builds Docker and [OCI](https://github.com/opencontainers/image-spec) images for your Java applications and is available as plugins for [Maven](jib-maven-plugin) and [Gradle](jib-gradle-plugin).
 
 [Maven](https://maven.apache.org/): See documentation for [jib-maven-plugin](jib-maven-plugin).\
-[Gradle](https://gradle.org/): See documentation for [jib-gradle-plugin](jib-gradle-plugin).
-
-*Jib as a container-building library for Java is work-in-progress. [Watch for updates.](https://github.com/GoogleContainerTools/jib/issues/337)*
+[Gradle](https://gradle.org/): See documentation for [jib-gradle-plugin](jib-gradle-plugin).\
+[Jib Core Library](https://search.maven.org/artifact/com.google.cloud.tools/jib-core): See documentation for the [Java library for building containers](jib-core).
 
 For more information, check out the [official blog post](https://cloudplatform.googleblog.com/2018/07/introducing-jib-build-java-docker-images-better.html) or watch [this talk](https://www.youtube.com/watch?v=H6gR_Cv4yWI) ([slides](https://speakerdeck.com/coollog/build-containers-faster-with-jib-a-google-image-build-tool-for-java-applications)).
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@
 
 ## What is Jib?
 
-Jib builds Docker and [OCI](https://github.com/opencontainers/image-spec) images for your Java applications and is available as plugins for [Maven](jib-maven-plugin) and [Gradle](jib-gradle-plugin).
+Jib builds Docker and [OCI](https://github.com/opencontainers/image-spec) images for your Java applications. It is available as plugins for [Maven](jib-maven-plugin) and [Gradle](jib-gradle-plugin) and as a Java library.
 
 [Maven](https://maven.apache.org/): See documentation for [jib-maven-plugin](jib-maven-plugin).\
 [Gradle](https://gradle.org/): See documentation for [jib-gradle-plugin](jib-gradle-plugin).\
-[Jib Core Library](https://search.maven.org/artifact/com.google.cloud.tools/jib-core): See documentation for the [Java library for building containers](jib-core).
+[Jib Core](jib-core): A general-purpose container-building library for Java.
 
 For more information, check out the [official blog post](https://cloudplatform.googleblog.com/2018/07/introducing-jib-build-java-docker-images-better.html) or watch [this talk](https://www.youtube.com/watch?v=H6gR_Cv4yWI) ([slides](https://speakerdeck.com/coollog/build-containers-faster-with-jib-a-google-image-build-tool-for-java-applications)).
 
@@ -37,6 +37,10 @@ See documentation for using [jib-maven-plugin](jib-maven-plugin#quickstart).
 ### Gradle
 
 See documentation for using [jib-gradle-plugin](jib-gradle-plugin#quickstart).
+
+### Jib Core
+
+See documentation for using [Jib Core](jib-core#adding-jib-core-to-your-build)
 
 ## How Jib Works
 

--- a/jib-core/README.md
+++ b/jib-core/README.md
@@ -4,7 +4,7 @@
 
 # Jib Core - Java library for building containers
 
-Jib Core is a Java library for building Docker and [OCI](https://github.com/opencontainers/image-spec) container images. Jib Core implements a general-purpose container builder that can be used to build containers without a Docker daemon, for any purpose. The implementation is pure Java.
+Jib Core is a Java library for building Docker and [OCI](https://github.com/opencontainers/image-spec) container images. It implements a general-purpose container builder that can be used to build containers without a Docker daemon, for any application. The implementation is pure Java.
 
 Jib is also available as plugins for Maven and Gradle. The plugins are specifically for building containers for JVM languages and separate the application into multiple layers to optimize for fast rebuilds.\
 For the Maven plugin, see the [jib-maven-plugin project](../jib-maven-plugin).\

--- a/jib-core/README.md
+++ b/jib-core/README.md
@@ -6,7 +6,9 @@
 
 Jib Core is a Java library for building Docker and [OCI](https://github.com/opencontainers/image-spec) container images. It implements a general-purpose container builder that can be used to build containers without a Docker daemon, for any application. The implementation is pure Java.
 
-Jib is also available as plugins for Maven and Gradle. The plugins are specifically for building containers for JVM languages and separate the application into multiple layers to optimize for fast rebuilds.\
+*The API is currently in alpha and may change substantially.*
+
+Jib Core powers the popular Jib plugins for Maven and Gradle. The plugins build containers specifically for JVM languages and separate the application into multiple layers to optimize for fast rebuilds.\
 For the Maven plugin, see the [jib-maven-plugin project](../jib-maven-plugin).\
 For the Gradle plugin, see the [jib-gradle-plugin project](../jib-gradle-plugin).
 

--- a/jib-core/README.md
+++ b/jib-core/README.md
@@ -4,11 +4,13 @@
 
 # Jib Core - Java library for building containers
 
-Jib Core is a Java library for building Docker and [OCI](https://github.com/opencontainers/image-spec) container images.
+Jib Core is a Java library for building Docker and [OCI](https://github.com/opencontainers/image-spec) container images. Jib Core implements a general-purpose container builder that can be used to build containers without a Docker daemon, for any purpose. The implementation is pure Java.
 
-For information about the Jib project, see the [Jib project README](../README.md).\
+Jib is also available as plugins for Maven and Gradle. The plugins are specifically for building containers for JVM languages and separate the application into multiple layers to optimize for fast rebuilds.\
 For the Maven plugin, see the [jib-maven-plugin project](../jib-maven-plugin).\
 For the Gradle plugin, see the [jib-gradle-plugin project](../jib-gradle-plugin).
+
+For information about the Jib project, see the [Jib project README](../README.md).
 
 ## Upcoming features
 
@@ -42,7 +44,7 @@ dependencies {
 ```java
 Jib.from("busybox")
    .addLayer(Arrays.asList(Paths.get("helloworld.sh")), AbsoluteUnixPath.get("/")) 
-   .setEntrypoint("/bin/sh", "-c", "chmod +x /helloworld.sh && /helloworld.sh")
+   .setEntrypoint("sh", "/helloworld.sh")
    .containerize(
        Containerizer.to(RegistryImage.named("gcr.io/my-project/hello-from-jib")
                                      .addCredential("myusername", "mypassword")));
@@ -50,9 +52,9 @@ Jib.from("busybox")
 
 1. [`Jib.from("busybox")`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Jib.html#from-java.lang.String-) creates a new [`JibContainerBuilder`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/JibContainerBuilder.html) configured with [`busybox`](https://hub.docker.com/_/busybox/) as the base image.
 1. [`.addLayer(...)`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/JibContainerBuilder.html#addLayer-java.util.List-com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath-) configures the `JibContainerBuilder` with a new layer with `helloworld.sh` (local file) to be placed into the container at `/helloworld.sh`.
-1. [`.setEntrypoint("/helloworld.sh")`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/JibContainerBuilder.html#setEntrypoint-java.lang.String...-) sets the entrypoint of the container to `/helloworld.sh`.
+1. [`.setEntrypoint("sh", "/helloworld.sh")`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/JibContainerBuilder.html#setEntrypoint-java.lang.String...-) sets the entrypoint of the container to run `/helloworld.sh`.
 1. [`RegistryImage.named("gcr.io/my-project/hello-from-jib")`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/RegistryImage.html#named-java.lang.String-) creates a new [`RegistryImage`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/RegistryImage.html) configured with `gcr.io/my-project/hello-from-jib` as the target image to push to.
-1. [`.addCredential`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/RegistryImage.html#addCredential-java.lang.String-java.lang.String-) adds the username/password credentials to authenticate the push to `gcr.io/my-project/hello-from-jib`.
+1. [`.addCredential`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/RegistryImage.html#addCredential-java.lang.String-java.lang.String-) adds the username/password credentials to authenticate the push to `gcr.io/my-project/hello-from-jib`. See [`CredentialRetrieverFactory`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactory.html) for common credential retrievers (to retrieve credentials from Docker config or credential helpers, for example). These credential retrievers an be used with [`.addCredentialRetriever`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/RegistryImage.html#addCredentialRetriever-com.google.cloud.tools.jib.configuration.credentials.CredentialRetriever-).
 1. [`Containerizer.to`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html#to-com.google.cloud.tools.jib.api.RegistryImage-) creates a new [`Containerizer`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html) configured to push to the `RegistryImage`.
 1. [`.containerize`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/JibContainerBuilder.html#containerize-com.google.cloud.tools.jib.api.Containerizer-) executes the containerization. If successful, the container image will be available at `gcr.io/my-project/hello-from-jib`.
 
@@ -89,7 +91,7 @@ Other useful classes:
 
 ## How Jib Core works
 
-Jib Core implements a general-purpose container builder. The system consists 3 main parts:
+The Jib Core system consists 3 main parts:
 
 - an execution orchestrator that executes an asynchronous pipeline of containerization steps,
 - an image manipulator capable of handling Docker and OCI image formats, and

--- a/jib-core/README.md
+++ b/jib-core/README.md
@@ -4,13 +4,13 @@
 
 # Jib Core - Java library for building containers
 
-Jib Core is a library for building Docker and [OCI](https://github.com/opencontainers/image-spec) images.
+Jib Core is a Java library for building Docker and [OCI](https://github.com/opencontainers/image-spec) container images. 
 
 For information about the Jib project, see the [Jib project README](../README.md).
 For the Maven plugin, see the [jib-maven-plugin project](../jib-maven-plugin).
 For the Gradle plugin, see the [jib-gradle-plugin project](../jib-gradle-plugin).
 
-## Upcoming Features
+## Upcoming features
 
 See [Milestones](https://github.com/GoogleContainerTools/jib/milestones) for planned features. [Get involved with the community](https://github.com/GoogleContainerTools/jib/tree/master#get-involved-with-the-community) for the latest updates.
 
@@ -22,7 +22,7 @@ Add Jib Core as a dependency using Maven:
 <dependency>
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>jib-core</artifactId>
-  <version>0.1.0-rc1</version>
+  <version>0.1.0</version>
 </dependency>
 ```
 
@@ -30,14 +30,68 @@ Add Jib Core as a dependency using Gradle:
 
 ```groovy
 dependencies {
-  compile 'com.google.cloud.tools:jib-core:0.1.0-rc1'
+  compile 'com.google.cloud.tools:jib-core:0.1.0'
 }
 ```
 
-## Quickstart
+## Simple example
 
 ```java
-
+Jib.from("busybox")
+   .addLayer(Arrays.asList(Paths.get("helloworld.sh")), "/") 
+   .setEntrypoint("/helloworld.sh")
+   .containerize(
+       Containerizer.to(RegistryImage.named("gcr.io/my-project/hello-from-jib")
+                                     .addCredential("myusername", "mypassword")));
 ```
+
+1. [`Jib.from("busybox")`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Jib.html#from-java.lang.String-) creates a new [`JibContainerBuilder`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/JibContainerBuilder.html) configured with [`busybox`](https://hub.docker.com/_/busybox/) as the base image.
+1. [`.addLayer(...)`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/JibContainerBuilder.html#addLayer-java.util.List-com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath-) configures the `JibContainerBuilder` with a new layer with `helloworld.sh` (local file) to be placed into the container at `/helloworld.sh`.
+1. [`.setEntrypoint("/helloworld.sh")`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/JibContainerBuilder.html#setEntrypoint-java.lang.String...-) sets the entrypoint of the container to `/helloworld.sh`.
+1. [`RegistryImage.named("gcr.io/my-project/hello-from-jib")`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/RegistryImage.html#named-java.lang.String-) creates a new [`RegistryImage`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/RegistryImage.html) configured with `gcr.io/my-project/hello-from-jib` as the target image to push to.
+1. [`.addCredential`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/RegistryImage.html#addCredential-java.lang.String-java.lang.String-) adds the username/password credentials to authenticate the push to `gcr.io/my-project/hello-from-jib`.
+1. [`Containerizer.to`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html#to-com.google.cloud.tools.jib.api.RegistryImage-) creates a new [`Containerizer`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html) configured to push to the `RegistryImage`.
+1. `.containerize` executes the containerization. If successful, the container image will be available at `gcr.io/my-project/hello-from-jib`.
+
+## API overview
+
+[`Jib`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Jib.html) - the main entrypoint for using Jib Core
+
+[`JibContainerBuilder`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/JibContainerBuilder.html) - configures the container to build
+
+[`Containerizer`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html) - configures how and where to containerize to
+
+Three `TargetImage` types define the 3 different targets Jib can build to:
+- [`RegistryImage`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/RegistryImage.html) - builds to a container registry
+- [`DockerDaemonImage`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/DockerDaemonImage.html) - builds to a Docker daemon
+- [`TarImage`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/TarImage.html) - saves as a tarball archive
+
+Other useful classes:
+
+- ImageReference
+- LayerConfiguration
+- CredentialRetriever
+- EventHandlers
+- `CredentialRetrieverFactory`
+
+## API reference
+
+[API reference](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/package-summary.html)
+
+## How Jib Core works
+
+TODO
+
+## How Jib Works
+
+See the [Jib project README](/../../#how-jib-works).
+
+## Frequently Asked Questions (FAQ)
+
+See the [Jib project FAQ](../docs/faq.md).
+
+## Community
+
+See the [Jib project README](/../../#community).
 
 [![Analytics](https://cloud-tools-for-java-metrics.appspot.com/UA-121724379-2/jib-core)](https://github.com/igrigorik/ga-beacon)

--- a/jib-core/README.md
+++ b/jib-core/README.md
@@ -1,3 +1,43 @@
-[![Analytics](https://cloud-tools-for-java-metrics.appspot.com/UA-121724379-2/jib-core)](https://github.com/igrigorik/ga-beacon)
+[![experimental](https://img.shields.io/badge/stability-experimental-red.svg)]
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.google.cloud.tools/jib-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.google.cloud.tools/jib-core)
+[![Gitter version](https://img.shields.io/gitter/room/gitterHQ/gitter.svg)](https://gitter.im/google/jib)
 
-Jib core library. NOT intended for use outside of `jib-maven-plugin` or `jib-gradle-plugin` in its current state. We are working on making this into a library for Java.
+# Jib Core - Java library for building containers
+
+Jib Core is a library for building Docker and [OCI](https://github.com/opencontainers/image-spec) images.
+
+For information about the Jib project, see the [Jib project README](../README.md).
+For the Maven plugin, see the [jib-maven-plugin project](../jib-maven-plugin).
+For the Gradle plugin, see the [jib-gradle-plugin project](../jib-gradle-plugin).
+
+## Upcoming Features
+
+See [Milestones](https://github.com/GoogleContainerTools/jib/milestones) for planned features. [Get involved with the community](https://github.com/GoogleContainerTools/jib/tree/master#get-involved-with-the-community) for the latest updates.
+
+## Adding Jib Core to your build
+
+Add Jib Core as a dependency using Maven:
+
+```xml
+<dependency>
+  <groupId>com.google.cloud.tools</groupId>
+  <artifactId>jib-core</artifactId>
+  <version>0.1.0-rc1</version>
+</dependency>
+```
+
+Add Jib Core as a dependency using Gradle:
+
+```groovy
+dependencies {
+  compile 'com.google.cloud.tools:jib-core:0.1.0-rc1'
+}
+```
+
+## Quickstart
+
+```java
+
+```
+
+[![Analytics](https://cloud-tools-for-java-metrics.appspot.com/UA-121724379-2/jib-core)](https://github.com/igrigorik/ga-beacon)

--- a/jib-core/README.md
+++ b/jib-core/README.md
@@ -1,4 +1,4 @@
-[![experimental](https://img.shields.io/badge/stability-experimental-red.svg)]
+![experimental](https://img.shields.io/badge/stability-experimental-red.svg)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.google.cloud.tools/jib-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.google.cloud.tools/jib-core)
 [![Gitter version](https://img.shields.io/gitter/room/gitterHQ/gitter.svg)](https://gitter.im/google/jib)
 
@@ -6,16 +6,16 @@
 
 Jib Core is a Java library for building Docker and [OCI](https://github.com/opencontainers/image-spec) container images.
 
-For information about the Jib project, see the [Jib project README](../README.md).
-For the Maven plugin, see the [jib-maven-plugin project](../jib-maven-plugin).
+For information about the Jib project, see the [Jib project README](../README.md).\
+For the Maven plugin, see the [jib-maven-plugin project](../jib-maven-plugin).\
 For the Gradle plugin, see the [jib-gradle-plugin project](../jib-gradle-plugin).
 
 ## Upcoming features
 
-See [Milestones](https://github.com/GoogleContainerTools/jib/milestones) for planned features. [Get involved with the community](https://github.com/GoogleContainerTools/jib/tree/master#get-involved-with-the-community) for the latest updates.
-
 - extensions to make building Java and other language-specific containers easier
 - structured events to handle react to parts of Jib Core's execution
+
+See [Milestones](https://github.com/GoogleContainerTools/jib/milestones) for planned features. [Get involved with the community](https://github.com/GoogleContainerTools/jib/tree/master#get-involved-with-the-community) for the latest updates.
 
 ## Adding Jib Core to your build
 
@@ -54,7 +54,7 @@ Jib.from("busybox")
 1. [`RegistryImage.named("gcr.io/my-project/hello-from-jib")`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/RegistryImage.html#named-java.lang.String-) creates a new [`RegistryImage`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/RegistryImage.html) configured with `gcr.io/my-project/hello-from-jib` as the target image to push to.
 1. [`.addCredential`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/RegistryImage.html#addCredential-java.lang.String-java.lang.String-) adds the username/password credentials to authenticate the push to `gcr.io/my-project/hello-from-jib`.
 1. [`Containerizer.to`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html#to-com.google.cloud.tools.jib.api.RegistryImage-) creates a new [`Containerizer`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html) configured to push to the `RegistryImage`.
-1. `.containerize` executes the containerization. If successful, the container image will be available at `gcr.io/my-project/hello-from-jib`.
+1. [`.containerize`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/JibContainerBuilder.html#containerize-com.google.cloud.tools.jib.api.Containerizer-) executes the containerization. If successful, the container image will be available at `gcr.io/my-project/hello-from-jib`.
 
 ## Tutorials
 
@@ -98,7 +98,7 @@ Jib Core implements a general-purpose container builder. The system consists 3 m
 Some other parts of Jib Core internals include:
 
 - a caching mechanism to speed up builds (configurable with [`Containerizer.setApplicationLayersCache`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html#setApplicationLayersCache-java.nio.file.Path-) and [`Containerizer.setBaseImageLayersCache`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html#setBaseImageLayersCache-java.nio.file.Path-))
-- an eventing system to react to events from Jib Core during its execution
+- an eventing system to react to events from Jib Core during its execution (add handlers with [`Containerizer.setEventHandlers`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html#setEventHandlers-com.google.cloud.tools.jib.event.EventHandlers-))
 - support for fully-concurrent multi-threaded executions
 
 ## How Jib Works

--- a/jib-core/README.md
+++ b/jib-core/README.md
@@ -4,7 +4,7 @@
 
 # Jib Core - Java library for building containers
 
-Jib Core is a Java library for building Docker and [OCI](https://github.com/opencontainers/image-spec) container images. 
+Jib Core is a Java library for building Docker and [OCI](https://github.com/opencontainers/image-spec) container images.
 
 For information about the Jib project, see the [Jib project README](../README.md).
 For the Maven plugin, see the [jib-maven-plugin project](../jib-maven-plugin).
@@ -13,6 +13,9 @@ For the Gradle plugin, see the [jib-gradle-plugin project](../jib-gradle-plugin)
 ## Upcoming features
 
 See [Milestones](https://github.com/GoogleContainerTools/jib/milestones) for planned features. [Get involved with the community](https://github.com/GoogleContainerTools/jib/tree/master#get-involved-with-the-community) for the latest updates.
+
+- extensions to make building Java and other language-specific containers easier
+- structured events to handle react to parts of Jib Core's execution
 
 ## Adding Jib Core to your build
 
@@ -53,6 +56,10 @@ Jib.from("busybox")
 1. [`Containerizer.to`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html#to-com.google.cloud.tools.jib.api.RegistryImage-) creates a new [`Containerizer`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html) configured to push to the `RegistryImage`.
 1. `.containerize` executes the containerization. If successful, the container image will be available at `gcr.io/my-project/hello-from-jib`.
 
+## Tutorials
+
+*None yet available. We welcome contributions for examples and/or tutorials!*
+
 ## API overview
 
 [`Jib`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Jib.html) - the main entrypoint for using Jib Core
@@ -61,6 +68,8 @@ Jib.from("busybox")
 
 [`Containerizer`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html) - configures how and where to containerize to
 
+[`JibContainer`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/JibContainer.html) - information about the built container
+
 Three `TargetImage` types define the 3 different targets Jib can build to:
 - [`RegistryImage`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/RegistryImage.html) - builds to a container registry
 - [`DockerDaemonImage`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/DockerDaemonImage.html) - builds to a Docker daemon
@@ -68,11 +77,11 @@ Three `TargetImage` types define the 3 different targets Jib can build to:
 
 Other useful classes:
 
-- ImageReference
-- LayerConfiguration
-- CredentialRetriever
-- EventHandlers
-- `CredentialRetrieverFactory`
+- [`ImageReference`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/image/ImageReference.html) - represents an image reference and has useful methods for parsing and manipulating image references
+- [`LayerConfiguration`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/configuration/LayerConfiguration.html) - configures a container layer to build
+- [`CredentialRetriever`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/configuration/credentials/CredentialRetriever.html) - implement with custom methods for retrieving credentials for authenticating against a container registry
+- [`CredentialRetrieverFactory`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactory.html) - provides useful `CredentialRetriever`s to retrieve credentials from Docker config and credential helpers
+- [`EventHandlers`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/event/EventHandlers.html) - attach event handlers to handle events dispatched during the container build execution
 
 ## API reference
 
@@ -80,7 +89,17 @@ Other useful classes:
 
 ## How Jib Core works
 
-TODO
+Jib Core implements a general-purpose container builder. The system consists 3 main parts:
+
+- an execution orchestrator that executes an asynchronous pipeline of containerization steps,
+- an image manipulator capable of handling Docker and OCI image formats, and
+- a registry client that implements the [Docker Registry V2 API](https://docs.docker.com/registry/spec/api/).
+
+Some other parts of Jib Core internals include:
+
+- a caching mechanism to speed up builds (configurable with [`Containerizer.setApplicationLayersCache`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html#setApplicationLayersCache-java.nio.file.Path-) and [`Containerizer.setBaseImageLayersCache`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/api/Containerizer.html#setBaseImageLayersCache-java.nio.file.Path-))
+- an eventing system to react to events from Jib Core during its execution
+- support for fully-concurrent multi-threaded executions
 
 ## How Jib Works
 

--- a/jib-core/README.md
+++ b/jib-core/README.md
@@ -12,8 +12,8 @@ For the Gradle plugin, see the [jib-gradle-plugin project](../jib-gradle-plugin)
 
 ## Upcoming features
 
-- extensions to make building Java and other language-specific containers easier
-- structured events to handle react to parts of Jib Core's execution
+- Extensions to make building Java and other language-specific containers easier
+- Structured events to handle react to parts of Jib Core's execution
 
 See [Milestones](https://github.com/GoogleContainerTools/jib/milestones) for planned features. [Get involved with the community](https://github.com/GoogleContainerTools/jib/tree/master#get-involved-with-the-community) for the latest updates.
 

--- a/jib-core/README.md
+++ b/jib-core/README.md
@@ -13,7 +13,7 @@ For the Gradle plugin, see the [jib-gradle-plugin project](../jib-gradle-plugin)
 ## Upcoming features
 
 - Extensions to make building Java and other language-specific containers easier
-- Structured events to handle react to parts of Jib Core's execution
+- Structured events to react to parts of Jib Core's execution
 
 See [Milestones](https://github.com/GoogleContainerTools/jib/milestones) for planned features. [Get involved with the community](https://github.com/GoogleContainerTools/jib/tree/master#get-involved-with-the-community) for the latest updates.
 
@@ -58,7 +58,7 @@ Jib.from("busybox")
 
 ## Tutorials
 
-*None yet available. We welcome contributions for examples and/or tutorials!*
+*None yet available. We welcome contributions for examples and tutorials!*
 
 ## API overview
 
@@ -79,7 +79,7 @@ Other useful classes:
 
 - [`ImageReference`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/image/ImageReference.html) - represents an image reference and has useful methods for parsing and manipulating image references
 - [`LayerConfiguration`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/configuration/LayerConfiguration.html) - configures a container layer to build
-- [`CredentialRetriever`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/configuration/credentials/CredentialRetriever.html) - implement with custom methods for retrieving credentials for authenticating against a container registry
+- [`CredentialRetriever`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/configuration/credentials/CredentialRetriever.html) - implement with custom credential retrieval methods for authenticating against a container registry
 - [`CredentialRetrieverFactory`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactory.html) - provides useful `CredentialRetriever`s to retrieve credentials from Docker config and credential helpers
 - [`EventHandlers`](http://static.javadoc.io/com.google.cloud.tools/jib-core/0.1.0/com/google/cloud/tools/jib/event/EventHandlers.html) - attach event handlers to handle events dispatched during the container build execution
 

--- a/jib-core/README.md
+++ b/jib-core/README.md
@@ -41,8 +41,8 @@ dependencies {
 
 ```java
 Jib.from("busybox")
-   .addLayer(Arrays.asList(Paths.get("helloworld.sh")), "/") 
-   .setEntrypoint("/helloworld.sh")
+   .addLayer(Arrays.asList(Paths.get("helloworld.sh")), AbsoluteUnixPath.get("/")) 
+   .setEntrypoint("/bin/sh", "-c", "chmod +x /helloworld.sh && /helloworld.sh")
    .containerize(
        Containerizer.to(RegistryImage.named("gcr.io/my-project/hello-from-jib")
                                      .addCredential("myusername", "mypassword")));


### PR DESCRIPTION
Preview at: https://github.com/GoogleContainerTools/jib/tree/jib-core-readme/jib-core

This provides initial documentation for Jib Core.