### PR TITLE
Ensure Gradle dependency files exist

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurations.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurations.java
@@ -131,12 +131,16 @@ class GradleLayerConfigurations {
 
     // Adds dependency files.
     for (File dependencyFile : dependencyFiles) {
-      boolean isSnapshot = dependencyFile.getName().contains("SNAPSHOT");
-      LayerType layerType = isSnapshot ? LayerType.SNAPSHOT_DEPENDENCIES : LayerType.DEPENDENCIES;
-      layerBuilder.addFile(
-          layerType,
-          dependencyFile.toPath(),
-          dependenciesExtractionPath.resolve(dependencyFile.getName()));
+      if (dependencyFile.exists()) {
+        boolean isSnapshot = dependencyFile.getName().contains("SNAPSHOT");
+        LayerType layerType = isSnapshot ? LayerType.SNAPSHOT_DEPENDENCIES : LayerType.DEPENDENCIES;
+        layerBuilder.addFile(
+            layerType,
+            dependencyFile.toPath(),
+            dependenciesExtractionPath.resolve(dependencyFile.getName()));
+      } else {
+        logger.info("\t'" + dependencyFile + "' (not found, skipped)");
+      }
     }
 
     // Adds all the extra files.

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurationsTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurationsTest.java
@@ -212,6 +212,22 @@ public class GradleLayerConfigurationsTest {
   }
 
   @Test
+  public void test_missingDependencyFiles() throws IOException {
+    Path nonexistentFile = Paths.get("/nonexistent/dependency");
+    FileCollection runtimeFileCollection =
+        new TestFileCollection(Collections.singleton(nonexistentFile));
+    Mockito.when(mockMainSourceSet.getRuntimeClasspath()).thenReturn(runtimeFileCollection);
+
+    AbsoluteUnixPath appRoot = AbsoluteUnixPath.get("/app");
+    GradleLayerConfigurations.getForProject(
+        mockProject, mockLogger, extraFilesDirectory, Collections.emptyMap(), appRoot);
+
+    Mockito.verify(mockLogger)
+        .info("Adding corresponding output directories of source sets to image");
+    Mockito.verify(mockLogger).info("\t'" + nonexistentFile + "' (not found, skipped)");
+  }
+
+  @Test
   public void test_extraFiles() throws IOException {
     JavaLayerConfigurations javaLayerConfigurations =
         GradleLayerConfigurations.getForProject(


### PR DESCRIPTION
Check that referenced dependency files exist before configuring the layers.  Logs skipped files.

Fixes #1271