### PR TITLE
 Adds ProgressEventHandler.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/ProgressEvent.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/ProgressEvent.java
@@ -36,7 +36,7 @@ public class ProgressEvent implements JibEvent {
   /** Units of progress. */
   private final long progressUnits;
 
-  ProgressEvent(Allocation allocation, long progressUnits) {
+  public ProgressEvent(Allocation allocation, long progressUnits) {
     this.allocation = allocation;
     this.progressUnits = progressUnits;
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/ProgressEvent.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/ProgressEvent.java
@@ -46,7 +46,7 @@ public class ProgressEvent implements JibEvent {
    *
    * @return the {@link Allocation}
    */
-  Allocation getAllocation() {
+  public Allocation getAllocation() {
     return allocation;
   }
 
@@ -56,7 +56,7 @@ public class ProgressEvent implements JibEvent {
    *
    * @return units of allocation
    */
-  long getUnits() {
+  public long getUnits() {
     return progressUnits;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/Allocation.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/Allocation.java
@@ -60,7 +60,7 @@ public class Allocation {
   /** The number of allocation units this node holds. */
   private final long allocationUnits;
 
-  /** How much of the root allocation (1.0) this allocation accounts for. */
+  /** How much of the root allocation (1.0) each allocation unit accounts for. */
   private final double fractionOfRoot;
 
   private Allocation(String description, long allocationUnits, @Nullable Allocation parent) {
@@ -68,7 +68,7 @@ public class Allocation {
     this.allocationUnits = allocationUnits;
     this.parent = parent;
 
-    this.fractionOfRoot = parent == null ? 1.0 : parent.fractionOfRoot / parent.allocationUnits;
+    this.fractionOfRoot = (parent == null ? 1.0 : parent.fractionOfRoot) / allocationUnits;
   }
 
   /**
@@ -113,10 +113,10 @@ public class Allocation {
   }
 
   /**
-   * Gets how much of the root allocation this allocation accounts for. The entire root allocation
-   * is {@code 1.0}.
+   * Gets how much of the root allocation each of the allocation units of this allocation accounts
+   * for. The entire root allocation is {@code 1.0}.
    *
-   * @return the fraction of the root allocation this allocation accounts for
+   * @return the fraction of the root allocation this allocation's allocation units accounts for
    */
   public double getFractionOfRoot() {
     return fractionOfRoot;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTracker.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTracker.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.event.progress;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Keeps track of the progress for {@link Allocation}s as well as their order in which they appear.
+ *
+ * <p>This implementation is thread-safe.
+ */
+class AllocationCompletionTracker {
+
+  /**
+   * Holds the progress units completed along with a creation order. This is used as the value of
+   * the {@link #completionMap}.
+   */
+  private static class InsertionOrderUnits implements Comparable<InsertionOrderUnits> {
+
+    /** Monotonically-increasing source for {@link #index}. */
+    private static final AtomicInteger currentIndex = new AtomicInteger();
+
+    /** The creation order that monotonically increases. */
+    private final int index = currentIndex.getAndIncrement();
+
+    /**
+     * Progress units completed. This can be shared across multiple threads and should be updated
+     * atomically.
+     */
+    private final AtomicLong units = new AtomicLong();
+
+    /** The {@link Allocation} this is for. */
+    private final Allocation allocation;
+
+    private InsertionOrderUnits(Allocation allocation) {
+      this.allocation = allocation;
+    }
+
+    @Override
+    public int compareTo(InsertionOrderUnits otherInsertionOrderUnits) {
+      return index - otherInsertionOrderUnits.index;
+    }
+  }
+
+  /**
+   * Maps from {@link Allocation} to the number of progress units completed in that {@link
+   * Allocation}, while keeping track of the insertion order of the {@link Allocation}s with {@link
+   * InsertionOrderUnits}.
+   */
+  private final ConcurrentHashMap<Allocation, InsertionOrderUnits> completionMap =
+      new ConcurrentHashMap<>();
+
+  /**
+   * Puts an entry for {@code allocation} in the map if not present, with progress initialized to
+   * {@code 0}.
+   *
+   * @param allocation the {@link Allocation}
+   * @return {@code true} if the map was updated; {@code false} if {@code allocation} was already
+   *     present
+   */
+  boolean putIfAbsent(Allocation allocation) {
+    // Note: Could have false positives.
+    boolean alreadyPresent = completionMap.containsKey(allocation);
+    completionMap.computeIfAbsent(allocation, InsertionOrderUnits::new);
+    return alreadyPresent;
+  }
+
+  /**
+   * Updates the progress for {@link Allocation} atomically relative to the {@code allocation}.
+   *
+   * @param allocation the {@link Allocation} to update progress for
+   * @param units the units of progress
+   */
+  void updateProgress(Allocation allocation, long units) {
+    completionMap.compute(
+        allocation,
+        (ignored, insertionOrderUnits) -> {
+          if (insertionOrderUnits == null) {
+            insertionOrderUnits = new InsertionOrderUnits(allocation);
+          }
+
+          updateProgress(insertionOrderUnits, units);
+
+          return insertionOrderUnits;
+        });
+  }
+
+  /**
+   * Gets a list of the unfinished {@link Allocation}s in the order in which those {@link
+   * Allocation}s were encountered.
+   *
+   * @return a list of unfinished {@link Allocation}s
+   */
+  List<Allocation> getUnfinishedAllocations() {
+    Queue<InsertionOrderUnits> unfinishedInsertionOrderUnits = new PriorityQueue<>();
+
+    for (InsertionOrderUnits insertionOrderUnits : completionMap.values()) {
+      if (insertionOrderUnits.units.get() == insertionOrderUnits.allocation.getAllocationUnits()) {
+        unfinishedInsertionOrderUnits.add(insertionOrderUnits);
+      }
+    }
+
+    List<Allocation> unfinishedAllocations = new ArrayList<>();
+    for (InsertionOrderUnits insertionOrderUnits : unfinishedInsertionOrderUnits) {
+      unfinishedAllocations.add(insertionOrderUnits.allocation);
+    }
+    return unfinishedAllocations;
+  }
+
+  /**
+   * Helper method for {@link #updateProgress(Allocation, long)}. This method is <em>not</em>
+   * thread-safe for the {@code insertionOrderUnits} and should be called atomically relative to the
+   * {@code insertionOrderUnits}.
+   *
+   * @param insertionOrderUnits the {@link InsertionOrderUnits} to update progress for
+   * @param units the units of progress
+   */
+  private void updateProgress(InsertionOrderUnits insertionOrderUnits, long units) {
+    Allocation allocation = insertionOrderUnits.allocation;
+
+    long newUnits = insertionOrderUnits.units.addAndGet(units);
+    if (newUnits > allocation.getAllocationUnits()) {
+      throw new IllegalStateException(
+          "Progress exceeds max for '"
+              + allocation.getDescription()
+              + "': "
+              + newUnits
+              + " > "
+              + allocation.getAllocationUnits());
+    }
+
+    // Updates the parent allocations if this allocation completed.
+    if (newUnits == allocation.getAllocationUnits()) {
+      allocation
+          .getParent()
+          .ifPresent(
+              parentAllocation ->
+                  updateProgress(
+                      Preconditions.checkNotNull(completionMap.get(parentAllocation)), 1L));
+    }
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTracker.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTracker.java
@@ -80,8 +80,8 @@ class AllocationCompletionTracker {
    * @param allocation the {@link Allocation} to update progress for
    * @param units the units of progress
    * @return {@code true} if the map was updated; {@code false} if {@code allocation} was already
-   *     present. Note that there could be false positives if called concurrently, but never false
-   *     negatives.
+   *     present. Note that this may return {@code true} even if the map was not updated if called
+   *     concurrently, but never {@code false} if the map was updated.
    */
   boolean updateProgress(Allocation allocation, long units) {
     if (units == 0L) {
@@ -107,7 +107,9 @@ class AllocationCompletionTracker {
 
   /**
    * Gets a list of the unfinished {@link Allocation}s in the order in which those {@link
-   * Allocation}s were encountered.
+   * Allocation}s were encountered. This can be used to display, for example, currently executing
+   * tasks. The order helps to keep the displayed tasks in a deterministic order (new subtasks
+   * appear below older ones) and not jumbled together in some random order.
    *
    * @return a list of unfinished {@link Allocation}s
    */

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTracker.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTracker.java
@@ -98,7 +98,7 @@ class AllocationCompletionTracker {
             insertionOrderUnits = new InsertionOrderUnits(allocation);
           }
 
-          updateProgress(insertionOrderUnits, units);
+          updateInsertionOrderUnits(insertionOrderUnits, units);
 
           return insertionOrderUnits;
         });
@@ -130,14 +130,17 @@ class AllocationCompletionTracker {
   }
 
   /**
-   * Helper method for {@link #updateProgress(Allocation, long)}. This method is <em>not</em>
-   * thread-safe for the {@code insertionOrderUnits} and should be called atomically relative to the
-   * {@code insertionOrderUnits}.
+   * Helper method for {@link #updateProgress(Allocation, long)}. Adds units to {@code
+   * insertionOrderUnits}. Updates {@link InsertionOrderUnits} for parent {@link Allocation}s if
+   * {@code insertionOrderUnits.units} reached completion (equals {@code
+   * allocation.getAllocationUnits()}. This method is <em>not</em> thread-safe for the {@code
+   * insertionOrderUnits} and should be called atomically relative to the {@code
+   * insertionOrderUnits}.
    *
    * @param insertionOrderUnits the {@link InsertionOrderUnits} to update progress for
    * @param units the units of progress
    */
-  private void updateProgress(InsertionOrderUnits insertionOrderUnits, long units) {
+  private void updateInsertionOrderUnits(InsertionOrderUnits insertionOrderUnits, long units) {
     Allocation allocation = insertionOrderUnits.allocation;
 
     long newUnits = insertionOrderUnits.units.addAndGet(units);
@@ -157,7 +160,7 @@ class AllocationCompletionTracker {
           .getParent()
           .ifPresent(
               parentAllocation ->
-                  updateProgress(
+                  updateInsertionOrderUnits(
                       Preconditions.checkNotNull(completionMap.get(parentAllocation)), 1L));
     }
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTracker.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTracker.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.jib.event.progress;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.Queue;
@@ -104,10 +103,6 @@ class AllocationCompletionTracker {
           return insertionOrderUnits;
         });
     return true;
-  }
-
-  List<Allocation> getKeys() {
-    return Collections.list(completionMap.keys());
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandler.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandler.java
@@ -17,14 +17,7 @@
 package com.google.cloud.tools.jib.event.progress;
 
 import com.google.cloud.tools.jib.event.events.ProgressEvent;
-import com.google.common.base.Preconditions;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.PriorityQueue;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.function.Consumer;
 
@@ -36,121 +29,15 @@ import java.util.function.Consumer;
  */
 class ProgressEventHandler implements Consumer<ProgressEvent> {
 
-  /**
-   * Maps from {@link Allocation} to the number of progress units completed in that {@link
-   * Allocation}, while keeping track of the insertion order of the {@link Allocation}s.
-   */
-  private static class AllocationCompletionMap {
-
-    /** Holds the progress units completed along with a creation order. */
-    private static class InsertionOrderUnits implements Comparable<InsertionOrderUnits> {
-
-      /** Monotonically-increasing source for {@link #index}. */
-      private static final AtomicInteger currentIndex = new AtomicInteger();
-
-      /** The creation order that monotonically increases. */
-      private final int index = currentIndex.getAndIncrement();
-
-      /**
-       * Progress units completed. This can be shared across multiple threads and should be updated
-       * atomically.
-       */
-      private final AtomicLong units = new AtomicLong();
-
-      /** The {@link Allocation} this is for. */
-      private final Allocation allocation;
-
-      private InsertionOrderUnits(Allocation allocation) {
-        this.allocation = allocation;
-      }
-
-      @Override
-      public int compareTo(InsertionOrderUnits otherInsertionOrderUnits) {
-        return index - otherInsertionOrderUnits.index;
-      }
-    }
-
-    private final ConcurrentHashMap<Allocation, InsertionOrderUnits> completionMap =
-        new ConcurrentHashMap<>();
-
-    /**
-     * Puts an entry for {@code allocation} in the map if not present, with progress initialized to
-     * {@code 0}.
-     *
-     * @param allocation the {@link Allocation}
-     * @return {@code true} if the map was updated; {@code false} if {@code allocation} was already
-     *     present
-     */
-    private boolean putIfAbsent(Allocation allocation) {
-      // Note: Could have false positives.
-      boolean alreadyPresent = completionMap.containsKey(allocation);
-      completionMap.computeIfAbsent(allocation, InsertionOrderUnits::new);
-      return alreadyPresent;
-    }
-
-    /**
-     * Updates the progress for {@link Allocation} atomically relative to the {@code allocation}.
-     *
-     * @param allocation the {@link Allocation} to update progress for
-     * @param units the units of progress
-     */
-    private void updateProgress(Allocation allocation, long units) {
-      completionMap.compute(
-          allocation,
-          (ignored, insertionOrderUnits) -> {
-            if (insertionOrderUnits == null) {
-              insertionOrderUnits = new InsertionOrderUnits(allocation);
-            }
-
-            updateProgress(insertionOrderUnits, units);
-
-            return insertionOrderUnits;
-          });
-    }
-
-    /**
-     * Helper method for {@link #updateProgress(Allocation, long)}. This method is <em>not</em>
-     * thread-safe for the {@code insertionOrderUnits} and should be called atomically relative to
-     * the {@code insertionOrderUnits}.
-     *
-     * @param insertionOrderUnits the {@link InsertionOrderUnits} to update progress for
-     * @param units the units of progress
-     */
-    private void updateProgress(InsertionOrderUnits insertionOrderUnits, long units) {
-      Allocation allocation = insertionOrderUnits.allocation;
-
-      long newUnits = insertionOrderUnits.units.addAndGet(units);
-      if (newUnits > allocation.getAllocationUnits()) {
-        throw new IllegalStateException(
-            "Progress exceeds max for '"
-                + allocation.getDescription()
-                + "': "
-                + newUnits
-                + " > "
-                + allocation.getAllocationUnits());
-      }
-
-      // Updates the parent allocations if this allocation completed.
-      if (newUnits == allocation.getAllocationUnits()) {
-        allocation
-            .getParent()
-            .ifPresent(
-                parentAllocation ->
-                    updateProgress(
-                        Preconditions.checkNotNull(completionMap.get(parentAllocation)), 1L));
-      }
-    }
-  }
-
   /** Keeps track of the progress for each {@link Allocation} encountered. */
-  private final AllocationCompletionMap completionMap = new AllocationCompletionMap();
+  private final AllocationCompletionTracker completionTracker = new AllocationCompletionTracker();
 
   /** Accumulates an overall progress, with {@code 1.0} indicating full completion. */
   private final DoubleAdder progress = new DoubleAdder();
 
   /**
-   * A callback to notify that {@link #progress} or {@link #completionMap} could have changed. Note
-   * that every change will be reported, but there could be false positives.
+   * A callback to notify that {@link #progress} or {@link #completionTracker} could have changed.
+   * Note that every change will be reported, but there could be false positives.
    */
   private final Runnable updateNotifier;
 
@@ -166,13 +53,13 @@ class ProgressEventHandler implements Consumer<ProgressEvent> {
     long allocationUnits = allocation.getAllocationUnits();
 
     if (progressUnits == 0) {
-      completionMap.putIfAbsent(allocation);
+      completionTracker.putIfAbsent(allocation);
       return;
     }
 
     progress.add(progressUnits * allocationFraction / allocationUnits);
 
-    completionMap.updateProgress(allocation, progressUnits);
+    completionTracker.updateProgress(allocation, progressUnits);
 
     updateNotifier.run();
   }
@@ -195,21 +82,6 @@ class ProgressEventHandler implements Consumer<ProgressEvent> {
   // TODO: Change this to do every time update notifier is called, so this is not called many times
   // per update.
   List<Allocation> getUnfinishedAllocations() {
-    Queue<AllocationCompletionMap.InsertionOrderUnits> unfinishedInsertionOrderUnits =
-        new PriorityQueue<>();
-
-    for (AllocationCompletionMap.InsertionOrderUnits insertionOrderUnits :
-        completionMap.completionMap.values()) {
-      if (insertionOrderUnits.units.get() == insertionOrderUnits.allocation.getAllocationUnits()) {
-        unfinishedInsertionOrderUnits.add(insertionOrderUnits);
-      }
-    }
-
-    List<Allocation> unfinishedAllocations = new ArrayList<>();
-    for (AllocationCompletionMap.InsertionOrderUnits insertionOrderUnits :
-        unfinishedInsertionOrderUnits) {
-      unfinishedAllocations.add(insertionOrderUnits.allocation);
-    }
-    return unfinishedAllocations;
+    return completionTracker.getUnfinishedAllocations();
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandler.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandler.java
@@ -51,10 +51,9 @@ class ProgressEventHandler implements Consumer<ProgressEvent> {
     Allocation allocation = progressEvent.getAllocation();
     long progressUnits = progressEvent.getUnits();
     double allocationFraction = allocation.getFractionOfRoot();
-    long allocationUnits = allocation.getAllocationUnits();
 
     if (progressUnits != 0) {
-      progress.add(progressUnits * allocationFraction / allocationUnits);
+      progress.add(progressUnits * allocationFraction);
     }
 
     if (completionTracker.updateProgress(allocation, progressUnits)) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandler.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandler.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.event.progress;
+
+import com.google.cloud.tools.jib.event.events.ProgressEvent;
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.DoubleAdder;
+import java.util.function.Consumer;
+
+/**
+ * Handles {@link ProgressEvent}s by accumulating an overall progress and keeping track of which
+ * {@link Allocation}s are complete.
+ *
+ * <p>This implementation is thread-safe.
+ */
+class ProgressEventHandler implements Consumer<ProgressEvent> {
+
+  /**
+   * Maps from {@link Allocation} to the number of progress units completed in that {@link
+   * Allocation}, while keeping track of the insertion order of the {@link Allocation}s.
+   */
+  private static class AllocationCompletionMap {
+
+    /**
+     * Holds the progress units completed along with a creation order.
+     */
+    private static class InsertionOrderUnits implements Comparable<InsertionOrderUnits> {
+
+      /** Monotonically-increasing source for {@link #index}. */
+      private static final AtomicInteger currentIndex = new AtomicInteger();
+
+      /** The creation order that monotonically increases. */
+      private final int index = currentIndex.getAndIncrement();
+
+      /**
+       * Progress units completed. This can be shared across multiple threads and should be updated
+       * atomically.
+       */
+      private final AtomicLong units = new AtomicLong();
+
+      /** The {@link Allocation} this is for. */
+      private final Allocation allocation;
+
+      private InsertionOrderUnits(Allocation allocation) {
+        this.allocation = allocation;
+      }
+
+      @Override
+      public int compareTo(InsertionOrderUnits otherInsertionOrderUnits) {
+        return index - otherInsertionOrderUnits.index;
+      }
+    }
+
+    private final ConcurrentHashMap<Allocation, InsertionOrderUnits> completionMap =
+        new ConcurrentHashMap<>();
+
+    /**
+     * Puts an entry for {@code allocation} in the map if not present, with progress initialized to
+     * {@code 0}.
+     *
+     * @param allocation the {@link Allocation}
+     */
+    private void putIfAbsent(Allocation allocation) {
+      completionMap.computeIfAbsent(allocation, InsertionOrderUnits::new);
+    }
+
+    /**
+     * Updates the progress for {@link Allocation} atomically relative to the {@code allocation}.
+     *
+     * @param allocation the {@link Allocation} to update progress for
+     * @param units the units of progress
+     */
+    private void updateProgress(Allocation allocation, long units) {
+      completionMap.compute(
+          allocation,
+          (ignored, insertionOrderUnits) -> {
+            if (insertionOrderUnits == null) {
+              insertionOrderUnits = new InsertionOrderUnits(allocation);
+            }
+
+            updateProgress(insertionOrderUnits, units);
+
+            return insertionOrderUnits;
+          });
+    }
+
+    /**
+     * Helper method for {@link #updateProgress(Allocation, long)}. This method is <em>not</em>
+     * thread-safe for the {@code insertionOrderUnits} and should be called atomically relative to
+     * the {@code insertionOrderUnits}.
+     *
+     * @param insertionOrderUnits the {@link InsertionOrderUnits} to update progress for
+     * @param units the units of progress
+     */
+    private void updateProgress(InsertionOrderUnits insertionOrderUnits, long units) {
+      Allocation allocation = insertionOrderUnits.allocation;
+
+      long newUnits = insertionOrderUnits.units.addAndGet(units);
+      if (newUnits > allocation.getAllocationUnits()) {
+        throw new IllegalStateException(
+            "Progress exceeds max for '"
+                + allocation.getDescription()
+                + "': "
+                + newUnits
+                + " > "
+                + allocation.getAllocationUnits());
+      }
+
+      // Updates the parent allocations if this allocation completed.
+      if (newUnits == allocation.getAllocationUnits()) {
+        allocation
+            .getParent()
+            .ifPresent(
+                parentAllocation ->
+                    updateProgress(
+                        Preconditions.checkNotNull(completionMap.get(parentAllocation)), 1L));
+      }
+    }
+  }
+
+  /** Keeps track of the progress for each {@link Allocation} encountered. */
+  private final AllocationCompletionMap completionMap = new AllocationCompletionMap();
+
+  /** Accumulates an overall progress, with {@code 1.0} indicating full completion. */
+  private final DoubleAdder progress = new DoubleAdder();
+
+  /** A callback to notify that {@link #progress} or {@link #completionMap} has changed. */
+  private final Runnable updateNotifier;
+
+  ProgressEventHandler(Runnable updateNotifier) {
+    this.updateNotifier = updateNotifier;
+  }
+
+  @Override
+  public void accept(ProgressEvent progressEvent) {
+    Allocation allocation = progressEvent.getAllocation();
+    long progressUnits = progressEvent.getUnits();
+    double allocationFraction = allocation.getFractionOfRoot();
+    long allocationUnits = allocation.getAllocationUnits();
+
+    if (progressUnits == 0) {
+      completionMap.putIfAbsent(allocation);
+      updateNotifier.run();
+      return;
+    }
+
+    progress.add(progressUnits * allocationFraction / allocationUnits);
+
+    completionMap.updateProgress(allocation, progressUnits);
+  }
+
+  /**
+   * Gets the overall progress, with {@code 1.0} meaning fully complete.
+   *
+   * @return the overall progress
+   */
+  double getProgress() {
+    return progress.sum();
+  }
+
+  /**
+   * Gets a list of the unfinished {@link Allocation}s in the order in which those {@link
+   * Allocation}s were encountered.
+   *
+   * @return a list of unfinished {@link Allocation}s
+   */
+  List<Allocation> getUnfinishedAllocations() {
+    Queue<AllocationCompletionMap.InsertionOrderUnits> unfinishedInsertionOrderUnits =
+        new PriorityQueue<>();
+
+    for (AllocationCompletionMap.InsertionOrderUnits insertionOrderUnits :
+        completionMap.completionMap.values()) {
+      if (insertionOrderUnits.units.get() == insertionOrderUnits.allocation.getAllocationUnits()) {
+        unfinishedInsertionOrderUnits.add(insertionOrderUnits);
+      }
+    }
+
+    List<Allocation> unfinishedAllocations = new ArrayList<>();
+    for (AllocationCompletionMap.InsertionOrderUnits insertionOrderUnits :
+        unfinishedInsertionOrderUnits) {
+      unfinishedAllocations.add(insertionOrderUnits.allocation);
+    }
+    return unfinishedAllocations;
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/events/ProgressEventTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/events/ProgressEventTest.java
@@ -63,10 +63,10 @@ public class ProgressEventTest {
   public void testAccumulateProgress() {
     Consumer<ProgressEvent> progressEventConsumer =
         progressEvent -> {
-          Allocation allocation = progressEvent.getAllocation();
+          double fractionOfRoot = progressEvent.getAllocation().getFractionOfRoot();
           long units = progressEvent.getUnits();
 
-          progress += units * allocation.getFractionOfRoot() / allocation.getAllocationUnits();
+          progress += units * fractionOfRoot;
         };
 
     EventDispatcher eventDispatcher = makeEventDispatcher(progressEventConsumer);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTrackerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTrackerTest.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -99,7 +100,7 @@ public class AllocationCompletionTrackerTest {
 
   @Test
   public void testGetUnfinishedAllocations_multipleThreads()
-      throws InterruptedException, ExecutionException, IOException {
+      throws InterruptedException, ExecutionException, IOException, TimeoutException {
     try (MultithreadedExecutor multithreadedExecutor = new MultithreadedExecutor()) {
       AllocationCompletionTracker allocationCompletionTracker = new AllocationCompletionTracker();
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTrackerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTrackerTest.java
@@ -105,33 +105,17 @@ public class AllocationCompletionTrackerTest {
 
       // Adds root, child1, and child1Child.
       Assert.assertEquals(
-          Collections.singletonList(true),
-          multithreadedExecutor.invokeAll(
-              Collections.singletonList(
-                  () -> {
-                    boolean updated =
-                        allocationCompletionTracker.updateProgress(AllocationTree.root, 0L);
-                    Assert.assertEquals(
-                        Collections.singletonList(true),
-                        multithreadedExecutor.invokeAll(
-                            Collections.singletonList(
-                                () -> {
-                                  boolean updated2 =
-                                      allocationCompletionTracker.updateProgress(
-                                          AllocationTree.child1, 0L);
-
-                                  Assert.assertEquals(
-                                      Collections.singletonList(true),
-                                      multithreadedExecutor.invokeAll(
-                                          Collections.singletonList(
-                                              () ->
-                                                  allocationCompletionTracker.updateProgress(
-                                                      AllocationTree.child1Child, 0L))));
-
-                                  return updated2;
-                                })));
-                    return updated;
-                  })));
+          true,
+          multithreadedExecutor.invoke(
+              () -> allocationCompletionTracker.updateProgress(AllocationTree.root, 0L)));
+      Assert.assertEquals(
+          true,
+          multithreadedExecutor.invoke(
+              () -> allocationCompletionTracker.updateProgress(AllocationTree.child1, 0L)));
+      Assert.assertEquals(
+          true,
+          multithreadedExecutor.invoke(
+              () -> allocationCompletionTracker.updateProgress(AllocationTree.child1Child, 0L)));
       Assert.assertEquals(
           Arrays.asList(AllocationTree.root, AllocationTree.child1, AllocationTree.child1Child),
           allocationCompletionTracker.getUnfinishedAllocations());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTrackerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/AllocationCompletionTrackerTest.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.event.progress;
+
+/** Tests for {@link AllocationCompletionTracker}. */
+public class AllocationCompletionTrackerTest {}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/AllocationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/AllocationTest.java
@@ -33,7 +33,7 @@ public class AllocationTest {
 
     Assert.assertEquals("node2", node2.getDescription());
     Assert.assertEquals(3, node2.getAllocationUnits());
-    Assert.assertEquals(1.0 / 2, node2.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
+    Assert.assertEquals(1.0 / 2 / 3, node2.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
     Assert.assertTrue(node2.getParent().isPresent());
     Assert.assertEquals(node1, node2.getParent().get());
 
@@ -41,7 +41,7 @@ public class AllocationTest {
     Assert.assertEquals(2, node1.getAllocationUnits());
     Assert.assertTrue(node1.getParent().isPresent());
     Assert.assertEquals(root, node1.getParent().get());
-    Assert.assertEquals(1.0, node1.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
+    Assert.assertEquals(1.0 / 2, node1.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
 
     Assert.assertEquals("root", root.getDescription());
     Assert.assertEquals(1, root.getAllocationUnits());
@@ -59,14 +59,14 @@ public class AllocationTest {
     Allocation rightRight = right.newChild("ignored", 100);
     Allocation rightRightDown = rightRight.newChild("ignored", 200);
 
-    Assert.assertEquals(1.0, root.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
-    Assert.assertEquals(1.0 / 10, left.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
-    Assert.assertEquals(1.0 / 10, right.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
-    Assert.assertEquals(1.0 / 10 / 2, leftDown.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
-    Assert.assertEquals(1.0 / 10 / 4, rightLeft.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
-    Assert.assertEquals(1.0 / 10 / 4, rightRight.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
+    Assert.assertEquals(1.0 / 10, root.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
+    Assert.assertEquals(1.0 / 10 / 2, left.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
+    Assert.assertEquals(1.0 / 10 / 4, right.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
+    Assert.assertEquals(1.0 / 10 / 2 / 20, leftDown.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
+    Assert.assertEquals(1.0 / 10 / 4 / 20, rightLeft.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
+    Assert.assertEquals(1.0 / 10 / 4 / 100, rightRight.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
     Assert.assertEquals(
-        1.0 / 10 / 4 / 100, rightRightDown.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
+        1.0 / 10 / 4 / 100 / 200, rightRightDown.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
   }
 
   @Test
@@ -84,10 +84,10 @@ public class AllocationTest {
 
     // Checks that the leaf allocations add up to a full 1.0.
     double total =
-        leftLeftDown.getFractionOfRoot()
-            + leftMiddle.getFractionOfRoot()
-            + leftRight.getFractionOfRoot()
-            + rightDown.getFractionOfRoot();
+        leftLeftDown.getFractionOfRoot() * leftLeftDown.getAllocationUnits()
+            + leftMiddle.getFractionOfRoot() * leftMiddle.getAllocationUnits()
+            + leftRight.getFractionOfRoot() * leftRight.getAllocationUnits()
+            + rightDown.getFractionOfRoot() * rightDown.getAllocationUnits();
     Assert.assertEquals(1.0, total, DOUBLE_ERROR_MARGIN);
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/MultithreadedExecutor.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/MultithreadedExecutor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.event.progress;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+/** Testing infrastructure for running code across multiple threads. */
+class MultithreadedExecutor {
+
+  private static final Duration MULTITHREADED_TEST_TIMEOUT = Duration.ofSeconds(1);
+
+  private final ExecutorService executorService = Executors.newFixedThreadPool(20);
+
+  <E> List<E> invokeAll(List<Callable<E>> callables)
+      throws InterruptedException, ExecutionException {
+    List<Future<E>> futures =
+        executorService.invokeAll(
+            callables, MULTITHREADED_TEST_TIMEOUT.getSeconds(), TimeUnit.SECONDS);
+
+    List<E> returnValues = new ArrayList<>();
+    for (Future<E> future : futures) {
+      returnValues.add(future.get());
+    }
+
+    return returnValues;
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/MultithreadedExecutor.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/MultithreadedExecutor.java
@@ -29,6 +29,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.junit.Assert;
 
 /** Testing infrastructure for running code across multiple threads. */
 class MultithreadedExecutor implements Closeable {
@@ -52,7 +53,8 @@ class MultithreadedExecutor implements Closeable {
 
     List<E> returnValues = new ArrayList<>();
     for (Future<E> future : futures) {
-      returnValues.add(future.get(MULTITHREADED_TEST_TIMEOUT.getSeconds(), TimeUnit.SECONDS));
+      Assert.assertTrue(future.isDone());
+      returnValues.add(future.get());
     }
 
     return returnValues;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/MultithreadedExecutor.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/MultithreadedExecutor.java
@@ -20,6 +20,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -35,6 +36,11 @@ class MultithreadedExecutor implements Closeable {
   private static final int THREAD_COUNT = 20;
 
   private final ExecutorService executorService = Executors.newFixedThreadPool(THREAD_COUNT);
+
+  <E> E invoke(Callable<E> callable) throws ExecutionException, InterruptedException {
+    List<E> returnValue = invokeAll(Collections.singletonList(callable));
+    return returnValue.get(0);
+  }
 
   <E> List<E> invokeAll(List<Callable<E>> callables)
       throws InterruptedException, ExecutionException {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandlerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandlerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.event.progress;
+
+import com.google.cloud.tools.jib.event.DefaultEventDispatcher;
+import com.google.cloud.tools.jib.event.EventDispatcher;
+import com.google.cloud.tools.jib.event.EventHandlers;
+import com.google.cloud.tools.jib.event.JibEventType;
+import com.google.cloud.tools.jib.event.events.ProgressEvent;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for {@link ProgressEventHandler}. */
+public class ProgressEventHandlerTest {
+
+  /** {@link Allocation} tree for testing. */
+  private static class AllocationTree {
+
+    /** The root node. */
+    private static final Allocation root = Allocation.newRoot("root", 2);
+
+    /** First child of the root node. */
+    private static final Allocation child1 = root.newChild("child1", 1);
+    /** Child of the first child of the root node. */
+    private static final Allocation child1Child = child1.newChild("child1Child", 100);
+
+    /** Second child of the root node. */
+    private static final Allocation child2 = root.newChild("child2", 200);
+
+    private AllocationTree() {}
+  }
+
+  private static final double DOUBLE_ERROR_MARGIN = 1e-10;
+
+  @Test
+  public void testAccept() throws ExecutionException, InterruptedException {
+    MultithreadedExecutor multithreadedExecutor = new MultithreadedExecutor();
+
+    ProgressEventHandler progressEventHandler = new ProgressEventHandler(() -> {});
+    EventDispatcher eventDispatcher =
+        new DefaultEventDispatcher(
+            new EventHandlers().add(JibEventType.PROGRESS, progressEventHandler));
+
+    // Adds root, child1, and child1Child.
+    multithreadedExecutor.invokeAll(
+        Collections.singletonList(
+            () -> {
+              eventDispatcher.dispatch(new ProgressEvent(AllocationTree.root, 0L));
+
+              multithreadedExecutor.invokeAll(
+                  Collections.singletonList(
+                      () -> {
+                        eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1, 0L));
+
+                        multithreadedExecutor.invokeAll(
+                            Collections.singletonList(
+                                () -> new ProgressEvent(AllocationTree.child1Child, 0L)));
+                        return null;
+                      }));
+              return null;
+            }));
+    Assert.assertEquals(0.0, progressEventHandler.getProgress(), DOUBLE_ERROR_MARGIN);
+
+    // Adds 50 to child1Child and 100 to child2.
+    List<Callable<Void>> callables = new ArrayList<>(150);
+    callables.addAll(
+        Collections.nCopies(
+            50,
+            () -> {
+              eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 1L));
+              return null;
+            }));
+    callables.addAll(
+        Collections.nCopies(
+            100,
+            () -> {
+              eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 1L));
+              return null;
+            }));
+
+    multithreadedExecutor.invokeAll(callables);
+    Assert.assertEquals(
+        1.0 / 2 / 100 * 50 + 1.0 / 2 / 200 * 100,
+        progressEventHandler.getProgress(),
+        DOUBLE_ERROR_MARGIN);
+
+    // 0 progress doesn't do anything.
+    multithreadedExecutor.invokeAll(
+        Collections.nCopies(
+            100,
+            () -> {
+              eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1, 0L));
+              return null;
+            }));
+    Assert.assertEquals(
+        1.0 / 2 / 100 * 50 + 1.0 / 2 / 200 * 100,
+        progressEventHandler.getProgress(),
+        DOUBLE_ERROR_MARGIN);
+
+    // Adds 50 to child1Child and 100 to child2 to finish it up.
+    multithreadedExecutor.invokeAll(callables);
+    Assert.assertEquals(1.0, progressEventHandler.getProgress(), DOUBLE_ERROR_MARGIN);
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandlerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandlerTest.java
@@ -61,23 +61,21 @@ public class ProgressEventHandlerTest {
               new EventHandlers().add(JibEventType.PROGRESS, progressEventHandler));
 
       // Adds root, child1, and child1Child.
-      multithreadedExecutor.invokeAll(
-          Collections.singletonList(
-              () -> {
-                eventDispatcher.dispatch(new ProgressEvent(AllocationTree.root, 0L));
-
-                multithreadedExecutor.invokeAll(
-                    Collections.singletonList(
-                        () -> {
-                          eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1, 0L));
-
-                          multithreadedExecutor.invokeAll(
-                              Collections.singletonList(
-                                  () -> new ProgressEvent(AllocationTree.child1Child, 0L)));
-                          return null;
-                        }));
-                return null;
-              }));
+      multithreadedExecutor.invoke(
+          () -> {
+            eventDispatcher.dispatch(new ProgressEvent(AllocationTree.root, 0L));
+            return null;
+          });
+      multithreadedExecutor.invoke(
+          () -> {
+            eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1, 0L));
+            return null;
+          });
+      multithreadedExecutor.invoke(
+          () -> {
+            eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 0L));
+            return null;
+          });
       Assert.assertEquals(0.0, progressEventHandler.getProgress(), DOUBLE_ERROR_MARGIN);
 
       // Adds 50 to child1Child and 100 to child2.

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandlerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandlerTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -53,7 +54,8 @@ public class ProgressEventHandlerTest {
   private static final double DOUBLE_ERROR_MARGIN = 1e-10;
 
   @Test
-  public void testAccept() throws ExecutionException, InterruptedException, IOException {
+  public void testAccept()
+      throws ExecutionException, InterruptedException, IOException, TimeoutException {
     try (MultithreadedExecutor multithreadedExecutor = new MultithreadedExecutor()) {
       ProgressEventHandler progressEventHandler = new ProgressEventHandler(() -> {});
       EventDispatcher eventDispatcher =


### PR DESCRIPTION
Part of #1297 

`ProgressEventHandler` keeps an overall progress state as well as tracks unfinished allocations via the `AllocationCompletionTracker`. `ProgressEventHandler` will be the only concurrently-modifiable class in Jib (as of yet).