### PR TITLE
Define run.main for the main class to launch

### DIFF
--- a/examples/micronaut/build.gradle
+++ b/examples/micronaut/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 
 compileJava.options.compilerArgs += '-parameters'
 compileTestJava.options.compilerArgs += '-parameters'
+run.main = 'example.micronaut.Application'
 
 /** CHANGE THIS TO THE IMAGE YOU WANT TO PUSH TO */
 // jib.to.image = 'gcr.io/PROJECT_ID/micronaut-jib'


### PR DESCRIPTION
When running the Micronaut application locally, with `./gradlew run`, a main class should be specified so the JavaExec task knows which main class to run.

This should fix #1242
