### PR TITLE
Add DockerHealthCheck class

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
@@ -29,13 +29,13 @@ public class DockerHealthCheck {
   /** Builds the immutable {@link DockerHealthCheck}. */
   public static class Builder {
 
-    private final ImmutableList<String> command;
+    @Nullable private final ImmutableList<String> command;
     @Nullable private Duration interval;
     @Nullable private Duration timeout;
     @Nullable private Duration startPeriod;
     @Nullable private Integer retries;
 
-    private Builder(ImmutableList<String> command) {
+    private Builder(@Nullable ImmutableList<String> command) {
       this.command = command;
     }
 
@@ -105,7 +105,7 @@ public class DockerHealthCheck {
    * @return the new {@link DockerHealthCheck.Builder}
    */
   public static Builder withInheritedCommand() {
-    return new Builder(ImmutableList.of());
+    return new Builder(null);
   }
 
   /**
@@ -143,14 +143,14 @@ public class DockerHealthCheck {
     return new Builder(ImmutableList.of("CMD-SHELL", command));
   }
 
-  private final ImmutableList<String> command;
+  @Nullable private final ImmutableList<String> command;
   @Nullable private final Duration interval;
   @Nullable private final Duration timeout;
   @Nullable private final Duration startPeriod;
   @Nullable private final Integer retries;
 
   private DockerHealthCheck(
-      ImmutableList<String> command,
+      @Nullable ImmutableList<String> command,
       @Nullable Duration interval,
       @Nullable Duration timeout,
       @Nullable Duration startPeriod,
@@ -162,22 +162,52 @@ public class DockerHealthCheck {
     this.retries = retries;
   }
 
-  public List<String> getCommand() {
-    return command;
+  /**
+   * Gets the optional healthcheck command. A missing command means that it will be inherited from
+   * the base image.
+   *
+   * @return the healthcheck command
+   */
+  public Optional<List<String>> getCommand() {
+    return Optional.ofNullable(command);
   }
 
+  /**
+   * Gets the optional healthcheck interval. A missing command means that it will be inherited from
+   * the base image.
+   *
+   * @return the healthcheck interval
+   */
   public Optional<Duration> getInterval() {
     return Optional.ofNullable(interval);
   }
 
+  /**
+   * Gets the optional healthcheck timeout. A missing command means that it will be inherited from
+   * the base image.
+   *
+   * @return the healthcheck timeout
+   */
   public Optional<Duration> getTimeout() {
     return Optional.ofNullable(timeout);
   }
 
+  /**
+   * Gets the optional healthcheck start period. A missing command means that it will be inherited
+   * from the base image.
+   *
+   * @return the healthcheck start period
+   */
   public Optional<Duration> getStartPeriod() {
     return Optional.ofNullable(startPeriod);
   }
 
+  /**
+   * Gets the optional healthcheck retry count. A missing command means that it will be inherited
+   * from the base image.
+   *
+   * @return the healthcheck retry count
+   */
   public Optional<Integer> getRetries() {
     return Optional.ofNullable(retries);
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
@@ -104,7 +104,7 @@ public class DockerHealthCheck {
    *
    * @return the new {@link DockerHealthCheck.Builder}
    */
-  public static Builder withInheritedCommand() {
+  public static Builder builderWithInheritedCommand() {
     return new Builder(null);
   }
 
@@ -115,7 +115,7 @@ public class DockerHealthCheck {
    * @param command the healthcheck command to execute
    * @return the new {@link DockerHealthCheck.Builder}
    */
-  public static Builder withExecCommand(List<String> command) {
+  public static Builder builderWithExecCommand(List<String> command) {
     return new Builder(ImmutableList.<String>builder().add("CMD").addAll(command).build());
   }
 
@@ -126,7 +126,7 @@ public class DockerHealthCheck {
    * @param command the healthcheck command to execute
    * @return the new {@link DockerHealthCheck.Builder}
    */
-  public static Builder withExecCommand(String... command) {
+  public static Builder builderWithExecCommand(String... command) {
     return new Builder(
         ImmutableList.<String>builder().add("CMD").addAll(Arrays.asList(command)).build());
   }
@@ -139,7 +139,7 @@ public class DockerHealthCheck {
    * @param command the shell command to run
    * @return the new {@link DockerHealthCheck.Builder}
    */
-  public static Builder withShellCommand(String command) {
+  public static Builder builderWithShellCommand(String command) {
     return new Builder(ImmutableList.of("CMD-SHELL", command));
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
@@ -90,7 +90,7 @@ public class DockerHealthCheck {
   }
 
   /**
-   * Creates a disabled {@link DockerHealthCheck}.
+   * Creates a disabled {@link DockerHealthCheck} (corresponds to "NONE" in container config).
    *
    * @return the new {@link DockerHealthCheck}
    */
@@ -100,7 +100,7 @@ public class DockerHealthCheck {
 
   /**
    * Creates a new {@link DockerHealthCheck.Builder} with the command set to be inherited from the
-   * base image.
+   * base image (corresponds to empty list in container config).
    *
    * @return the new {@link DockerHealthCheck.Builder}
    */
@@ -110,7 +110,7 @@ public class DockerHealthCheck {
 
   /**
    * Creates a new {@link DockerHealthCheck.Builder} with the specified healthcheck command to be
-   * directly executed.
+   * directly executed (corresponds to "CMD" in container config).
    *
    * @param command the healthcheck command to execute
    * @return the new {@link DockerHealthCheck.Builder}
@@ -121,7 +121,7 @@ public class DockerHealthCheck {
 
   /**
    * Creates a new {@link DockerHealthCheck.Builder} with the specified healthcheck command to be
-   * directly executed.
+   * directly executed (corresponds to "CMD" in container config).
    *
    * @param command the healthcheck command to execute
    * @return the new {@link DockerHealthCheck.Builder}
@@ -133,8 +133,8 @@ public class DockerHealthCheck {
 
   /**
    * Creates a new {@link DockerHealthCheck.Builder} with the specified healthcheck command to be
-   * run by the container's default shell. This command cannot be run on containers with no default
-   * shell.
+   * run by the container's default shell (corresponds to "CMD-SHELL" in container config). This
+   * command cannot be run on containers with no default shell.
    *
    * @param command the shell command to run
    * @return the new {@link DockerHealthCheck.Builder}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.configuration;
+
+import com.google.common.collect.ImmutableList;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.annotation.Nullable;
+
+/** Configuration information for performing healthchecks on a Docker container. */
+public class DockerHealthCheck {
+
+  /** Builds the immutable {@link DockerHealthCheck}. */
+  public static class Builder {
+
+    private final ImmutableList<String> command;
+    @Nullable private Duration interval;
+    @Nullable private Duration timeout;
+    @Nullable private Duration startPeriod;
+    @Nullable private Integer retries;
+
+    private Builder(ImmutableList<String> command) {
+      this.command = command;
+    }
+
+    /**
+     * Sets the time between healthchecks.
+     *
+     * @param interval the duration to wait between healthchecks.
+     * @return this
+     */
+    public Builder setInterval(Duration interval) {
+      this.interval = interval;
+      return this;
+    }
+
+    /**
+     * Sets the time until a healthcheck is considered hung.
+     *
+     * @param timeout the duration to wait until considering the healthcheck to be hung.
+     * @return this
+     */
+    public Builder setTimeout(Duration timeout) {
+      this.timeout = timeout;
+      return this;
+    }
+
+    /**
+     * Sets the initialization time to wait before using healthchecks.
+     *
+     * @param startPeriod the duration to wait before using healthchecks
+     * @return this
+     */
+    public Builder setStartPeriod(Duration startPeriod) {
+      this.startPeriod = startPeriod;
+      return this;
+    }
+
+    /**
+     * Sets the number of times to retry the healthcheck before the container is considered to be
+     * unhealthy.
+     *
+     * @param retries the number of retries before the container is considered to be unhealthy
+     * @return this
+     */
+    public Builder setRetries(int retries) {
+      this.retries = retries;
+      return this;
+    }
+
+    public DockerHealthCheck build() {
+      return new DockerHealthCheck(command, interval, timeout, startPeriod, retries);
+    }
+  }
+
+  /**
+   * Creates a disabled {@link DockerHealthCheck}.
+   *
+   * @return the new {@link DockerHealthCheck}
+   */
+  public static DockerHealthCheck disabled() {
+    return new DockerHealthCheck(ImmutableList.of("NONE"), null, null, null, null);
+  }
+
+  /**
+   * Creates a new {@link DockerHealthCheck.Builder} with the command set to be inherited from the
+   * base image.
+   *
+   * @return the new {@link DockerHealthCheck.Builder}
+   */
+  public static Builder withInheritedCommand() {
+    return new Builder(ImmutableList.of());
+  }
+
+  /**
+   * Creates a new {@link DockerHealthCheck.Builder} with the specified healthcheck command to be
+   * directly executed.
+   *
+   * @param command the healthcheck command to execute
+   * @return the new {@link DockerHealthCheck.Builder}
+   */
+  public static Builder withExecCommand(List<String> command) {
+    return new Builder(ImmutableList.<String>builder().add("CMD").addAll(command).build());
+  }
+
+  /**
+   * Creates a new {@link DockerHealthCheck.Builder} with the specified healthcheck command to be
+   * directly executed.
+   *
+   * @param command the healthcheck command to execute
+   * @return the new {@link DockerHealthCheck.Builder}
+   */
+  public static Builder withExecCommand(String... command) {
+    return new Builder(
+        ImmutableList.<String>builder().add("CMD").addAll(Arrays.asList(command)).build());
+  }
+
+  /**
+   * Creates a new {@link DockerHealthCheck.Builder} with the specified healthcheck command to be
+   * run by the container's default shell. This command cannot be run on containers with no default
+   * shell.
+   *
+   * @param command the shell command to run
+   * @return the new {@link DockerHealthCheck.Builder}
+   */
+  public static Builder withShellCommand(String command) {
+    return new Builder(ImmutableList.of("CMD-SHELL", command));
+  }
+
+  private final ImmutableList<String> command;
+  @Nullable private final Duration interval;
+  @Nullable private final Duration timeout;
+  @Nullable private final Duration startPeriod;
+  @Nullable private final Integer retries;
+
+  private DockerHealthCheck(
+      ImmutableList<String> command,
+      @Nullable Duration interval,
+      @Nullable Duration timeout,
+      @Nullable Duration startPeriod,
+      @Nullable Integer retries) {
+    this.command = command;
+    this.interval = interval;
+    this.timeout = timeout;
+    this.startPeriod = startPeriod;
+    this.retries = retries;
+  }
+
+  public List<String> getCommand() {
+    return command;
+  }
+
+  public Optional<Duration> getInterval() {
+    return Optional.ofNullable(interval);
+  }
+
+  public Optional<Duration> getTimeout() {
+    return Optional.ofNullable(timeout);
+  }
+
+  public Optional<Duration> getStartPeriod() {
+    return Optional.ofNullable(startPeriod);
+  }
+
+  public Optional<Integer> getRetries() {
+    return Optional.ofNullable(retries);
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/DockerHealthCheckTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/DockerHealthCheckTest.java
@@ -34,40 +34,49 @@ public class DockerHealthCheckTest {
             .setRetries(10)
             .build();
 
+    Assert.assertTrue(healthCheck.getInterval().isPresent());
     Assert.assertEquals(Duration.ofNanos(123), healthCheck.getInterval().get());
+    Assert.assertTrue(healthCheck.getTimeout().isPresent());
     Assert.assertEquals(Duration.ofNanos(456), healthCheck.getTimeout().get());
+    Assert.assertTrue(healthCheck.getStartPeriod().isPresent());
     Assert.assertEquals(Duration.ofNanos(789), healthCheck.getStartPeriod().get());
+    Assert.assertTrue(healthCheck.getRetries().isPresent());
     Assert.assertEquals(10, (int) healthCheck.getRetries().get());
   }
 
   @Test
   public void testBuild_propagated() {
     DockerHealthCheck healthCheck = DockerHealthCheck.withInheritedCommand().build();
-    Assert.assertEquals(ImmutableList.of(), healthCheck.getCommand());
+    Assert.assertFalse(healthCheck.getCommand().isPresent());
   }
 
   @Test
   public void testBuild_execArray() {
     DockerHealthCheck healthCheck = DockerHealthCheck.withExecCommand("test", "command").build();
-    Assert.assertEquals(ImmutableList.of("CMD", "test", "command"), healthCheck.getCommand());
+    Assert.assertTrue(healthCheck.getCommand().isPresent());
+    Assert.assertEquals(ImmutableList.of("CMD", "test", "command"), healthCheck.getCommand().get());
   }
 
   @Test
   public void testBuild_execList() {
     DockerHealthCheck healthCheck =
         DockerHealthCheck.withExecCommand(ImmutableList.of("test", "command")).build();
-    Assert.assertEquals(ImmutableList.of("CMD", "test", "command"), healthCheck.getCommand());
+    Assert.assertTrue(healthCheck.getCommand().isPresent());
+    Assert.assertEquals(ImmutableList.of("CMD", "test", "command"), healthCheck.getCommand().get());
   }
 
   @Test
   public void testBuild_shell() {
     DockerHealthCheck healthCheck = DockerHealthCheck.withShellCommand("shell command").build();
-    Assert.assertEquals(ImmutableList.of("CMD-SHELL", "shell command"), healthCheck.getCommand());
+    Assert.assertTrue(healthCheck.getCommand().isPresent());
+    Assert.assertEquals(
+        ImmutableList.of("CMD-SHELL", "shell command"), healthCheck.getCommand().get());
   }
 
   @Test
   public void testDisabled() {
     DockerHealthCheck healthCheck = DockerHealthCheck.disabled();
-    Assert.assertEquals(ImmutableList.of("NONE"), healthCheck.getCommand());
+    Assert.assertTrue(healthCheck.getCommand().isPresent());
+    Assert.assertEquals(ImmutableList.of("NONE"), healthCheck.getCommand().get());
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/DockerHealthCheckTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/DockerHealthCheckTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.configuration;
+
+import com.google.common.collect.ImmutableList;
+import java.time.Duration;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for {@link DockerHealthCheck}. */
+public class DockerHealthCheckTest {
+
+  @Test
+  public void testBuild_parameters() {
+    DockerHealthCheck healthCheck =
+        DockerHealthCheck.withInheritedCommand()
+            .setInterval(Duration.ofNanos(123))
+            .setTimeout(Duration.ofNanos(456))
+            .setStartPeriod(Duration.ofNanos(789))
+            .setRetries(10)
+            .build();
+
+    Assert.assertEquals(Duration.ofNanos(123), healthCheck.getInterval().get());
+    Assert.assertEquals(Duration.ofNanos(456), healthCheck.getTimeout().get());
+    Assert.assertEquals(Duration.ofNanos(789), healthCheck.getStartPeriod().get());
+    Assert.assertEquals(10, (int) healthCheck.getRetries().get());
+  }
+
+  @Test
+  public void testBuild_propagated() {
+    DockerHealthCheck healthCheck = DockerHealthCheck.withInheritedCommand().build();
+    Assert.assertEquals(ImmutableList.of(), healthCheck.getCommand());
+  }
+
+  @Test
+  public void testBuild_execArray() {
+    DockerHealthCheck healthCheck = DockerHealthCheck.withExecCommand("test", "command").build();
+    Assert.assertEquals(ImmutableList.of("CMD", "test", "command"), healthCheck.getCommand());
+  }
+
+  @Test
+  public void testBuild_execList() {
+    DockerHealthCheck healthCheck =
+        DockerHealthCheck.withExecCommand(ImmutableList.of("test", "command")).build();
+    Assert.assertEquals(ImmutableList.of("CMD", "test", "command"), healthCheck.getCommand());
+  }
+
+  @Test
+  public void testBuild_shell() {
+    DockerHealthCheck healthCheck = DockerHealthCheck.withShellCommand("shell command").build();
+    Assert.assertEquals(ImmutableList.of("CMD-SHELL", "shell command"), healthCheck.getCommand());
+  }
+
+  @Test
+  public void testDisabled() {
+    DockerHealthCheck healthCheck = DockerHealthCheck.disabled();
+    Assert.assertEquals(ImmutableList.of("NONE"), healthCheck.getCommand());
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/DockerHealthCheckTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/DockerHealthCheckTest.java
@@ -27,7 +27,7 @@ public class DockerHealthCheckTest {
   @Test
   public void testBuild_parameters() {
     DockerHealthCheck healthCheck =
-        DockerHealthCheck.withInheritedCommand()
+        DockerHealthCheck.builderWithInheritedCommand()
             .setInterval(Duration.ofNanos(123))
             .setTimeout(Duration.ofNanos(456))
             .setStartPeriod(Duration.ofNanos(789))
@@ -46,13 +46,14 @@ public class DockerHealthCheckTest {
 
   @Test
   public void testBuild_propagated() {
-    DockerHealthCheck healthCheck = DockerHealthCheck.withInheritedCommand().build();
+    DockerHealthCheck healthCheck = DockerHealthCheck.builderWithInheritedCommand().build();
     Assert.assertFalse(healthCheck.getCommand().isPresent());
   }
 
   @Test
   public void testBuild_execArray() {
-    DockerHealthCheck healthCheck = DockerHealthCheck.withExecCommand("test", "command").build();
+    DockerHealthCheck healthCheck =
+        DockerHealthCheck.builderWithExecCommand("test", "command").build();
     Assert.assertTrue(healthCheck.getCommand().isPresent());
     Assert.assertEquals(ImmutableList.of("CMD", "test", "command"), healthCheck.getCommand().get());
   }
@@ -60,14 +61,15 @@ public class DockerHealthCheckTest {
   @Test
   public void testBuild_execList() {
     DockerHealthCheck healthCheck =
-        DockerHealthCheck.withExecCommand(ImmutableList.of("test", "command")).build();
+        DockerHealthCheck.builderWithExecCommand(ImmutableList.of("test", "command")).build();
     Assert.assertTrue(healthCheck.getCommand().isPresent());
     Assert.assertEquals(ImmutableList.of("CMD", "test", "command"), healthCheck.getCommand().get());
   }
 
   @Test
   public void testBuild_shell() {
-    DockerHealthCheck healthCheck = DockerHealthCheck.withShellCommand("shell command").build();
+    DockerHealthCheck healthCheck =
+        DockerHealthCheck.builderWithShellCommand("shell command").build();
     Assert.assertTrue(healthCheck.getCommand().isPresent());
     Assert.assertEquals(
         ImmutableList.of("CMD-SHELL", "shell command"), healthCheck.getCommand().get());


### PR DESCRIPTION
Adds a `DockerHealthCheck` class to be used for configuring container healthchecks in jib-core. To be used used in #1217, towards #676.