### PR TITLE
Ensure internally-created executor service is shutdown on completion

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 import org.hamcrest.CoreMatchers;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -58,7 +59,12 @@ import org.slf4j.LoggerFactory;
 public class BuildStepsIntegrationTest {
 
   @ClassRule public static final LocalRegistry localRegistry = new LocalRegistry(5000);
-  @ClassRule public static final ExecutorService executorService = Executors.newCachedThreadPool();
+  private static final ExecutorService executorService = Executors.newCachedThreadPool();
+
+  @AfterClass
+  public static void cleanUp() {
+    executorService.shutdown();
+  }
 
   /**
    * Lists the files in the {@code resourcePath} resources directory and builds a {@link

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -41,6 +41,8 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Stream;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -56,6 +58,7 @@ import org.slf4j.LoggerFactory;
 public class BuildStepsIntegrationTest {
 
   @ClassRule public static final LocalRegistry localRegistry = new LocalRegistry(5000);
+  @ClassRule public static final ExecutorService executorService = Executors.newCachedThreadPool();
 
   /**
    * Lists the files in the {@code resourcePath} resources directory and builds a {@link
@@ -288,6 +291,7 @@ public class BuildStepsIntegrationTest {
         .setApplicationLayersCacheDirectory(cacheDirectory)
         .setAllowInsecureRegistries(true)
         .setLayerConfigurations(fakeLayerConfigurations)
-        .setToolName("jib-integration-test");
+        .setToolName("jib-integration-test")
+        .setExecutorService(executorService);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -426,13 +426,13 @@ public class JibContainerBuilder {
 
   @VisibleForTesting
   JibContainer containerize(
-      Containerizer containerizer, Supplier<ExecutorService> executorServiceFactory)
+      Containerizer containerizer, Supplier<ExecutorService> defaultExecutorServiceFactory)
       throws InterruptedException, ExecutionException, IOException,
           CacheDirectoryCreationException {
 
     boolean shutdownExecutorService = !containerizer.getExecutorService().isPresent();
     ExecutorService executorService =
-        containerizer.getExecutorService().orElseGet(executorServiceFactory);
+        containerizer.getExecutorService().orElseGet(defaultExecutorServiceFactory);
 
     BuildConfiguration buildConfiguration = toBuildConfiguration(containerizer, executorService);
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -61,9 +61,6 @@ import javax.annotation.Nullable;
 // TODO: Add tests once containerize() is added.
 public class JibContainerBuilder {
 
-  @VisibleForTesting
-  static Supplier<ExecutorService> executorServiceFactory = Executors::newCachedThreadPool;
-
   private final ContainerConfiguration.Builder containerConfigurationBuilder =
       ContainerConfiguration.builder();
   private final BuildConfiguration.Builder buildConfigurationBuilder;
@@ -421,6 +418,15 @@ public class JibContainerBuilder {
    * @throws IOException if an I/O exception occurs
    */
   public JibContainer containerize(Containerizer containerizer)
+      throws InterruptedException, ExecutionException, IOException,
+          CacheDirectoryCreationException {
+
+    return containerize(containerizer, Executors::newCachedThreadPool);
+  }
+
+  @VisibleForTesting
+  JibContainer containerize(
+      Containerizer containerizer, Supplier<ExecutorService> executorServiceFactory)
       throws InterruptedException, ExecutionException, IOException,
           CacheDirectoryCreationException {
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -444,6 +444,8 @@ public class JibContainerBuilder {
    * Builds a {@link BuildConfiguration} using this and a {@link Containerizer}.
    *
    * @param containerizer the {@link Containerizer}
+   * @param executorService the {@link ExecutorService} to use, overriding the executor in the
+   *     {@link Containerizer}
    * @return the {@link BuildConfiguration}
    * @throws CacheDirectoryCreationException if a cache directory could not be created
    * @throws IOException if an I/O exception occurs

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
@@ -223,6 +223,9 @@ public class BuildConfiguration {
       if (applicationLayersCacheDirectory == null) {
         missingFields.add("application layers cache directory");
       }
+      if (executorService == null) {
+        missingFields.add("executor service");
+      }
 
       switch (missingFields.size()) {
         case 0: // No errors
@@ -232,10 +235,6 @@ public class BuildConfiguration {
                     "Base image '"
                         + baseImageConfiguration.getImage()
                         + "' does not use a specific image digest - build may not be reproducible"));
-          }
-
-          if (executorService == null) {
-            executorService = Executors.newCachedThreadPool();
           }
 
           return new BuildConfiguration(
@@ -250,7 +249,7 @@ public class BuildConfiguration {
               layerConfigurations,
               toolName,
               eventDispatcher,
-              executorService);
+              Preconditions.checkNotNull(executorService));
 
         case 1:
           throw new IllegalStateException(missingFields.get(0) + " is required but not set");

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
@@ -16,9 +16,12 @@
 
 package com.google.cloud.tools.jib.api;
 
+import com.google.cloud.tools.jib.builder.BuildSteps;
+import com.google.cloud.tools.jib.builder.steps.BuildResult;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.configuration.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.configuration.LayerConfiguration;
 import com.google.cloud.tools.jib.configuration.Port;
 import com.google.cloud.tools.jib.configuration.credentials.Credential;
@@ -26,19 +29,29 @@ import com.google.cloud.tools.jib.configuration.credentials.CredentialRetriever;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.event.JibEvent;
 import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.ImageFormat;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.registry.credentials.CredentialRetrievalException;
+import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.security.DigestException;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -58,6 +71,18 @@ public class JibContainerBuilderTest {
   @Mock private Consumer<JibEvent> mockJibEventConsumer;
   @Mock private JibEvent mockJibEvent;
 
+  private Supplier<ExecutorService> oldExecutorServiceFactory;
+
+  @Before
+  public void setUp() {
+    oldExecutorServiceFactory = JibContainerBuilder.executorServiceFactory;
+  }
+
+  @After
+  public void tearDown() {
+    JibContainerBuilder.executorServiceFactory = oldExecutorServiceFactory;
+  }
+
   @Test
   public void testToBuildConfiguration_containerConfigurationSet()
       throws InvalidImageReferenceException, CacheDirectoryCreationException, IOException {
@@ -74,7 +99,8 @@ public class JibContainerBuilderTest {
             .setWorkingDirectory(AbsoluteUnixPath.get("/working/directory"));
 
     BuildConfiguration buildConfiguration =
-        jibContainerBuilder.toBuildConfiguration(Containerizer.to(baseImage));
+        jibContainerBuilder.toBuildConfiguration(
+            Containerizer.to(baseImage), MoreExecutors.newDirectExecutorService());
     ContainerConfiguration containerConfiguration = buildConfiguration.getContainerConfiguration();
     Assert.assertEquals(Arrays.asList("entry", "point"), containerConfiguration.getEntrypoint());
     Assert.assertEquals(
@@ -106,7 +132,8 @@ public class JibContainerBuilderTest {
             .setProgramArguments("program", "arguments");
 
     BuildConfiguration buildConfiguration =
-        jibContainerBuilder.toBuildConfiguration(Containerizer.to(baseImage));
+        jibContainerBuilder.toBuildConfiguration(
+            Containerizer.to(baseImage), MoreExecutors.newDirectExecutorService());
     ContainerConfiguration containerConfiguration = buildConfiguration.getContainerConfiguration();
     Assert.assertEquals(Arrays.asList("entry", "point"), containerConfiguration.getEntrypoint());
     Assert.assertEquals(
@@ -141,7 +168,9 @@ public class JibContainerBuilderTest {
     JibContainerBuilder jibContainerBuilder =
         new JibContainerBuilder(baseImage, spyBuildConfigurationBuilder)
             .setLayers(Arrays.asList(mockLayerConfiguration1, mockLayerConfiguration2));
-    BuildConfiguration buildConfiguration = jibContainerBuilder.toBuildConfiguration(containerizer);
+    BuildConfiguration buildConfiguration =
+        jibContainerBuilder.toBuildConfiguration(
+            containerizer, containerizer.getExecutorService().get());
 
     Assert.assertEquals(
         spyBuildConfigurationBuilder.build().getContainerConfiguration(),
@@ -201,11 +230,99 @@ public class JibContainerBuilderTest {
                 containerizer
                     .withAdditionalTag("tag1")
                     .withAdditionalTag("tag2")
-                    .setToolName("toolName"));
+                    .setToolName("toolName"),
+                MoreExecutors.newDirectExecutorService());
     Assert.assertSame(
         ImageFormat.OCI.getManifestTemplateClass(), buildConfiguration.getTargetFormat());
     Assert.assertEquals(
         ImmutableSet.of("latest", "tag1", "tag2"), buildConfiguration.getAllTargetImageTags());
     Assert.assertEquals("toolName", buildConfiguration.getToolName());
+  }
+
+  /** Verify that an internally-created ExecutorService is shutdown. */
+  @Test
+  public void testContainerize_executorCreated() throws Exception {
+    JibContainerBuilder.executorServiceFactory = Suppliers.ofInstance(mockExecutorService);
+
+    RegistryImage baseImage = RegistryImage.named("test-image");
+    JibContainerBuilder jibContainerBuilder =
+        new JibContainerBuilder(baseImage, spyBuildConfigurationBuilder)
+            .setEntrypoint(Arrays.asList("entry", "point"))
+            .setEnvironment(ImmutableMap.of("name", "value"))
+            .setExposedPorts(ImmutableSet.of(Port.tcp(1234), Port.udp(5678)))
+            .setLabels(ImmutableMap.of("key", "value"))
+            .setProgramArguments(Arrays.asList("program", "arguments"))
+            .setCreationTime(Instant.ofEpochMilli(1000))
+            .setUser("user")
+            .setWorkingDirectory(AbsoluteUnixPath.get("/working/directory"));
+
+    Containerizer mockContainerizer = createMockContainerizer();
+
+    jibContainerBuilder.containerize(mockContainerizer);
+
+    Mockito.verify(mockExecutorService).shutdown();
+  }
+
+  /** Verify that a provided ExecutorService is not shutdown. */
+  @Test
+  public void testContainerize_configuredExecutor() throws Exception {
+    JibContainerBuilder.executorServiceFactory =
+        () -> {
+          throw new AssertionError();
+        };
+
+    RegistryImage baseImage = RegistryImage.named("test-image");
+    JibContainerBuilder jibContainerBuilder =
+        new JibContainerBuilder(baseImage, spyBuildConfigurationBuilder)
+            .setEntrypoint(Arrays.asList("entry", "point"))
+            .setEnvironment(ImmutableMap.of("name", "value"))
+            .setExposedPorts(ImmutableSet.of(Port.tcp(1234), Port.udp(5678)))
+            .setLabels(ImmutableMap.of("key", "value"))
+            .setProgramArguments(Arrays.asList("program", "arguments"))
+            .setCreationTime(Instant.ofEpochMilli(1000))
+            .setUser("user")
+            .setWorkingDirectory(AbsoluteUnixPath.get("/working/directory"));
+    Containerizer mockContainerizer = createMockContainerizer();
+    Mockito.when(mockContainerizer.getExecutorService())
+        .thenReturn(Optional.of(mockExecutorService));
+
+    jibContainerBuilder.containerize(mockContainerizer);
+
+    Mockito.verify(mockExecutorService, Mockito.never()).shutdown();
+  }
+
+  private Containerizer createMockContainerizer()
+      throws CacheDirectoryCreationException, InvalidImageReferenceException, InterruptedException,
+          ExecutionException, DigestException {
+
+    ImageReference targetImage = ImageReference.parse("target-image");
+    TargetImage mockTargetImage = Mockito.mock(TargetImage.class);
+    Containerizer mockContainerizer = Mockito.mock(Containerizer.class);
+    BuildSteps mockBuildSteps = Mockito.mock(BuildSteps.class);
+    BuildResult mockBuildResult = Mockito.mock(BuildResult.class);
+
+    Mockito.when(mockTargetImage.toImageConfiguration())
+        .thenReturn(ImageConfiguration.builder(targetImage).build());
+    Mockito.when(mockTargetImage.toBuildSteps(Mockito.any(BuildConfiguration.class)))
+        .thenReturn(mockBuildSteps);
+    Mockito.when(mockBuildSteps.run()).thenReturn(mockBuildResult);
+    Mockito.when(mockBuildResult.getImageDigest())
+        .thenReturn(
+            DescriptorDigest.fromHash(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+    Mockito.when(mockBuildResult.getImageId())
+        .thenReturn(
+            DescriptorDigest.fromHash(
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"));
+
+    Mockito.when(mockContainerizer.getTargetImage()).thenReturn(mockTargetImage);
+    Mockito.when(mockContainerizer.getAdditionalTags()).thenReturn(Collections.emptySet());
+    Mockito.when(mockContainerizer.getBaseImageLayersCacheDirectory()).thenReturn(Paths.get("/"));
+    Mockito.when(mockContainerizer.getApplicationLayersCacheDirectory()).thenReturn(Paths.get("/"));
+    Mockito.when(mockContainerizer.getAllowInsecureRegistries()).thenReturn(false);
+    Mockito.when(mockContainerizer.getToolName()).thenReturn("mocktool");
+    Mockito.when(mockContainerizer.getExecutorService()).thenReturn(Optional.empty());
+    Mockito.when(mockContainerizer.getEventHandlers()).thenReturn(Optional.empty());
+    return mockContainerizer;
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
@@ -48,7 +48,6 @@ import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,8 +67,6 @@ public class JibContainerBuilderTest {
   @Mock private ExecutorService mockExecutorService;
   @Mock private Consumer<JibEvent> mockJibEventConsumer;
   @Mock private JibEvent mockJibEvent;
-
-  private Supplier<ExecutorService> oldExecutorServiceFactory;
 
   @Test
   public void testToBuildConfiguration_containerConfigurationSet()

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
@@ -27,6 +27,7 @@ import com.google.cloud.tools.jib.event.progress.Allocation;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.registry.credentials.CredentialRetrievalException;
 import com.google.common.util.concurrent.ListeningExecutorService;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -134,6 +135,7 @@ public class RetrieveRegistryCredentialsStepTest {
                 .build())
         .setBaseImageLayersCacheDirectory(Paths.get("ignored"))
         .setApplicationLayersCacheDirectory(Paths.get("ignored"))
+        .setExecutorService(MoreExecutors.newDirectExecutorService())
         .build();
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.jib.image.json.OCIManifestTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -101,7 +102,8 @@ public class BuildConfigurationTest {
             .setTargetFormat(OCIManifestTemplate.class)
             .setAllowInsecureRegistries(true)
             .setLayerConfigurations(expectedLayerConfigurations)
-            .setToolName(expectedCreatedBy);
+            .setToolName(expectedCreatedBy)
+            .setExecutorService(MoreExecutors.newDirectExecutorService());
     BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();
 
     Assert.assertNotNull(buildConfiguration.getContainerConfiguration());
@@ -151,6 +153,7 @@ public class BuildConfigurationTest {
     Assert.assertEquals(
         expectedEntrypoint, buildConfiguration.getContainerConfiguration().getEntrypoint());
     Assert.assertEquals(expectedCreatedBy, buildConfiguration.getToolName());
+    Assert.assertNotNull(buildConfiguration.getExecutorService());
   }
 
   @Test
@@ -178,7 +181,8 @@ public class BuildConfigurationTest {
             .setBaseImageConfiguration(baseImageConfiguration)
             .setTargetImageConfiguration(targetImageConfiguration)
             .setBaseImageLayersCacheDirectory(Paths.get("ignored"))
-            .setApplicationLayersCacheDirectory(Paths.get("ignored"));
+            .setApplicationLayersCacheDirectory(Paths.get("ignored"))
+            .setExecutorService(MoreExecutors.newDirectExecutorService());
     BuildConfiguration buildConfiguration = buildConfigurationBuilder.build();
 
     Assert.assertEquals(ImmutableSet.of("targettag"), buildConfiguration.getAllTargetImageTags());
@@ -204,6 +208,7 @@ public class BuildConfigurationTest {
               ImageConfiguration.builder(Mockito.mock(ImageReference.class)).build())
           .setBaseImageLayersCacheDirectory(Paths.get("ignored"))
           .setApplicationLayersCacheDirectory(Paths.get("ignored"))
+          .setExecutorService(MoreExecutors.newDirectExecutorService())
           .build();
       Assert.fail("Build configuration should not be built with missing values");
 
@@ -216,6 +221,7 @@ public class BuildConfigurationTest {
       BuildConfiguration.builder()
           .setBaseImageLayersCacheDirectory(Paths.get("ignored"))
           .setApplicationLayersCacheDirectory(Paths.get("ignored"))
+          .setExecutorService(MoreExecutors.newDirectExecutorService())
           .build();
       Assert.fail("Build configuration should not be built with missing values");
 
@@ -233,7 +239,7 @@ public class BuildConfigurationTest {
     } catch (IllegalStateException ex) {
       Assert.assertEquals(
           "base image configuration, target image configuration, base image layers cache directory, "
-              + "and application layers cache directory are required but not set",
+              + "application layers cache directory, and executor service are required but not set",
           ex.getMessage());
     }
   }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTestHelper.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTestHelper.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.api;
 
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.configuration.CacheDirectoryCreationException;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 
 /** Test helper to expose package-private members of {@link JibContainerBuilder}. */
@@ -26,7 +27,9 @@ public class JibContainerBuilderTestHelper {
   public static BuildConfiguration toBuildConfiguration(
       JibContainerBuilder jibContainerBuilder, Containerizer containerizer)
       throws IOException, CacheDirectoryCreationException {
-    return jibContainerBuilder.toBuildConfiguration(containerizer);
+    return jibContainerBuilder.toBuildConfiguration(
+        containerizer,
+        containerizer.getExecutorService().orElseGet(MoreExecutors::newDirectExecutorService));
   }
 
   private JibContainerBuilderTestHelper() {}


### PR DESCRIPTION
Ensure that internally-created `ExecutorService` is shutdown.

Fixes #1310 