### PR TITLE
Rename Maven profile ID

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ To build, use the provided `build.sh` which builds and tests each of the compone
    * In `jib-core`, run `./gradlew clean goJF build integrationTest`
    * In `jib-gradle-plugin`, run `./gradlew clean goJF build integrationTest`
    * In `jib-plugins-common`, run `./gradlew clean goJF build`
-   * In `jib-maven-plugin`, run `./mvnw clean fmt:format verify -Pintegration-tests`
+   * In `jib-maven-plugin`, run `./mvnw clean fmt:format verify -PintegrationTest`
 5. Associate the change with an existing issue or file a [new issue](../../issues).
 6. Create a pull request!
 

--- a/build.sh
+++ b/build.sh
@@ -90,7 +90,7 @@ for target in "$@"; do
 
     it)
       doBuild jib-core ./gradlew $gradleOptions integrationTest
-      doBuild jib-maven-plugin ./mvnw $mavenOptions -Pintegration-tests verify -U
+      doBuild jib-maven-plugin ./mvnw $mavenOptions -PintegrationTest verify -U
       doBuild jib-gradle-plugin ./gradlew $gradleOptions integrationTest
       ;;
 

--- a/jib-maven-plugin/pom.xml
+++ b/jib-maven-plugin/pom.xml
@@ -141,7 +141,7 @@
   <profiles>
     <!-- Profile for running integration tests. -->
     <profile>
-      <id>integration-tests</id>
+      <id>integrationTest</id>
       <build>
         <plugins>
           <plugin>
@@ -160,7 +160,7 @@
             </configuration>
             <executions>
               <execution>
-                <id>integration-tests</id>
+                <id>integration-test</id>
                 <goals>
                   <goal>integration-test</goal>
                   <goal>verify</goal>

--- a/jib-maven-plugin/scripts/prepare_release.sh
+++ b/jib-maven-plugin/scripts/prepare_release.sh
@@ -52,7 +52,7 @@ if [[ $(git status -uno --porcelain) ]]; then
 fi
 
 # Runs integration tests.
-./mvnw -X -Pintegration-tests verify
+./mvnw -X -PintegrationTest verify
 
 # Checks out a new branch for this version release (eg. 1.5.7).
 BRANCH=maven_release_v${VERSION}

--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -32,5 +32,5 @@ fi
 
 (cd github/jib/jib-core; ./gradlew clean build integrationTest --info --stacktrace)
 (cd github/jib/jib-plugins-common; ./gradlew clean build --info --stacktrace)
-(cd github/jib/jib-maven-plugin; ./mvnw clean install -P integration-tests -B -U -X)
+(cd github/jib/jib-maven-plugin; ./mvnw clean install -PintegrationTest -B -U -X)
 (cd github/jib/jib-gradle-plugin; ./gradlew clean build integrationTest --info --stacktrace)


### PR DESCRIPTION
I am always confuse by the different names between Maven and Gradle. This will make them consistent.