### PR TITLE
Update com.fasterxml.jackson.core:jackson-databind to 2.9.8

### DIFF
--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -38,7 +38,7 @@ dependencies {
   implementation 'com.google.http-client:google-http-client:1.23.0'
   implementation 'org.apache.commons:commons-compress:1.18'
   implementation 'com.google.guava:guava:23.5-jre'
-  implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
+  implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
   implementation 'org.javassist:javassist:3.24.1-GA'
 
   testImplementation 'junit:junit:4.12'

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -64,7 +64,7 @@ dependencies {
   compile 'com.google.http-client:google-http-client:1.23.0'
   compile 'org.apache.commons:commons-compress:1.18'
   compile 'com.google.guava:guava:23.5-jre'
-  compile 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
+  compile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
   compile 'org.javassist:javassist:3.24.1-GA'
 
   testCompile 'junit:junit:4.12'

--- a/jib-maven-plugin/pom.xml
+++ b/jib-maven-plugin/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.6</version>
+      <version>2.9.8</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/jib-plugins-common/build.gradle
+++ b/jib-plugins-common/build.gradle
@@ -32,7 +32,7 @@ dependencies {
   compile 'com.google.http-client:google-http-client:1.23.0'
   compile 'org.apache.commons:commons-compress:1.18'
   compile 'com.google.guava:guava:23.5-jre'
-  compile 'com.fasterxml.jackson.core:jackson-databind:2.9.6'
+  compile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
   compile 'org.javassist:javassist:3.24.1-GA'
 
   testCompile 'junit:junit:4.12'


### PR DESCRIPTION
Making github security alert go away.