### PR TITLE
Replace javassist with org.ow2.asm

### DIFF
--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -39,7 +39,7 @@ dependencies {
   implementation 'org.apache.commons:commons-compress:1.18'
   implementation 'com.google.guava:guava:23.5-jre'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
-  implementation 'org.javassist:javassist:3.24.1-GA'
+  implementation 'org.ow2.asm:asm:6.2.1'
 
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.mockito:mockito-core:2.23.4'

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -39,7 +39,7 @@ dependencies {
   implementation 'org.apache.commons:commons-compress:1.18'
   implementation 'com.google.guava:guava:23.5-jre'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
-  implementation 'org.ow2.asm:asm:6.2.1'
+  implementation 'org.ow2.asm:asm:7.0'
 
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.mockito:mockito-core:2.23.4'

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
@@ -33,6 +33,7 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 
 /**
  * Finds main classes in a list of class files. Main classes are classes that define the {@code
@@ -112,16 +113,17 @@ public class MainClassFinder {
     private boolean visitedMainClass;
 
     private MainClassVisitor() {
-      super(Opcodes.ASM6);
+      super(Opcodes.ASM7);
     }
 
     @Override
     @Nullable
     public MethodVisitor visitMethod(
-        int access, String name, String desc, String signature, String[] exceptions) {
-      if (access == Opcodes.ACC_PUBLIC + Opcodes.ACC_STATIC
+        int access, String name, String descriptor, String signature, String[] exceptions) {
+      if (access == (Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC)
           && name.equals("main")
-          && desc.equals("([Ljava/lang/String;)V")) {
+          && descriptor.equals(
+              Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(String[].class)))) {
         visitedMainClass = true;
       }
       return null;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
@@ -110,6 +110,9 @@ public class MainClassFinder {
   /** {@link ClassVisitor} that keeps track of whether or not it has visited a main class. */
   private static class MainClassVisitor extends ClassVisitor {
 
+    private static final String MAIN_DESCRIPTOR =
+        Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(String[].class));
+
     private boolean visitedMainClass;
 
     private MainClassVisitor() {
@@ -120,10 +123,10 @@ public class MainClassFinder {
     @Nullable
     public MethodVisitor visitMethod(
         int access, String name, String descriptor, String signature, String[] exceptions) {
-      if (access == (Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC)
+      int optionalAccess = Opcodes.ACC_FINAL | Opcodes.ACC_DEPRECATED;
+      if ((access & ~optionalAccess) == (Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC)
           && name.equals("main")
-          && descriptor.equals(
-              Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(String[].class)))) {
+          && descriptor.equals(MAIN_DESCRIPTOR)) {
         visitedMainClass = true;
       }
       return null;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
@@ -110,8 +110,11 @@ public class MainClassFinder {
   /** {@link ClassVisitor} that keeps track of whether or not it has visited a main class. */
   private static class MainClassVisitor extends ClassVisitor {
 
+    /** The return/argument types for main. */
     private static final String MAIN_DESCRIPTOR =
         Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(String[].class));
+
+    /** Accessors that main may or may not have. */
     private static final int OPTIONAL_ACCESS = Opcodes.ACC_FINAL | Opcodes.ACC_DEPRECATED;
 
     private boolean visitedMainClass;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
@@ -192,7 +192,7 @@ public class MainClassFinder {
       ClassReader reader = new ClassReader(classFileInputStream);
       reader.accept(mainClassVisitor, 0);
       if (mainClassVisitor.visitedMainClass) {
-        return Optional.of(reader.getClassName().replace("/", "."));
+        return Optional.of(reader.getClassName().replace('/', '.'));
       }
 
     } catch (ArrayIndexOutOfBoundsException ignored) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
@@ -190,7 +190,7 @@ public class MainClassFinder {
       }
 
     } catch (ArrayIndexOutOfBoundsException ignored) {
-      // Not a valid class file
+      // Not a valid class file (thrown by ClassReader if it reads an invalid format)
       eventDispatcher.dispatch(LogEvent.warn("Invalid class file found: " + file));
 
     } catch (IOException ignored) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
@@ -112,6 +112,7 @@ public class MainClassFinder {
 
     private static final String MAIN_DESCRIPTOR =
         Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(String[].class));
+    private static final int OPTIONAL_ACCESS = Opcodes.ACC_FINAL | Opcodes.ACC_DEPRECATED;
 
     private boolean visitedMainClass;
 
@@ -123,8 +124,7 @@ public class MainClassFinder {
     @Nullable
     public MethodVisitor visitMethod(
         int access, String name, String descriptor, String signature, String[] exceptions) {
-      int optionalAccess = Opcodes.ACC_FINAL | Opcodes.ACC_DEPRECATED;
-      if ((access & ~optionalAccess) == (Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC)
+      if ((access & ~OPTIONAL_ACCESS) == (Opcodes.ACC_PUBLIC | Opcodes.ACC_STATIC)
           && name.equals("main")
           && descriptor.equals(MAIN_DESCRIPTOR)) {
         visitedMainClass = true;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/MainClassFinder.java
@@ -191,7 +191,7 @@ public class MainClassFinder {
 
     } catch (ArrayIndexOutOfBoundsException ignored) {
       // Not a valid class file
-      eventDispatcher.dispatch(LogEvent.debug("Invalid class file found: " + file));
+      eventDispatcher.dispatch(LogEvent.warn("Invalid class file found: " + file));
 
     } catch (IOException ignored) {
       // Could not read class file.

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -65,7 +65,7 @@ dependencies {
   compile 'org.apache.commons:commons-compress:1.18'
   compile 'com.google.guava:guava:23.5-jre'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
-  compile 'org.javassist:javassist:3.24.1-GA'
+  compile 'org.ow2.asm:asm:6.2.1'
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:2.23.4'

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -65,7 +65,7 @@ dependencies {
   compile 'org.apache.commons:commons-compress:1.18'
   compile 'com.google.guava:guava:23.5-jre'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
-  compile 'org.ow2.asm:asm:6.2.1'
+  compile 'org.ow2.asm:asm:7.0'
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:2.23.4'

--- a/jib-maven-plugin/pom.xml
+++ b/jib-maven-plugin/pom.xml
@@ -77,7 +77,7 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
-      <version>6.2.1</version>
+      <version>7.0</version>
       <scope>compile</scope>
     </dependency>
     <!-- End dependencies from jib-core -->

--- a/jib-maven-plugin/pom.xml
+++ b/jib-maven-plugin/pom.xml
@@ -75,9 +75,9 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.javassist</groupId>
-      <artifactId>javassist</artifactId>
-      <version>3.24.1-GA</version>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>6.2.1</version>
       <scope>compile</scope>
     </dependency>
     <!-- End dependencies from jib-core -->

--- a/jib-plugins-common/build.gradle
+++ b/jib-plugins-common/build.gradle
@@ -33,7 +33,7 @@ dependencies {
   compile 'org.apache.commons:commons-compress:1.18'
   compile 'com.google.guava:guava:23.5-jre'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
-  compile 'org.ow2.asm:asm:6.2.1'
+  compile 'org.ow2.asm:asm:7.0'
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:2.23.4'

--- a/jib-plugins-common/build.gradle
+++ b/jib-plugins-common/build.gradle
@@ -33,7 +33,7 @@ dependencies {
   compile 'org.apache.commons:commons-compress:1.18'
   compile 'com.google.guava:guava:23.5-jre'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'
-  compile 'org.javassist:javassist:3.24.1-GA'
+  compile 'org.ow2.asm:asm:6.2.1'
 
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:2.23.4'


### PR DESCRIPTION
All tests pass, but given how the main class finder is an important feature and historically has had many edge cases, we may want to do some extra manual testing on a big project.

This is about 1/7 the size of javassist, so I think we can say this fixes #841.