### PR TITLE
Explicitly note JVM flags for Java 8

### DIFF
--- a/examples/dropwizard/pom.xml
+++ b/examples/dropwizard/pom.xml
@@ -70,7 +70,7 @@
                             <port>8080</port>
                         </ports>
 
-                        <!-- good defaults intended for containers -->
+                        <!-- good defaults intended for Java 8 containers -->
                         <jvmFlags>
                             <jmxFlag>-server</jmxFlag>
                             <jmxFlag>-Djava.awt.headless=true</jmxFlag>

--- a/examples/ktor/build.gradle.kts
+++ b/examples/ktor/build.gradle.kts
@@ -43,7 +43,7 @@ jib {
         ports = listOf("8080")
         mainClass = main_class
 
-        // good defauls intended for containers
+        // good defauls intended for Java 8 containers
         jvmFlags = listOf(
                 "-server",
                 "-Djava.awt.headless=true",


### PR DESCRIPTION
Note that JVM flags in dropwizad example are for Java 8.  OpenJDK 11 doesn't support the `-XX:+UseCGroupMemoryLimitForHeap`, and has deprecated `-XX:InitialRAMFraction`, `-XX:MinRAMFraction`, and `-XX:MaxRAMFraction`.