### PR TITLE
Filter non-existent dependency files.

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurations.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurations.java
@@ -106,7 +106,7 @@ class GradleLayerConfigurations {
     FileCollection dependencyFiles =
         allFiles
             .minus(classesOutputDirectories)
-            .filter(file -> !file.toPath().equals(resourcesOutputDirectory));
+            .filter(file -> !file.toPath().equals(resourcesOutputDirectory) && file.exists());
 
     // Adds class files.
     logger.info("Adding corresponding output directories of source sets to image");

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurationsTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurationsTest.java
@@ -132,6 +132,8 @@ public class GradleLayerConfigurationsTest {
         Paths.get(
             Resources.getResource("application/dependencies/dependencyX-1.0.0-SNAPSHOT.jar")
                 .toURI()));
+    // A file added to SourceSet.allFiles that does not actually exist.
+    allFiles.add(Paths.get("/dev/null/cannot/exist/on/any/os"));
     FileCollection runtimeFileCollection = new TestFileCollection(allFiles);
 
     Mockito.when(mockProject.getConvention()).thenReturn(mockConvention);


### PR DESCRIPTION
<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->

It is possible for allFiles to contain non-existent files, so they must be filtered to prevent issues during layer calculation.

Fixes #1271 