### PR TITLE
Disables Apache HTTP logging at registry client level.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/Connection.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/Connection.java
@@ -78,6 +78,13 @@ public class Connection implements Closeable {
     return url -> new Connection(url, transport);
   }
 
+  static {
+    // Disables annoying Apache HTTP client logging.
+    System.setProperty(
+        "org.apache.commons.logging.Log", "org.apache.commons.logging.impl.SimpleLog");
+    System.setProperty("org.apache.commons.logging.simplelog.defaultlog", "error");
+  }
+
   private HttpRequestFactory requestFactory;
 
   @Nullable private HttpResponse httpResponse;

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -57,7 +57,6 @@ class TaskCommon {
   }
 
   /** Disables annoying Apache HTTP client logging. */
-  // TODO: Instead of disabling logging, have authentication credentials be provided
   static void disableHttpLogging() {
     // Disables Apache HTTP client logging.
     OutputEventListenerBackedLoggerContext context =

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -67,7 +67,6 @@ public class BuildDockerMojo extends JibPluginConfiguration {
           HelpfulSuggestions.forDockerNotInstalled(HELPFUL_SUGGESTIONS_PREFIX));
     }
 
-    MojoCommon.disableHttpLogging();
     try {
       AbsoluteUnixPath appRoot = MojoCommon.getAppRootChecked(this);
       MavenProjectProperties projectProperties =

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -85,7 +85,6 @@ public class BuildImageMojo extends JibPluginConfiguration {
               "mvn compile jib:build -Dimage=<your image name>"));
     }
 
-    MojoCommon.disableHttpLogging();
     try {
       AbsoluteUnixPath appRoot = MojoCommon.getAppRootChecked(this);
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -60,7 +60,6 @@ public class BuildTarMojo extends JibPluginConfiguration {
       return;
     }
 
-    MojoCommon.disableHttpLogging();
     try {
       AbsoluteUnixPath appRoot = MojoCommon.getAppRootChecked(this);
       MavenProjectProperties projectProperties =

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/DockerContextMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/DockerContextMojo.java
@@ -69,7 +69,6 @@ public class DockerContextMojo extends JibPluginConfiguration {
 
     try {
       JibSystemProperties.checkHttpTimeoutProperty();
-      MojoCommon.disableHttpLogging();
       AbsoluteUnixPath appRoot = MojoCommon.getAppRootChecked(this);
 
       MavenProjectProperties projectProperties =

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
@@ -100,13 +100,5 @@ class MojoCommon {
     return permissionsMap;
   }
 
-  /** Disables annoying Apache HTTP client logging. */
-  // TODO: Instead of disabling logging, have authentication credentials be provided
-  static void disableHttpLogging() {
-    System.setProperty(
-        "org.apache.commons.logging.Log", "org.apache.commons.logging.impl.SimpleLog");
-    System.setProperty("org.apache.commons.logging.simplelog.defaultlog", "error");
-  }
-
   private MojoCommon() {}
 }


### PR DESCRIPTION
This moves the disableHttpLogging logic to the registry client level under `registry.Connection`, where the Apache `HttpTransport` is set up. The implications of this are:

- Jib Core does not show up with annoying logs anymore
- Removes all the disable logging logic from Maven side
- Gradle still needs its own disable logging logic due to how the logging is handled in Gradle