### PR TITLE
Add docker client executable/environment configuration to Maven

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
@@ -100,7 +100,12 @@ class LoadDockerStep implements AsyncStep<BuildResult>, Callable<BuildResult> {
           buildConfiguration.getTargetImageConfiguration().getImage();
 
       // Load the image to docker daemon.
-      dockerClient.load(new ImageToTarballTranslator(image).toTarballBlob(targetImageReference));
+      buildConfiguration
+          .getEventDispatcher()
+          .dispatch(
+              LogEvent.debug(
+                  dockerClient.load(
+                      new ImageToTarballTranslator(image).toTarballBlob(targetImageReference))));
 
       // Tags the image with all the additional tags, skipping the one 'docker load' already loaded.
       for (String tag : buildConfiguration.getAllTargetImageTags()) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
@@ -127,7 +127,6 @@ public class DockerClient {
    *
    * @param dockerExecutable path to {@code docker}
    * @param dockerEnvironment environment variables for {@code docker}
-   * @return a new {@link DockerClient}
    */
   private DockerClient(Path dockerExecutable, ImmutableMap<String, String> dockerEnvironment) {
     this(defaultProcessBuilderFactory(dockerExecutable.toString(), dockerEnvironment));

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -225,7 +225,8 @@ public class SingleProjectIntegrationTest {
         buildResult, "jibDockerBuild", "Built image to Docker daemon as ");
     JibRunHelper.assertImageDigestAndId(simpleTestProject.getProjectRoot());
     Assert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(targetImage));
-    Assert.assertThat(buildResult.getOutput(), CoreMatchers.containsString("Docker load called."));
+    Assert.assertThat(
+        buildResult.getOutput(), CoreMatchers.containsString("Docker load called. value1 value2"));
   }
 
   @Test

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -25,7 +25,11 @@ import java.time.Instant;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.UnexpectedBuildFailure;
 import org.hamcrest.CoreMatchers;
-import org.junit.*;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
 
 /** Integration tests for building single project images. */
 public class SingleProjectIntegrationTest {

--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/build-dockerclient.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/build-dockerclient.gradle
@@ -1,0 +1,23 @@
+plugins {
+  id 'java'
+  id 'com.google.cloud.tools.jib'
+}
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compile files('libs/dependency-1.0.0.jar')
+}
+
+jib {
+  to {
+    image = System.getProperty("_TARGET_IMAGE")
+  }
+}
+
+jibDockerBuild.dockerClient.executable = file('mock-docker.sh')

--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/build-dockerclient.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/build-dockerclient.gradle
@@ -20,4 +20,9 @@ jib {
   }
 }
 
-jibDockerBuild.dockerClient.executable = file('mock-docker.sh')
+jibDockerBuild {
+  dockerClient {
+    executable = file('mock-docker.sh')
+    environment = [envvar1:'value1', envvar2:'value2']
+  }
+}

--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/mock-docker.sh
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/mock-docker.sh
@@ -3,4 +3,4 @@
 # Read stdin to avoid broken pipe
 cat > /dev/null
 
-echo "Docker load called."
+echo "Docker load called. $envvar1 $envvar2"

