### PR TITLE
Avoid creating directory in exploded-war build output directory in Ja…

### DIFF
--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaLayerConfigurationsHelperTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaLayerConfigurationsHelperTest.java
@@ -17,30 +17,28 @@
 package com.google.cloud.tools.jib.plugins.common;
 
 import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.filesystem.FileOperations;
 import com.google.cloud.tools.jib.frontend.JavaLayerConfigurations;
 import com.google.cloud.tools.jib.image.LayerEntry;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.junit.Assert;
-import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 /** Tests for {@link JavaLayerConfigurationsHelper}. */
 public class JavaLayerConfigurationsHelperTest {
-
-  @ClassRule public static TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   private static <T> void assertLayerEntriesUnordered(
       List<T> expectedPaths, List<LayerEntry> entries, Function<LayerEntry, T> fieldSelector) {
@@ -60,24 +58,14 @@ public class JavaLayerConfigurationsHelperTest {
         expectedPaths, entries, layerEntry -> layerEntry.getExtractionPath().toString());
   }
 
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
   @Test
   public void testFromExplodedWar() throws URISyntaxException, IOException {
     // Copy test files to a temporary directory that we can safely operate on
-    Path temporaryExplodedWar = temporaryFolder.newFolder("exploded-war").toPath();
     Path resourceExplodedWar = Paths.get(Resources.getResource("exploded-war").toURI());
-    try (Stream<Path> stream = Files.walk(resourceExplodedWar)) {
-      stream.forEach(
-          source -> {
-            try {
-              Files.copy(
-                  source,
-                  temporaryExplodedWar.resolve(resourceExplodedWar.relativize(source)),
-                  StandardCopyOption.REPLACE_EXISTING);
-            } catch (IOException ex) {
-              Assert.fail("Failed to copy resources to temp directory: " + ex.getMessage());
-            }
-          });
-    }
+    FileOperations.copy(ImmutableList.of(resourceExplodedWar), temporaryFolder.getRoot().toPath());
+    Path temporaryExplodedWar = temporaryFolder.getRoot().toPath().resolve("exploded-war");
 
     Files.createDirectories(temporaryExplodedWar.resolve("WEB-INF/classes/empty_dir"));
     Path extraFilesDirectory = Paths.get(Resources.getResource("layer").toURI());


### PR DESCRIPTION
Closes #1164. Copies test resources to a temp directory we can operate on instead of polluting the test files.