### PR TITLE
Ignore DirectoryNotEmptyException too since it is what is thrown on L…

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
@@ -74,9 +74,11 @@ class DefaultCacheStorageWriter {
     try {
       Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE);
 
-    } catch (FileAlreadyExistsException ignored) {
+    } catch (FileAlreadyExistsException | DirectoryNotEmptyException ignored) {
       // If the file already exists, we skip renaming and use the existing file. This happens if a
-      // new layer happens to have the same content as a previously-cached layer.
+      // new layer happens to have the same content as a previously-cached layer. Depending on the
+      // implementation, either FileAlreadyExistsException or DirectoryNotEmptyException will be
+      // thrown if it already exists.
       //
       // Do not attempt to remove the try-catch block with the idea of checking file existence
       // before moving; there can be concurrent file moves.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
@@ -78,7 +78,7 @@ class DefaultCacheStorageWriter {
       // If the file already exists, we skip renaming and use the existing file. This happens if a
       // new layer happens to have the same content as a previously-cached layer. Depending on the
       // implementation, either FileAlreadyExistsException or DirectoryNotEmptyException will be
-      // thrown if it already exists.
+      // thrown if destination already exists.
       //
       // Do not attempt to remove the try-catch block with the idea of checking file existence
       // before moving; there can be concurrent file moves.


### PR DESCRIPTION
…inux when trying to atomically move a directory to an existing one.

Fixes #1273 
