### PR TITLE
Do not fail when attempting to delete temp directory

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/TemporaryDirectory.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/TemporaryDirectory.java
@@ -19,7 +19,9 @@ package com.google.cloud.tools.jib.filesystem;
 import com.google.common.io.MoreFiles;
 import com.google.common.io.RecursiveDeleteOption;
 import java.io.Closeable;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -53,7 +55,11 @@ public class TemporaryDirectory implements Closeable {
   @Override
   public void close() throws IOException {
     if (Files.exists(temporaryDirectory)) {
-      MoreFiles.deleteRecursively(temporaryDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
+      try {
+        MoreFiles.deleteRecursively(temporaryDirectory, RecursiveDeleteOption.ALLOW_INSECURE);
+      } catch (FileNotFoundException | FileSystemException ex) {
+        // TODO log error; deletion is best-effort
+      }
     }
   }
 }


### PR DESCRIPTION
Although I'm unable to reproduce the error in #1438, the actual error is occurring when deleting our `com.google.cloud.tools.jib.filesystem.TemporaryDirectory` which explicitly notes that the temporary directory may not be closed:
https://github.com/GoogleContainerTools/jib/blob/653ed72f36d0d5467d61757e2b3cd389c06ce496/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/TemporaryDirectory.java#L26-L29

This patch changes `TemporaryDirectory#close()` to ignore any exceptions when deleting the temporary directory.  Although this patch doesn't fix the underlying problem in #1438, an error when deleting a temporary directory shouldn't fail the build.

It would be good to somehow log this, so I left a todo.