### PR TITLE
Add FilePermissions class

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/FilePermissions.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/FilePermissions.java
@@ -22,14 +22,17 @@ import com.google.common.collect.ImmutableMap;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
 
-/** Represents read/write/execute file permissions. */
+/** Represents read/write/execute file permissions for owner, group, and others. */
 public class FilePermissions {
 
-  /** Matches an octal string representation of file permissions. */
-  private static final String octalPattern = "[0-7][0-7][0-7]";
+  /**
+   * Matches an octal string representation of file permissions. From left to right, each digit
+   * represents permissions for owner, group, and other.
+   */
+  private static final String OCTAL_PATTERN = "[0-7][0-7][0-7]";
 
   /** Maps from a {@link PosixFilePermission} to its corresponding file permission bit. */
-  private static final ImmutableMap<PosixFilePermission, Integer> permissionMap =
+  private static final ImmutableMap<PosixFilePermission, Integer> PERMISSION_MAP =
       ImmutableMap.<PosixFilePermission, Integer>builder()
           .put(PosixFilePermission.OWNER_READ, 0400)
           .put(PosixFilePermission.OWNER_WRITE, 0200)
@@ -51,7 +54,7 @@ public class FilePermissions {
    */
   public static FilePermissions fromOctalString(String octalPermissions) {
     Preconditions.checkArgument(
-        octalPermissions.matches(octalPattern),
+        octalPermissions.matches(OCTAL_PATTERN),
         "octalPermissions must be a 3-digit octal number (000-777)");
     return new FilePermissions(Integer.parseInt(octalPermissions, 8));
   }
@@ -66,7 +69,7 @@ public class FilePermissions {
       Set<PosixFilePermission> posixFilePermissions) {
     int permissionBits = 0;
     for (PosixFilePermission permission : posixFilePermissions) {
-      permissionBits |= permissionMap.get(permission);
+      permissionBits |= PERMISSION_MAP.get(permission);
     }
     return new FilePermissions(permissionBits);
   }
@@ -101,6 +104,6 @@ public class FilePermissions {
 
   @Override
   public int hashCode() {
-    return Integer.hashCode(permissionBits);
+    return permissionBits;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/FilePermissions.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/FilePermissions.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.configuration;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
+
+/** Represents read/write/execute file permissions. */
+public class FilePermissions {
+
+  /** Matches an octal string representation of file permissions. */
+  private static final String octalPattern = "[0-7][0-7][0-7]";
+
+  /** Maps from a {@link PosixFilePermission} to its corresponding file permission bit. */
+  private static final ImmutableMap<PosixFilePermission, Integer> permissionMap =
+      ImmutableMap.<PosixFilePermission, Integer>builder()
+          .put(PosixFilePermission.OWNER_READ, 0400)
+          .put(PosixFilePermission.OWNER_WRITE, 0200)
+          .put(PosixFilePermission.OWNER_EXECUTE, 0100)
+          .put(PosixFilePermission.GROUP_READ, 040)
+          .put(PosixFilePermission.GROUP_WRITE, 020)
+          .put(PosixFilePermission.GROUP_EXECUTE, 010)
+          .put(PosixFilePermission.OTHERS_READ, 04)
+          .put(PosixFilePermission.OTHERS_WRITE, 02)
+          .put(PosixFilePermission.OTHERS_EXECUTE, 01)
+          .build();
+
+  /**
+   * Creates a new {@link FilePermissions} from an octal string representation (e.g. "123", "644",
+   * "755", etc).
+   *
+   * @param octalPermissions the octal string representation of the permissions
+   * @return a new {@link FilePermissions} with the given permissions
+   */
+  public static FilePermissions fromOctalString(String octalPermissions) {
+    Preconditions.checkArgument(
+        octalPermissions.matches(octalPattern),
+        "octalPermissions must be a 3-digit octal number (000-777)");
+    return new FilePermissions(Integer.parseInt(octalPermissions, 8));
+  }
+
+  /**
+   * Creates a new {@link FilePermissions} from a set of {@link PosixFilePermission}.
+   *
+   * @param posixFilePermissions the set of {@link PosixFilePermission}
+   * @return a new {@link FilePermissions} with the given permissions
+   */
+  public static FilePermissions fromPosixFilePermissions(
+      Set<PosixFilePermission> posixFilePermissions) {
+    int permissionBits = 0;
+    for (PosixFilePermission permission : posixFilePermissions) {
+      permissionBits |= permissionMap.get(permission);
+    }
+    return new FilePermissions(permissionBits);
+  }
+
+  private final int permissionBits;
+
+  @VisibleForTesting
+  FilePermissions(int permissionBits) {
+    this.permissionBits = permissionBits;
+  }
+
+  /**
+   * Takes an integer mode, sets its lowest 9 bits to the corresponding permissions on the {@link
+   * FilePermissions}, and returns the result.
+   *
+   * @param mode the original mode
+   * @return the mode with the permission bits set
+   */
+  public int applyToFileMode(int mode) {
+    return (mode & ~0777) | permissionBits;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof FilePermissions)) {
+      return false;
+    }
+    FilePermissions otherFilePermissions = (FilePermissions) other;
+    return permissionBits == otherFilePermissions.permissionBits;
+  }
+
+  @Override
+  public int hashCode() {
+    return Integer.hashCode(permissionBits);
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/FilePermissions.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/FilePermissions.java
@@ -79,14 +79,12 @@ public class FilePermissions {
   }
 
   /**
-   * Takes an integer mode, sets its lowest 9 bits to the corresponding permissions on the {@link
-   * FilePermissions}, and returns the result.
+   * Gets the corresponding permissions bits specified by the {@link FilePermissions}
    *
-   * @param mode the original mode
-   * @return the mode with the permission bits set
+   * @return the permission bits
    */
-  public int applyToFileMode(int mode) {
-    return (mode & ~0777) | permissionBits;
+  public int getPermissionBits() {
+    return permissionBits;
   }
 
   @Override

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/FilePermissionsTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/FilePermissionsTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.configuration;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.nio.file.attribute.PosixFilePermission;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for {@link FilePermissions}. */
+public class FilePermissionsTest {
+
+  @Test
+  public void testFromOctalString() {
+    Assert.assertEquals(new FilePermissions(0777), FilePermissions.fromOctalString("777"));
+    Assert.assertEquals(new FilePermissions(0000), FilePermissions.fromOctalString("000"));
+    Assert.assertEquals(new FilePermissions(0123), FilePermissions.fromOctalString("123"));
+    Assert.assertEquals(new FilePermissions(0755), FilePermissions.fromOctalString("755"));
+    Assert.assertEquals(new FilePermissions(0644), FilePermissions.fromOctalString("644"));
+
+    ImmutableList<String> badStrings = ImmutableList.of("abc", "-123", "777444333", "987", "3");
+    for (String badString : badStrings) {
+      try {
+        FilePermissions.fromOctalString(badString);
+        Assert.fail();
+      } catch (IllegalArgumentException ex) {
+        Assert.assertEquals(
+            "octalPermissions must be a 3-digit octal number (000-777)", ex.getMessage());
+      }
+    }
+  }
+
+  @Test
+  public void testFromPosixFilePermissions() {
+    Assert.assertEquals(
+        new FilePermissions(0000), FilePermissions.fromPosixFilePermissions(ImmutableSet.of()));
+    Assert.assertEquals(
+        new FilePermissions(0110),
+        FilePermissions.fromPosixFilePermissions(
+            ImmutableSet.of(PosixFilePermission.OWNER_EXECUTE, PosixFilePermission.GROUP_EXECUTE)));
+    Assert.assertEquals(
+        new FilePermissions(0202),
+        FilePermissions.fromPosixFilePermissions(
+            ImmutableSet.of(PosixFilePermission.OWNER_WRITE, PosixFilePermission.OTHERS_WRITE)));
+    Assert.assertEquals(
+        new FilePermissions(0044),
+        FilePermissions.fromPosixFilePermissions(
+            ImmutableSet.of(PosixFilePermission.GROUP_READ, PosixFilePermission.OTHERS_READ)));
+    Assert.assertEquals(
+        new FilePermissions(0777),
+        FilePermissions.fromPosixFilePermissions(
+            ImmutableSet.copyOf(PosixFilePermission.values())));
+  }
+
+  @Test
+  public void testApplyToFileMode() {
+    Assert.assertEquals(040123, new FilePermissions(0123).applyToFileMode(040765));
+    Assert.assertEquals(0100456, new FilePermissions(0456).applyToFileMode(0100020));
+    Assert.assertEquals(01234777, new FilePermissions(0777).applyToFileMode(01234000));
+    Assert.assertEquals(0555, new FilePermissions(0555).applyToFileMode(0));
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/FilePermissionsTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/FilePermissionsTest.java
@@ -66,12 +66,4 @@ public class FilePermissionsTest {
         FilePermissions.fromPosixFilePermissions(
             ImmutableSet.copyOf(PosixFilePermission.values())));
   }
-
-  @Test
-  public void testApplyToFileMode() {
-    Assert.assertEquals(040123, new FilePermissions(0123).applyToFileMode(040765));
-    Assert.assertEquals(0100456, new FilePermissions(0456).applyToFileMode(0100020));
-    Assert.assertEquals(01234777, new FilePermissions(0777).applyToFileMode(01234000));
-    Assert.assertEquals(0555, new FilePermissions(0555).applyToFileMode(0));
-  }
 }


### PR DESCRIPTION
Fixes #1165 

Adds a `FilePermissions` class that can be instantiated from either an octal string or a set of `PosixFilePermissions`. Also has a getter for the file permission bits.