### PR TITLE
 Update documentation for 0.10.1

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -316,7 +316,7 @@ jib {
 }
 ```
 
-Some plugins, such as the [Docker Prepare Gradle Plugin](https://github.com/gclayburg/dockerPreparePlugin), will even automatically generate a Docker context for your project.
+Some plugins, such as the [Docker Prepare Gradle Plugin](https://github.com/gclayburg/dockerPreparePlugin), will even automatically generate a Docker context for your project, including a Dockerfile.
 
 ### How can I inspect the image Jib built?
 

--- a/jib-gradle-plugin/README.md
+++ b/jib-gradle-plugin/README.md
@@ -132,26 +132,6 @@ tasks.build.dependsOn tasks.jib
 
 Then, ```gradle build``` will build and containerize your application.
 
-### Export to a Docker context
-
-Jib can also export a Docker context so that you can build with Docker, if needed:
-
-```shell
-gradle jibExportDockerContext
-```
-
-The Docker context will be created at `build/jib-docker-context` by default. You can change this directory with the `targetDir` configuration option or the `--jibTargetDir` parameter:
-
-```shell
-gradle jibExportDockerContext --jibTargetDir=my/docker/context/
-```
-
-You can then build your image with Docker:
-
-```shell
-docker build -t myimage my/docker/context/
-```
-
 ### Additional Build Artifacts
 
 As part of an image build, Jib also writes out the _image digest_ to

--- a/jib-maven-plugin/README.md
+++ b/jib-maven-plugin/README.md
@@ -173,26 +173,6 @@ Then, you can build your container image by running:
 mvn package
 ```
 
-### Export to a Docker context
-
-Jib can also export a Docker context so that you can build with Docker, if needed:
-
-```shell
-mvn compile jib:exportDockerContext
-```
-
-The Docker context will be created at `target/jib-docker-context` by default. You can change this directory with the `targetDir` configuration option or the `jibTargetDir` parameter:
-
-```shell
-mvn compile jib:exportDockerContext -DjibTargetDir=my/docker/context/
-```
-
-You can then build your image with Docker:
-
-```shell
-docker build -t myimage my/docker/context/
-```
-
 ### Additional Build Artifacts
 
 As part of an image build, Jib also writes out the _image digest_ to


### PR DESCRIPTION
- Removes docker context generator
- Adds FAQ entries for what a Jib-like Dockerfile looks like and suggestions for inspecting container images