### PR TITLE
Update gradle extraDirectory config parameter to include path and permissions field

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,16 +9,16 @@ All notable changes to this project will be documented in this file.
 - `jib.to.credHelper` and `jib.from.credHelper` can be used to specify a credential helper suffix or a full path to a credential helper executable ([#925](https://github.com/GoogleContainerTools/jib/issues/925))
 - `container.user` configuration parameter to configure the user and group to run the container as ([#1029](https://github.com/GoogleContainerTools/jib/issues/1029))
 - Preliminary support for building images for WAR projects ([#431](https://github.com/GoogleContainerTools/jib/issues/431))
-
+- `jib.extraDirectory` closure with a `path` and `permissions` field ([#794](https://github.com/GoogleContainerTools/jib/issues/794))
+  - `jib.extraDirectory.path` configures the extra layer directory (still also configurable via `jib.extraDirectory = file(...)`)
+  - `jib.extraDirectory.permissions` is a map from absolute path on container to the file's permission bits (represented as an octal string)
+  
 ### Changed
 
 - Removed deprecated `jib.jvmFlags`, `jib.mainClass`, `jib.args`, and `jib.format` in favor of the equivalents under `jib.container` ([#461](https://github.com/GoogleContainerTools/jib/issues/461))
 - `jibExportDockerContext` generates different directory layout and `Dockerfile` to enable WAR support ([#1007](https://github.com/GoogleContainerTools/jib/pull/1007))
 - File timestamps in the built image are set to 1 second since the epoch (hence 1970-01-01T00:00:01Z) to resolve compatibility with applications on Java 6 or below where the epoch means nonexistent or I/O errors; previously they were set to the epoch ([#1079](https://github.com/GoogleContainerTools/jib/issues/1079))
 - Sets tag to "latest" instead of "unspecified" if `jib.to.image` and project version are both unspecified when running `jibDockerBuild` or `jibBuildTar` ([#1096](https://github.com/GoogleContainerTools/jib/issues/1096))
-- `jib.extraDirectory` parameter is now a configuration object with a `path` and a `permissions` field ([#794](https://github.com/GoogleContainerTools/jib/issues/794))
-  - `jib.extraDirectory.path` is used in place of the original `jib.extraDirectory` and allows you to configure the extra layer directory
-  - `jib.extraDirectory.permissions` is a map from absolute path on container to the file's permission bits (represented as an octal string)
 
 ### Fixed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -16,6 +16,9 @@ All notable changes to this project will be documented in this file.
 - `jibExportDockerContext` generates different directory layout and `Dockerfile` to enable WAR support ([#1007](https://github.com/GoogleContainerTools/jib/pull/1007))
 - File timestamps in the built image are set to 1 second since the epoch (hence 1970-01-01T00:00:01Z) to resolve compatibility with applications on Java 6 or below where the epoch means nonexistent or I/O errors; previously they were set to the epoch ([#1079](https://github.com/GoogleContainerTools/jib/issues/1079))
 - Sets tag to "latest" instead of "unspecified" if `jib.to.image` and project version are both unspecified when running `jibDockerBuild` or `jibBuildTar` ([#1096](https://github.com/GoogleContainerTools/jib/issues/1096))
+- `jib.extraDirectory` parameter is now a configuration object with a `path` and a `permissions` field ([#794](https://github.com/GoogleContainerTools/jib/issues/794))
+  - `jib.extraDirectory.path` is used in place of the original `jib.extraDirectory` and allows you to configure the extra layer directory
+  - `jib.extraDirectory.permissions` is a map from absolute path on container to the file's permission bits (represented as an octal string)
 
 ### Fixed
 

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -142,7 +142,7 @@ public class SingleProjectIntegrationTest {
 
     Instant beforeBuild = Instant.now();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n",
+        "Hello, world. An argument.\nrw-r--r--\nrw-r--r--\nfoo\ncat\n",
         JibRunHelper.buildAndRun(simpleTestProject, targetImage));
     assertDockerInspect(targetImage);
     assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);
@@ -153,7 +153,7 @@ public class SingleProjectIntegrationTest {
     String targetImage = "localhost:6000/compleximage:gradle" + System.nanoTime();
     Instant beforeBuild = Instant.now();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nenvvalue1\nenvvalue2\n",
+        "Hello, world. An argument.\nrwxr-xr-x\nrwxrwxrwx\nfoo\ncat\n-Xms512m\n-Xdebug\nenvvalue1\nenvvalue2\n",
         buildAndRunComplex(targetImage, "testuser2", "testpassword2", localRegistry2));
     assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);
   }
@@ -163,7 +163,7 @@ public class SingleProjectIntegrationTest {
     String targetImage = "localhost:5000/compleximage:gradle" + System.nanoTime();
     Instant beforeBuild = Instant.now();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n-Xms512m\n-Xdebug\nenvvalue1\nenvvalue2\n",
+        "Hello, world. An argument.\nrwxr-xr-x\nrwxrwxrwx\nfoo\ncat\n-Xms512m\n-Xdebug\nenvvalue1\nenvvalue2\n",
         buildAndRunComplex(targetImage, "testuser", "testpassword", localRegistry1));
     assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);
   }
@@ -173,7 +173,7 @@ public class SingleProjectIntegrationTest {
     String targetImage = "simpleimage:gradle" + System.nanoTime();
     Instant beforeBuild = Instant.now();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n",
+        "Hello, world. An argument.\nrw-r--r--\nrw-r--r--\nfoo\ncat\n",
         JibRunHelper.buildToDockerDaemonAndRun(simpleTestProject, targetImage));
     assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);
     assertDockerInspect(targetImage);
@@ -201,7 +201,7 @@ public class SingleProjectIntegrationTest {
 
     assertDockerInspect(imageName);
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n",
+        "Hello, world. An argument.\nrw-r--r--\nrw-r--r--\nfoo\ncat\n",
         new Command("docker", "run", "--rm", imageName).run());
 
     // Checks that generating the Docker context again is skipped.
@@ -249,7 +249,7 @@ public class SingleProjectIntegrationTest {
 
     new Command("docker", "load", "--input", outputPath).run();
     Assert.assertEquals(
-        "Hello, world. An argument.\nfoo\ncat\n",
+        "Hello, world. An argument.\nrw-r--r--\nrw-r--r--\nfoo\ncat\n",
         new Command("docker", "run", "--rm", targetImage).run());
     assertDockerInspect(targetImage);
     assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);

--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/build.gradle
@@ -25,7 +25,9 @@ jib {
     ports = ['1000/tcp', '2000-2003/udp']
     labels = [key1:'value1', key2:'value2']
   }
-  extraDirectory = file('src/main/custom-extra-dir')
+  extraDirectory {
+    path = file('src/main/custom-extra-dir')
+  }
 
   // Does not have tests use user-level cache for base image layers.
   useOnlyProjectCache = true

--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/build.gradle
@@ -25,9 +25,7 @@ jib {
     ports = ['1000/tcp', '2000-2003/udp']
     labels = [key1:'value1', key2:'value2']
   }
-  extraDirectory {
-    path = file('src/main/custom-extra-dir')
-  }
+  extraDirectory = file('src/main/custom-extra-dir')
 
   // Does not have tests use user-level cache for base image layers.
   useOnlyProjectCache = true

--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/complex-build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/complex-build.gradle
@@ -38,8 +38,11 @@ jib {
     ports = ['1000/tcp', '2000-2003/udp']
     labels = [key1:'value1', key2:'value2']
   }
+  extraDirectory {
+    path = file('src/main/custom-extra-dir')
+    permissions = ['/foo':'755', '/bar/cat':'777']
+  }
   allowInsecureRegistries = true
-  extraDirectory = file('src/main/custom-extra-dir')
 
   // Does not have tests use user-level cache for base image layers.
   useOnlyProjectCache = true

--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/src/main/java/com/test/HelloWorld.java
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/src/main/java/com/test/HelloWorld.java
@@ -24,6 +24,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermissions;
 
 /** Example class that uses a dependency and a resource file. */
 public class HelloWorld {
@@ -41,6 +42,10 @@ public class HelloWorld {
 
     // Prints the contents of the extra files.
     if (Files.exists(Paths.get("/foo"))) {
+      System.out.println(
+          PosixFilePermissions.toString(Files.getPosixFilePermissions(Paths.get("/foo"))));
+      System.out.println(
+          PosixFilePermissions.toString(Files.getPosixFilePermissions(Paths.get("/bar/cat"))));
       System.out.println(new String(Files.readAllBytes(Paths.get("/foo")), StandardCharsets.UTF_8));
       System.out.println(
           new String(Files.readAllBytes(Paths.get("/bar/cat")), StandardCharsets.UTF_8));

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -84,7 +84,11 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
     AbsoluteUnixPath appRoot = PluginConfigurationProcessor.getAppRootChecked(jibExtension);
     GradleProjectProperties gradleProjectProperties =
         GradleProjectProperties.getForProject(
-            getProject(), getLogger(), jibExtension.getExtraDirectoryPath(), appRoot);
+            getProject(),
+            getLogger(),
+            jibExtension.getExtraDirectory().getPath(),
+            jibExtension.getExtraDirectory().getPermissions(),
+            appRoot);
 
     GradleHelpfulSuggestionsBuilder gradleHelpfulSuggestionsBuilder =
         new GradleHelpfulSuggestionsBuilder(HELPFUL_SUGGESTIONS_PREFIX, jibExtension);

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -82,7 +82,11 @@ public class BuildImageTask extends DefaultTask implements JibTask {
     AbsoluteUnixPath appRoot = PluginConfigurationProcessor.getAppRootChecked(jibExtension);
     GradleProjectProperties gradleProjectProperties =
         GradleProjectProperties.getForProject(
-            getProject(), getLogger(), jibExtension.getExtraDirectoryPath(), appRoot);
+            getProject(),
+            getLogger(),
+            jibExtension.getExtraDirectory().getPath(),
+            jibExtension.getExtraDirectory().getPermissions(),
+            appRoot);
 
     if (Strings.isNullOrEmpty(jibExtension.getTo().getImage())) {
       throw new GradleException(

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -78,7 +78,8 @@ public class BuildTarTask extends DefaultTask implements JibTask {
   @InputFiles
   public FileCollection getInputFiles() {
     return GradleProjectProperties.getInputFiles(
-        Preconditions.checkNotNull(jibExtension).getExtraDirectoryPath().toFile(), getProject());
+        Preconditions.checkNotNull(jibExtension).getExtraDirectory().getPath().toFile(),
+        getProject());
   }
 
   /**
@@ -109,7 +110,11 @@ public class BuildTarTask extends DefaultTask implements JibTask {
     AbsoluteUnixPath appRoot = PluginConfigurationProcessor.getAppRootChecked(jibExtension);
     GradleProjectProperties gradleProjectProperties =
         GradleProjectProperties.getForProject(
-            getProject(), getLogger(), jibExtension.getExtraDirectoryPath(), appRoot);
+            getProject(),
+            getLogger(),
+            jibExtension.getExtraDirectory().getPath(),
+            jibExtension.getExtraDirectory().getPermissions(),
+            appRoot);
 
     GradleHelpfulSuggestionsBuilder gradleHelpfulSuggestionsBuilder =
         new GradleHelpfulSuggestionsBuilder(HELPFUL_SUGGESTIONS_PREFIX, jibExtension);

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerContextTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerContextTask.java
@@ -61,7 +61,8 @@ public class DockerContextTask extends DefaultTask implements JibTask {
   @InputFiles
   public FileCollection getInputFiles() {
     return GradleProjectProperties.getInputFiles(
-        Preconditions.checkNotNull(jibExtension).getExtraDirectoryPath().toFile(), getProject());
+        Preconditions.checkNotNull(jibExtension).getExtraDirectory().getPath().toFile(),
+        getProject());
   }
 
   /**
@@ -110,7 +111,11 @@ public class DockerContextTask extends DefaultTask implements JibTask {
     AbsoluteUnixPath appRoot = PluginConfigurationProcessor.getAppRootChecked(jibExtension);
     GradleProjectProperties gradleProjectProperties =
         GradleProjectProperties.getForProject(
-            getProject(), getLogger(), jibExtension.getExtraDirectoryPath(), appRoot);
+            getProject(),
+            getLogger(),
+            jibExtension.getExtraDirectory().getPath(),
+            jibExtension.getExtraDirectory().getPermissions(),
+            appRoot);
     String targetDir = getTargetDir();
 
     List<String> entrypoint =

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParameters.java
@@ -30,12 +30,12 @@ import org.gradle.api.tasks.Internal;
 /** Object in {@link JibExtension} that configures the extra directory. */
 public class ExtraDirectoryParameters {
 
-  private Path path;
-  private Map<String, String> permissions = Collections.emptyMap();
-
   private static Path resolveDefaultExtraDirectory(Path projectDirectory) {
     return projectDirectory.resolve("src").resolve("main").resolve("jib");
   }
+
+  private Path path;
+  private Map<String, String> permissions = Collections.emptyMap();
 
   @Inject
   public ExtraDirectoryParameters(Path projectDirectory) {
@@ -66,6 +66,13 @@ public class ExtraDirectoryParameters {
     this.path = path.toPath();
   }
 
+  /**
+   * Gets the permissions for files in the extra layer on the container. Maps from absolute path on
+   * the container to a 3-digit octal string representation of the file permission bits (e.g. {@code
+   * "/path/on/container" -> "755"}).
+   *
+   * @return the permissions map from path on container to file permissions
+   */
   @Input
   public Map<String, String> getPermissions() {
     if (System.getProperty(PropertyNames.EXTRA_DIRECTORY_PERMISSIONS) != null) {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParameters.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.gradle;
+
+import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
+import com.google.cloud.tools.jib.plugins.common.PropertyNames;
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Map;
+import javax.inject.Inject;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+
+/** Object in {@link JibExtension} that configures the extra directory. */
+public class ExtraDirectoryParameters {
+
+  private Path path;
+  private Map<String, String> permissions = Collections.emptyMap();
+
+  private static Path resolveDefaultExtraDirectory(Path projectDirectory) {
+    return projectDirectory.resolve("src").resolve("main").resolve("jib");
+  }
+
+  @Inject
+  public ExtraDirectoryParameters(Path projectDirectory) {
+    path = resolveDefaultExtraDirectory(projectDirectory);
+  }
+
+  @Input
+  public String getPathString() {
+    // Gradle warns about @Input annotations on File objects, so we have to expose a getter for a
+    // String to make them go away.
+    if (System.getProperty(PropertyNames.EXTRA_DIRECTORY_PATH) != null) {
+      return System.getProperty(PropertyNames.EXTRA_DIRECTORY_PATH);
+    }
+    return path.toString();
+  }
+
+  @Internal
+  public Path getPath() {
+    // Gradle warns about @Input annotations on File objects, so we have to expose a getter for a
+    // String to make them go away.
+    if (System.getProperty(PropertyNames.EXTRA_DIRECTORY_PATH) != null) {
+      return Paths.get(System.getProperty(PropertyNames.EXTRA_DIRECTORY_PATH));
+    }
+    return path;
+  }
+
+  public void setPath(File path) {
+    this.path = path.toPath();
+  }
+
+  @Input
+  public Map<String, String> getPermissions() {
+    if (System.getProperty(PropertyNames.EXTRA_DIRECTORY_PERMISSIONS) != null) {
+      return ConfigurationPropertyValidator.parseMapProperty(
+          System.getProperty(PropertyNames.EXTRA_DIRECTORY_PERMISSIONS));
+    }
+    return permissions;
+  }
+
+  public void setPermissions(Map<String, String> permissions) {
+    this.permissions = permissions;
+  }
+}

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTask.java
@@ -149,8 +149,8 @@ public class FilesTask extends DefaultTask {
     printProjectFiles(project);
 
     // Print extra layer
-    if (Files.exists(jibExtension.getExtraDirectoryPath())) {
-      System.out.println(jibExtension.getExtraDirectoryPath());
+    if (Files.exists(jibExtension.getExtraDirectory().getPath())) {
+      System.out.println(jibExtension.getExtraDirectory().getPath());
     }
 
     // Find project dependencies

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurations.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurations.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.gradle;
 
+import com.google.cloud.tools.jib.configuration.FilePermissions;
 import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
 import com.google.cloud.tools.jib.frontend.JavaLayerConfigurations;
@@ -26,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
@@ -49,13 +51,17 @@ class GradleLayerConfigurations {
    * @throws IOException if an I/O exception occurred during resolution
    */
   static JavaLayerConfigurations getForProject(
-      Project project, Logger logger, Path extraDirectory, AbsoluteUnixPath appRoot)
+      Project project,
+      Logger logger,
+      Path extraDirectory,
+      Map<AbsoluteUnixPath, FilePermissions> permissions,
+      AbsoluteUnixPath appRoot)
       throws IOException {
     if (GradleProjectProperties.getWarTask(project) != null) {
       logger.info("WAR project identified, creating WAR image: " + project.getDisplayName());
-      return getForWarProject(project, logger, extraDirectory, appRoot);
+      return getForWarProject(project, extraDirectory, permissions, appRoot);
     } else {
-      return getForNonWarProject(project, logger, extraDirectory, appRoot);
+      return getForNonWarProject(project, logger, extraDirectory, permissions, appRoot);
     }
   }
 
@@ -70,7 +76,11 @@ class GradleLayerConfigurations {
    * @throws IOException if an I/O exception occurred during resolution
    */
   private static JavaLayerConfigurations getForNonWarProject(
-      Project project, Logger logger, Path extraDirectory, AbsoluteUnixPath appRoot)
+      Project project,
+      Logger logger,
+      Path extraDirectory,
+      Map<AbsoluteUnixPath, FilePermissions> permissions,
+      AbsoluteUnixPath appRoot)
       throws IOException {
     AbsoluteUnixPath dependenciesExtractionPath =
         appRoot.resolve(JavaEntrypointConstructor.DEFAULT_RELATIVE_DEPENDENCIES_PATH_ON_IMAGE);
@@ -127,7 +137,11 @@ class GradleLayerConfigurations {
     // Adds all the extra files.
     if (Files.exists(extraDirectory)) {
       layerBuilder.addDirectoryContents(
-          LayerType.EXTRA_FILES, extraDirectory, path -> true, AbsoluteUnixPath.get("/"));
+          LayerType.EXTRA_FILES,
+          extraDirectory,
+          path -> true,
+          AbsoluteUnixPath.get("/"),
+          permissions);
     }
 
     return layerBuilder.build();
@@ -137,17 +151,21 @@ class GradleLayerConfigurations {
    * Resolves the {@link JavaLayerConfigurations} for a WAR Gradle {@link Project}.
    *
    * @param project the Gradle {@link Project}
-   * @param logger the build logger for providing feedback about the resolution
    * @param extraDirectory path to the source directory for the extra files layer
+   * @param permissions map from path on container to file permissions
    * @param appRoot root directory in the image where the app will be placed
    * @return {@link JavaLayerConfigurations} for the layers for the Gradle {@link Project}
    * @throws IOException if an I/O exception occurred during resolution
    */
   private static JavaLayerConfigurations getForWarProject(
-      Project project, Logger logger, Path extraDirectory, AbsoluteUnixPath appRoot)
+      Project project,
+      Path extraDirectory,
+      Map<AbsoluteUnixPath, FilePermissions> permissions,
+      AbsoluteUnixPath appRoot)
       throws IOException {
     Path explodedWarPath = GradleProjectProperties.getExplodedWarDirectory(project);
-    return JavaLayerConfigurationsHelper.fromExplodedWar(explodedWarPath, appRoot, extraDirectory);
+    return JavaLayerConfigurationsHelper.fromExplodedWar(
+        explodedWarPath, appRoot, extraDirectory, permissions);
   }
 
   private GradleLayerConfigurations() {}

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurations.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurations.java
@@ -46,6 +46,7 @@ class GradleLayerConfigurations {
    * @param project the Gradle {@link Project}
    * @param logger the logger for providing feedback about the resolution
    * @param extraDirectory path to the source directory for the extra files layer
+   * @param permissions map from path on container to file permissions for extra-layer files
    * @param appRoot root directory in the image where the app will be placed
    * @return {@link JavaLayerConfigurations} for the layers for the Gradle {@link Project}
    * @throws IOException if an I/O exception occurred during resolution
@@ -71,6 +72,7 @@ class GradleLayerConfigurations {
    * @param project the Gradle {@link Project}
    * @param logger the logger for providing feedback about the resolution
    * @param extraDirectory path to the source directory for the extra files layer
+   * @param permissions map from path on container to file permissions for extra-layer files
    * @param appRoot root directory in the image where the app will be placed
    * @return {@link JavaLayerConfigurations} for the layers for the Gradle {@link Project}
    * @throws IOException if an I/O exception occurred during resolution
@@ -152,7 +154,7 @@ class GradleLayerConfigurations {
    *
    * @param project the Gradle {@link Project}
    * @param extraDirectory path to the source directory for the extra files layer
-   * @param permissions map from path on container to file permissions
+   * @param permissions map from path on container to file permissions for extra-layer files
    * @param appRoot root directory in the image where the app will be placed
    * @return {@link JavaLayerConfigurations} for the layers for the Gradle {@link Project}
    * @throws IOException if an I/O exception occurred during resolution

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.event.JibEventType;
 import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.frontend.JavaLayerConfigurations;
+import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.MainClassResolver;
 import com.google.cloud.tools.jib.plugins.common.ProjectProperties;
@@ -32,6 +33,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.gradle.api.GradleException;
@@ -57,12 +59,21 @@ class GradleProjectProperties implements ProjectProperties {
 
   /** @return a GradleProjectProperties from the given project and logger. */
   static GradleProjectProperties getForProject(
-      Project project, Logger logger, Path extraDirectory, AbsoluteUnixPath appRoot) {
+      Project project,
+      Logger logger,
+      Path extraDirectory,
+      Map<String, String> permissions,
+      AbsoluteUnixPath appRoot) {
     try {
       return new GradleProjectProperties(
           project,
           makeEventHandlers(logger),
-          GradleLayerConfigurations.getForProject(project, logger, extraDirectory, appRoot));
+          GradleLayerConfigurations.getForProject(
+              project,
+              logger,
+              extraDirectory,
+              ConfigurationPropertyValidator.convertPermissionsMap(permissions),
+              appRoot));
 
     } catch (IOException ex) {
       throw new GradleException("Obtaining project build output files failed", ex);

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -17,15 +17,11 @@
 package com.google.cloud.tools.jib.gradle;
 
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
-import java.io.File;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 
@@ -52,6 +48,15 @@ import org.gradle.api.tasks.Optional;
  *     format = OCI
  *     appRoot = "/app";
  *   }
+ *   extraDirectory {
+ *     path = file('path/to/extra/dir')
+ *     permissions = [
+ *       '/path/on/container/file1': 744,
+ *       '/path/on/container/file2': 123
+ *     ]
+ *   }
+ *   allowInsecureRegistries = false
+ *   useOnlyProjectCache = false
  * }
  * }</pre>
  */
@@ -61,16 +66,13 @@ public class JibExtension {
   private static final boolean DEFAULT_USE_ONLY_PROJECT_CACHE = false;
   private static final boolean DEFAULT_ALLOW_INSECURE_REGISTIRIES = false;
 
-  private static Path resolveDefaultExtraDirectory(Path projectDirectory) {
-    return projectDirectory.resolve("src").resolve("main").resolve("jib");
-  }
-
   private final BaseImageParameters from;
   private final TargetImageParameters to;
   private final ContainerParameters container;
+  private final ExtraDirectoryParameters extraDirectory;
+
   private final Property<Boolean> useOnlyProjectCache;
   private final Property<Boolean> allowInsecureRegistries;
-  private final Property<Path> extraDirectory;
 
   public JibExtension(Project project) {
     ObjectFactory objectFactory = project.getObjects();
@@ -78,15 +80,15 @@ public class JibExtension {
     from = objectFactory.newInstance(BaseImageParameters.class, "jib.from");
     to = objectFactory.newInstance(TargetImageParameters.class, "jib.to");
     container = objectFactory.newInstance(ContainerParameters.class);
+    extraDirectory =
+        objectFactory.newInstance(ExtraDirectoryParameters.class, project.getProjectDir().toPath());
 
     useOnlyProjectCache = objectFactory.property(Boolean.class);
     allowInsecureRegistries = objectFactory.property(Boolean.class);
-    extraDirectory = objectFactory.property(Path.class);
 
     // Sets defaults.
     useOnlyProjectCache.set(DEFAULT_USE_ONLY_PROJECT_CACHE);
     allowInsecureRegistries.set(DEFAULT_ALLOW_INSECURE_REGISTIRIES);
-    extraDirectory.set(resolveDefaultExtraDirectory(project.getProjectDir().toPath()));
   }
 
   public void from(Action<? super BaseImageParameters> action) {
@@ -101,12 +103,12 @@ public class JibExtension {
     action.execute(container);
   }
 
-  public void setAllowInsecureRegistries(boolean allowInsecureRegistries) {
-    this.allowInsecureRegistries.set(allowInsecureRegistries);
+  public void extraDirectory(Action<? super ExtraDirectoryParameters> action) {
+    action.execute(extraDirectory);
   }
 
-  public void setExtraDirectory(File extraDirectory) {
-    this.extraDirectory.set(extraDirectory.toPath());
+  public void setAllowInsecureRegistries(boolean allowInsecureRegistries) {
+    this.allowInsecureRegistries.set(allowInsecureRegistries);
   }
 
   void setUseOnlyProjectCache(boolean useOnlyProjectCache) {
@@ -131,6 +133,12 @@ public class JibExtension {
     return container;
   }
 
+  @Nested
+  @Optional
+  public ExtraDirectoryParameters getExtraDirectory() {
+    return extraDirectory;
+  }
+
   @Input
   @Optional
   boolean getUseOnlyProjectCache() {
@@ -147,24 +155,5 @@ public class JibExtension {
       return Boolean.getBoolean(PropertyNames.ALLOW_INSECURE_REGISTRIES);
     }
     return allowInsecureRegistries.get();
-  }
-
-  @Input
-  String getExtraDirectory() {
-    // Gradle warns about @Input annotations on File objects, so we have to expose a getter for a
-    // String to make them go away.
-    if (System.getProperty(PropertyNames.EXTRA_DIRECTORY) != null) {
-      return System.getProperty(PropertyNames.EXTRA_DIRECTORY);
-    }
-    return extraDirectory.get().toString();
-  }
-
-  @Internal
-  Path getExtraDirectoryPath() {
-    // TODO: Should inform user about nonexistent directory if using custom directory.
-    if (System.getProperty(PropertyNames.EXTRA_DIRECTORY) != null) {
-      return Paths.get(System.getProperty(PropertyNames.EXTRA_DIRECTORY));
-    }
-    return extraDirectory.get();
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.gradle;
 
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
+import java.io.File;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
@@ -105,6 +106,10 @@ public class JibExtension {
 
   public void extraDirectory(Action<? super ExtraDirectoryParameters> action) {
     action.execute(extraDirectory);
+  }
+
+  public void setExtraDirectory(File extraDirectory) {
+    this.extraDirectory.setPath(extraDirectory);
   }
 
   public void setAllowInsecureRegistries(boolean allowInsecureRegistries) {

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/DockerContextTaskTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/DockerContextTaskTest.java
@@ -43,6 +43,7 @@ public class DockerContextTaskTest {
 
   @Mock private ContainerParameters containerParameters;
   @Mock private BaseImageParameters baseImageParameters;
+  @Mock private ExtraDirectoryParameters extraDirectoryParameters;
 
   private DockerContextTask task;
   private Project project;
@@ -57,13 +58,16 @@ public class DockerContextTaskTest {
     Mockito.when(jibExtension.getContainer()).thenReturn(containerParameters);
     Mockito.when(containerParameters.getEnvironment())
         .thenReturn(ImmutableMap.of("envKey", "envVal"));
-    Mockito.when(jibExtension.getExtraDirectoryPath())
-        .thenReturn(projectRoot.newFolder("src", "main", "jib").toPath());
-    Mockito.when(jibExtension.getContainer().getMainClass()).thenReturn("MainClass");
-    Mockito.when(jibExtension.getFrom()).thenReturn(baseImageParameters);
-    Mockito.when(baseImageParameters.getImage()).thenReturn("base image");
+    Mockito.when(containerParameters.getMainClass()).thenReturn("MainClass");
     Mockito.when(containerParameters.getAppRoot()).thenReturn("/app");
     Mockito.when(containerParameters.getArgs()).thenCallRealMethod();
+
+    Mockito.when(jibExtension.getFrom()).thenReturn(baseImageParameters);
+    Mockito.when(baseImageParameters.getImage()).thenReturn("base image");
+
+    Mockito.when(jibExtension.getExtraDirectory()).thenReturn(extraDirectoryParameters);
+    Mockito.when(extraDirectoryParameters.getPath())
+        .thenReturn(projectRoot.newFolder("src", "main", "jib").toPath());
 
     project = ProjectBuilder.builder().withProjectDir(projectRoot.getRoot()).build();
     project.getPluginManager().apply("java");

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurationsTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurationsTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -176,7 +177,11 @@ public class GradleLayerConfigurationsTest {
     AbsoluteUnixPath appRoot = AbsoluteUnixPath.get("/app");
     JavaLayerConfigurations javaLayerConfigurations =
         GradleLayerConfigurations.getForProject(
-            mockProject, mockLogger, Paths.get("nonexistent/path"), appRoot);
+            mockProject,
+            mockLogger,
+            Paths.get("nonexistent/path"),
+            Collections.emptyMap(),
+            appRoot);
     assertSourcePathsUnordered(
         expectedDependenciesFiles, javaLayerConfigurations.getDependencyLayerEntries());
     assertSourcePathsUnordered(
@@ -198,7 +203,7 @@ public class GradleLayerConfigurationsTest {
 
     AbsoluteUnixPath appRoot = AbsoluteUnixPath.get("/app");
     GradleLayerConfigurations.getForProject(
-        mockProject, mockLogger, Paths.get("nonexistent/path"), appRoot);
+        mockProject, mockLogger, Paths.get("nonexistent/path"), Collections.emptyMap(), appRoot);
 
     Mockito.verify(mockLogger)
         .info("Adding corresponding output directories of source sets to image");
@@ -210,7 +215,11 @@ public class GradleLayerConfigurationsTest {
   public void test_extraFiles() throws IOException {
     JavaLayerConfigurations javaLayerConfigurations =
         GradleLayerConfigurations.getForProject(
-            mockProject, mockLogger, extraFilesDirectory, AbsoluteUnixPath.get("/app"));
+            mockProject,
+            mockLogger,
+            extraFilesDirectory,
+            Collections.emptyMap(),
+            AbsoluteUnixPath.get("/app"));
 
     ImmutableList<Path> expectedExtraFiles =
         ImmutableList.of(
@@ -229,7 +238,11 @@ public class GradleLayerConfigurationsTest {
   public void testGetForProject_nonDefaultAppRoot() throws IOException {
     JavaLayerConfigurations configuration =
         GradleLayerConfigurations.getForProject(
-            mockProject, mockLogger, extraFilesDirectory, AbsoluteUnixPath.get("/my/app"));
+            mockProject,
+            mockLogger,
+            extraFilesDirectory,
+            Collections.emptyMap(),
+            AbsoluteUnixPath.get("/my/app"));
 
     assertExtractionPathsUnordered(
         Arrays.asList(
@@ -261,6 +274,7 @@ public class GradleLayerConfigurationsTest {
             mockProject,
             mockLogger,
             extraFilesDirectory,
+            Collections.emptyMap(),
             AbsoluteUnixPath.get(JavaLayerConfigurations.DEFAULT_APP_ROOT));
 
     assertExtractionPathsUnordered(
@@ -289,7 +303,11 @@ public class GradleLayerConfigurationsTest {
 
     JavaLayerConfigurations configuration =
         GradleLayerConfigurations.getForProject(
-            mockWebAppProject, mockLogger, extraFilesDirectory, AbsoluteUnixPath.get("/my/app"));
+            mockWebAppProject,
+            mockLogger,
+            extraFilesDirectory,
+            Collections.emptyMap(),
+            AbsoluteUnixPath.get("/my/app"));
     ImmutableList<Path> expectedDependenciesFiles =
         ImmutableList.of(
             webAppDirectory.resolve("jib-exploded-war/WEB-INF/lib/dependency-1.0.0.jar"));
@@ -371,6 +389,7 @@ public class GradleLayerConfigurationsTest {
             mockWebAppProject,
             mockLogger,
             extraFilesDirectory,
+            Collections.emptyMap(),
             AbsoluteUnixPath.get(JavaLayerConfigurations.DEFAULT_WEB_APP_ROOT));
 
     assertExtractionPathsUnordered(
@@ -413,6 +432,7 @@ public class GradleLayerConfigurationsTest {
         mockWebAppProject,
         mockLogger,
         extraFilesDirectory,
+        Collections.emptyMap(),
         AbsoluteUnixPath.get(JavaLayerConfigurations.DEFAULT_WEB_APP_ROOT)); // should pass
   }
 
@@ -425,6 +445,7 @@ public class GradleLayerConfigurationsTest {
         mockWebAppProject,
         mockLogger,
         extraFilesDirectory,
+        Collections.emptyMap(),
         AbsoluteUnixPath.get(JavaLayerConfigurations.DEFAULT_WEB_APP_ROOT)); // should pass
   }
 
@@ -437,6 +458,7 @@ public class GradleLayerConfigurationsTest {
         mockWebAppProject,
         mockLogger,
         extraFilesDirectory,
+        Collections.emptyMap(),
         AbsoluteUnixPath.get(JavaLayerConfigurations.DEFAULT_WEB_APP_ROOT)); // should pass
   }
 

--- a/jib-gradle-plugin/src/test/resources/projects/multi-service/complex-service/build.gradle
+++ b/jib-gradle-plugin/src/test/resources/projects/multi-service/complex-service/build.gradle
@@ -17,7 +17,9 @@ jib {
   to {
     image = System.getProperty("_TARGET_IMAGE")
   }
-  extraDirectory = file('src/main/other-jib')
+  extraDirectory {
+    path = file('src/main/other-jib')
+  }
 }
 
 sourceSets {

--- a/jib-gradle-plugin/src/test/resources/projects/simple/build.gradle
+++ b/jib-gradle-plugin/src/test/resources/projects/simple/build.gradle
@@ -18,5 +18,7 @@ jib {
   to {
     image = System.getProperty("_TARGET_IMAGE")
   }
-  extraDirectory = file('src/main/custom-extra-dir')
+  extraDirectory {
+    path = file('src/main/custom-extra-dir')
+  }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -174,7 +174,7 @@ abstract class JibPluginConfiguration extends AbstractMojo {
   @Parameter(
       defaultValue = "${project.basedir}/src/main/jib",
       required = true,
-      property = PropertyNames.EXTRA_DIRECTORY)
+      property = PropertyNames.EXTRA_DIRECTORY_PATH)
   private File extraDirectory;
 
   @Parameter(defaultValue = "false", property = PropertyNames.SKIP)

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenLayerConfigurations.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenLayerConfigurations.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.function.Predicate;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.project.MavenProject;
@@ -119,7 +120,9 @@ class MavenLayerConfigurations {
     // at build.getFinalName().
     Path explodedWarPath =
         Paths.get(project.getBuild().getDirectory()).resolve(project.getBuild().getFinalName());
-    return JavaLayerConfigurationsHelper.fromExplodedWar(explodedWarPath, appRoot, extraDirectory);
+    // TODO: Replace Collections.emptyMap() with configured permissions
+    return JavaLayerConfigurationsHelper.fromExplodedWar(
+        explodedWarPath, appRoot, extraDirectory, Collections.emptyMap());
   }
 
   private MavenLayerConfigurations() {}

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidator.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidator.java
@@ -188,8 +188,8 @@ public class ConfigurationPropertyValidator {
   }
 
   /**
-   * Validates and converts a {@code String->String} map to an {@code
-   * AbsoluteUnixPath->FilePermission} map.
+   * Validates and converts a {@code String->String} file-path-to-file-permissions map to an
+   * equivalent {@code AbsoluteUnixPath->FilePermission} map.
    *
    * @param inputMap the map to convert
    * @return the converted map

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidator.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidator.java
@@ -16,9 +16,11 @@
 
 package com.google.cloud.tools.jib.plugins.common;
 
+import com.google.cloud.tools.jib.configuration.FilePermissions;
 import com.google.cloud.tools.jib.configuration.credentials.Credential;
 import com.google.cloud.tools.jib.event.EventDispatcher;
 import com.google.cloud.tools.jib.event.events.LogEvent;
+import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
@@ -29,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -182,6 +185,24 @@ public class ConfigurationPropertyValidator {
     }
     items.add(property.substring(startIndex));
     return ImmutableList.copyOf(items);
+  }
+
+  /**
+   * Validates and converts a {@code String->String} map to an {@code
+   * AbsoluteUnixPath->FilePermission} map.
+   *
+   * @param inputMap the map to convert
+   * @return the converted map
+   */
+  public static Map<AbsoluteUnixPath, FilePermissions> convertPermissionsMap(
+      Map<String, String> inputMap) {
+    ImmutableMap.Builder<AbsoluteUnixPath, FilePermissions> permissionsMap = ImmutableMap.builder();
+    for (Entry<String, String> entry : inputMap.entrySet()) {
+      AbsoluteUnixPath key = AbsoluteUnixPath.get(entry.getKey());
+      FilePermissions value = FilePermissions.fromOctalString(entry.getValue());
+      permissionsMap.put(key, value);
+    }
+    return permissionsMap.build();
   }
 
   private ConfigurationPropertyValidator() {}

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaLayerConfigurationsHelper.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaLayerConfigurationsHelper.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.plugins.common;
 
+import com.google.cloud.tools.jib.configuration.FilePermissions;
 import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.frontend.JavaLayerConfigurations;
 import com.google.cloud.tools.jib.frontend.JavaLayerConfigurations.Builder;
@@ -23,13 +24,28 @@ import com.google.cloud.tools.jib.frontend.JavaLayerConfigurations.LayerType;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.function.Predicate;
 
 /** Helper for constructing {@link JavaLayerConfigurations}. */
 public class JavaLayerConfigurationsHelper {
 
+  /**
+   * Constructs a new {@link JavaLayerConfigurations} for a WAR project.
+   *
+   * @param explodedWar the exploded WAR directory
+   * @param appRoot root directory in the image where the app will be placed
+   * @param extraFilesDirectory path to the source directory for the extra files layer
+   * @param permissions map from path on container to file permissions
+   * @return {@link JavaLayerConfigurations} for the layers for the exploded WAR
+   * @throws IOException if adding layer contents fails
+   */
   public static JavaLayerConfigurations fromExplodedWar(
-      Path explodedWar, AbsoluteUnixPath appRoot, Path extraFilesDirectory) throws IOException {
+      Path explodedWar,
+      AbsoluteUnixPath appRoot,
+      Path extraFilesDirectory,
+      Map<AbsoluteUnixPath, FilePermissions> permissions)
+      throws IOException {
     Path webInfLib = explodedWar.resolve("WEB-INF/lib");
     Path webInfClasses = explodedWar.resolve("WEB-INF/classes");
 
@@ -66,7 +82,11 @@ public class JavaLayerConfigurationsHelper {
     // Adds all the extra files.
     if (Files.exists(extraFilesDirectory)) {
       layerBuilder.addDirectoryContents(
-          LayerType.EXTRA_FILES, extraFilesDirectory, path -> true, AbsoluteUnixPath.get("/"));
+          LayerType.EXTRA_FILES,
+          extraFilesDirectory,
+          path -> true,
+          AbsoluteUnixPath.get("/"),
+          permissions);
     }
 
     return layerBuilder.build();

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
@@ -41,6 +41,7 @@ public class PropertyNames {
   public static final String CONTAINER_USE_CURRENT_TIMESTAMP = "jib.container.useCurrentTimestamp";
   public static final String USE_ONLY_PROJECT_CACHE = "jib.useOnlyProjectCache";
   public static final String ALLOW_INSECURE_REGISTRIES = "jib.allowInsecureRegistries";
-  public static final String EXTRA_DIRECTORY = "jib.extraDirectory";
+  public static final String EXTRA_DIRECTORY_PATH = "jib.extraDirectory.path";
+  public static final String EXTRA_DIRECTORY_PERMISSIONS = "jib.extraDirectory.permissions";
   public static final String SKIP = "jib.skip";
 }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidatorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidatorTest.java
@@ -16,9 +16,11 @@
 
 package com.google.cloud.tools.jib.plugins.common;
 
+import com.google.cloud.tools.jib.configuration.FilePermissions;
 import com.google.cloud.tools.jib.configuration.credentials.Credential;
 import com.google.cloud.tools.jib.event.EventDispatcher;
 import com.google.cloud.tools.jib.event.events.LogEvent;
+import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.common.collect.ImmutableList;
@@ -167,6 +169,26 @@ public class ConfigurationPropertyValidatorTest {
         ConfigurationPropertyValidator.parseMapProperty("abc=def,gh\\,i=j\\\\\\,kl,mno=,pqr=stu"));
     try {
       ConfigurationPropertyValidator.parseMapProperty("not valid");
+      Assert.fail();
+    } catch (IllegalArgumentException ignored) {
+      // pass
+    }
+  }
+
+  @Test
+  public void testConvertPermissionsMap() {
+    Assert.assertEquals(
+        ImmutableMap.of(
+            AbsoluteUnixPath.get("/test/folder/file1"),
+            FilePermissions.fromOctalString("123"),
+            AbsoluteUnixPath.get("/test/file2"),
+            FilePermissions.fromOctalString("456")),
+        ConfigurationPropertyValidator.convertPermissionsMap(
+            ImmutableMap.of("/test/folder/file1", "123", "/test/file2", "456")));
+
+    try {
+      ConfigurationPropertyValidator.convertPermissionsMap(
+          ImmutableMap.of("a path", "not valid permission"));
       Assert.fail();
     } catch (IllegalArgumentException ignored) {
       // pass

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaLayerConfigurationsHelperTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaLayerConfigurationsHelperTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -61,13 +62,17 @@ public class JavaLayerConfigurationsHelperTest {
 
     JavaLayerConfigurations configuration =
         JavaLayerConfigurationsHelper.fromExplodedWar(
-            explodedWar, AbsoluteUnixPath.get("/my/app"), extraFilesDirectory);
+            explodedWar,
+            AbsoluteUnixPath.get("/my/app"),
+            extraFilesDirectory,
+            Collections.emptyMap());
 
     assertSourcePathsUnordered(
-        Arrays.asList(explodedWar.resolve("WEB-INF/lib/dependency-1.0.0.jar")),
+        Collections.singletonList(explodedWar.resolve("WEB-INF/lib/dependency-1.0.0.jar")),
         configuration.getDependencyLayerEntries());
     assertSourcePathsUnordered(
-        Arrays.asList(explodedWar.resolve("WEB-INF/lib/dependencyX-1.0.0-SNAPSHOT.jar")),
+        Collections.singletonList(
+            explodedWar.resolve("WEB-INF/lib/dependencyX-1.0.0-SNAPSHOT.jar")),
         configuration.getSnapshotDependencyLayerEntries());
     assertSourcePathsUnordered(
         Arrays.asList(
@@ -100,10 +105,10 @@ public class JavaLayerConfigurationsHelperTest {
         configuration.getExtraFilesLayerEntries());
 
     assertExtractionPathsUnordered(
-        Arrays.asList("/my/app/WEB-INF/lib/dependency-1.0.0.jar"),
+        Collections.singletonList("/my/app/WEB-INF/lib/dependency-1.0.0.jar"),
         configuration.getDependencyLayerEntries());
     assertExtractionPathsUnordered(
-        Arrays.asList("/my/app/WEB-INF/lib/dependencyX-1.0.0-SNAPSHOT.jar"),
+        Collections.singletonList("/my/app/WEB-INF/lib/dependencyX-1.0.0-SNAPSHOT.jar"),
         configuration.getSnapshotDependencyLayerEntries());
     assertExtractionPathsUnordered(
         Arrays.asList(


### PR DESCRIPTION
Toward #794 

`extraDirectory` configuration parameter is now an object with a `path` and `permissions` field, instead of just being a file
  - `extraDirectory.path` covers the original purpose of `extraDirectory`
  - `extraDirectory.permissions` is a map from path on container to an octal string representation of the file's permission bits

For example, if your extra directory is `(project dir)/src/main/custom-jib`, and you want to give executable permissions to `path/to/file1` and `path/to/file2` within, you would add this configuration to your `build.gradle`:

```groovy
jib {
  ...
  extraDirectory {
    path = file('src/main/custom-jib')
    permissions = [
      '/path/to/file1': '755',
      '/path/to/file2': '755'
    ]
  }
}
```

The old method of configuring the extra directory is also still supported:
```groovy
jib {
  ...
  extraDirectory = file('src/main/custom-jib')
}
```