### PR TITLE
Fix NullPointerException with incomplete auth config

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/AuthParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/AuthParameters.java
@@ -17,11 +17,8 @@
 package com.google.cloud.tools.jib.gradle;
 
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
-import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
-import javax.inject.Inject;
 import org.gradle.api.tasks.Input;
-import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 
 /**
@@ -32,35 +29,6 @@ public class AuthParameters implements AuthProperty {
 
   @Nullable private String username;
   @Nullable private String password;
-  private String descriptor;
-
-  /**
-   * Constructs a new {@link AuthParameters}.
-   *
-   * @param descriptor the name of the auth configuration property
-   */
-  @Inject
-  public AuthParameters(String descriptor) {
-    this.descriptor = descriptor;
-  }
-
-  @Internal
-  @Override
-  public String getPropertyDescriptor() {
-    return Preconditions.checkNotNull(descriptor);
-  }
-
-  @Internal
-  @Override
-  public String getUsernamePropertyDescriptor() {
-    return Preconditions.checkNotNull(descriptor) + ".username";
-  }
-
-  @Internal
-  @Override
-  public String getPasswordPropertyDescriptor() {
-    return Preconditions.checkNotNull(descriptor) + ".password";
-  }
 
   @Input
   @Optional

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
@@ -34,8 +34,8 @@ public class BaseImageParameters {
   @Nullable private String credHelper;
 
   @Inject
-  public BaseImageParameters(ObjectFactory objectFactory, String imageDescriptor) {
-    auth = objectFactory.newInstance(AuthParameters.class, imageDescriptor + ".auth");
+  public BaseImageParameters(ObjectFactory objectFactory) {
+    auth = objectFactory.newInstance(AuthParameters.class);
   }
 
   @Input

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -58,6 +58,21 @@ class GradleRawConfiguration implements RawConfiguration {
   }
 
   @Override
+  public String getAuthDescriptor(String source) {
+    return source + ".auth";
+  }
+
+  @Override
+  public String getUsernameAuthDescriptor(String source) {
+    return getAuthDescriptor(source) + ".username";
+  }
+
+  @Override
+  public String getPasswordAuthDescriptor(String source) {
+    return getAuthDescriptor(source) + ".password";
+  }
+
+  @Override
   public Optional<String> getToCredHelper() {
     return Optional.ofNullable(jibExtension.getTo().getCredHelper());
   }
@@ -130,6 +145,11 @@ class GradleRawConfiguration implements RawConfiguration {
   @Override
   public Optional<AuthProperty> getInferredAuth(String authTarget) {
     return Optional.empty();
+  }
+
+  @Override
+  public String getInferredAuthDescriptor() {
+    return "";
   }
 
   @Override

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -78,8 +78,8 @@ public class JibExtension {
   public JibExtension(Project project) {
     ObjectFactory objectFactory = project.getObjects();
 
-    from = objectFactory.newInstance(BaseImageParameters.class, "jib.from");
-    to = objectFactory.newInstance(TargetImageParameters.class, "jib.to");
+    from = objectFactory.newInstance(BaseImageParameters.class);
+    to = objectFactory.newInstance(TargetImageParameters.class);
     container = objectFactory.newInstance(ContainerParameters.class);
     extraDirectory =
         objectFactory.newInstance(ExtraDirectoryParameters.class, project.getProjectDir().toPath());

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TargetImageParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TargetImageParameters.java
@@ -39,8 +39,8 @@ public class TargetImageParameters {
   @Nullable private String credHelper;
 
   @Inject
-  public TargetImageParameters(ObjectFactory objectFactory, String imageDescriptor) {
-    auth = objectFactory.newInstance(AuthParameters.class, imageDescriptor + ".auth");
+  public TargetImageParameters(ObjectFactory objectFactory) {
+    auth = objectFactory.newInstance(AuthParameters.class);
   }
 
   @Input

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
@@ -39,9 +39,6 @@ public class GradleRawConfigurationTest {
 
     Mockito.when(authParameters.getUsername()).thenReturn("user");
     Mockito.when(authParameters.getPassword()).thenReturn("password");
-    Mockito.when(authParameters.getPropertyDescriptor()).thenReturn("auth source");
-    Mockito.when(authParameters.getUsernamePropertyDescriptor()).thenReturn("from.auth.username");
-    Mockito.when(authParameters.getPasswordPropertyDescriptor()).thenReturn("<to><auth><password>");
 
     Mockito.when(jibExtension.getFrom()).thenReturn(baseImageParameters);
     Mockito.when(jibExtension.getTo()).thenReturn(targetImageParameters);
@@ -74,9 +71,9 @@ public class GradleRawConfigurationTest {
     AuthProperty fromAuth = rawConfiguration.getFromAuth();
     Assert.assertEquals("user", fromAuth.getUsername());
     Assert.assertEquals("password", fromAuth.getPassword());
-    Assert.assertEquals("auth source", fromAuth.getPropertyDescriptor());
-    Assert.assertEquals("from.auth.username", fromAuth.getUsernamePropertyDescriptor());
-    Assert.assertEquals("<to><auth><password>", fromAuth.getPasswordPropertyDescriptor());
+    Assert.assertEquals("test.auth", rawConfiguration.getAuthDescriptor("test"));
+    Assert.assertEquals("test2.auth.username", rawConfiguration.getUsernameAuthDescriptor("test2"));
+    Assert.assertEquals("test3.auth.password", rawConfiguration.getPasswordAuthDescriptor("test3"));
 
     Assert.assertTrue(rawConfiguration.getAllowInsecureRegistries());
     Assert.assertEquals("/app/root", rawConfiguration.getAppRoot());

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -49,22 +49,6 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
 
     @Nullable @Parameter private String username;
     @Nullable @Parameter private String password;
-    @Nullable private String descriptor;
-
-    @Override
-    public String getPropertyDescriptor() {
-      return Preconditions.checkNotNull(descriptor);
-    }
-
-    @Override
-    public String getUsernamePropertyDescriptor() {
-      return Preconditions.checkNotNull(descriptor) + "<username>";
-    }
-
-    @Override
-    public String getPasswordPropertyDescriptor() {
-      return Preconditions.checkNotNull(descriptor) + "<password>";
-    }
 
     @Override
     @Nullable
@@ -86,10 +70,6 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
     @VisibleForTesting
     void setPassword(String password) {
       this.password = password;
-    }
-
-    private void setPropertyDescriptor(String descriptor) {
-      this.descriptor = descriptor;
     }
   }
 
@@ -229,12 +209,6 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   private boolean skip;
 
   @Nullable @Component protected SettingsDecrypter settingsDecrypter;
-
-  /** Default constructor handles setting up auth property descriptors. */
-  JibPluginConfiguration() {
-    to.auth.setPropertyDescriptor("<to><auth>");
-    from.auth.setPropertyDescriptor("<from><auth>");
-  }
 
   MavenSession getSession() {
     return Preconditions.checkNotNull(session);

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
@@ -73,6 +73,21 @@ class MavenRawConfiguration implements RawConfiguration {
   }
 
   @Override
+  public String getAuthDescriptor(String source) {
+    return "<" + source + "><auth>";
+  }
+
+  @Override
+  public String getUsernameAuthDescriptor(String source) {
+    return getAuthDescriptor(source) + "<username>";
+  }
+
+  @Override
+  public String getPasswordAuthDescriptor(String source) {
+    return getAuthDescriptor(source) + "<password>";
+  }
+
+  @Override
   public Optional<String> getToCredHelper() {
     return Optional.ofNullable(jibPluginConfiguration.getTargetImageCredentialHelperName());
   }
@@ -146,6 +161,11 @@ class MavenRawConfiguration implements RawConfiguration {
   public Optional<AuthProperty> getInferredAuth(String authTarget)
       throws InferredAuthRetrievalException {
     return mavenSettingsServerCredentials.retrieve(authTarget);
+  }
+
+  @Override
+  public String getInferredAuthDescriptor() {
+    return MavenSettingsServerCredentials.CREDENTIAL_SOURCE;
   }
 
   @Override

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentials.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentials.java
@@ -136,21 +136,6 @@ class MavenSettingsServerCredentials {
           public String getPassword() {
             return password;
           }
-
-          @Override
-          public String getPropertyDescriptor() {
-            return CREDENTIAL_SOURCE;
-          }
-
-          @Override
-          public String getUsernamePropertyDescriptor() {
-            return CREDENTIAL_SOURCE;
-          }
-
-          @Override
-          public String getPasswordPropertyDescriptor() {
-            return CREDENTIAL_SOURCE;
-          }
         });
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
@@ -70,19 +70,7 @@ public class JibPluginConfigurationTest {
   }
 
   @Test
-  public void testAuthDefaults() {
-    Assert.assertEquals(
-        "<from><auth><username>",
-        testPluginConfiguration.getBaseImageAuth().getUsernamePropertyDescriptor());
-    Assert.assertEquals(
-        "<from><auth><password>",
-        testPluginConfiguration.getBaseImageAuth().getPasswordPropertyDescriptor());
-    Assert.assertEquals(
-        "<to><auth><username>",
-        testPluginConfiguration.getTargetImageAuth().getUsernamePropertyDescriptor());
-    Assert.assertEquals(
-        "<to><auth><password>",
-        testPluginConfiguration.getTargetImageAuth().getPasswordPropertyDescriptor());
+  public void testDefaults() {
     Assert.assertEquals("", testPluginConfiguration.getAppRoot());
   }
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenRawConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenRawConfigurationTest.java
@@ -52,9 +52,6 @@ public class MavenRawConfigurationTest {
     AuthConfiguration auth = Mockito.mock(AuthConfiguration.class);
     Mockito.when(auth.getUsername()).thenReturn("user");
     Mockito.when(auth.getPassword()).thenReturn("password");
-    Mockito.when(auth.getPropertyDescriptor()).thenReturn("auth source");
-    Mockito.when(auth.getUsernamePropertyDescriptor()).thenReturn("from.auth.username");
-    Mockito.when(auth.getPasswordPropertyDescriptor()).thenReturn("<to><auth><password>");
 
     Mockito.when(jibPluginConfiguration.getSession()).thenReturn(mavenSession);
     Mockito.when(jibPluginConfiguration.getBaseImageAuth()).thenReturn(auth);
@@ -84,16 +81,15 @@ public class MavenRawConfigurationTest {
     AuthProperty fromAuth = rawConfiguration.getFromAuth();
     Assert.assertEquals("user", fromAuth.getUsername());
     Assert.assertEquals("password", fromAuth.getPassword());
-    Assert.assertEquals("auth source", fromAuth.getPropertyDescriptor());
-    Assert.assertEquals("from.auth.username", fromAuth.getUsernamePropertyDescriptor());
-    Assert.assertEquals("<to><auth><password>", fromAuth.getPasswordPropertyDescriptor());
+    Assert.assertEquals("<test><auth>", rawConfiguration.getAuthDescriptor("test"));
+    Assert.assertEquals(
+        "<test><auth><username>", rawConfiguration.getUsernameAuthDescriptor("test"));
+    Assert.assertEquals(
+        "<test><auth><password>", rawConfiguration.getPasswordAuthDescriptor("test"));
 
     AuthProperty mavenSettingsAuth = rawConfiguration.getInferredAuth("base registry").get();
     Assert.assertEquals("maven settings user", mavenSettingsAuth.getUsername());
     Assert.assertEquals("maven settings password", mavenSettingsAuth.getPassword());
-    Assert.assertEquals("Maven settings", mavenSettingsAuth.getPropertyDescriptor());
-    Assert.assertEquals("Maven settings", mavenSettingsAuth.getUsernamePropertyDescriptor());
-    Assert.assertEquals("Maven settings", mavenSettingsAuth.getPasswordPropertyDescriptor());
 
     Assert.assertFalse(rawConfiguration.getInferredAuth("unknown registry").isPresent());
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentialsTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentialsTest.java
@@ -62,7 +62,6 @@ public class MavenSettingsServerCredentialsTest {
     Assert.assertTrue(auth.isPresent());
     Assert.assertEquals("server1 username", auth.get().getUsername());
     Assert.assertEquals("server1 password", auth.get().getPassword());
-    Assert.assertEquals("Maven settings", auth.get().getPropertyDescriptor());
 
     Mockito.verifyZeroInteractions(mockEventDispatcher);
   }
@@ -114,7 +113,6 @@ public class MavenSettingsServerCredentialsTest {
     Assert.assertTrue(auth.isPresent());
     Assert.assertEquals("server1 username", auth.get().getUsername());
     Assert.assertEquals("server1 password", auth.get().getPassword());
-    Assert.assertEquals("Maven settings", auth.get().getPropertyDescriptor());
 
     Mockito.verify(mockDecrypter).decrypt(Mockito.any());
     Mockito.verify(mockResult).getProblems();

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/AuthProperty.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/AuthProperty.java
@@ -26,25 +26,4 @@ public interface AuthProperty {
 
   @Nullable
   String getPassword();
-
-  /**
-   * Returns the full descriptor used to configure the {@link AuthProperty}.
-   *
-   * @return the descriptor used to configure the property (e.g. 'jib.to.auth')
-   */
-  String getPropertyDescriptor();
-
-  /**
-   * Returns the full descriptor used to configure the {@link AuthProperty}'s username.
-   *
-   * @return the descriptor used to configure the username property (e.g. 'jib.to.auth.username')
-   */
-  String getUsernamePropertyDescriptor();
-
-  /**
-   * Returns the full descriptor used to configure the {@link AuthProperty}'s password.
-   *
-   * @return the descriptor used to configure the password property (e.g. 'jib.to.auth.password')
-   */
-  String getPasswordPropertyDescriptor();
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidator.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidator.java
@@ -48,6 +48,8 @@ public class ConfigurationPropertyValidator {
    * @param usernameProperty the name of the username system property
    * @param passwordProperty the name of the password system property
    * @param auth the configured credentials
+   * @param authUsernameDescriptor the name of the auth username parameter
+   * @param authPasswordDescriptor the name of the auth password parameter
    * @return a new {@link Authorization} from the system properties or build configuration, or
    *     {@link Optional#empty} if neither is configured.
    */
@@ -55,7 +57,9 @@ public class ConfigurationPropertyValidator {
       EventDispatcher eventDispatcher,
       String usernameProperty,
       String passwordProperty,
-      AuthProperty auth) {
+      AuthProperty auth,
+      String authUsernameDescriptor,
+      String authPasswordDescriptor) {
     // System property takes priority over build configuration
     String commandlineUsername = System.getProperty(usernameProperty);
     String commandlinePassword = System.getProperty(passwordProperty);
@@ -89,14 +93,14 @@ public class ConfigurationPropertyValidator {
     if (Strings.isNullOrEmpty(auth.getUsername())) {
       eventDispatcher.dispatch(
           LogEvent.warn(
-              auth.getUsernamePropertyDescriptor()
+              authUsernameDescriptor
                   + " is missing from build configuration; ignoring auth section."));
       return Optional.empty();
     }
     if (Strings.isNullOrEmpty(auth.getPassword())) {
       eventDispatcher.dispatch(
           LogEvent.warn(
-              auth.getPasswordPropertyDescriptor()
+              authPasswordDescriptor
                   + " is missing from build configuration; ignoring auth section."));
       return Optional.empty();
     }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
@@ -35,6 +35,12 @@ public interface RawConfiguration {
 
   AuthProperty getToAuth();
 
+  String getAuthDescriptor(String source);
+
+  String getUsernameAuthDescriptor(String source);
+
+  String getPasswordAuthDescriptor(String source);
+
   Optional<String> getFromCredHelper();
 
   Optional<String> getToCredHelper();
@@ -69,6 +75,8 @@ public interface RawConfiguration {
   // from settings.xml is not necessary raw configuration values. Consider removing it.
   // https://github.com/GoogleContainerTools/jib/pull/1163#discussion_r228389684
   Optional<AuthProperty> getInferredAuth(String authTarget) throws InferredAuthRetrievalException;
+
+  String getInferredAuthDescriptor();
 
   ImageFormat getImageFormat();
 }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidatorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidatorTest.java
@@ -41,8 +41,6 @@ public class ConfigurationPropertyValidatorTest {
 
   @Test
   public void testGetImageAuth() {
-    Mockito.when(mockAuth.getUsernamePropertyDescriptor()).thenReturn("user");
-    Mockito.when(mockAuth.getPasswordPropertyDescriptor()).thenReturn("pass");
     Mockito.when(mockAuth.getUsername()).thenReturn("vwxyz");
     Mockito.when(mockAuth.getPassword()).thenReturn("98765");
 
@@ -52,7 +50,12 @@ public class ConfigurationPropertyValidatorTest {
     Credential expected = Credential.basic("abcde", "12345");
     Optional<Credential> actual =
         ConfigurationPropertyValidator.getImageCredential(
-            mockEventDispatcher, "jib.test.auth.user", "jib.test.auth.pass", mockAuth);
+            mockEventDispatcher,
+            "jib.test.auth.user",
+            "jib.test.auth.pass",
+            mockAuth,
+            "user",
+            "pass");
     Assert.assertTrue(actual.isPresent());
     Assert.assertEquals(expected.toString(), actual.get().toString());
 
@@ -62,7 +65,12 @@ public class ConfigurationPropertyValidatorTest {
     expected = Credential.basic("vwxyz", "98765");
     actual =
         ConfigurationPropertyValidator.getImageCredential(
-            mockEventDispatcher, "jib.test.auth.user", "jib.test.auth.pass", mockAuth);
+            mockEventDispatcher,
+            "jib.test.auth.user",
+            "jib.test.auth.pass",
+            mockAuth,
+            "user",
+            "pass");
     Assert.assertTrue(actual.isPresent());
     Assert.assertEquals(expected.toString(), actual.get().toString());
     Mockito.verify(mockEventDispatcher, Mockito.never()).dispatch(LogEvent.warn(Mockito.any()));
@@ -72,7 +80,12 @@ public class ConfigurationPropertyValidatorTest {
     Mockito.when(mockAuth.getPassword()).thenReturn(null);
     actual =
         ConfigurationPropertyValidator.getImageCredential(
-            mockEventDispatcher, "jib.test.auth.user", "jib.test.auth.pass", mockAuth);
+            mockEventDispatcher,
+            "jib.test.auth.user",
+            "jib.test.auth.pass",
+            mockAuth,
+            "user",
+            "pass");
     Assert.assertFalse(actual.isPresent());
 
     // Password missing
@@ -80,7 +93,12 @@ public class ConfigurationPropertyValidatorTest {
     Mockito.when(mockAuth.getPassword()).thenReturn(null);
     actual =
         ConfigurationPropertyValidator.getImageCredential(
-            mockEventDispatcher, "jib.test.auth.user", "jib.test.auth.pass", mockAuth);
+            mockEventDispatcher,
+            "jib.test.auth.user",
+            "jib.test.auth.pass",
+            mockAuth,
+            "user",
+            "pass");
     Assert.assertFalse(actual.isPresent());
     Mockito.verify(mockEventDispatcher)
         .dispatch(
@@ -91,7 +109,12 @@ public class ConfigurationPropertyValidatorTest {
     Mockito.when(mockAuth.getPassword()).thenReturn("98765");
     actual =
         ConfigurationPropertyValidator.getImageCredential(
-            mockEventDispatcher, "jib.test.auth.user", "jib.test.auth.pass", mockAuth);
+            mockEventDispatcher,
+            "jib.test.auth.user",
+            "jib.test.auth.pass",
+            mockAuth,
+            "user",
+            "pass");
     Assert.assertFalse(actual.isPresent());
     Mockito.verify(mockEventDispatcher)
         .dispatch(


### PR DESCRIPTION
Fixes #1177.

`PluginConfigurationProcessor` is getting messy so I think we should figure out how to reduce the number of parameters in each method soon.