### PR TITLE
Add clearer error messages for null elements in config lists

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -72,7 +72,8 @@ public class ContainerConfiguration {
       if (programArguments == null) {
         this.programArguments = null;
       } else {
-        Preconditions.checkArgument(!programArguments.contains(null));
+        Preconditions.checkArgument(
+            !programArguments.contains(null), "args list contains null elements");
         this.programArguments = ImmutableList.copyOf(programArguments);
       }
       return this;
@@ -88,8 +89,12 @@ public class ContainerConfiguration {
       if (environmentMap == null) {
         this.environmentMap = null;
       } else {
-        Preconditions.checkArgument(!Iterables.any(environmentMap.keySet(), Objects::isNull));
-        Preconditions.checkArgument(!Iterables.any(environmentMap.values(), Objects::isNull));
+        Preconditions.checkArgument(
+            !Iterables.any(environmentMap.keySet(), Objects::isNull),
+            "environment map contains null keys");
+        Preconditions.checkArgument(
+            !Iterables.any(environmentMap.values(), Objects::isNull),
+            "environment map contains null values");
         this.environmentMap = new HashMap<>(environmentMap);
       }
       return this;
@@ -112,7 +117,8 @@ public class ContainerConfiguration {
       if (exposedPorts == null) {
         this.exposedPorts = null;
       } else {
-        Preconditions.checkArgument(!exposedPorts.contains(null));
+        Preconditions.checkArgument(
+            !exposedPorts.contains(null), "ports list contains null elements");
         this.exposedPorts = new HashSet<>(exposedPorts);
       }
       return this;
@@ -135,7 +141,7 @@ public class ContainerConfiguration {
       if (volumes == null) {
         this.volumes = null;
       } else {
-        Preconditions.checkArgument(!volumes.contains(null));
+        Preconditions.checkArgument(!volumes.contains(null), "volumes list contains null elements");
         this.volumes = new HashSet<>(volumes);
       }
       return this;
@@ -158,8 +164,10 @@ public class ContainerConfiguration {
       if (labels == null) {
         this.labels = null;
       } else {
-        Preconditions.checkArgument(!Iterables.any(labels.keySet(), Objects::isNull));
-        Preconditions.checkArgument(!Iterables.any(labels.values(), Objects::isNull));
+        Preconditions.checkArgument(
+            !Iterables.any(labels.keySet(), Objects::isNull), "labels map contains null keys");
+        Preconditions.checkArgument(
+            !Iterables.any(labels.values(), Objects::isNull), "labels map contains null values");
         this.labels = new HashMap<>(labels);
       }
       return this;
@@ -182,7 +190,8 @@ public class ContainerConfiguration {
       if (entrypoint == null) {
         this.entrypoint = null;
       } else {
-        Preconditions.checkArgument(!entrypoint.contains(null));
+        Preconditions.checkArgument(
+            !entrypoint.contains(null), "entrypoint contains null elements");
         this.entrypoint = ImmutableList.copyOf(entrypoint);
       }
       return this;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -73,7 +73,7 @@ public class ContainerConfiguration {
         this.programArguments = null;
       } else {
         Preconditions.checkArgument(
-            !programArguments.contains(null), "args list contains null elements");
+            !programArguments.contains(null), "program arguments list contains null elements");
         this.programArguments = ImmutableList.copyOf(programArguments);
       }
       return this;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
@@ -39,7 +39,8 @@ public class ImageConfiguration {
      * @return this
      */
     public Builder setCredentialRetrievers(List<CredentialRetriever> credentialRetrievers) {
-      Preconditions.checkArgument(!credentialRetrievers.contains(null));
+      Preconditions.checkArgument(
+          !credentialRetrievers.contains(null), "credential retriever list contains null elements");
       this.credentialRetrievers = ImmutableList.copyOf(credentialRetrievers);
       return this;
     }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
@@ -38,7 +38,7 @@ public class ContainerConfigurationTest {
       ContainerConfiguration.builder().setProgramArguments(Arrays.asList("first", null));
       Assert.fail("The IllegalArgumentException should be thrown.");
     } catch (IllegalArgumentException ex) {
-      Assert.assertNull(ex.getMessage());
+      Assert.assertEquals("args list contains null elements", ex.getMessage());
     }
 
     // Entrypoint element should not be null.
@@ -46,7 +46,7 @@ public class ContainerConfigurationTest {
       ContainerConfiguration.builder().setEntrypoint(Arrays.asList("first", null));
       Assert.fail("The IllegalArgumentException should be thrown.");
     } catch (IllegalArgumentException ex) {
-      Assert.assertNull(ex.getMessage());
+      Assert.assertEquals("entrypoint contains null elements", ex.getMessage());
     }
 
     // Exposed ports element should not be null.
@@ -55,38 +55,54 @@ public class ContainerConfigurationTest {
       ContainerConfiguration.builder().setExposedPorts(badPorts);
       Assert.fail("The IllegalArgumentException should be thrown.");
     } catch (IllegalArgumentException ex) {
-      Assert.assertNull(ex.getMessage());
+      Assert.assertEquals("ports list contains null elements", ex.getMessage());
     }
 
-    // Labels element should not be null.
-    Map<String, String> badLabels = new HashMap<>();
-    badLabels.put("label-key", null);
+    // Volume element should not be null.
+    Set<AbsoluteUnixPath> badVolumes =
+        new HashSet<>(Arrays.asList(AbsoluteUnixPath.get("/"), null));
     try {
-      ContainerConfiguration.builder().setLabels(badLabels);
+      ContainerConfiguration.builder().setVolumes(badVolumes);
       Assert.fail("The IllegalArgumentException should be thrown.");
     } catch (IllegalArgumentException ex) {
-      Assert.assertNull(ex.getMessage());
+      Assert.assertEquals("volumes list contains null elements", ex.getMessage());
     }
 
-    // Environment keys element should not be null.
     Map<String, String> nullKeyMap = new HashMap<>();
     nullKeyMap.put(null, "value");
+    Map<String, String> nullValueMap = new HashMap<>();
+    nullValueMap.put("key", null);
 
+    // Label keys should not be null.
+    try {
+      ContainerConfiguration.builder().setLabels(nullKeyMap);
+      Assert.fail("The IllegalArgumentException should be thrown.");
+    } catch (IllegalArgumentException ex) {
+      Assert.assertEquals("labels map contains null keys", ex.getMessage());
+    }
+
+    // Labels values should not be null.
+    try {
+      ContainerConfiguration.builder().setLabels(nullValueMap);
+      Assert.fail("The IllegalArgumentException should be thrown.");
+    } catch (IllegalArgumentException ex) {
+      Assert.assertEquals("labels map contains null values", ex.getMessage());
+    }
+
+    // Environment keys should not be null.
     try {
       ContainerConfiguration.builder().setEnvironment(nullKeyMap);
       Assert.fail("The IllegalArgumentException should be thrown.");
     } catch (IllegalArgumentException ex) {
-      Assert.assertNull(ex.getMessage());
+      Assert.assertEquals("environment map contains null keys", ex.getMessage());
     }
 
-    // Environment values element should not be null.
-    Map<String, String> nullValueMap = new HashMap<>();
-    nullValueMap.put("key", null);
+    // Environment values should not be null.
     try {
       ContainerConfiguration.builder().setEnvironment(nullValueMap);
       Assert.fail("The IllegalArgumentException should be thrown.");
     } catch (IllegalArgumentException ex) {
-      Assert.assertNull(ex.getMessage());
+      Assert.assertEquals("environment map contains null values", ex.getMessage());
     }
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
@@ -38,7 +38,7 @@ public class ContainerConfigurationTest {
       ContainerConfiguration.builder().setProgramArguments(Arrays.asList("first", null));
       Assert.fail("The IllegalArgumentException should be thrown.");
     } catch (IllegalArgumentException ex) {
-      Assert.assertEquals("args list contains null elements", ex.getMessage());
+      Assert.assertEquals("program arguments list contains null elements", ex.getMessage());
     }
 
     // Entrypoint element should not be null.


### PR DESCRIPTION
Fixes #416. Just adds a message to the `IllegalArgumentException`s that are thrown when a configured list contains a null element.