### PR TITLE
Consolidate digest generation in LoadDockerStep and WriteTarFileStep

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildResult.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildResult.java
@@ -16,11 +16,46 @@
 
 package com.google.cloud.tools.jib.builder.steps;
 
+import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
+import com.google.cloud.tools.jib.image.Image;
+import com.google.cloud.tools.jib.image.Layer;
+import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
+import com.google.cloud.tools.jib.image.json.ImageToJsonTranslator;
+import com.google.cloud.tools.jib.json.JsonTemplateMapper;
+import com.google.common.io.ByteStreams;
+import java.io.IOException;
 import java.util.Objects;
 
 /** Used to record the results of a build. */
 public class BuildResult {
+
+  /**
+   * Gets a {@link BuildResult} from an {@link Image}.
+   *
+   * @param image the image
+   * @param targetFormat the target format of the image
+   * @return a new {@link BuildResult} with the image's digest and id
+   * @throws IOException if writing the digest or container configuration fails
+   */
+  static BuildResult fromImage(
+      Image<Layer> image, Class<? extends BuildableManifestTemplate> targetFormat)
+      throws IOException {
+    ImageToJsonTranslator imageToJsonTranslator = new ImageToJsonTranslator(image);
+    BlobDescriptor containerConfigurationBlobDescriptor =
+        imageToJsonTranslator
+            .getContainerConfigurationBlob()
+            .writeTo(ByteStreams.nullOutputStream());
+    BuildableManifestTemplate manifestTemplate =
+        imageToJsonTranslator.getManifestTemplate(
+            targetFormat, containerConfigurationBlobDescriptor);
+    DescriptorDigest imageDigest =
+        JsonTemplateMapper.toBlob(manifestTemplate)
+            .writeTo(ByteStreams.nullOutputStream())
+            .getDigest();
+    DescriptorDigest imageId = containerConfigurationBlobDescriptor.getDigest();
+    return new BuildResult(imageDigest, imageId);
+  }
 
   private final DescriptorDigest imageDigest;
   private final DescriptorDigest imageId;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
@@ -18,19 +18,13 @@ package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.NonBlockingSteps;
-import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.docker.ImageToTarballTranslator;
 import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.filesystem.FileOperations;
-import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.Layer;
-import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
-import com.google.cloud.tools.jib.image.json.ImageToJsonTranslator;
-import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -110,22 +104,6 @@ public class WriteTarFileStep implements AsyncStep<BuildResult>, Callable<BuildR
           .writeTo(outputStream);
     }
 
-    // TODO: Consolidate image digest generation with PushImageStep and LoadDockerStep.
-    // Gets the image manifest to generate the image digest.
-    ImageToJsonTranslator imageToJsonTranslator = new ImageToJsonTranslator(image);
-    BlobDescriptor containerConfigurationBlobDescriptor =
-        imageToJsonTranslator
-            .getContainerConfigurationBlob()
-            .writeTo(ByteStreams.nullOutputStream());
-    BuildableManifestTemplate manifestTemplate =
-        imageToJsonTranslator.getManifestTemplate(
-            buildConfiguration.getTargetFormat(), containerConfigurationBlobDescriptor);
-    DescriptorDigest imageDigest =
-        JsonTemplateMapper.toBlob(manifestTemplate)
-            .writeTo(ByteStreams.nullOutputStream())
-            .getDigest();
-    DescriptorDigest imageId = containerConfigurationBlobDescriptor.getDigest();
-
-    return new BuildResult(imageDigest, imageId);
+    return BuildResult.fromImage(image, buildConfiguration.getTargetFormat());
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildResultTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildResultTest.java
@@ -17,6 +17,10 @@
 package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.image.DescriptorDigest;
+import com.google.cloud.tools.jib.image.Image;
+import com.google.cloud.tools.jib.image.Layer;
+import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
+import java.io.IOException;
 import java.security.DigestException;
 import org.junit.Assert;
 import org.junit.Before;
@@ -58,5 +62,18 @@ public class BuildResultTest {
     Assert.assertEquals(container1, container2);
     Assert.assertEquals(container1.hashCode(), container2.hashCode());
     Assert.assertNotEquals(container1, container3);
+  }
+
+  @Test
+  public void testFromImage() throws IOException {
+    Image<Layer> image1 = Image.builder(V22ManifestTemplate.class).setUser("user").build();
+    Image<Layer> image2 = Image.builder(V22ManifestTemplate.class).setUser("user").build();
+    Image<Layer> image3 = Image.builder(V22ManifestTemplate.class).setUser("anotherUser").build();
+    Assert.assertEquals(
+        BuildResult.fromImage(image1, V22ManifestTemplate.class),
+        BuildResult.fromImage(image2, V22ManifestTemplate.class));
+    Assert.assertNotEquals(
+        BuildResult.fromImage(image1, V22ManifestTemplate.class),
+        BuildResult.fromImage(image3, V22ManifestTemplate.class));
   }
 }


### PR DESCRIPTION
Fixes a todo that has been around for a while. It may be possible to consolidate a bit more in `PushImageStep`, but that has a bit of extra code for pushing to multiple tags, so I ignored it for now.