### PR TITLE
Add system properties for setting cache directories

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `jib.baseImageCache` and `jib.applicationCache` system properties for setting cache directories ([#1238](https://github.com/GoogleContainerTools/jib/issues/1238))
+
 ### Changed
 
 ### Fixed

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -144,7 +144,7 @@ class GradleProjectProperties implements ProjectProperties {
   }
 
   @Override
-  public Path getCacheDirectory() {
+  public Path getDefaultCacheDirectory() {
     return project.getBuildDir().toPath().resolve(CACHE_DIRECTORY_NAME);
   }
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `jib.baseImageCache` and `jib.applicationCache` system properties for setting cache directories ([#1238](https://github.com/GoogleContainerTools/jib/issues/1238))
+
 ### Changed
 
 ### Fixed

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -148,7 +148,7 @@ public class MavenProjectProperties implements ProjectProperties {
   }
 
   @Override
-  public Path getCacheDirectory() {
+  public Path getDefaultCacheDirectory() {
     return Paths.get(project.getBuild().getDirectory(), CACHE_DIRECTORY_NAME);
   }
 

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -450,11 +450,9 @@ public class PluginConfigurationProcessor {
    */
   private static Path getCheckedCacheDirectory(String property, Path defaultPath) {
     if (System.getProperty(property) != null) {
-      Path path = Paths.get(System.getProperty(property));
-      return path.isAbsolute() ? path : Paths.get(System.getProperty("user.dir")).resolve(path);
-    } else {
-      return defaultPath;
+      return Paths.get(System.getProperty(property));
     }
+    return defaultPath;
   }
 
   private final JibContainerBuilder jibContainerBuilder;

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -40,6 +40,7 @@ import com.google.common.base.Verify;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
@@ -421,13 +422,38 @@ public class PluginConfigurationProcessor {
         .setToolName(projectProperties.getToolName())
         .setEventHandlers(projectProperties.getEventHandlers())
         .setAllowInsecureRegistries(rawConfiguration.getAllowInsecureRegistries())
-        .setBaseImageLayersCache(Containerizer.DEFAULT_BASE_CACHE_DIRECTORY)
-        .setApplicationLayersCache(projectProperties.getCacheDirectory());
+        .setBaseImageLayersCache(
+            getCheckedCacheDirectory(
+                PropertyNames.BASE_IMAGE_LAYERS_CACHE, Containerizer.DEFAULT_BASE_CACHE_DIRECTORY))
+        .setApplicationLayersCache(
+            getCheckedCacheDirectory(
+                PropertyNames.APPLICATION_IMAGE_LAYERS_CACHE,
+                projectProperties.getDefaultCacheDirectory()));
 
     rawConfiguration.getToTags().forEach(containerizer::withAdditionalTag);
 
     if (rawConfiguration.getUseOnlyProjectCache()) {
-      containerizer.setBaseImageLayersCache(projectProperties.getCacheDirectory());
+      containerizer.setBaseImageLayersCache(
+          getCheckedCacheDirectory(
+              PropertyNames.BASE_IMAGE_LAYERS_CACHE, projectProperties.getDefaultCacheDirectory()));
+    }
+  }
+
+  /**
+   * Returns the value of a cache directory system property if it is set, otherwise returns {@code
+   * defaultPath}.
+   *
+   * @param property the name of the system property to check
+   * @param defaultPath the path to return if the system property isn't set
+   * @return the value of a cache directory system property if it is set, otherwise returns {@code
+   *     defaultPath}
+   */
+  private static Path getCheckedCacheDirectory(String property, Path defaultPath) {
+    if (System.getProperty(property) != null) {
+      Path path = Paths.get(System.getProperty(property));
+      return path.isAbsolute() ? path : Paths.get(System.getProperty("user.dir")).resolve(path);
+    } else {
+      return defaultPath;
     }
   }
 

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -424,18 +424,17 @@ public class PluginConfigurationProcessor {
         .setAllowInsecureRegistries(rawConfiguration.getAllowInsecureRegistries())
         .setBaseImageLayersCache(
             getCheckedCacheDirectory(
-                PropertyNames.BASE_IMAGE_LAYERS_CACHE, Containerizer.DEFAULT_BASE_CACHE_DIRECTORY))
+                PropertyNames.BASE_IMAGE_CACHE, Containerizer.DEFAULT_BASE_CACHE_DIRECTORY))
         .setApplicationLayersCache(
             getCheckedCacheDirectory(
-                PropertyNames.APPLICATION_IMAGE_LAYERS_CACHE,
-                projectProperties.getDefaultCacheDirectory()));
+                PropertyNames.APPLICATION_CACHE, projectProperties.getDefaultCacheDirectory()));
 
     rawConfiguration.getToTags().forEach(containerizer::withAdditionalTag);
 
     if (rawConfiguration.getUseOnlyProjectCache()) {
       containerizer.setBaseImageLayersCache(
           getCheckedCacheDirectory(
-              PropertyNames.BASE_IMAGE_LAYERS_CACHE, projectProperties.getDefaultCacheDirectory()));
+              PropertyNames.BASE_IMAGE_CACHE, projectProperties.getDefaultCacheDirectory()));
     }
   }
 

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
@@ -41,7 +41,7 @@ public interface ProjectProperties {
 
   JavaLayerConfigurations getJavaLayerConfigurations();
 
-  Path getCacheDirectory();
+  Path getDefaultCacheDirectory();
 
   String getJarPluginName();
 

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
@@ -42,6 +42,8 @@ public class PropertyNames {
   public static final String CONTAINER_PORTS = "jib.container.ports";
   public static final String CONTAINER_USE_CURRENT_TIMESTAMP = "jib.container.useCurrentTimestamp";
   public static final String USE_ONLY_PROJECT_CACHE = "jib.useOnlyProjectCache";
+  public static final String BASE_IMAGE_LAYERS_CACHE = "jib.baseImageLayersCache";
+  public static final String APPLICATION_IMAGE_LAYERS_CACHE = "jib.applicationImageLayersCache";
   public static final String ALLOW_INSECURE_REGISTRIES = "jib.allowInsecureRegistries";
   public static final String EXTRA_DIRECTORY_PATH = "jib.extraDirectory.path";
   public static final String EXTRA_DIRECTORY_PERMISSIONS = "jib.extraDirectory.permissions";

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
@@ -42,8 +42,8 @@ public class PropertyNames {
   public static final String CONTAINER_PORTS = "jib.container.ports";
   public static final String CONTAINER_USE_CURRENT_TIMESTAMP = "jib.container.useCurrentTimestamp";
   public static final String USE_ONLY_PROJECT_CACHE = "jib.useOnlyProjectCache";
-  public static final String BASE_IMAGE_LAYERS_CACHE = "jib.baseImageLayersCache";
-  public static final String APPLICATION_IMAGE_LAYERS_CACHE = "jib.applicationImageLayersCache";
+  public static final String BASE_IMAGE_LAYERS_CACHE = "jib.baseImageCache";
+  public static final String APPLICATION_IMAGE_LAYERS_CACHE = "jib.applicationImageCache";
   public static final String ALLOW_INSECURE_REGISTRIES = "jib.allowInsecureRegistries";
   public static final String EXTRA_DIRECTORY_PATH = "jib.extraDirectory.path";
   public static final String EXTRA_DIRECTORY_PERMISSIONS = "jib.extraDirectory.permissions";

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
@@ -42,8 +42,8 @@ public class PropertyNames {
   public static final String CONTAINER_PORTS = "jib.container.ports";
   public static final String CONTAINER_USE_CURRENT_TIMESTAMP = "jib.container.useCurrentTimestamp";
   public static final String USE_ONLY_PROJECT_CACHE = "jib.useOnlyProjectCache";
-  public static final String BASE_IMAGE_LAYERS_CACHE = "jib.baseImageCache";
-  public static final String APPLICATION_IMAGE_LAYERS_CACHE = "jib.applicationImageCache";
+  public static final String BASE_IMAGE_CACHE = "jib.baseImageCache";
+  public static final String APPLICATION_CACHE = "jib.applicationCache";
   public static final String ALLOW_INSECURE_REGISTRIES = "jib.allowInsecureRegistries";
   public static final String EXTRA_DIRECTORY_PATH = "jib.extraDirectory.path";
   public static final String EXTRA_DIRECTORY_PERMISSIONS = "jib.extraDirectory.permissions";

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -116,8 +116,8 @@ public class PluginConfigurationProcessorTest {
       throws InferredAuthRetrievalException, InvalidContainerVolumeException,
           MainClassInferenceException, InvalidAppRootException, IOException,
           InvalidWorkingDirectoryException, InvalidImageReferenceException {
-    System.setProperty(PropertyNames.BASE_IMAGE_LAYERS_CACHE, "new/base/cache");
-    System.setProperty(PropertyNames.APPLICATION_IMAGE_LAYERS_CACHE, "/new/application/cache");
+    System.setProperty(PropertyNames.BASE_IMAGE_CACHE, "new/base/cache");
+    System.setProperty(PropertyNames.APPLICATION_CACHE, "/new/application/cache");
 
     PluginConfigurationProcessor.processCommonConfiguration(
         rawConfiguration, projectProperties, containerizer, targetImageReference, false);
@@ -125,8 +125,8 @@ public class PluginConfigurationProcessorTest {
     Mockito.verify(containerizer).setBaseImageLayersCache(Paths.get("new/base/cache"));
     Mockito.verify(containerizer).setApplicationLayersCache(Paths.get("/new/application/cache"));
 
-    System.clearProperty(PropertyNames.BASE_IMAGE_LAYERS_CACHE);
-    System.clearProperty(PropertyNames.APPLICATION_IMAGE_LAYERS_CACHE);
+    System.clearProperty(PropertyNames.BASE_IMAGE_CACHE);
+    System.clearProperty(PropertyNames.APPLICATION_CACHE);
   }
 
   @Test

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -75,7 +75,7 @@ public class PluginConfigurationProcessorTest {
     Mockito.when(projectProperties.getMainClassFromJar()).thenReturn("java.lang.Object");
     Mockito.when(projectProperties.getEventHandlers())
         .thenReturn(new EventHandlers().add(JibEventType.LOGGING, logger));
-    Mockito.when(projectProperties.getCacheDirectory()).thenReturn(Paths.get("cache"));
+    Mockito.when(projectProperties.getDefaultCacheDirectory()).thenReturn(Paths.get("cache"));
 
     Mockito.when(containerizer.setToolName(Mockito.anyString())).thenReturn(containerizer);
     Mockito.when(containerizer.setEventHandlers(Mockito.any(EventHandlers.class)))
@@ -103,8 +103,32 @@ public class PluginConfigurationProcessorTest {
         Arrays.asList("java", "-cp", "/app/resources:/app/classes:/app/libs/*", "java.lang.Object"),
         buildConfiguration.getContainerConfiguration().getEntrypoint());
 
+    Mockito.verify(containerizer)
+        .setBaseImageLayersCache(Containerizer.DEFAULT_BASE_CACHE_DIRECTORY);
+    Mockito.verify(containerizer).setApplicationLayersCache(Paths.get("cache"));
+
     ArgumentMatcher<LogEvent> isLogWarn = logEvent -> logEvent.getLevel() == LogEvent.Level.WARN;
     Mockito.verify(logger, Mockito.never()).accept(Mockito.argThat(isLogWarn));
+  }
+
+  @Test
+  public void testPluginConfigurationProcessor_cacheDirectorySystemProperties()
+      throws InferredAuthRetrievalException, InvalidContainerVolumeException,
+          MainClassInferenceException, InvalidAppRootException, IOException,
+          InvalidWorkingDirectoryException, InvalidImageReferenceException {
+    System.setProperty(PropertyNames.BASE_IMAGE_LAYERS_CACHE, "new/base/cache");
+    System.setProperty(PropertyNames.APPLICATION_IMAGE_LAYERS_CACHE, "/new/application/cache");
+
+    PluginConfigurationProcessor.processCommonConfiguration(
+        rawConfiguration, projectProperties, containerizer, targetImageReference, false);
+
+    Mockito.verify(containerizer)
+        .setBaseImageLayersCache(
+            Paths.get(System.getProperty("user.dir")).resolve("new/base/cache"));
+    Mockito.verify(containerizer).setApplicationLayersCache(Paths.get("/new/application/cache"));
+
+    System.clearProperty(PropertyNames.BASE_IMAGE_LAYERS_CACHE);
+    System.clearProperty(PropertyNames.APPLICATION_IMAGE_LAYERS_CACHE);
   }
 
   @Test
@@ -179,7 +203,6 @@ public class PluginConfigurationProcessorTest {
 
     JibContainerBuilder jibContainerBuilder = processor.getJibContainerBuilder();
     BuildConfiguration buildConfiguration = getBuildConfiguration(jibContainerBuilder);
-    Assert.assertNull(buildConfiguration.getContainerConfiguration().getEntrypoint());
     Assert.assertNotNull(buildConfiguration.getContainerConfiguration());
     Assert.assertNull(buildConfiguration.getContainerConfiguration().getEntrypoint());
     Mockito.verifyZeroInteractions(logger);

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -122,9 +122,7 @@ public class PluginConfigurationProcessorTest {
     PluginConfigurationProcessor.processCommonConfiguration(
         rawConfiguration, projectProperties, containerizer, targetImageReference, false);
 
-    Mockito.verify(containerizer)
-        .setBaseImageLayersCache(
-            Paths.get(System.getProperty("user.dir")).resolve("new/base/cache"));
+    Mockito.verify(containerizer).setBaseImageLayersCache(Paths.get("new/base/cache"));
     Mockito.verify(containerizer).setApplicationLayersCache(Paths.get("/new/application/cache"));
 
     System.clearProperty(PropertyNames.BASE_IMAGE_LAYERS_CACHE);


### PR DESCRIPTION
Fixes #1238.

Adds two system properties for setting cache directories:
* `jib.baseImageCache`
* `jib.applicationCache`