### PR TITLE
Add Automatic-Module-Name: in MANIFEST.MF

### DIFF
--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 jar {
   manifest {
     attributes 'Implementation-Version': version
+    attributes 'Automatic-Module-Name': 'com.google.cloud.tools.jib'
 
     // OSGi metadata
     attributes 'Bundle-SymbolicName': 'com.google.cloud.tools.jib'


### PR DESCRIPTION
Following [Stephen Colebourne's excellent advice on using the super-package as the module name](https://blog.joda.org/2017/04/java-se-9-jpms-module-naming.html), I suggest **`com.google.cloud.tools.jib`** as the module name for our `jib-core` library.

Note that once we decided the name, we should never change after the library goes GA.

Note that any traditional JARs prior to Java 9 are automatically turned into modules (the feature called `automatic modules` when specified on the module path. Even now, users can use `jib-core` with JPMS. However, if we do not declare an official name for `jib-core`, [it will become ugly in the JPMS world in the not-too-distant future](http://branchandbound.net/blog/java/2017/12/automatic-module-name/).

I've done a few sanity checks suggested in the above link, and our `jib-core` appears to be safe.
- No internal types from the JDK: `~/jdk-11.0.1/bin/jdeps --jdk-internals build/libs/jib-core-0.1.1-SNAPSHOT.jar` shows nothing.
- No default (unnamed) package.
- No split packages.
- No `META-INF/services`, so nothing to worry.

Some details:

## Status quo ##

- The name of the automatic module is `jib.core`, derived from the JAR name, `jib-core-<version>.jar`:
```
$ ./gradlew build
$ ~/jdk-11.0.1/bin/java --module-path build/libs/jib-core-0.1.1-SNAPSHOT.jar --describe-module jib.core
jib.core@0.1.1-SNAPSHOT file://.../jib/jib-core/build/libs/jib-core-0.1.1-SNAPSHOT.jar automatic
requires java.base mandated
contains com.google.cloud.tools.jib
contains com.google.cloud.tools.jib.api
contains com.google.cloud.tools.jib.async
contains com.google.cloud.tools.jib.blob
...
```

- `MANIFEST.MF` doesn't have the `Automatic-Module-Name` entry:
```
$ unzip -p build/libs/jib-core-0.1.1-SNAPSHOT.jar META-INF/MANIFEST.MF | grep -v '^ ' | cut -d: -f1
Manifest-Version
Bnd-LastModified
Bundle-DocURL
Bundle-License
Bundle-ManifestVersion
Bundle-Name
Bundle-SymbolicName
Bundle-Vendor
Bundle-Version
Created-By
Export-Package
Implementation-Version
Import-Package
Require-Capability
Tool
```

## After the PR ###
- The name of the automatic module is `com.google.cloud.tools.jib`:
```
$ ./gradlew build
$ ~/jdk-11.0.1/bin/java --module-path build/libs/jib-core-0.1.1-SNAPSHOT.jar --describe-module jib.core
jib.core not found

$ ~/jdk-11.0.1/bin/java --module-path build/libs/jib-core-0.1.1-SNAPSHOT.jar --describe-module com.google.cloud.tools.jib
com.google.cloud.tools.jib@0.1.1-SNAPSHOT file://.../jib/jib-core/build/libs/jib-core-0.1.1-SNAPSHOT.jar automatic
requires java.base mandated
contains com.google.cloud.tools.jib
contains com.google.cloud.tools.jib.api
contains com.google.cloud.tools.jib.async
...
```
- `MANIFEST.MF` has the `Automatic-Module-Name` entry:
```
$ unzip -p build/libs/jib-core-0.1.1-SNAPSHOT.jar META-INF/MANIFEST.MF | grep Automatic-Module-Name
Automatic-Module-Name: com.google.cloud.tools.jib
```