### PR TITLE
Upgrade Google HTTP Client dependency

### DIFF
--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -35,7 +35,7 @@ configurations {
 
 dependencies {
   // Make sure these are consistent with jib-maven-plugin.
-  implementation 'com.google.http-client:google-http-client:1.23.0'
+  implementation 'com.google.http-client:google-http-client:1.27.0'
   implementation 'org.apache.commons:commons-compress:1.18'
   implementation 'com.google.guava:guava:23.5-jre'
   implementation 'com.fasterxml.jackson.core:jackson-databind:2.9.8'

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -36,6 +36,7 @@ import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.util.function.Function;
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import org.apache.http.NoHttpResponseException;
 import org.apache.http.conn.HttpHostConnectException;
@@ -151,7 +152,7 @@ class RegistryEndpointCaller<T> {
     try {
       return call(url, connectionFactory);
 
-    } catch (SSLPeerUnverifiedException ex) {
+    } catch (SSLPeerUnverifiedException | SSLHandshakeException ex) {
       return handleUnverifiableServerException(url);
 
     } catch (HttpHostConnectException ex) {
@@ -176,7 +177,7 @@ class RegistryEndpointCaller<T> {
               "Cannot verify server at " + url + ". Attempting again with no TLS verification."));
       return call(url, getInsecureConnectionFactory());
 
-    } catch (SSLPeerUnverifiedException ex) {
+    } catch (SSLPeerUnverifiedException | SSLHandshakeException ex) {
       return fallBackToHttp(url);
     }
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -36,8 +36,7 @@ import java.net.URL;
 import java.security.GeneralSecurityException;
 import java.util.function.Function;
 import javax.annotation.Nullable;
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLException;
 import org.apache.http.NoHttpResponseException;
 import org.apache.http.conn.HttpHostConnectException;
 
@@ -152,7 +151,7 @@ class RegistryEndpointCaller<T> {
     try {
       return call(url, connectionFactory);
 
-    } catch (SSLPeerUnverifiedException | SSLHandshakeException ex) {
+    } catch (SSLException ex) {
       return handleUnverifiableServerException(url);
 
     } catch (HttpHostConnectException ex) {
@@ -177,7 +176,7 @@ class RegistryEndpointCaller<T> {
               "Cannot verify server at " + url + ". Attempting again with no TLS verification."));
       return call(url, getInsecureConnectionFactory());
 
-    } catch (SSLPeerUnverifiedException | SSLHandshakeException ex) {
+    } catch (SSLException ex) {
       return fallBackToHttp(url);
     }
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
@@ -22,8 +22,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
-import javax.net.ssl.SSLHandshakeException;
-import javax.net.ssl.SSLPeerUnverifiedException;
+import javax.net.ssl.SSLException;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -71,7 +70,7 @@ public class WithServerConnectionTest {
       try {
         connection.send("GET", new Request.Builder().build());
         Assert.fail("Should fail if cannot verify peer");
-      } catch (SSLPeerUnverifiedException | SSLHandshakeException ex) {
+      } catch (SSLException ex) {
         Assert.assertNotNull(ex.getMessage());
       }
     }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
@@ -22,6 +22,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
+import javax.net.ssl.SSLHandshakeException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import org.junit.Assert;
 import org.junit.Test;
@@ -70,7 +71,7 @@ public class WithServerConnectionTest {
       try {
         connection.send("GET", new Request.Builder().build());
         Assert.fail("Should fail if cannot verify peer");
-      } catch (SSLPeerUnverifiedException ex) {
+      } catch (SSLPeerUnverifiedException | SSLHandshakeException ex) {
         Assert.assertNotNull(ex.getMessage());
       }
     }

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -61,7 +61,7 @@ configurations {
 
 dependencies {
   // These are copied over from jib-core and are necessary for the jib-core sourcesets.
-  compile 'com.google.http-client:google-http-client:1.23.0'
+  compile 'com.google.http-client:google-http-client:1.27.0'
   compile 'org.apache.commons:commons-compress:1.18'
   compile 'com.google.guava:guava:23.5-jre'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'

--- a/jib-maven-plugin/pom.xml
+++ b/jib-maven-plugin/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>1.23.0</version>
+      <version>1.27.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/jib-plugins-common/build.gradle
+++ b/jib-plugins-common/build.gradle
@@ -29,7 +29,7 @@ sourceSets {
 
 dependencies {
   // Make sure these are consistent with jib-maven-plugin.
-  compile 'com.google.http-client:google-http-client:1.23.0'
+  compile 'com.google.http-client:google-http-client:1.27.0'
   compile 'org.apache.commons:commons-compress:1.18'
   compile 'com.google.guava:guava:23.5-jre'
   compile 'com.fasterxml.jackson.core:jackson-databind:2.9.8'


### PR DESCRIPTION
Not really necessary, but the latest 1.27.0 defines `Automatic-Module-Name`.