### PR TITLE
Avoid nested Futures by calling combiners in a blocking manner

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/async/AsyncDependencies.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/async/AsyncDependencies.java
@@ -22,6 +22,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Builds a list of dependency {@link ListenableFuture}s to wait on before calling a {@link
@@ -71,7 +72,8 @@ public class AsyncDependencies {
   }
 
   /**
-   * Calls {@code combiner} when all the added futures succeed.
+   * Creates the {@link ListenableFuture} which will return the result of calling {@code combiner}
+   * when all the added futures succeed.
    *
    * @param combiner the {@link Callable}
    * @param <C> the return type of {@code combiner}
@@ -79,5 +81,20 @@ public class AsyncDependencies {
    */
   public <C> ListenableFuture<C> whenAllSucceed(Callable<C> combiner) {
     return Futures.whenAllSucceed(futures).call(combiner, listeningExecutorService);
+  }
+
+  /**
+   * Calls {@code combiner} when all the added futures succeed.
+   *
+   * @param combiner the {@link Callable}
+   * @param <C> the return type of {@code combiner}
+   * @return a {@link ListenableFuture} to handle completion of the call to {@code combiner}
+   * @throws ExecutionException if {@code combiner} threw an exception
+   * @throws InterruptedException if the current thread was interrupted while waiting for {@code
+   *     combiner}
+   */
+  public <C> C whenAllSucceedBlocking(Callable<C> combiner)
+      throws InterruptedException, ExecutionException {
+    return Futures.whenAllSucceed(futures).call(combiner, listeningExecutorService).get();
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
@@ -83,8 +83,7 @@ class LoadDockerStep implements AsyncStep<BuildResult>, Callable<BuildResult> {
         .addSteps(NonBlockingSteps.get(pullAndCacheBaseImageLayersStep))
         .addSteps(buildAndCacheApplicationLayerSteps)
         .addStep(NonBlockingSteps.get(buildImageStep))
-        .whenAllSucceed(this::afterPushBaseImageLayerFuturesFuture)
-        .get();
+        .whenAllSucceedBlocking(this::afterPushBaseImageLayerFuturesFuture);
   }
 
   private BuildResult afterPushBaseImageLayerFuturesFuture()

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
@@ -84,8 +84,7 @@ public class WriteTarFileStep implements AsyncStep<BuildResult>, Callable<BuildR
         .addSteps(NonBlockingSteps.get(pullAndCacheBaseImageLayersStep))
         .addSteps(buildAndCacheApplicationLayerSteps)
         .addStep(NonBlockingSteps.get(buildImageStep))
-        .whenAllSucceed(this::writeTarFile)
-        .get();
+        .whenAllSucceedBlocking(this::writeTarFile);
   }
 
   private BuildResult writeTarFile() throws ExecutionException, IOException {


### PR DESCRIPTION
Added `whenAllSucceedBlocking()`, which waits for `combiner` to complete.

This is mainly to [avoid returning nested futures](https://github.com/google/guava/wiki/ListenableFutureExplained#avoid-nested-futures) in `PushImageStep` (although we are sort of OK with the nested futures because the combiner is meant to be called after the depending futures have been completed.) This will give an added benefit of better readability, as it was a bit complex to reason about the number of consecutive `.get()` calls or digest the meaning of returning `ListenableFuture<ListenableFuture<BuildResult>>`.

That said, `PushImageStep` will see a subtle difference in semantics regarding future execution (for example, an outer future may be scheduled to wait until an inner future completes prior to this change, while now an "outer" task will run explicitly after the "inner" task completes), but in the end, I believe the change doesn't matter because `PushImageStep.afterPushSteps()` is a private method, all those consecutive `.get()` calls just wait for all the tasks to complete in the same sequence after this change, and thus `PushImageStep.call()` is a blocking call ultimately.  I think wrapping tasks in `Future` here is an unnecessary layering, when we know how we chain the calls until blocking.