### PR TITLE
[chore] Simplify ZipUtil.unzip

### DIFF
--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ZipUtil.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ZipUtil.java
@@ -38,7 +38,6 @@ public class ZipUtil {
    * @throws IOException when I/O error occurs
    */
   public static void unzip(Path archive, Path destination) throws IOException {
-    String canonicalDestination = destination.toFile().getCanonicalPath();
 
     try (InputStream fileIn = Files.newInputStream(archive);
         ZipInputStream zipIn = new ZipInputStream(new BufferedInputStream(fileIn))) {
@@ -46,8 +45,7 @@ public class ZipUtil {
       for (ZipEntry entry = zipIn.getNextEntry(); entry != null; entry = zipIn.getNextEntry()) {
         Path entryPath = destination.resolve(entry.getName());
 
-        String canonicalTarget = entryPath.toFile().getCanonicalPath();
-        if (!canonicalTarget.startsWith(canonicalDestination + File.separator)) {
+        if (!entryPath.toRealPath().startsWith(destination.toRealPath())) {
           String offender = entry.getName() + " from " + archive;
           throw new IOException("Blocked unzipping files outside destination: " + offender);
         }


### PR DESCRIPTION
There is no associated issue for this, as it is a minor thing I noticed when going through the LGTM issues for this project. (I'm currently looking for instances of ZipSlip, which this code currently protects against). I'm unsure if this is the correct thing to do here as it's not issue worthy. I'll understand if it gets rejected. :)

You can simplify checking that destination files remain within the destination folder using `Path.startsWith()`, rather than doing a string prefix comparison. `Path.toRealPath()` resolves symlinks like `File.getCanonicalPath()`, so behaviour should remain identical.

There are a [couple of other alerts](https://lgtm.com/projects/g/GoogleContainerTools/jib/alerts) for this project on LGTM.com that would probably be good to fix too.

*(Full disclosure: I'm part of the team behind LGTM.com)*