### PR TITLE
Add enum for matching progress events to build steps

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildStepType.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildStepType.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.builder;
+
+/** Types corresponding to steps in the containerization process. */
+public enum BuildStepType {
+  AuthenticatePush,
+  BuildAndCacheApplicationLayer,
+  BuildImage,
+  LoadDocker,
+  PullAndCacheBaseImageLayer,
+  PullBaseImage,
+  PushBlob,
+  PushContainerConfiguration,
+  PushImage,
+  PushLayers,
+  RetrieveRegistryCredentials,
+  WriteTarFile
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildStepType.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildStepType.java
@@ -18,16 +18,16 @@ package com.google.cloud.tools.jib.builder;
 
 /** Types corresponding to steps in the containerization process. */
 public enum BuildStepType {
-  AuthenticatePush,
-  BuildAndCacheApplicationLayer,
-  BuildImage,
-  LoadDocker,
-  PullAndCacheBaseImageLayer,
-  PullBaseImage,
-  PushBlob,
-  PushContainerConfiguration,
-  PushImage,
-  PushLayers,
-  RetrieveRegistryCredentials,
-  WriteTarFile
+  AUTHENTICATE_PUSH,
+  BUILD_AND_CACHE_APPLICATION_LAYER,
+  BUILD_IMAGE,
+  LOAD_DOCKER,
+  PULL_AND_CACHE_BASE_IMAGE_LAYER,
+  PULL_BASE_IMAGE,
+  PUSH_BLOB,
+  PUSH_CONTAINER_CONFIGURATION,
+  PUSH_IMAGE,
+  PUSH_LAYERS,
+  RETRIEVE_REGISTRY_CREDENTIALS,
+  WRITE_TAR_FILE
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildStepType.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildStepType.java
@@ -18,16 +18,43 @@ package com.google.cloud.tools.jib.builder;
 
 /** Types corresponding to steps in the containerization process. */
 public enum BuildStepType {
+
+  /** Root type that corresponds to build startup. */
+  ALL,
+
+  /** Authentication step for pushing to target registry. */
   AUTHENTICATE_PUSH,
+
+  /** Step for building/caching an application layer. */
   BUILD_AND_CACHE_APPLICATION_LAYER,
+
+  /** Step for building image layers/configuration. */
   BUILD_IMAGE,
+
+  /** Step for loading the image into the Docker daemon. */
   LOAD_DOCKER,
+
+  /** Step for pulling/caching a base image layer. */
   PULL_AND_CACHE_BASE_IMAGE_LAYER,
+
+  /** Step for pulling the base image manifest. */
   PULL_BASE_IMAGE,
-  PUSH_BLOB,
+
+  /** Step for pushing the container configuration to the target registry. */
   PUSH_CONTAINER_CONFIGURATION,
+
+  /** Step for pushing the image manifest to the target registry. */
   PUSH_IMAGE,
+
+  /** Step for pushing the image layers to the target registry. */
   PUSH_LAYERS,
-  RETRIEVE_REGISTRY_CREDENTIALS,
+
+  /** Step for retrieving credentials for the base image registry. */
+  RETRIEVE_REGISTRY_CREDENTIALS_BASE,
+
+  /** Step for retrieving credentials for the target image registry. */
+  RETRIEVE_REGISTRY_CREDENTIALS_TARGET,
+
+  /** Step for writing the image tarball to disk. */
   WRITE_TAR_FILE
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcher.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcher.java
@@ -22,7 +22,6 @@ import com.google.cloud.tools.jib.event.progress.Allocation;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Verify;
 import java.io.Closeable;
-import javax.annotation.Nullable;
 
 /**
  * Dispatches {@link ProgressEvent}s associated with a managed {@link Allocation}. Keeps track of
@@ -64,7 +63,7 @@ public class ProgressEventDispatcher implements Closeable {
   public static ProgressEventDispatcher newRoot(
       EventDispatcher eventDispatcher, String description, long allocationUnits) {
     return newProgressEventDispatcher(
-        eventDispatcher, Allocation.newRoot(description, allocationUnits), null);
+        eventDispatcher, Allocation.newRoot(description, allocationUnits), BuildStepType.ALL);
   }
 
   /**
@@ -76,9 +75,7 @@ public class ProgressEventDispatcher implements Closeable {
    * @return a new {@link ProgressEventDispatcher}
    */
   private static ProgressEventDispatcher newProgressEventDispatcher(
-      EventDispatcher eventDispatcher,
-      Allocation allocation,
-      @Nullable BuildStepType buildStepType) {
+      EventDispatcher eventDispatcher, Allocation allocation, BuildStepType buildStepType) {
     ProgressEventDispatcher progressEventDispatcher =
         new ProgressEventDispatcher(eventDispatcher, allocation, buildStepType);
     progressEventDispatcher.dispatchProgress(0);
@@ -87,15 +84,13 @@ public class ProgressEventDispatcher implements Closeable {
 
   private final EventDispatcher eventDispatcher;
   private final Allocation allocation;
+  private final BuildStepType buildStepType;
 
   private long remainingAllocationUnits;
   private boolean closed = false;
-  @Nullable private BuildStepType buildStepType;
 
   private ProgressEventDispatcher(
-      EventDispatcher eventDispatcher,
-      Allocation allocation,
-      @Nullable BuildStepType buildStepType) {
+      EventDispatcher eventDispatcher, Allocation allocation, BuildStepType buildStepType) {
     this.eventDispatcher = eventDispatcher;
     this.allocation = allocation;
     this.buildStepType = buildStepType;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.builder.steps;
 import com.google.cloud.tools.jib.async.AsyncDependencies;
 import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
@@ -80,7 +81,8 @@ class AuthenticatePushStep implements AsyncStep<Authorization>, Callable<Authori
     String registry = buildConfiguration.getTargetImageConfiguration().getImageRegistry();
 
     try (ProgressEventDispatcher ignored =
-            progressEventDispatcherFactory.create("authenticating push to " + registry, 1);
+            progressEventDispatcherFactory.create(
+                BuildStepType.AuthenticatePush, "authenticating push to " + registry, 1);
         TimerEventDispatcher ignored2 =
             new TimerEventDispatcher(
                 buildConfiguration.getEventDispatcher(), String.format(DESCRIPTION, registry))) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
@@ -82,7 +82,7 @@ class AuthenticatePushStep implements AsyncStep<Authorization>, Callable<Authori
 
     try (ProgressEventDispatcher ignored =
             progressEventDispatcherFactory.create(
-                BuildStepType.AuthenticatePush, "authenticating push to " + registry, 1);
+                BuildStepType.AUTHENTICATE_PUSH, "authenticating push to " + registry, 1);
         TimerEventDispatcher ignored2 =
             new TimerEventDispatcher(
                 buildConfiguration.getEventDispatcher(), String.format(DESCRIPTION, registry))) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
@@ -52,7 +52,7 @@ class BuildAndCacheApplicationLayerStep implements AsyncStep<CachedLayer>, Calla
 
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create(
-                BuildStepType.BuildAndCacheApplicationLayer,
+                BuildStepType.BUILD_AND_CACHE_APPLICATION_LAYER,
                 "setting up to build application layers",
                 layerCount);
         TimerEventDispatcher ignored =
@@ -112,7 +112,7 @@ class BuildAndCacheApplicationLayerStep implements AsyncStep<CachedLayer>, Calla
 
     try (ProgressEventDispatcher ignored =
             progressEventDispatcherFactory.create(
-                BuildStepType.BuildAndCacheApplicationLayer,
+                BuildStepType.BUILD_AND_CACHE_APPLICATION_LAYER,
                 "building " + layerType + " layer",
                 1);
         TimerEventDispatcher ignored2 =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.blob.Blob;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.cache.Cache;
@@ -51,7 +52,9 @@ class BuildAndCacheApplicationLayerStep implements AsyncStep<CachedLayer>, Calla
 
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create(
-                "setting up to build application layers", layerCount);
+                BuildStepType.BuildAndCacheApplicationLayer,
+                "setting up to build application layers",
+                layerCount);
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), DESCRIPTION)) {
       ImmutableList.Builder<BuildAndCacheApplicationLayerStep> buildAndCacheApplicationLayerSteps =
@@ -108,7 +111,10 @@ class BuildAndCacheApplicationLayerStep implements AsyncStep<CachedLayer>, Calla
     buildConfiguration.getEventDispatcher().dispatch(LogEvent.progress(description + "..."));
 
     try (ProgressEventDispatcher ignored =
-            progressEventDispatcherFactory.create("building " + layerType + " layer", 1);
+            progressEventDispatcherFactory.create(
+                BuildStepType.BuildAndCacheApplicationLayer,
+                "building " + layerType + " layer",
+                1);
         TimerEventDispatcher ignored2 =
             new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), description)) {
       Cache cache = buildConfiguration.getApplicationLayersCache();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.cloud.tools.jib.async.AsyncDependencies;
 import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
@@ -92,7 +93,8 @@ class BuildImageStep
   private Image<Layer> afterCachedLayerSteps()
       throws ExecutionException, LayerPropertyNotFoundException {
     try (ProgressEventDispatcher ignored =
-            progressEventDispatcherFactory.create("building image format", 1);
+            progressEventDispatcherFactory.create(
+                BuildStepType.BuildImage, "building image format", 1);
         TimerEventDispatcher ignored2 =
             new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), DESCRIPTION)) {
       // Constructs the image.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
@@ -94,7 +94,7 @@ class BuildImageStep
       throws ExecutionException, LayerPropertyNotFoundException {
     try (ProgressEventDispatcher ignored =
             progressEventDispatcherFactory.create(
-                BuildStepType.BuildImage, "building image format", 1);
+                BuildStepType.BUILD_IMAGE, "building image format", 1);
         TimerEventDispatcher ignored2 =
             new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), DESCRIPTION)) {
       // Constructs the image.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
@@ -96,7 +96,7 @@ class LoadDockerStep implements AsyncStep<BuildResult>, Callable<BuildResult> {
 
     try (ProgressEventDispatcher ignored =
         progressEventDispatcherFactory.create(
-            BuildStepType.LoadDocker, "loading to Docker daemon", 1)) {
+            BuildStepType.LOAD_DOCKER, "loading to Docker daemon", 1)) {
       Image<Layer> image = NonBlockingSteps.get(NonBlockingSteps.get(buildImageStep));
       ImageReference targetImageReference =
           buildConfiguration.getTargetImageConfiguration().getImage();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.builder.steps;
 import com.google.cloud.tools.jib.async.AsyncDependencies;
 import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.docker.DockerClient;
@@ -94,7 +95,8 @@ class LoadDockerStep implements AsyncStep<BuildResult>, Callable<BuildResult> {
         .dispatch(LogEvent.progress("Loading to Docker daemon..."));
 
     try (ProgressEventDispatcher ignored =
-        progressEventDispatcherFactory.create("loading to Docker daemon", 1)) {
+        progressEventDispatcherFactory.create(
+            BuildStepType.LoadDocker, "loading to Docker daemon", 1)) {
       Image<Layer> image = NonBlockingSteps.get(NonBlockingSteps.get(buildImageStep));
       ImageReference targetImageReference =
           buildConfiguration.getTargetImageConfiguration().getImage();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ProgressEventDispatcherContainer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ProgressEventDispatcherContainer.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.builder.steps;
 
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.http.BlobProgressListener;
 import com.google.common.base.Preconditions;
@@ -35,12 +36,16 @@ class ProgressEventDispatcherContainer implements BlobProgressListener, Closeabl
 
   private final ProgressEventDispatcher.Factory progressEventDispatcherFactory;
   private final String description;
+  private final BuildStepType type;
   @Nullable private ProgressEventDispatcher progressEventDispatcher;
 
   ProgressEventDispatcherContainer(
-      ProgressEventDispatcher.Factory progressEventDispatcherFactory, String description) {
+      ProgressEventDispatcher.Factory progressEventDispatcherFactory,
+      String description,
+      BuildStepType type) {
     this.progressEventDispatcherFactory = progressEventDispatcherFactory;
     this.description = description;
+    this.type = type;
   }
 
   @Override
@@ -62,6 +67,6 @@ class ProgressEventDispatcherContainer implements BlobProgressListener, Closeabl
 
   void initializeWithBlobSize(long blobSize) {
     Preconditions.checkState(progressEventDispatcher == null);
-    progressEventDispatcher = progressEventDispatcherFactory.create(description, blobSize);
+    progressEventDispatcher = progressEventDispatcherFactory.create(type, description, blobSize);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.cache.Cache;
@@ -68,7 +69,10 @@ class PullAndCacheBaseImageLayerStep implements AsyncStep<CachedLayer>, Callable
   @Override
   public CachedLayer call() throws IOException, CacheCorruptedException {
     try (ProgressEventDispatcher progressEventDispatcher =
-            progressEventDispatcherFactory.create("checking base image layer " + layerDigest, 1);
+            progressEventDispatcherFactory.create(
+                BuildStepType.PullAndCacheBaseImageLayer,
+                "checking base image layer " + layerDigest,
+                1);
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(
                 buildConfiguration.getEventDispatcher(), String.format(DESCRIPTION, layerDigest))) {
@@ -89,7 +93,8 @@ class PullAndCacheBaseImageLayerStep implements AsyncStep<CachedLayer>, Callable
       try (ProgressEventDispatcherContainer progressEventDispatcherContainer =
           new ProgressEventDispatcherContainer(
               progressEventDispatcher.newChildProducer(),
-              "pulling base image layer " + layerDigest)) {
+              "pulling base image layer " + layerDigest,
+              BuildStepType.PullAndCacheBaseImageLayer)) {
         return cache.writeCompressedLayer(
             registryClient.pullBlob(
                 layerDigest,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
@@ -70,7 +70,7 @@ class PullAndCacheBaseImageLayerStep implements AsyncStep<CachedLayer>, Callable
   public CachedLayer call() throws IOException, CacheCorruptedException {
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create(
-                BuildStepType.PullAndCacheBaseImageLayer,
+                BuildStepType.PULL_AND_CACHE_BASE_IMAGE_LAYER,
                 "checking base image layer " + layerDigest,
                 1);
         TimerEventDispatcher ignored =
@@ -94,7 +94,7 @@ class PullAndCacheBaseImageLayerStep implements AsyncStep<CachedLayer>, Callable
           new ProgressEventDispatcherContainer(
               progressEventDispatcher.newChildProducer(),
               "pulling base image layer " + layerDigest,
-              BuildStepType.PullAndCacheBaseImageLayer)) {
+              BuildStepType.PULL_AND_CACHE_BASE_IMAGE_LAYER)) {
         return cache.writeCompressedLayer(
             registryClient.pullBlob(
                 layerDigest,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayersStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayersStep.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.builder.steps;
 import com.google.cloud.tools.jib.async.AsyncDependencies;
 import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.builder.steps.PullBaseImageStep.BaseImageWithAuthorization;
@@ -75,7 +76,9 @@ class PullAndCacheBaseImageLayersStep
 
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create(
-                "checking base image layers", baseImageLayers.size());
+                BuildStepType.PullAndCacheBaseImageLayer,
+                "checking base image layers",
+                baseImageLayers.size());
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), DESCRIPTION)) {
       ImmutableList.Builder<PullAndCacheBaseImageLayerStep> pullAndCacheBaseImageLayerStepsBuilder =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayersStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayersStep.java
@@ -76,7 +76,7 @@ class PullAndCacheBaseImageLayersStep
 
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create(
-                BuildStepType.PullAndCacheBaseImageLayer,
+                BuildStepType.PULL_AND_CACHE_BASE_IMAGE_LAYER,
                 "checking base image layers",
                 baseImageLayers.size());
         TimerEventDispatcher ignored =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -120,7 +120,7 @@ class PullBaseImageStep
 
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create(
-                BuildStepType.PullBaseImage, "pulling base image manifest", 2);
+                BuildStepType.PULL_BASE_IMAGE, "pulling base image manifest", 2);
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), DESCRIPTION)) {
       // First, try with no credentials.
@@ -236,7 +236,7 @@ class PullBaseImageStep
             new ProgressEventDispatcherContainer(
                 progressEventDispatcher.newChildProducer(),
                 "pull container configuration " + containerConfigurationDigest,
-                BuildStepType.PullBaseImage)) {
+                BuildStepType.PULL_BASE_IMAGE)) {
           String containerConfigurationString =
               Blobs.writeToString(
                   registryClient.pullBlob(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.builder.steps;
 import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.NonBlockingSteps;
 import com.google.cloud.tools.jib.blob.Blobs;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.builder.steps.PullBaseImageStep.BaseImageWithAuthorization;
@@ -118,7 +119,8 @@ class PullBaseImageStep
                     + "..."));
 
     try (ProgressEventDispatcher progressEventDispatcher =
-            progressEventDispatcherFactory.create("pulling base image manifest", 2);
+            progressEventDispatcherFactory.create(
+                BuildStepType.PullBaseImage, "pulling base image manifest", 2);
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), DESCRIPTION)) {
       // First, try with no credentials.
@@ -233,7 +235,8 @@ class PullBaseImageStep
         try (ProgressEventDispatcherContainer progressEventDispatcherContainer =
             new ProgressEventDispatcherContainer(
                 progressEventDispatcher.newChildProducer(),
-                "pull container configuration " + containerConfigurationDigest)) {
+                "pull container configuration " + containerConfigurationDigest,
+                BuildStepType.PullBaseImage)) {
           String containerConfigurationString =
               Blobs.writeToString(
                   registryClient.pullBlob(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.NonBlockingSteps;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
@@ -96,7 +97,9 @@ class PushBlobStep implements AsyncStep<BlobDescriptor>, Callable<BlobDescriptor
   public BlobDescriptor call() throws IOException, RegistryException, ExecutionException {
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDipatcherFactory.create(
-                "pushing blob " + blobDescriptor.getDigest(), blobDescriptor.getSize());
+                BuildStepType.PushBlob,
+                "pushing blob " + blobDescriptor.getDigest(),
+                blobDescriptor.getSize());
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(
                 buildConfiguration.getEventDispatcher(), DESCRIPTION + blobDescriptor)) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -66,6 +66,7 @@ class PushBlobStep implements AsyncStep<BlobDescriptor>, Callable<BlobDescriptor
   private final AuthenticatePushStep authenticatePushStep;
   private final BlobDescriptor blobDescriptor;
   private final Blob blob;
+  private final BuildStepType buildStepType;
 
   private final ListenableFuture<BlobDescriptor> listenableFuture;
 
@@ -75,12 +76,14 @@ class PushBlobStep implements AsyncStep<BlobDescriptor>, Callable<BlobDescriptor
       ProgressEventDispatcher.Factory progressEventDipatcherFactory,
       AuthenticatePushStep authenticatePushStep,
       BlobDescriptor blobDescriptor,
-      Blob blob) {
+      Blob blob,
+      BuildStepType buildStepType) {
     this.buildConfiguration = buildConfiguration;
     this.progressEventDipatcherFactory = progressEventDipatcherFactory;
     this.authenticatePushStep = authenticatePushStep;
     this.blobDescriptor = blobDescriptor;
     this.blob = blob;
+    this.buildStepType = buildStepType;
 
     listenableFuture =
         AsyncDependencies.using(listeningExecutorService)
@@ -97,7 +100,7 @@ class PushBlobStep implements AsyncStep<BlobDescriptor>, Callable<BlobDescriptor
   public BlobDescriptor call() throws IOException, RegistryException, ExecutionException {
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDipatcherFactory.create(
-                BuildStepType.PUSH_BLOB,
+                buildStepType,
                 "pushing blob " + blobDescriptor.getDigest(),
                 blobDescriptor.getSize());
         TimerEventDispatcher ignored =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -97,7 +97,7 @@ class PushBlobStep implements AsyncStep<BlobDescriptor>, Callable<BlobDescriptor
   public BlobDescriptor call() throws IOException, RegistryException, ExecutionException {
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDipatcherFactory.create(
-                BuildStepType.PushBlob,
+                BuildStepType.PUSH_BLOB,
                 "pushing blob " + blobDescriptor.getDigest(),
                 blobDescriptor.getSize());
         TimerEventDispatcher ignored =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushContainerConfigurationStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushContainerConfigurationStep.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.NonBlockingSteps;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
@@ -85,7 +86,8 @@ class PushContainerConfigurationStep
   private PushBlobStep afterBuildConfigurationFutureFuture()
       throws ExecutionException, IOException {
     try (ProgressEventDispatcher progressEventDispatcher =
-            progressEventDispatcherFactory.create("pushing container configuration", 1);
+            progressEventDispatcherFactory.create(
+                BuildStepType.PushContainerConfiguration, "pushing container configuration", 1);
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), DESCRIPTION)) {
       Image<Layer> image = NonBlockingSteps.get(NonBlockingSteps.get(buildImageStep));

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushContainerConfigurationStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushContainerConfigurationStep.java
@@ -102,7 +102,8 @@ class PushContainerConfigurationStep
           progressEventDispatcher.newChildProducer(),
           authenticatePushStep,
           blobDescriptor,
-          containerConfigurationBlob);
+          containerConfigurationBlob,
+          BuildStepType.PUSH_CONTAINER_CONFIGURATION);
     }
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushContainerConfigurationStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushContainerConfigurationStep.java
@@ -87,7 +87,7 @@ class PushContainerConfigurationStep
       throws ExecutionException, IOException {
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create(
-                BuildStepType.PushContainerConfiguration, "pushing container configuration", 1);
+                BuildStepType.PUSH_CONTAINER_CONFIGURATION, "pushing container configuration", 1);
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), DESCRIPTION)) {
       Image<Layer> image = NonBlockingSteps.get(NonBlockingSteps.get(buildImageStep));

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -123,7 +123,7 @@ class PushImageStep implements AsyncStep<BuildResult>, Callable<BuildResult> {
     ImmutableSet<String> targetImageTags = buildConfiguration.getAllTargetImageTags();
     ProgressEventDispatcher progressEventDispatcher =
         progressEventDispatcherFactory.create(
-            BuildStepType.PushImage, "pushing image manifest", targetImageTags.size());
+            BuildStepType.PUSH_IMAGE, "pushing image manifest", targetImageTags.size());
 
     try (TimerEventDispatcher ignored =
         new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), DESCRIPTION)) {
@@ -155,7 +155,7 @@ class PushImageStep implements AsyncStep<BuildResult>, Callable<BuildResult> {
                 () -> {
                   try (ProgressEventDispatcher ignored2 =
                       progressEventDispatcherFactory.create(
-                          BuildStepType.PushImage, "tagging with " + tag, 1)) {
+                          BuildStepType.PUSH_IMAGE, "tagging with " + tag, 1)) {
                     buildConfiguration
                         .getEventDispatcher()
                         .dispatch(LogEvent.info("Tagging with " + tag + "..."));

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.async.AsyncDependencies;
 import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.NonBlockingSteps;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
@@ -121,7 +122,8 @@ class PushImageStep implements AsyncStep<BuildResult>, Callable<BuildResult> {
       throws ExecutionException, IOException, InterruptedException {
     ImmutableSet<String> targetImageTags = buildConfiguration.getAllTargetImageTags();
     ProgressEventDispatcher progressEventDispatcher =
-        progressEventDispatcherFactory.create("pushing image manifest", targetImageTags.size());
+        progressEventDispatcherFactory.create(
+            BuildStepType.PushImage, "pushing image manifest", targetImageTags.size());
 
     try (TimerEventDispatcher ignored =
         new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), DESCRIPTION)) {
@@ -152,7 +154,8 @@ class PushImageStep implements AsyncStep<BuildResult>, Callable<BuildResult> {
             listeningExecutorService.submit(
                 () -> {
                   try (ProgressEventDispatcher ignored2 =
-                      progressEventDispatcherFactory.create("tagging with " + tag, 1)) {
+                      progressEventDispatcherFactory.create(
+                          BuildStepType.PushImage, "tagging with " + tag, 1)) {
                     buildConfiguration
                         .getEventDispatcher()
                         .dispatch(LogEvent.info("Tagging with " + tag + "..."));

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayersStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayersStep.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.async.AsyncDependencies;
 import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.NonBlockingSteps;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.cache.CachedLayer;
@@ -79,7 +80,8 @@ class PushLayersStep
           NonBlockingSteps.get(cachedLayerStep);
 
       try (ProgressEventDispatcher progressEventDispatcher =
-          progressEventDispatcherFactory.create("setting up to push layers", cachedLayers.size())) {
+          progressEventDispatcherFactory.create(
+              BuildStepType.PushLayers, "setting up to push layers", cachedLayers.size())) {
         // Constructs a PushBlobStep for each layer.
         ImmutableList.Builder<AsyncStep<PushBlobStep>> pushBlobStepsBuilder =
             ImmutableList.builder();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayersStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayersStep.java
@@ -113,6 +113,7 @@ class PushLayersStep
         progressEventDispatcherFactory,
         authenticatePushStep,
         new BlobDescriptor(cachedLayer.getSize(), cachedLayer.getDigest()),
-        cachedLayer.getBlob());
+        cachedLayer.getBlob(),
+        BuildStepType.PUSH_LAYERS);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayersStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayersStep.java
@@ -81,7 +81,7 @@ class PushLayersStep
 
       try (ProgressEventDispatcher progressEventDispatcher =
           progressEventDispatcherFactory.create(
-              BuildStepType.PushLayers, "setting up to push layers", cachedLayers.size())) {
+              BuildStepType.PUSH_LAYERS, "setting up to push layers", cachedLayers.size())) {
         // Constructs a PushBlobStep for each layer.
         ImmutableList.Builder<AsyncStep<PushBlobStep>> pushBlobStepsBuilder =
             ImmutableList.builder();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStep.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.async.AsyncStep;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
@@ -101,7 +102,10 @@ class RetrieveRegistryCredentialsStep implements AsyncStep<Credential>, Callable
     buildConfiguration.getEventDispatcher().dispatch(LogEvent.progress(description + "..."));
 
     try (ProgressEventDispatcher ignored =
-            progressEventDispatcherFactory.create("retrieving credentials for " + registry, 1);
+            progressEventDispatcherFactory.create(
+                BuildStepType.RetrieveRegistryCredentials,
+                "retrieving credentials for " + registry,
+                1);
         TimerEventDispatcher ignored2 =
             new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), description)) {
       for (CredentialRetriever credentialRetriever : credentialRetrievers) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStep.java
@@ -103,7 +103,7 @@ class RetrieveRegistryCredentialsStep implements AsyncStep<Credential>, Callable
 
     try (ProgressEventDispatcher ignored =
             progressEventDispatcherFactory.create(
-                BuildStepType.RetrieveRegistryCredentials,
+                BuildStepType.RETRIEVE_REGISTRY_CREDENTIALS,
                 "retrieving credentials for " + registry,
                 1);
         TimerEventDispatcher ignored2 =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
@@ -96,7 +96,7 @@ public class WriteTarFileStep implements AsyncStep<BuildResult>, Callable<BuildR
 
     try (ProgressEventDispatcher ignored =
         progressEventDispatcherFactory.create(
-            BuildStepType.WriteTarFile, "writing to tar file", 1)) {
+            BuildStepType.WRITE_TAR_FILE, "writing to tar file", 1)) {
       Image<Layer> image = NonBlockingSteps.get(NonBlockingSteps.get(buildImageStep));
 
       // Builds the image to a tarball.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.builder.steps;
 import com.google.cloud.tools.jib.async.AsyncDependencies;
 import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.NonBlockingSteps;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.docker.ImageToTarballTranslator;
@@ -94,7 +95,8 @@ public class WriteTarFileStep implements AsyncStep<BuildResult>, Callable<BuildR
         .dispatch(LogEvent.progress("Building image to tar file..."));
 
     try (ProgressEventDispatcher ignored =
-        progressEventDispatcherFactory.create("writing to tar file", 1)) {
+        progressEventDispatcherFactory.create(
+            BuildStepType.WriteTarFile, "writing to tar file", 1)) {
       Image<Layer> image = NonBlockingSteps.get(NonBlockingSteps.get(buildImageStep));
 
       // Builds the image to a tarball.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/ProgressEvent.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/ProgressEvent.java
@@ -19,8 +19,6 @@ package com.google.cloud.tools.jib.event.events;
 import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.event.JibEvent;
 import com.google.cloud.tools.jib.event.progress.Allocation;
-import java.util.Optional;
-import javax.annotation.Nullable;
 
 /**
  * Event representing progress. The progress accounts for allocation units in an {@link Allocation},
@@ -40,10 +38,9 @@ public class ProgressEvent implements JibEvent {
   private final long progressUnits;
 
   /** The step in the build process that the progress event corresponds to. */
-  @Nullable private final BuildStepType buildStepType;
+  private final BuildStepType buildStepType;
 
-  public ProgressEvent(
-      Allocation allocation, long progressUnits, @Nullable BuildStepType buildStepType) {
+  public ProgressEvent(Allocation allocation, long progressUnits, BuildStepType buildStepType) {
     this.allocation = allocation;
     this.progressUnits = progressUnits;
     this.buildStepType = buildStepType;
@@ -73,7 +70,7 @@ public class ProgressEvent implements JibEvent {
    *
    * @return the build step
    */
-  public Optional<BuildStepType> getBuildStepType() {
-    return Optional.ofNullable(buildStepType);
+  public BuildStepType getBuildStepType() {
+    return buildStepType;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/ProgressEvent.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/ProgressEvent.java
@@ -16,8 +16,11 @@
 
 package com.google.cloud.tools.jib.event.events;
 
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.event.JibEvent;
 import com.google.cloud.tools.jib.event.progress.Allocation;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * Event representing progress. The progress accounts for allocation units in an {@link Allocation},
@@ -36,9 +39,14 @@ public class ProgressEvent implements JibEvent {
   /** Units of progress. */
   private final long progressUnits;
 
-  public ProgressEvent(Allocation allocation, long progressUnits) {
+  /** The step in the build process that the progress event corresponds to. */
+  @Nullable private final BuildStepType buildStepType;
+
+  public ProgressEvent(
+      Allocation allocation, long progressUnits, @Nullable BuildStepType buildStepType) {
     this.allocation = allocation;
     this.progressUnits = progressUnits;
+    this.buildStepType = buildStepType;
   }
 
   /**
@@ -58,5 +66,14 @@ public class ProgressEvent implements JibEvent {
    */
   public long getUnits() {
     return progressUnits;
+  }
+
+  /**
+   * Gets the build step that the progress event corresponds to.
+   *
+   * @return the build step
+   */
+  public Optional<BuildStepType> getBuildStepType() {
+    return Optional.ofNullable(buildStepType);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandler.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandler.java
@@ -16,13 +16,10 @@
 
 package com.google.cloud.tools.jib.event.progress;
 
-import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.event.events.ProgressEvent;
 import com.google.common.collect.ImmutableList;
-import java.util.Optional;
 import java.util.concurrent.atomic.DoubleAdder;
 import java.util.function.Consumer;
-import javax.annotation.Nullable;
 
 /**
  * Handles {@link ProgressEvent}s by accumulating an overall progress and keeping track of which
@@ -35,15 +32,10 @@ public class ProgressEventHandler implements Consumer<ProgressEvent> {
   /** Contains the accumulated progress and which {@link Allocation}s are not yet complete. */
   public static class Update {
 
-    @Nullable private final BuildStepType buildStepType;
     private final double progress;
     private final ImmutableList<Allocation> unfinishedAllocations;
 
-    private Update(
-        @Nullable BuildStepType buildStepType,
-        double progress,
-        ImmutableList<Allocation> unfinishedAllocations) {
-      this.buildStepType = buildStepType;
+    private Update(double progress, ImmutableList<Allocation> unfinishedAllocations) {
       this.progress = progress;
       this.unfinishedAllocations = unfinishedAllocations;
     }
@@ -65,15 +57,6 @@ public class ProgressEventHandler implements Consumer<ProgressEvent> {
      */
     public ImmutableList<Allocation> getUnfinishedAllocations() {
       return unfinishedAllocations;
-    }
-
-    /**
-     * Gets the build step that the progress update corresponds to.
-     *
-     * @return the build step
-     */
-    public Optional<BuildStepType> getBuildStepType() {
-      return Optional.ofNullable(buildStepType);
     }
   }
 
@@ -107,10 +90,7 @@ public class ProgressEventHandler implements Consumer<ProgressEvent> {
     if (completionTracker.updateProgress(allocation, progressUnits)) {
       // Note: Could produce false positives.
       updateNotifier.accept(
-          new Update(
-              progressEvent.getBuildStepType().orElse(null),
-              progress.sum(),
-              completionTracker.getUnfinishedAllocations()));
+          new Update(progress.sum(), completionTracker.getUnfinishedAllocations()));
     }
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcherTest.java
@@ -39,7 +39,7 @@ public class ProgressEventDispatcherTest {
     try (ProgressEventDispatcher progressEventDispatcher =
             ProgressEventDispatcher.newRoot(mockEventDispatcher, "ignored", 10);
         ProgressEventDispatcher ignored =
-            progressEventDispatcher.newChildProducer().create("ignored", 20)) {
+            progressEventDispatcher.newChildProducer().create(null, "ignored", 20)) {
       // empty
     }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcherTest.java
@@ -39,7 +39,7 @@ public class ProgressEventDispatcherTest {
     try (ProgressEventDispatcher progressEventDispatcher =
             ProgressEventDispatcher.newRoot(mockEventDispatcher, "ignored", 10);
         ProgressEventDispatcher ignored =
-            progressEventDispatcher.newChildProducer().create(null, "ignored", 20)) {
+            progressEventDispatcher.newChildProducer().create(BuildStepType.ALL, "ignored", 20)) {
       // empty
     }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/events/ProgressEventTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/events/ProgressEventTest.java
@@ -71,16 +71,16 @@ public class ProgressEventTest {
 
     EventDispatcher eventDispatcher = makeEventDispatcher(progressEventConsumer);
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50, null));
     Assert.assertEquals(1.0 / 2 / 100 * 50, progress, DOUBLE_ERROR_MARGIN);
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50, null));
     Assert.assertEquals(1.0 / 2, progress, DOUBLE_ERROR_MARGIN);
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 10));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 10, null));
     Assert.assertEquals(1.0 / 2 + 1.0 / 2 / 200 * 10, progress, DOUBLE_ERROR_MARGIN);
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 190));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 190, null));
     Assert.assertEquals(1.0, progress, DOUBLE_ERROR_MARGIN);
   }
 
@@ -96,19 +96,19 @@ public class ProgressEventTest {
 
     EventDispatcher eventDispatcher = makeEventDispatcher(progressEventConsumer);
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50, null));
 
     Assert.assertEquals(1, allocationCompletionMap.size());
     Assert.assertEquals(50, allocationCompletionMap.get(AllocationTree.child1Child).longValue());
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50, null));
 
     Assert.assertEquals(3, allocationCompletionMap.size());
     Assert.assertEquals(100, allocationCompletionMap.get(AllocationTree.child1Child).longValue());
     Assert.assertEquals(1, allocationCompletionMap.get(AllocationTree.child1).longValue());
     Assert.assertEquals(1, allocationCompletionMap.get(AllocationTree.root).longValue());
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 200));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 200, null));
 
     Assert.assertEquals(4, allocationCompletionMap.size());
     Assert.assertEquals(100, allocationCompletionMap.get(AllocationTree.child1Child).longValue());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/events/ProgressEventTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/events/ProgressEventTest.java
@@ -72,16 +72,16 @@ public class ProgressEventTest {
 
     EventDispatcher eventDispatcher = makeEventDispatcher(progressEventConsumer);
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50, null));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50, BuildStepType.ALL));
     Assert.assertEquals(1.0 / 2 / 100 * 50, progress, DOUBLE_ERROR_MARGIN);
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50, null));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50, BuildStepType.ALL));
     Assert.assertEquals(1.0 / 2, progress, DOUBLE_ERROR_MARGIN);
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 10, null));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 10, BuildStepType.ALL));
     Assert.assertEquals(1.0 / 2 + 1.0 / 2 / 200 * 10, progress, DOUBLE_ERROR_MARGIN);
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 190, null));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 190, BuildStepType.ALL));
     Assert.assertEquals(1.0, progress, DOUBLE_ERROR_MARGIN);
   }
 
