### PR TITLE
Make DefaultCacheStorageWriter.moveIfDoesNotExist() more robust to concurrency

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
@@ -71,7 +71,7 @@ class DefaultCacheStorageWriter {
     }
 
     try {
-      Files.move(source, destination, StandardCopyOption.ATOMIC_MOVE);
+      Files.move(source, destination);
 
     } catch (FileSystemException ex) {
       if (!Files.exists(destination)) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
@@ -75,6 +75,7 @@ class DefaultCacheStorageWriter {
 
     } catch (FileSystemException ex) {
       if (!Files.exists(destination)) {
+        // TODO to log that the destination exists
         throw ex;
       }
     }


### PR DESCRIPTION
`DefaultCacheStorageWriter.moveIfDoesNotExist()` uses `Files.move()` to move a cache-layer into place.  The implementation first attempted to perform an atomic rename, but should that operation error in certain ways then it would retry the move as a copy-and-delete.  But it turns out that (1) the underlying primitives may throw other hard-to-enumerate platform-specific exceptions, which we were not catching, and which may be thrown in a concurrency situation where two jobs are attempting to install the same cache-layer, and (2) `Files.move()` does a copy-and-delete when required.  

So this patch changes the code to just perform a `Files.move()` and lets the implementation do its best.  If an exception is raised but the destination directory now exists, then the implementation ignores the exception and treats it as a symptom of a concurrent installation.

Fixes #1273 