### PR TITLE
Attachs ProgressEventHandler as an event handler via the plugins.

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -20,12 +20,15 @@ import com.google.cloud.tools.jib.configuration.FilePermissions;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.event.JibEventType;
 import com.google.cloud.tools.jib.event.events.LogEvent;
+import com.google.cloud.tools.jib.event.progress.ProgressEventHandler;
 import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.frontend.JavaLayerConfigurations;
 import com.google.cloud.tools.jib.plugins.common.ProjectProperties;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.cloud.tools.jib.plugins.common.TimerEventHandler;
-import com.google.cloud.tools.jib.plugins.common.logging.LogEventHandlerBuilder;
+import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
+import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLoggerBuilder;
+import com.google.cloud.tools.jib.plugins.common.logging.ProgressDisplayGenerator;
 import com.google.cloud.tools.jib.plugins.common.logging.SingleThreadedExecutor;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
@@ -38,7 +41,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.apache.tools.ant.taskdefs.condition.Os;
 import org.gradle.api.GradleException;
@@ -54,7 +56,7 @@ import org.gradle.jvm.tasks.Jar;
 class GradleProjectProperties implements ProjectProperties {
 
   /** Used to generate the User-Agent header and history metadata. */
-  static final String TOOL_NAME = "jib-gradle-plugin";
+  private static final String TOOL_NAME = "jib-gradle-plugin";
 
   /** Used for logging during main class inference. */
   private static final String PLUGIN_NAME = "jib";
@@ -97,31 +99,42 @@ class GradleProjectProperties implements ProjectProperties {
 
   private static EventHandlers makeEventHandlers(
       Project project, Logger logger, SingleThreadedExecutor singleThreadedExecutor) {
-    LogEventHandlerBuilder logEventHandlerBuilder =
+    ConsoleLoggerBuilder consoleLoggerBuilder =
         (isProgressFooterEnabled(project)
-                ? LogEventHandlerBuilder.rich(singleThreadedExecutor)
-                : LogEventHandlerBuilder.plain(singleThreadedExecutor).progress(logger::lifecycle))
+                ? ConsoleLoggerBuilder.rich(singleThreadedExecutor)
+                : ConsoleLoggerBuilder.plain(singleThreadedExecutor).progress(logger::lifecycle))
             .lifecycle(logger::lifecycle);
     if (logger.isDebugEnabled()) {
-      logEventHandlerBuilder.debug(logger::debug);
+      consoleLoggerBuilder.debug(logger::debug);
     }
     if (logger.isInfoEnabled()) {
-      logEventHandlerBuilder.info(logger::info);
+      consoleLoggerBuilder.info(logger::info);
     }
     if (logger.isWarnEnabled()) {
-      logEventHandlerBuilder.warn(logger::warn);
+      consoleLoggerBuilder.warn(logger::warn);
     }
     if (logger.isErrorEnabled()) {
-      logEventHandlerBuilder.error(logger::error);
+      consoleLoggerBuilder.error(logger::error);
     }
-    Consumer<LogEvent> logEventHandler = logEventHandlerBuilder.build();
-
-    TimerEventHandler timerEventHandler =
-        new TimerEventHandler(message -> logEventHandler.accept(LogEvent.debug(message)));
+    ConsoleLogger consoleLogger = consoleLoggerBuilder.build();
 
     return new EventHandlers()
-        .add(JibEventType.LOGGING, logEventHandler)
-        .add(JibEventType.TIMING, timerEventHandler);
+        .add(
+            JibEventType.LOGGING,
+            logEvent -> consoleLogger.log(logEvent.getLevel(), logEvent.getMessage()))
+        .add(
+            JibEventType.TIMING,
+            new TimerEventHandler(message -> consoleLogger.log(LogEvent.Level.DEBUG, message)))
+        .add(
+            JibEventType.PROGRESS,
+            new ProgressEventHandler(
+                update -> {
+                  List<String> footer =
+                      ProgressDisplayGenerator.generateProgressDisplay(
+                          update.getProgress(), update.getUnfinishedAllocations());
+                  footer.add("");
+                  consoleLogger.setFooter(footer);
+                }));
   }
 
   private static boolean isProgressFooterEnabled(Project project) {

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooter.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooter.java
@@ -93,7 +93,8 @@ class AnsiLoggerWithFooter implements ConsoleLogger {
    *
    * @param newFooterLines the footer, with each line as an element (no newline at end)
    */
-  void setFooter(List<String> newFooterLines) {
+  @Override
+  public void setFooter(List<String> newFooterLines) {
     if (newFooterLines.equals(footerLines)) {
       return;
     }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLogger.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLogger.java
@@ -18,9 +18,10 @@ package com.google.cloud.tools.jib.plugins.common.logging;
 
 import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.event.events.LogEvent.Level;
+import java.util.List;
 
 /** Logs messages to the console. Implementations must be thread-safe. */
-interface ConsoleLogger {
+public interface ConsoleLogger {
 
   /**
    * Logs {@code message} to the console at {@link Level#LIFECYCLE}.
@@ -29,4 +30,11 @@ interface ConsoleLogger {
    * @param message the message
    */
   void log(LogEvent.Level logLevel, String message);
+
+  /**
+   * Sets the footer.
+   *
+   * @param footerLines the footer, with each line as an element (no newline at end)
+   */
+  void setFooter(List<String> footerLines);
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLoggerBuilder.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLoggerBuilder.java
@@ -16,15 +16,14 @@
 
 package com.google.cloud.tools.jib.plugins.common.logging;
 
-import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.event.events.LogEvent.Level;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-/** Builds a handler for {@link LogEvent}. */
-public class LogEventHandlerBuilder {
+/** Builds a handler for {@link ConsoleLogger}. */
+public class ConsoleLoggerBuilder {
 
   /**
    * Alias for function that takes a map from {@link Level} to a log message {@link Consumer} and
@@ -36,26 +35,26 @@ public class LogEventHandlerBuilder {
       extends Function<ImmutableMap<Level, Consumer<String>>, ConsoleLogger> {}
 
   /**
-   * Starts a {@link LogEventHandlerBuilder} for rich logging (ANSI support with footer).
+   * Starts a {@link ConsoleLoggerBuilder} for rich logging (ANSI support with footer).
    *
    * @param singleThreadedExecutor a {@link SingleThreadedExecutor} to ensure that all messages are
    *     logged in a sequential, deterministic order
-   * @return a new {@link LogEventHandlerBuilder}
+   * @return a new {@link ConsoleLoggerBuilder}
    */
-  public static LogEventHandlerBuilder rich(SingleThreadedExecutor singleThreadedExecutor) {
-    return new LogEventHandlerBuilder(
+  public static ConsoleLoggerBuilder rich(SingleThreadedExecutor singleThreadedExecutor) {
+    return new ConsoleLoggerBuilder(
         messageConsumers -> new AnsiLoggerWithFooter(messageConsumers, singleThreadedExecutor));
   }
 
   /**
-   * Starts a {@link LogEventHandlerBuilder} for plain-text logging (no ANSI support).
+   * Starts a {@link ConsoleLoggerBuilder} for plain-text logging (no ANSI support).
    *
    * @param singleThreadedExecutor a {@link SingleThreadedExecutor} to ensure that all messages are
    *     logged in a sequential, deterministic order
-   * @return a new {@link LogEventHandlerBuilder}
+   * @return a new {@link ConsoleLoggerBuilder}
    */
-  public static LogEventHandlerBuilder plain(SingleThreadedExecutor singleThreadedExecutor) {
-    return new LogEventHandlerBuilder(
+  public static ConsoleLoggerBuilder plain(SingleThreadedExecutor singleThreadedExecutor) {
+    return new ConsoleLoggerBuilder(
         messageConsumers -> new PlainConsoleLogger(messageConsumers, singleThreadedExecutor));
   }
 
@@ -64,7 +63,7 @@ public class LogEventHandlerBuilder {
   private final ConsoleLoggerFactory consoleLoggerFactory;
 
   @VisibleForTesting
-  LogEventHandlerBuilder(ConsoleLoggerFactory consoleLoggerFactory) {
+  ConsoleLoggerBuilder(ConsoleLoggerFactory consoleLoggerFactory) {
     this.consoleLoggerFactory = consoleLoggerFactory;
   }
 
@@ -74,7 +73,7 @@ public class LogEventHandlerBuilder {
    * @param messageConsumer the message {@link Consumer}
    * @return this
    */
-  public LogEventHandlerBuilder lifecycle(Consumer<String> messageConsumer) {
+  public ConsoleLoggerBuilder lifecycle(Consumer<String> messageConsumer) {
     messageConsumers.put(Level.LIFECYCLE, messageConsumer);
     return this;
   }
@@ -85,7 +84,7 @@ public class LogEventHandlerBuilder {
    * @param messageConsumer the message {@link Consumer}
    * @return this
    */
-  public LogEventHandlerBuilder progress(Consumer<String> messageConsumer) {
+  public ConsoleLoggerBuilder progress(Consumer<String> messageConsumer) {
     messageConsumers.put(Level.PROGRESS, messageConsumer);
     return this;
   }
@@ -96,7 +95,7 @@ public class LogEventHandlerBuilder {
    * @param messageConsumer the message {@link Consumer}
    * @return this
    */
-  public LogEventHandlerBuilder debug(Consumer<String> messageConsumer) {
+  public ConsoleLoggerBuilder debug(Consumer<String> messageConsumer) {
     messageConsumers.put(Level.DEBUG, messageConsumer);
     return this;
   }
@@ -107,7 +106,7 @@ public class LogEventHandlerBuilder {
    * @param messageConsumer the message {@link Consumer}
    * @return this
    */
-  public LogEventHandlerBuilder error(Consumer<String> messageConsumer) {
+  public ConsoleLoggerBuilder error(Consumer<String> messageConsumer) {
     messageConsumers.put(Level.ERROR, messageConsumer);
     return this;
   }
@@ -118,7 +117,7 @@ public class LogEventHandlerBuilder {
    * @param messageConsumer the message {@link Consumer}
    * @return this
    */
-  public LogEventHandlerBuilder info(Consumer<String> messageConsumer) {
+  public ConsoleLoggerBuilder info(Consumer<String> messageConsumer) {
     messageConsumers.put(Level.INFO, messageConsumer);
     return this;
   }
@@ -129,18 +128,17 @@ public class LogEventHandlerBuilder {
    * @param messageConsumer the message {@link Consumer}
    * @return this
    */
-  public LogEventHandlerBuilder warn(Consumer<String> messageConsumer) {
+  public ConsoleLoggerBuilder warn(Consumer<String> messageConsumer) {
     messageConsumers.put(Level.WARN, messageConsumer);
     return this;
   }
 
   /**
-   * Builds the {@link LogEvent} handler.
+   * Builds the {@link ConsoleLogger}.
    *
-   * @return the {@link Consumer}
+   * @return the {@link ConsoleLogger}
    */
-  public Consumer<LogEvent> build() {
-    ConsoleLogger consoleLogger = consoleLoggerFactory.apply(messageConsumers.build());
-    return logEvent -> consoleLogger.log(logEvent.getLevel(), logEvent.getMessage());
+  public ConsoleLogger build() {
+    return consoleLoggerFactory.apply(messageConsumers.build());
   }
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLogger.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLogger.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.plugins.common.logging;
 
 import com.google.cloud.tools.jib.event.events.LogEvent.Level;
 import com.google.common.collect.ImmutableMap;
+import java.util.List;
 import java.util.function.Consumer;
 
 /** Logs messages plainly. */
@@ -48,5 +49,10 @@ class PlainConsoleLogger implements ConsoleLogger {
     Consumer<String> messageConsumer = messageConsumers.get(logLevel);
 
     singleThreadedExecutor.execute(() -> messageConsumer.accept(message));
+  }
+
+  @Override
+  public void setFooter(List<String> footerLines) {
+    // No op.
   }
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ProgressDisplayGenerator.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ProgressDisplayGenerator.java
@@ -33,7 +33,7 @@ import java.util.Set;
  * &gt; task 1 running<br>
  * &gt; task 3 running
  */
-class ProgressDisplayGenerator {
+public class ProgressDisplayGenerator {
 
   /** Line above progress bar. */
   private static final String HEADER = "Executing tasks:";
@@ -48,7 +48,7 @@ class ProgressDisplayGenerator {
    * @param unfinishedAllocations the unfinished {@link Allocation}s
    * @return the progress display as a list of lines
    */
-  static List<String> generateProgressDisplay(
+  public static List<String> generateProgressDisplay(
       double progress, List<Allocation> unfinishedAllocations) {
     List<String> lines = new ArrayList<>();
 


### PR DESCRIPTION
Part of #1297 
To test the new progress logging, simply run with `-Djib.showProgress=true`.