@@ -97,19 +97,19 @@ public class ProgressEventTest {
 
     EventDispatcher eventDispatcher = makeEventDispatcher(progressEventConsumer);
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50, null));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50, BuildStepType.ALL));
 
     Assert.assertEquals(1, allocationCompletionMap.size());
     Assert.assertEquals(50, allocationCompletionMap.get(AllocationTree.child1Child).longValue());
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50, null));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 50, BuildStepType.ALL));
 
     Assert.assertEquals(3, allocationCompletionMap.size());
     Assert.assertEquals(100, allocationCompletionMap.get(AllocationTree.child1Child).longValue());
     Assert.assertEquals(1, allocationCompletionMap.get(AllocationTree.child1).longValue());
     Assert.assertEquals(1, allocationCompletionMap.get(AllocationTree.root).longValue());
 
-    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 200, null));
+    eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 200, BuildStepType.ALL));
 
     Assert.assertEquals(4, allocationCompletionMap.size());
     Assert.assertEquals(100, allocationCompletionMap.get(AllocationTree.child1Child).longValue());
@@ -120,18 +120,18 @@ public class ProgressEventTest {
 
   @Test
   public void testType() {
+    // Used to test whether or not progress event was consumed
+    boolean[] called = new boolean[] {false};
     Consumer<ProgressEvent> buildImageConsumer =
-        progressEvent ->
-            Assert.assertEquals(
-                BuildStepType.BUILD_IMAGE, progressEvent.getBuildStepType().orElse(null));
+        progressEvent -> {
+          Assert.assertEquals(BuildStepType.BUILD_IMAGE, progressEvent.getBuildStepType());
+          called[0] = true;
+        };
+
     EventDispatcher buildImageDispatcher = makeEventDispatcher(buildImageConsumer);
     buildImageDispatcher.dispatch(
         new ProgressEvent(AllocationTree.child1, 50, BuildStepType.BUILD_IMAGE));
-
-    Consumer<ProgressEvent> nullConsumer =
-        progressEvent -> Assert.assertNull(progressEvent.getBuildStepType().orElse(null));
-    EventDispatcher nullDispatcher = makeEventDispatcher(nullConsumer);
-    nullDispatcher.dispatch(new ProgressEvent(AllocationTree.child1, 50, null));
+    Assert.assertTrue(called[0]);
   }
 
   /**

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/events/ProgressEventTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/events/ProgressEventTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.event.events;
 
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.event.DefaultEventDispatcher;
 import com.google.cloud.tools.jib.event.EventDispatcher;
 import com.google.cloud.tools.jib.event.EventHandlers;
@@ -115,6 +116,22 @@ public class ProgressEventTest {
     Assert.assertEquals(1, allocationCompletionMap.get(AllocationTree.child1).longValue());
     Assert.assertEquals(200, allocationCompletionMap.get(AllocationTree.child2).longValue());
     Assert.assertEquals(2, allocationCompletionMap.get(AllocationTree.root).longValue());
+  }
+
+  @Test
+  public void testType() {
+    Consumer<ProgressEvent> buildImageConsumer =
+        progressEvent ->
+            Assert.assertEquals(
+                BuildStepType.BUILD_IMAGE, progressEvent.getBuildStepType().orElse(null));
+    EventDispatcher buildImageDispatcher = makeEventDispatcher(buildImageConsumer);
+    buildImageDispatcher.dispatch(
+        new ProgressEvent(AllocationTree.child1, 50, BuildStepType.BUILD_IMAGE));
+
+    Consumer<ProgressEvent> nullConsumer =
+        progressEvent -> Assert.assertNull(progressEvent.getBuildStepType().orElse(null));
+    EventDispatcher nullDispatcher = makeEventDispatcher(nullConsumer);
+    nullDispatcher.dispatch(new ProgressEvent(AllocationTree.child1, 50, null));
   }
 
   /**

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandlerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/ProgressEventHandlerTest.java
@@ -68,17 +68,17 @@ public class ProgressEventHandlerTest {
       // Adds root, child1, and child1Child.
       multithreadedExecutor.invoke(
           () -> {
-            eventDispatcher.dispatch(new ProgressEvent(AllocationTree.root, 0L));
+            eventDispatcher.dispatch(new ProgressEvent(AllocationTree.root, 0L, null));
             return null;
           });
       multithreadedExecutor.invoke(
           () -> {
-            eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1, 0L));
+            eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1, 0L, null));
             return null;
           });
       multithreadedExecutor.invoke(
           () -> {
-            eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 0L));
+            eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 0L, null));
             return null;
           });
       Assert.assertEquals(0.0, maxProgress.get(), DOUBLE_ERROR_MARGIN);
@@ -89,14 +89,14 @@ public class ProgressEventHandlerTest {
           Collections.nCopies(
               50,
               () -> {
-                eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 1L));
+                eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1Child, 1L, null));
                 return null;
               }));
       callables.addAll(
           Collections.nCopies(
               100,
               () -> {
-                eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 1L));
+                eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child2, 1L, null));
                 return null;
               }));
 
@@ -109,7 +109,7 @@ public class ProgressEventHandlerTest {
           Collections.nCopies(
               100,
               () -> {
-                eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1, 0L));
+                eventDispatcher.dispatch(new ProgressEvent(AllocationTree.child1, 0L, null));
                 return null;
               }));
       Assert.assertEquals(


### PR DESCRIPTION
Part of #1054. This PR adds a `BuildStepType` enum, which is passed to progress events so that jib-core users may know which progress events correspond to which steps in the build.

I'm still not totally familiar with the progress system, so let me know if this seems like an ok direction to take.

Possible followups:
- Add documentation for what each of the `BuildStepType`s mean
- Add an event for counting the number of layers involved in the push/pull steps, or modify/add progress events that make it possible to identify which layer a progress event was sent from