--- a/jib-gradle-plugin/src/integration-test/resources/projects/simple/mock-docker.sh
+++ b/jib-gradle-plugin/src/integration-test/resources/projects/simple/mock-docker.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Read stdin to avoid broken pipe
+cat > /dev/null
+
+echo "Docker load called."

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Setting proxy credentials (via system properties `http(s).proxyUser` and `http(s).proxyPassword`) is now supported.
 - Maven proxy settings are now supported.
 - Now checks for system properties in pom as well as commandline. ([#1201](https://github.com/GoogleContainerTools/jib/issues/1201))
+- `<dockerClient><executable>` and `<dockerClient><environment>` to set Docker client binary path (defaulting to `docker`) and additional environment variables to apply when running the binary ([#468](https://github.com/GoogleContainerTools/jib/issues/468))
 
 ### Changed
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -33,6 +33,7 @@ import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryExceptio
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.common.annotations.VisibleForTesting;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -54,14 +55,14 @@ public class BuildDockerMojo extends JibPluginConfiguration {
    * Object that configures the Docker executable and the additional environment variables to use
    * when executing the executable.
    */
-  private static class DockerClientConfiguration {
+  public static class DockerClientConfiguration {
 
-    @Nullable @Parameter private String executable;
+    @Nullable @Parameter private File executable;
     @Nullable @Parameter private Map<String, String> environment;
 
     @Nullable
     private Path getExecutable() {
-      return executable == null ? null : Paths.get(executable);
+      return executable == null ? null : executable.toPath();
     }
 
     @Nullable
@@ -73,7 +74,7 @@ public class BuildDockerMojo extends JibPluginConfiguration {
   @VisibleForTesting static final String GOAL_NAME = "dockerBuild";
   private static final String HELPFUL_SUGGESTIONS_PREFIX = "Build to Docker daemon failed";
 
-  private final DockerClientConfiguration dockerClientConfiguration = new DockerClientConfiguration();
+  @Parameter private DockerClientConfiguration dockerClient = new DockerClientConfiguration();
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
@@ -86,7 +87,7 @@ public class BuildDockerMojo extends JibPluginConfiguration {
       return;
     }
 
-    Path dockerExecutable = dockerClientConfiguration.getExecutable();
+    Path dockerExecutable = dockerClient.getExecutable();
     boolean isDockerInstalled =
         dockerExecutable == null
             ? DockerClient.isDefaultDockerInstalled()
@@ -119,7 +120,7 @@ public class BuildDockerMojo extends JibPluginConfiguration {
                   getSession().getSettings(), getSettingsDecrypter(), eventDispatcher),
               projectProperties,
               dockerExecutable,
-              dockerClientConfiguration.getEnvironment(),
+              dockerClient.getEnvironment(),
               mavenHelpfulSuggestionsBuilder.build());
       ProxyProvider.init(getSession().getSettings());
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
@@ -25,6 +25,7 @@ import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.ClassRule;
 import org.junit.Test;
 
@@ -107,6 +108,28 @@ public class BuildDockerMojoIntegrationTest {
         Instant.parse(
             new Command("docker", "inspect", "-f", "{{.Created}}", targetImage).run().trim());
     Assert.assertTrue(buildTime.isAfter(before) || buildTime.equals(before));
+  }
+
+  @Test
+  public void testExecute_dockerClient()
+      throws VerificationException, IOException, InterruptedException {
+    Assume.assumeFalse(System.getProperty("os.name").startsWith("Windows"));
+    new Command(
+            "chmod", "+x", simpleTestProject.getProjectRoot().resolve("mock-docker.sh").toString())
+        .run();
+
+    String targetImage = "simpleimage:maven" + System.nanoTime();
+    Verifier verifier = new Verifier(simpleTestProject.getProjectRoot().toString());
+    verifier.setSystemProperty("jib.useOnlyProjectCache", "true");
+    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
+    verifier.setAutoclean(false);
+    verifier.addCliOption("--file=pom-dockerclient.xml");
+    verifier.addCliOption("--debug");
+    verifier.executeGoal("package");
+
+    verifier.executeGoal("jib:dockerBuild");
+    verifier.verifyTextInLog("Docker load called.");
+    verifier.verifyErrorFreeLog();
   }
 
   @Test

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
@@ -128,7 +128,7 @@ public class BuildDockerMojoIntegrationTest {
     verifier.executeGoal("package");
 
     verifier.executeGoal("jib:dockerBuild");
-    verifier.verifyTextInLog("Docker load called.");
+    verifier.verifyTextInLog("Docker load called. value1 value2");
     verifier.verifyErrorFreeLog();
   }
 

--- a/jib-maven-plugin/src/test/resources/projects/simple/mock-docker.sh
+++ b/jib-maven-plugin/src/test/resources/projects/simple/mock-docker.sh
@@ -3,4 +3,4 @@
 # Read stdin to avoid broken pipe
 cat > /dev/null
 
-echo "Docker load called."
+echo "Docker load called. $envvar1 $envvar2"

--- a/jib-maven-plugin/src/test/resources/projects/simple/mock-docker.sh
+++ b/jib-maven-plugin/src/test/resources/projects/simple/mock-docker.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Read stdin to avoid broken pipe
+cat > /dev/null
+
+echo "Docker load called."

--- a/jib-maven-plugin/src/test/resources/projects/simple/pom-dockerclient.xml
+++ b/jib-maven-plugin/src/test/resources/projects/simple/pom-dockerclient.xml
@@ -1,0 +1,51 @@
+<project>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.test</groupId>
+  <artifactId>hello-world</artifactId>
+  <version>1</version>
+
+  <properties>
+    <java.target.version>1.8</java.target.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.test</groupId>
+      <artifactId>dependency</artifactId>
+      <version>1.0.0</version>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/libs/dependency-1.0.0.jar</systemPath>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>${jib-maven-plugin.version}</version>
+        <configuration>
+          <to>
+            <image>${_TARGET_IMAGE}</image>
+          </to>
+          <dockerClient>
+            <executable>${project.basedir}/mock-docker.sh</executable>
+          </dockerClient>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jib-maven-plugin/src/test/resources/projects/simple/pom-dockerclient.xml
+++ b/jib-maven-plugin/src/test/resources/projects/simple/pom-dockerclient.xml
@@ -43,6 +43,10 @@
           </to>
           <dockerClient>
             <executable>${project.basedir}/mock-docker.sh</executable>
+            <environment>
+              <envvar1>value1</envvar1>
+              <envvar2>value2</envvar2>
+            </environment>
           </dockerClient>
         </configuration>
       </plugin>

--- a/jib-maven-plugin/src/test/resources/projects/simple/pom-dockerclient.xml
+++ b/jib-maven-plugin/src/test/resources/projects/simple/pom-dockerclient.xml
@@ -6,7 +6,6 @@
   <version>1</version>
 
   <properties>
-    <java.target.version>1.8</java.target.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>
@@ -27,10 +26,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Fixes #468. Maven side of #1214.

Docker parameters can be configured using:
```
<configuration>
  <dockerClient>
    <executable>/path/to/executable</executable>
    <environment>
      <key1>value1</key1>
      <key2>value2</key2>
    </environment>
  </dockerClient>
</configuration>
```

~~Let me know if you have any ideas for how to test this (seems gradle side is also missing tests).~~ Also adds integration tests for both Maven and Gradle.