### PR TITLE
Change exposed port/volumes API to use sets instead of lists

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -32,8 +32,10 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
 
@@ -245,10 +247,10 @@ public class JibContainerBuilder {
    * <p>This is similar to <a href="https://docs.docker.com/engine/reference/builder/#volume">{@code
    * VOLUME} in Dockerfiles</a>.
    *
-   * @param volumes the list of directory paths on the container filesystem to set as volumes
+   * @param volumes the set of directory paths on the container filesystem to set as volumes
    * @return this
    */
-  public JibContainerBuilder setVolumes(List<AbsoluteUnixPath> volumes) {
+  public JibContainerBuilder setVolumes(Set<AbsoluteUnixPath> volumes) {
     containerConfigurationBuilder.setVolumes(volumes);
     return this;
   }
@@ -258,10 +260,10 @@ public class JibContainerBuilder {
    *
    * @param volumes the list of directory paths on the container filesystem to set as volumes
    * @return this
-   * @see #setVolumes(List) for more details
+   * @see #setVolumes(Set) for more details
    */
   public JibContainerBuilder setVolumes(AbsoluteUnixPath... volumes) {
-    return setVolumes(new ArrayList<>(Arrays.asList(volumes)));
+    return setVolumes(new HashSet<>(Arrays.asList(volumes)));
   }
 
   /**
@@ -269,7 +271,7 @@ public class JibContainerBuilder {
    *
    * @param volume a directory path on the container filesystem to represent a volume.
    * @return this
-   * @see #setVolumes(List) for more details
+   * @see #setVolumes(Set) for more details
    */
   public JibContainerBuilder addVolume(AbsoluteUnixPath volume) {
     containerConfigurationBuilder.addVolume(volume);
@@ -287,10 +289,10 @@ public class JibContainerBuilder {
    * href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#container-v1-core">Kubernetes
    * Container spec</a>.
    *
-   * @param ports the list of ports to expose
+   * @param ports the set of ports to expose
    * @return this
    */
-  public JibContainerBuilder setExposedPorts(List<Port> ports) {
+  public JibContainerBuilder setExposedPorts(Set<Port> ports) {
     containerConfigurationBuilder.setExposedPorts(ports);
     return this;
   }
@@ -300,10 +302,10 @@ public class JibContainerBuilder {
    *
    * @param ports the ports to expose
    * @return this
-   * @see #setExposedPorts(List) for more details
+   * @see #setExposedPorts(Set) for more details
    */
   public JibContainerBuilder setExposedPorts(Port... ports) {
-    return setExposedPorts(Arrays.asList(ports));
+    return setExposedPorts(new HashSet<>(Arrays.asList(ports)));
   }
 
   /**
@@ -311,7 +313,7 @@ public class JibContainerBuilder {
    *
    * @param port the port to expose
    * @return this
-   * @see #setExposedPorts(List) for more details
+   * @see #setExposedPorts(Set) for more details
    */
   public JibContainerBuilder addExposedPort(Port port) {
     containerConfigurationBuilder.addExposedPort(port);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -21,13 +21,15 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /** Immutable configuration options for the container. */
@@ -43,8 +45,8 @@ public class ContainerConfiguration {
     @Nullable private ImmutableList<String> entrypoint;
     @Nullable private ImmutableList<String> programArguments;
     @Nullable private Map<String, String> environmentMap;
-    @Nullable private List<Port> exposedPorts;
-    @Nullable private List<AbsoluteUnixPath> volumes;
+    @Nullable private Set<Port> exposedPorts;
+    @Nullable private Set<AbsoluteUnixPath> volumes;
     @Nullable private Map<String, String> labels;
     @Nullable private String user;
     @Nullable private AbsoluteUnixPath workingDirectory;
@@ -103,22 +105,22 @@ public class ContainerConfiguration {
     /**
      * Sets the container's exposed ports.
      *
-     * @param exposedPorts the list of ports
+     * @param exposedPorts the set of ports
      * @return this
      */
-    public Builder setExposedPorts(@Nullable List<Port> exposedPorts) {
+    public Builder setExposedPorts(@Nullable Set<Port> exposedPorts) {
       if (exposedPorts == null) {
         this.exposedPorts = null;
       } else {
         Preconditions.checkArgument(!exposedPorts.contains(null));
-        this.exposedPorts = new ArrayList<>(exposedPorts);
+        this.exposedPorts = new HashSet<>(exposedPorts);
       }
       return this;
     }
 
     public void addExposedPort(Port port) {
       if (exposedPorts == null) {
-        exposedPorts = new ArrayList<>();
+        exposedPorts = new HashSet<>();
       }
       exposedPorts.add(port);
     }
@@ -126,22 +128,22 @@ public class ContainerConfiguration {
     /**
      * Sets the container's volumes.
      *
-     * @param volumes the list of volumes
+     * @param volumes the set of volumes
      * @return this
      */
-    public Builder setVolumes(@Nullable List<AbsoluteUnixPath> volumes) {
+    public Builder setVolumes(@Nullable Set<AbsoluteUnixPath> volumes) {
       if (volumes == null) {
         this.volumes = null;
       } else {
         Preconditions.checkArgument(!volumes.contains(null));
-        this.volumes = new ArrayList<>(volumes);
+        this.volumes = new HashSet<>(volumes);
       }
       return this;
     }
 
     public void addVolume(AbsoluteUnixPath volume) {
       if (volumes == null) {
-        volumes = new ArrayList<>();
+        volumes = new HashSet<>();
       }
       volumes.add(volume);
     }
@@ -221,8 +223,8 @@ public class ContainerConfiguration {
           entrypoint,
           programArguments,
           environmentMap == null ? null : ImmutableMap.copyOf(environmentMap),
-          exposedPorts == null ? null : ImmutableList.copyOf(exposedPorts),
-          volumes == null ? null : ImmutableList.copyOf(volumes),
+          exposedPorts == null ? null : ImmutableSet.copyOf(exposedPorts),
+          volumes == null ? null : ImmutableSet.copyOf(volumes),
           labels == null ? null : ImmutableMap.copyOf(labels),
           user,
           workingDirectory);
@@ -244,8 +246,8 @@ public class ContainerConfiguration {
   @Nullable private final ImmutableList<String> entrypoint;
   @Nullable private final ImmutableList<String> programArguments;
   @Nullable private final ImmutableMap<String, String> environmentMap;
-  @Nullable private final ImmutableList<Port> exposedPorts;
-  @Nullable private final ImmutableList<AbsoluteUnixPath> volumes;
+  @Nullable private final ImmutableSet<Port> exposedPorts;
+  @Nullable private final ImmutableSet<AbsoluteUnixPath> volumes;
   @Nullable private final ImmutableMap<String, String> labels;
   @Nullable private final String user;
   @Nullable private final AbsoluteUnixPath workingDirectory;
@@ -255,8 +257,8 @@ public class ContainerConfiguration {
       @Nullable ImmutableList<String> entrypoint,
       @Nullable ImmutableList<String> programArguments,
       @Nullable ImmutableMap<String, String> environmentMap,
-      @Nullable ImmutableList<Port> exposedPorts,
-      @Nullable ImmutableList<AbsoluteUnixPath> volumes,
+      @Nullable ImmutableSet<Port> exposedPorts,
+      @Nullable ImmutableSet<AbsoluteUnixPath> volumes,
       @Nullable ImmutableMap<String, String> labels,
       @Nullable String user,
       @Nullable AbsoluteUnixPath workingDirectory) {
@@ -291,12 +293,12 @@ public class ContainerConfiguration {
   }
 
   @Nullable
-  public ImmutableList<Port> getExposedPorts() {
+  public ImmutableSet<Port> getExposedPorts() {
     return exposedPorts;
   }
 
   @Nullable
-  public ImmutableList<AbsoluteUnixPath> getVolumes() {
+  public ImmutableSet<AbsoluteUnixPath> getVolumes() {
     return volumes;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/ExposedPortsParser.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/ExposedPortsParser.java
@@ -18,7 +18,7 @@ package com.google.cloud.tools.jib.frontend;
 
 import com.google.cloud.tools.jib.configuration.Port;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -44,8 +44,8 @@ public class ExposedPortsParser {
    * @return the ports as a list of {@link Port}
    * @throws NumberFormatException if any of the ports are in an invalid format or out of range
    */
-  public static ImmutableList<Port> parse(List<String> ports) throws NumberFormatException {
-    ImmutableList.Builder<Port> result = new ImmutableList.Builder<>();
+  public static ImmutableSet<Port> parse(List<String> ports) throws NumberFormatException {
+    ImmutableSet.Builder<Port> result = new ImmutableSet.Builder<>();
 
     for (String port : ports) {
       Matcher matcher = portPattern.matcher(port);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/Image.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/Image.java
@@ -21,10 +21,12 @@ import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.image.json.HistoryEntry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /** Represents an image. */
@@ -44,8 +46,8 @@ public class Image<T extends Layer> {
     @Nullable private Instant created;
     @Nullable private ImmutableList<String> entrypoint;
     @Nullable private ImmutableList<String> programArguments;
-    @Nullable private ImmutableList<Port> exposedPorts;
-    @Nullable private ImmutableList<AbsoluteUnixPath> volumes;
+    @Nullable private ImmutableSet<Port> exposedPorts;
+    @Nullable private ImmutableSet<AbsoluteUnixPath> volumes;
     @Nullable private String workingDirectory;
     @Nullable private String user;
 
@@ -125,8 +127,8 @@ public class Image<T extends Layer> {
      * @param exposedPorts the list of exposed ports to add
      * @return this
      */
-    public Builder<T> setExposedPorts(@Nullable List<Port> exposedPorts) {
-      this.exposedPorts = (exposedPorts == null) ? null : ImmutableList.copyOf(exposedPorts);
+    public Builder<T> setExposedPorts(@Nullable Set<Port> exposedPorts) {
+      this.exposedPorts = (exposedPorts == null) ? null : ImmutableSet.copyOf(exposedPorts);
       return this;
     }
 
@@ -136,8 +138,8 @@ public class Image<T extends Layer> {
      * @param volumes the list of directories to create a volume.
      * @return this
      */
-    public Builder<T> setVolumes(@Nullable List<AbsoluteUnixPath> volumes) {
-      this.volumes = (volumes == null) ? null : ImmutableList.copyOf(volumes);
+    public Builder<T> setVolumes(@Nullable Set<AbsoluteUnixPath> volumes) {
+      this.volumes = (volumes == null) ? null : ImmutableSet.copyOf(volumes);
       return this;
     }
 
@@ -239,10 +241,10 @@ public class Image<T extends Layer> {
   @Nullable private final ImmutableList<String> programArguments;
 
   /** Ports that the container listens on. */
-  @Nullable private final ImmutableList<Port> exposedPorts;
+  @Nullable private final ImmutableSet<Port> exposedPorts;
 
-  /** List of directories to mount as volumes. */
-  @Nullable private final ImmutableList<AbsoluteUnixPath> volumes;
+  /** Directories to mount as volumes. */
+  @Nullable private final ImmutableSet<AbsoluteUnixPath> volumes;
 
   /** Labels on the container configuration */
   @Nullable private final ImmutableMap<String, String> labels;
@@ -260,8 +262,8 @@ public class Image<T extends Layer> {
       @Nullable ImmutableMap<String, String> environment,
       @Nullable ImmutableList<String> entrypoint,
       @Nullable ImmutableList<String> programArguments,
-      @Nullable ImmutableList<Port> exposedPorts,
-      @Nullable ImmutableList<AbsoluteUnixPath> volumes,
+      @Nullable ImmutableSet<Port> exposedPorts,
+      @Nullable ImmutableSet<AbsoluteUnixPath> volumes,
       @Nullable ImmutableMap<String, String> labels,
       @Nullable String workingDirectory,
       @Nullable String user) {
@@ -299,12 +301,12 @@ public class Image<T extends Layer> {
   }
 
   @Nullable
-  public ImmutableList<Port> getExposedPorts() {
+  public ImmutableSet<Port> getExposedPorts() {
     return exposedPorts;
   }
 
   @Nullable
-  public ImmutableList<AbsoluteUnixPath> getVolumes() {
+  public ImmutableSet<AbsoluteUnixPath> getVolumes() {
     return volumes;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
@@ -28,7 +28,7 @@ import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.cloud.tools.jib.image.ReferenceLayer;
 import com.google.cloud.tools.jib.image.ReferenceNoDiffIdLayer;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -148,12 +148,11 @@ public class JsonToImageTranslator {
 
     if (containerConfigurationTemplate.getContainerExposedPorts() != null) {
       imageBuilder.setExposedPorts(
-          portMapToList(containerConfigurationTemplate.getContainerExposedPorts()));
+          portMapToSet(containerConfigurationTemplate.getContainerExposedPorts()));
     }
 
     if (containerConfigurationTemplate.getContainerVolumes() != null) {
-      imageBuilder.setVolumes(
-          volumeMapToList(containerConfigurationTemplate.getContainerVolumes()));
+      imageBuilder.setVolumes(volumeMapToSet(containerConfigurationTemplate.getContainerVolumes()));
     }
 
     if (containerConfigurationTemplate.getContainerEnvironment() != null) {
@@ -174,19 +173,19 @@ public class JsonToImageTranslator {
   }
 
   /**
-   * Converts a map of exposed ports as strings to a list of {@link Port}s (e.g. {@code
+   * Converts a map of exposed ports as strings to a set of {@link Port}s (e.g. {@code
    * {"1000/tcp":{}}} -> {@code Port(1000, Protocol.TCP)}).
    *
    * @param portMap the map to convert
-   * @return a list of {@link Port}s
+   * @return a set of {@link Port}s
    */
   @VisibleForTesting
-  static ImmutableList<Port> portMapToList(@Nullable Map<String, Map<?, ?>> portMap)
+  static ImmutableSet<Port> portMapToSet(@Nullable Map<String, Map<?, ?>> portMap)
       throws BadContainerConfigurationFormatException {
     if (portMap == null) {
-      return ImmutableList.of();
+      return ImmutableSet.of();
     }
-    ImmutableList.Builder<Port> ports = new ImmutableList.Builder<>();
+    ImmutableSet.Builder<Port> ports = new ImmutableSet.Builder<>();
     for (Map.Entry<String, Map<?, ?>> entry : portMap.entrySet()) {
       String port = entry.getKey();
       Matcher matcher = PORT_PATTERN.matcher(port);
@@ -203,20 +202,20 @@ public class JsonToImageTranslator {
   }
 
   /**
-   * Converts a map of volumes strings to a list of {@link AbsoluteUnixPath}s (e.g. {@code {@code
+   * Converts a map of volumes strings to a set of {@link AbsoluteUnixPath}s (e.g. {@code {@code
    * {"/var/log/my-app-logs":{}}} -> AbsoluteUnixPath().get("/var/log/my-app-logs")}).
    *
    * @param volumeMap the map to convert
-   * @return a list of {@link AbsoluteUnixPath}s
+   * @return a set of {@link AbsoluteUnixPath}s
    */
   @VisibleForTesting
-  static ImmutableList<AbsoluteUnixPath> volumeMapToList(@Nullable Map<String, Map<?, ?>> volumeMap)
+  static ImmutableSet<AbsoluteUnixPath> volumeMapToSet(@Nullable Map<String, Map<?, ?>> volumeMap)
       throws BadContainerConfigurationFormatException {
     if (volumeMap == null) {
-      return ImmutableList.of();
+      return ImmutableSet.of();
     }
 
-    ImmutableList.Builder<AbsoluteUnixPath> volumeList = ImmutableList.builder();
+    ImmutableSet.Builder<AbsoluteUnixPath> volumeList = ImmutableSet.builder();
     for (String volume : volumeMap.keySet()) {
       try {
         volumeList.add(AbsoluteUnixPath.get(volume));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
@@ -66,7 +66,7 @@ public class JibContainerBuilderTest {
         new JibContainerBuilder(baseImage, spyBuildConfigurationBuilder)
             .setEntrypoint(Arrays.asList("entry", "point"))
             .setEnvironment(ImmutableMap.of("name", "value"))
-            .setExposedPorts(Arrays.asList(Port.tcp(1234), Port.udp(5678)))
+            .setExposedPorts(ImmutableSet.of(Port.tcp(1234), Port.udp(5678)))
             .setLabels(ImmutableMap.of("key", "value"))
             .setProgramArguments(Arrays.asList("program", "arguments"))
             .setCreationTime(Instant.ofEpochMilli(1000))
@@ -80,7 +80,7 @@ public class JibContainerBuilderTest {
     Assert.assertEquals(
         ImmutableMap.of("name", "value"), containerConfiguration.getEnvironmentMap());
     Assert.assertEquals(
-        Arrays.asList(Port.tcp(1234), Port.udp(5678)), containerConfiguration.getExposedPorts());
+        ImmutableSet.of(Port.tcp(1234), Port.udp(5678)), containerConfiguration.getExposedPorts());
     Assert.assertEquals(ImmutableMap.of("key", "value"), containerConfiguration.getLabels());
     Assert.assertEquals(
         Arrays.asList("program", "arguments"), containerConfiguration.getProgramArguments());
@@ -113,7 +113,7 @@ public class JibContainerBuilderTest {
         ImmutableMap.of("name", "value", "environment", "variable"),
         containerConfiguration.getEnvironmentMap());
     Assert.assertEquals(
-        Arrays.asList(Port.tcp(1234), Port.udp(5678), Port.tcp(1337)),
+        ImmutableSet.of(Port.tcp(1234), Port.udp(5678), Port.tcp(1337)),
         containerConfiguration.getExposedPorts());
     Assert.assertEquals(
         ImmutableMap.of("key", "value", "added", "label"), containerConfiguration.getLabels());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
@@ -30,6 +30,7 @@ import com.google.cloud.tools.jib.image.Layer;
 import com.google.cloud.tools.jib.image.json.HistoryEntry;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.security.DigestException;
@@ -104,7 +105,7 @@ public class BuildImageStepTest {
     Mockito.when(mockContainerConfiguration.getCreationTime()).thenReturn(Instant.EPOCH);
     Mockito.when(mockContainerConfiguration.getEnvironmentMap()).thenReturn(ImmutableMap.of());
     Mockito.when(mockContainerConfiguration.getProgramArguments()).thenReturn(ImmutableList.of());
-    Mockito.when(mockContainerConfiguration.getExposedPorts()).thenReturn(ImmutableList.of());
+    Mockito.when(mockContainerConfiguration.getExposedPorts()).thenReturn(ImmutableSet.of());
     Mockito.when(mockContainerConfiguration.getEntrypoint()).thenReturn(ImmutableList.of());
     Mockito.when(mockContainerConfiguration.getUser()).thenReturn("root");
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
@@ -23,7 +23,6 @@ import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.OCIManifestTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -59,7 +58,7 @@ public class BuildConfigurationTest {
     List<String> expectedEntrypoint = Arrays.asList("some", "entrypoint");
     List<String> expectedProgramArguments = Arrays.asList("arg1", "arg2");
     Map<String, String> expectedEnvironment = ImmutableMap.of("key", "value");
-    ImmutableList<Port> expectedExposedPorts = ImmutableList.of(Port.tcp(1000), Port.tcp(2000));
+    ImmutableSet<Port> expectedExposedPorts = ImmutableSet.of(Port.tcp(1000), Port.tcp(2000));
     Map<String, String> expectedLabels = ImmutableMap.of("key1", "value1", "key2", "value2");
     Class<? extends BuildableManifestTemplate> expectedTargetFormat = OCIManifestTemplate.class;
     Path expectedApplicationLayersCacheDirectory = Paths.get("application/layers");

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
@@ -20,9 +20,10 @@ import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Hashtable;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import org.junit.Assert;
 import org.junit.Test;
@@ -49,7 +50,7 @@ public class ContainerConfigurationTest {
     }
 
     // Exposed ports element should not be null.
-    List<Port> badPorts = Arrays.asList(Port.tcp(1000), null);
+    Set<Port> badPorts = new HashSet<>(Arrays.asList(Port.tcp(1000), null));
     try {
       ContainerConfiguration.builder().setExposedPorts(badPorts);
       Assert.fail("The IllegalArgumentException should be thrown.");

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/ExposedPortsParserTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/ExposedPortsParserTest.java
@@ -17,7 +17,7 @@
 package com.google.cloud.tools.jib.frontend;
 
 import com.google.cloud.tools.jib.configuration.Port;
-import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -31,8 +31,8 @@ public class ExposedPortsParserTest {
   public void testParse() {
     List<String> goodInputs =
         Arrays.asList("1000", "2000-2003", "3000-3000", "4000/tcp", "5000/udp", "6000-6002/udp");
-    ImmutableList<Port> expected =
-        new ImmutableList.Builder<Port>()
+    ImmutableSet<Port> expected =
+        new ImmutableSet.Builder<Port>()
             .add(
                 Port.tcp(1000),
                 Port.tcp(2000),
@@ -46,7 +46,7 @@ public class ExposedPortsParserTest {
                 Port.udp(6001),
                 Port.udp(6002))
             .build();
-    ImmutableList<Port> result = ExposedPortsParser.parse(goodInputs);
+    ImmutableSet<Port> result = ExposedPortsParser.parse(goodInputs);
     Assert.assertEquals(expected, result);
 
     List<String> badInputs = Arrays.asList("abc", "/udp", "1000/abc", "a100/tcp", "20/udpabc");

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageTest.java
@@ -18,8 +18,8 @@ package com.google.cloud.tools.jib.image;
 
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.configuration.Port;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
 import java.util.Arrays;
 import org.junit.Assert;
@@ -52,7 +52,7 @@ public class ImageTest {
             .addEnvironmentVariable("VARIABLE", "VALUE")
             .setEntrypoint(Arrays.asList("some", "command"))
             .setProgramArguments(Arrays.asList("arg1", "arg2"))
-            .setExposedPorts(ImmutableList.of(Port.tcp(1000), Port.tcp(2000)))
+            .setExposedPorts(ImmutableSet.of(Port.tcp(1000), Port.tcp(2000)))
             .setUser("john")
             .addLayer(mockLayer)
             .build();
@@ -64,7 +64,7 @@ public class ImageTest {
         ImmutableMap.of("crepecake", "is great", "VARIABLE", "VALUE"), image.getEnvironment());
     Assert.assertEquals(Arrays.asList("some", "command"), image.getEntrypoint());
     Assert.assertEquals(Arrays.asList("arg1", "arg2"), image.getProgramArguments());
-    Assert.assertEquals(ImmutableList.of(Port.tcp(1000), Port.tcp(2000)), image.getExposedPorts());
+    Assert.assertEquals(ImmutableSet.of(Port.tcp(1000), Port.tcp(2000)), image.getExposedPorts());
     Assert.assertEquals("john", image.getUser());
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslatorTest.java
@@ -28,6 +28,7 @@ import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Resources;
@@ -61,9 +62,9 @@ public class ImageToJsonTranslatorTest {
     testImageBuilder.setEntrypoint(Arrays.asList("some", "entrypoint", "command"));
     testImageBuilder.setProgramArguments(Arrays.asList("arg1", "arg2"));
     testImageBuilder.setExposedPorts(
-        ImmutableList.of(Port.tcp(1000), Port.tcp(2000), Port.udp(3000)));
+        ImmutableSet.of(Port.tcp(1000), Port.tcp(2000), Port.udp(3000)));
     testImageBuilder.setVolumes(
-        Arrays.asList(
+        ImmutableSet.of(
             AbsoluteUnixPath.get("/var/job-result-data"),
             AbsoluteUnixPath.get("/var/log/my-app-logs")));
     testImageBuilder.addLabels(ImmutableMap.of("key1", "value1", "key2", "value2"));
@@ -135,22 +136,22 @@ public class ImageToJsonTranslatorTest {
 
   @Test
   public void testPortListToMap() {
-    ImmutableList<Port> input = ImmutableList.of(Port.tcp(1000), Port.udp(2000));
+    ImmutableSet<Port> input = ImmutableSet.of(Port.tcp(1000), Port.udp(2000));
     ImmutableSortedMap<String, Map<?, ?>> expected =
         ImmutableSortedMap.of("1000/tcp", ImmutableMap.of(), "2000/udp", ImmutableMap.of());
-    Assert.assertEquals(expected, ImageToJsonTranslator.portListToMap(input));
+    Assert.assertEquals(expected, ImageToJsonTranslator.portSetToMap(input));
   }
 
   @Test
   public void testVolumeListToMap() {
-    ImmutableList<AbsoluteUnixPath> input =
-        ImmutableList.of(
+    ImmutableSet<AbsoluteUnixPath> input =
+        ImmutableSet.of(
             AbsoluteUnixPath.get("/var/job-result-data"),
             AbsoluteUnixPath.get("/var/log/my-app-logs"));
     ImmutableSortedMap<String, Map<?, ?>> expected =
         ImmutableSortedMap.of(
             "/var/job-result-data", ImmutableMap.of(), "/var/log/my-app-logs", ImmutableMap.of());
-    Assert.assertEquals(expected, ImageToJsonTranslator.volumesListToMap(input));
+    Assert.assertEquals(expected, ImageToJsonTranslator.volumesSetToMap(input));
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
@@ -27,6 +27,7 @@ import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -89,8 +90,8 @@ public class JsonToImageTranslatorTest {
             ImmutableMap.of(),
             "3000/udp",
             ImmutableMap.of());
-    ImmutableList<Port> expected = ImmutableList.of(Port.tcp(1000), Port.tcp(2000), Port.udp(3000));
-    Assert.assertEquals(expected, JsonToImageTranslator.portMapToList(input));
+    ImmutableSet<Port> expected = ImmutableSet.of(Port.tcp(1000), Port.tcp(2000), Port.udp(3000));
+    Assert.assertEquals(expected, JsonToImageTranslator.portMapToSet(input));
 
     ImmutableList<Map<String, Map<?, ?>>> badInputs =
         ImmutableList.of(
@@ -100,7 +101,7 @@ public class JsonToImageTranslatorTest {
             ImmutableMap.of("123/xxx", ImmutableMap.of()));
     for (Map<String, Map<?, ?>> badInput : badInputs) {
       try {
-        JsonToImageTranslator.portMapToList(badInput);
+        JsonToImageTranslator.portMapToSet(badInput);
         Assert.fail();
       } catch (BadContainerConfigurationFormatException ignored) {
       }
@@ -112,11 +113,11 @@ public class JsonToImageTranslatorTest {
     ImmutableSortedMap<String, Map<?, ?>> input =
         ImmutableSortedMap.of(
             "/var/job-result-data", ImmutableMap.of(), "/var/log/my-app-logs", ImmutableMap.of());
-    ImmutableList<AbsoluteUnixPath> expected =
-        ImmutableList.of(
+    ImmutableSet<AbsoluteUnixPath> expected =
+        ImmutableSet.of(
             AbsoluteUnixPath.get("/var/job-result-data"),
             AbsoluteUnixPath.get("/var/log/my-app-logs"));
-    Assert.assertEquals(expected, JsonToImageTranslator.volumeMapToList(input));
+    Assert.assertEquals(expected, JsonToImageTranslator.volumeMapToSet(input));
 
     ImmutableList<Map<String, Map<?, ?>>> badInputs =
         ImmutableList.of(
@@ -125,7 +126,7 @@ public class JsonToImageTranslatorTest {
             ImmutableMap.of("C:/udp", ImmutableMap.of()));
     for (Map<String, Map<?, ?>> badInput : badInputs) {
       try {
-        JsonToImageTranslator.volumeMapToList(badInput);
+        JsonToImageTranslator.volumeMapToSet(badInput);
         Assert.fail();
       } catch (BadContainerConfigurationFormatException ignored) {
       }
@@ -208,9 +209,9 @@ public class JsonToImageTranslatorTest {
     Assert.assertEquals(ImmutableMap.of("VAR1", "VAL1", "VAR2", "VAL2"), image.getEnvironment());
     Assert.assertEquals("/some/workspace", image.getWorkingDirectory());
     Assert.assertEquals(
-        ImmutableList.of(Port.tcp(1000), Port.tcp(2000), Port.udp(3000)), image.getExposedPorts());
+        ImmutableSet.of(Port.tcp(1000), Port.tcp(2000), Port.udp(3000)), image.getExposedPorts());
     Assert.assertEquals(
-        ImmutableList.of(
+        ImmutableSet.of(
             AbsoluteUnixPath.get("/var/job-result-data"),
             AbsoluteUnixPath.get("/var/log/my-app-logs")),
         image.getVolumes());

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -42,6 +42,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -251,11 +252,11 @@ public class PluginConfigurationProcessor {
             .setProgramArguments(rawConfiguration.getProgramArguments().orElse(null))
             .setEnvironment(rawConfiguration.getEnvironment())
             .setExposedPorts(ExposedPortsParser.parse(rawConfiguration.getPorts()))
-            .setVolumes(getVolumesList(rawConfiguration))
+            .setVolumes(new HashSet<>(getVolumesList(rawConfiguration)))
             .setLabels(rawConfiguration.getLabels())
             .setUser(rawConfiguration.getUser().orElse(null));
     getWorkingDirectoryChecked(rawConfiguration)
-        .ifPresent(workingDirectory -> jibContainerBuilder.setWorkingDirectory(workingDirectory));
+        .ifPresent(jibContainerBuilder::setWorkingDirectory);
     if (rawConfiguration.getUseCurrentTimestamp()) {
       eventDispatcher.dispatch(
           LogEvent.warn(


### PR DESCRIPTION
[Original comment suggesting this change.](https://github.com/GoogleContainerTools/jib/issues/595#issuecomment-441745538)

Changes API from using lists to using sets for exposed ports and volumes, since these should not contain duplicate values.