### PR TITLE
Update dependencies to use the 1.0.0 GA release of Micronaut

### DIFF
--- a/examples/micronaut/build.gradle
+++ b/examples/micronaut/build.gradle
@@ -10,32 +10,31 @@ version '0.1'
 group 'example.micronaut-jib'
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven { url 'https://jcenter.bintray.com' }
 }
 
 dependencyManagement {
     imports {
-        mavenBom 'io.micronaut:bom:1.0.0.M4'
+        mavenBom 'io.micronaut:micronaut-bom:1.0.0'
     }
 }
 
 dependencies {
-    annotationProcessor 'io.micronaut:inject-java'
-    compile 'io.micronaut:http-client'
-    compile 'io.micronaut:http-server-netty'
-    compile 'io.micronaut:runtime-groovy'
-    compile 'io.micronaut:inject'
-    compile 'io.micronaut:runtime'
-    compileOnly 'io.micronaut:inject-groovy'
-    compileOnly 'io.micronaut:inject-java'
+    annotationProcessor 'io.micronaut:micronaut-inject-java'
+    compile 'io.micronaut:micronaut-http-client'
+    compile 'io.micronaut:micronaut-http-server-netty'
+    compile 'io.micronaut:micronaut-runtime-groovy'
+    compile 'io.micronaut:micronaut-inject'
+    compile 'io.micronaut:micronaut-runtime'
+    compileOnly 'io.micronaut:micronaut-inject-groovy'
+    compileOnly 'io.micronaut:micronaut-inject-java'
     runtime 'ch.qos.logback:logback-classic:1.2.3'
-    testCompile 'io.micronaut:inject-groovy'
+    testCompile 'io.micronaut:micronaut-inject-groovy'
     testCompile('org.spockframework:spock-core:1.1-groovy-2.4') {
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'
     }
-    testCompile 'io.micronaut:inject-java'
+    testCompile 'io.micronaut:micronaut-inject-java'
 }
 
 compileJava.options.compilerArgs += '-parameters'


### PR DESCRIPTION
As per #1234, I suggest to upgrade the dependencies of Micronaut from the M4 milestone to the 1.0.0 GA release of the framework (released Oct 23)