### PR TITLE
Remove dependence of filesTask on classes and assembly

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -152,7 +152,6 @@ public class JibPlugin implements Plugin<Project> {
             dockerContextTask.dependsOn(dependsOnTask);
             buildDockerTask.dependsOn(dependsOnTask);
             buildTarTask.dependsOn(dependsOnTask);
-            filesTask.dependsOn(dependsOnTask);
 
             // Find project dependencies and add a dependency to their assemble task. We make sure
             // to only add the dependency after BasePlugin is evaluated as otherwise the assemble
@@ -170,7 +169,6 @@ public class JibPlugin implements Plugin<Project> {
                         dockerContextTask.dependsOn(assembleTask);
                         buildDockerTask.dependsOn(assembleTask);
                         buildTarTask.dependsOn(assembleTask);
-                        filesTask.dependsOn(assembleTask);
                       });
             }
           } catch (UnknownTaskException ex) {


### PR DESCRIPTION
The `_jibSkaffoldFiles` task doesn't need to depend on the `classes` and `assemble` tasks.

Fixes https://github.com/GoogleContainerTools/skaffold/issues/1197