### PR TITLE
Fix gradle validateTaskProperties warning about dockerClient.executable

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -89,7 +89,7 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
       throws InvalidImageReferenceException, IOException, BuildStepsExecutionException,
           CacheDirectoryCreationException, MainClassInferenceException,
           InferredAuthRetrievalException {
-    Path dockerExecutable = dockerClientParameters.getExecutable();
+    Path dockerExecutable = dockerClientParameters.getExecutablePath();
     boolean isDockerInstalled =
         dockerExecutable == null
             ? DockerClient.isDefaultDockerInstalled()
@@ -122,7 +122,7 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
               new GradleRawConfiguration(jibExtension),
               ignored -> java.util.Optional.empty(),
               projectProperties,
-              dockerClientParameters.getExecutable(),
+              dockerClientParameters.getExecutablePath(),
               dockerClientParameters.getEnvironment(),
               gradleHelpfulSuggestionsBuilder.build());
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerClientParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerClientParameters.java
@@ -21,6 +21,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 
 /**
@@ -35,7 +36,13 @@ public class DockerClientParameters {
   @Input
   @Nullable
   @Optional
-  public Path getExecutable() {
+  public String getExecutable() {
+    return executable == null ? null : executable.toString();
+  }
+
+  @Internal
+  @Nullable
+  Path getExecutablePath() {
     return executable;
   }
 


### PR DESCRIPTION
Fixes this warning that shows up after running gradle tests:

```
> Task :validateTaskProperties
Task property validation finished with warnings:
  - Warning: Task type 'com.google.cloud.tools.jib.gradle.BuildDockerTask': property 'dockerClient.executable' has @Input annotation used on property of type java.nio.file.Path.
```