### PR TITLE
Get maven auth system properties from pom and commandline

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -136,4 +136,9 @@ class GradleRawConfiguration implements RawConfiguration {
   public ImageFormat getImageFormat() {
     return jibExtension.getContainer().getFormat();
   }
+
+  @Override
+  public Optional<String> getProperty(String propertyName) {
+    return Optional.ofNullable(System.getProperty(propertyName));
+  }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -556,7 +556,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
    * @return the value of the system property, or null if not defined
    */
   @Nullable
-  private String getProperty(String propertyName) {
+  public String getProperty(String propertyName) {
     if (session != null && session.getSystemProperties().containsKey(propertyName)) {
       return session.getSystemProperties().getProperty(propertyName);
     }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -270,7 +270,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   }
 
   AuthConfiguration getBaseImageAuth() {
-    // TODO: handle properties here instead of in ConfigurationPropertyValidator
+    // System/pom properties for auth are handled in ConfigurationPropertyValidator
     return from.auth;
   }
 
@@ -320,7 +320,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   }
 
   AuthConfiguration getTargetImageAuth() {
-    // TODO: handle properties here instead of in ConfigurationPropertyValidator
+    // System/pom properties for auth are handled in ConfigurationPropertyValidator
     return to.auth;
   }
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
@@ -141,4 +141,9 @@ class MavenRawConfiguration implements RawConfiguration {
   public ImageFormat getImageFormat() {
     return ImageFormat.valueOf(jibPluginConfiguration.getFormat());
   }
+
+  @Override
+  public Optional<String> getProperty(String propertyName) {
+    return Optional.ofNullable(jibPluginConfiguration.getProperty(propertyName));
+  }
 }

--- a/jib-maven-plugin/src/test/resources/projects/simple/pom-complex-properties.xml
+++ b/jib-maven-plugin/src/test/resources/projects/simple/pom-complex-properties.xml
@@ -12,7 +12,11 @@
     <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>
 
     <jib.from.image>localhost:5000/distroless/java</jib.from.image>
+    <jib.from.auth.username>testuser</jib.from.auth.username>
+    <jib.from.auth.password>testpassword</jib.from.auth.password>
     <jib.to.image>${_TARGET_IMAGE}</jib.to.image>
+    <jib.to.auth.username>${_TARGET_USERNAME}</jib.to.auth.username>
+    <jib.to.auth.password>${_TARGET_PASSWORD}</jib.to.auth.password>
     <jib.container.useCurrentTimestamp>true</jib.container.useCurrentTimestamp>
     <jib.container.args>An argument.</jib.container.args>
     <jib.container.mainClass>com.test.HelloWorld</jib.container.mainClass>
@@ -52,20 +56,6 @@
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
         <version>${jib-maven-plugin.version}</version>
-        <configuration>
-          <from>
-            <auth>
-              <username>testuser</username>
-              <password>testpassword</password>
-            </auth>
-          </from>
-          <to>
-            <auth>
-              <username>${_TARGET_USERNAME}</username>
-              <password>${_TARGET_PASSWORD}</password>
-            </auth>
-          </to>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidator.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidator.java
@@ -48,8 +48,7 @@ public class ConfigurationPropertyValidator {
    * @param usernameProperty the name of the username system property
    * @param passwordProperty the name of the password system property
    * @param auth the configured credentials
-   * @param authUsernameDescriptor the name of the auth username parameter
-   * @param authPasswordDescriptor the name of the auth password parameter
+   * @param rawConfiguration the {@link RawConfiguration} that provides system properties
    * @return a new {@link Authorization} from the system properties or build configuration, or
    *     {@link Optional#empty} if neither is configured.
    */
@@ -58,11 +57,10 @@ public class ConfigurationPropertyValidator {
       String usernameProperty,
       String passwordProperty,
       AuthProperty auth,
-      String authUsernameDescriptor,
-      String authPasswordDescriptor) {
+      RawConfiguration rawConfiguration) {
     // System property takes priority over build configuration
-    String commandlineUsername = System.getProperty(usernameProperty);
-    String commandlinePassword = System.getProperty(passwordProperty);
+    String commandlineUsername = rawConfiguration.getProperty(usernameProperty).orElse(null);
+    String commandlinePassword = rawConfiguration.getProperty(passwordProperty).orElse(null);
     if (!Strings.isNullOrEmpty(commandlineUsername)
         && !Strings.isNullOrEmpty(commandlinePassword)) {
       return Optional.of(Credential.basic(commandlineUsername, commandlinePassword));
@@ -93,14 +91,14 @@ public class ConfigurationPropertyValidator {
     if (Strings.isNullOrEmpty(auth.getUsername())) {
       eventDispatcher.dispatch(
           LogEvent.warn(
-              authUsernameDescriptor
+              auth.getUsernameDescriptor()
                   + " is missing from build configuration; ignoring auth section."));
       return Optional.empty();
     }
     if (Strings.isNullOrEmpty(auth.getPassword())) {
       eventDispatcher.dispatch(
           LogEvent.warn(
-              authPasswordDescriptor
+              auth.getPasswordDescriptor()
                   + " is missing from build configuration; ignoring auth section."));
       return Optional.empty();
     }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -141,6 +141,7 @@ public class PluginConfigurationProcessor {
         new DefaultEventDispatcher(projectProperties.getEventHandlers());
     boolean isTargetImageCredentialPresent =
         configureCredentialRetrievers(
+            rawConfiguration,
             eventDispatcher,
             targetImage,
             targetImageReference,
@@ -191,6 +192,7 @@ public class PluginConfigurationProcessor {
     RegistryImage baseImage = RegistryImage.named(baseImageReference);
     boolean isBaseImageCredentialPresent =
         configureCredentialRetrievers(
+            rawConfiguration,
             eventDispatcher,
             baseImage,
             baseImageReference,
@@ -367,6 +369,7 @@ public class PluginConfigurationProcessor {
 
   // TODO: find a way to reduce the number of arguments.
   private static boolean configureCredentialRetrievers(
+      RawConfiguration rawConfiguration,
       EventDispatcher eventDispatcher,
       RegistryImage registryImage,
       ImageReference imageReference,
@@ -385,8 +388,7 @@ public class PluginConfigurationProcessor {
             usernamePropertyName,
             passwordPropertyName,
             knownAuth,
-            knownAuth.getUsernameDescriptor(),
-            knownAuth.getPasswordDescriptor());
+            rawConfiguration);
     boolean credentialPresent = optionalCredential.isPresent();
     if (optionalCredential.isPresent()) {
       defaultCredentialRetrievers.setKnownCredential(

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
@@ -68,4 +68,6 @@ public interface RawConfiguration {
   boolean getAllowInsecureRegistries();
 
   ImageFormat getImageFormat();
+
+  Optional<String> getProperty(String propertyName);
 }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidatorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidatorTest.java
@@ -38,15 +38,20 @@ public class ConfigurationPropertyValidatorTest {
   @Mock private EventDispatcher mockEventDispatcher;
   @Mock private AuthProperty mockAuth;
   @Mock private ImageReference mockImageReference;
+  @Mock private RawConfiguration mockConfiguration;
 
   @Test
   public void testGetImageAuth() {
+    Mockito.when(mockAuth.getUsernameDescriptor()).thenReturn("user");
+    Mockito.when(mockAuth.getPasswordDescriptor()).thenReturn("pass");
     Mockito.when(mockAuth.getUsername()).thenReturn("vwxyz");
     Mockito.when(mockAuth.getPassword()).thenReturn("98765");
 
     // System properties set
-    System.setProperty("jib.test.auth.user", "abcde");
-    System.setProperty("jib.test.auth.pass", "12345");
+    Mockito.when(mockConfiguration.getProperty("jib.test.auth.user"))
+        .thenReturn(Optional.of("abcde"));
+    Mockito.when(mockConfiguration.getProperty("jib.test.auth.pass"))
+        .thenReturn(Optional.of("12345"));
     Credential expected = Credential.basic("abcde", "12345");
     Optional<Credential> actual =
         ConfigurationPropertyValidator.getImageCredential(
@@ -54,14 +59,13 @@ public class ConfigurationPropertyValidatorTest {
             "jib.test.auth.user",
             "jib.test.auth.pass",
             mockAuth,
-            "user",
-            "pass");
+            mockConfiguration);
     Assert.assertTrue(actual.isPresent());
     Assert.assertEquals(expected.toString(), actual.get().toString());
 
     // Auth set in configuration
-    System.clearProperty("jib.test.auth.user");
-    System.clearProperty("jib.test.auth.pass");
+    Mockito.when(mockConfiguration.getProperty("jib.test.auth.user")).thenReturn(Optional.empty());
+    Mockito.when(mockConfiguration.getProperty("jib.test.auth.pass")).thenReturn(Optional.empty());
     expected = Credential.basic("vwxyz", "98765");
     actual =
         ConfigurationPropertyValidator.getImageCredential(
@@ -69,8 +73,7 @@ public class ConfigurationPropertyValidatorTest {
             "jib.test.auth.user",
             "jib.test.auth.pass",
             mockAuth,
-            "user",
-            "pass");
+            mockConfiguration);
     Assert.assertTrue(actual.isPresent());
     Assert.assertEquals(expected.toString(), actual.get().toString());
     Mockito.verify(mockEventDispatcher, Mockito.never()).dispatch(LogEvent.warn(Mockito.any()));
@@ -84,8 +87,7 @@ public class ConfigurationPropertyValidatorTest {
             "jib.test.auth.user",
             "jib.test.auth.pass",
             mockAuth,
-            "user",
-            "pass");
+            mockConfiguration);
     Assert.assertFalse(actual.isPresent());
 
     // Password missing
@@ -97,8 +99,7 @@ public class ConfigurationPropertyValidatorTest {
             "jib.test.auth.user",
             "jib.test.auth.pass",
             mockAuth,
-            "user",
-            "pass");
+            mockConfiguration);
     Assert.assertFalse(actual.isPresent());
     Mockito.verify(mockEventDispatcher)
         .dispatch(
@@ -113,8 +114,7 @@ public class ConfigurationPropertyValidatorTest {
             "jib.test.auth.user",
             "jib.test.auth.pass",
             mockAuth,
-            "user",
-            "pass");
+            mockConfiguration);
     Assert.assertFalse(actual.isPresent());
     Mockito.verify(mockEventDispatcher)
         .dispatch(


### PR DESCRIPTION
Follow-up to #1389, fixes #1201. Needed a bit of special work for this since auth properties are a special case and need to be defined together.