### PR TITLE
Add event for counting layers in pull/build/push steps

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `ProgressEvent#getBuildStepType` method to get which step in the build process a progress event corresponds to ([#1449](https://github.com/GoogleContainerTools/jib/pull/1449))
+- `LayerCountEvent` that is dispatched at the beginning of certain pull/build/push build steps to indicate the number of layers being processed ([#1461](https://github.com/GoogleContainerTools/jib/pull/1461))
 
 ### Changed
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -90,6 +90,8 @@ public class BuildStepsIntegrationTest {
   @ClassRule public static final LocalRegistry localRegistry = new LocalRegistry(5000);
   private static final ExecutorService executorService = Executors.newCachedThreadPool();
   private static final Logger logger = LoggerFactory.getLogger(BuildStepsIntegrationTest.class);
+  private static final String DISTROLESS_DIGEST =
+      "sha256:f488c213f278bc5f9ffe3ddf30c5dbb2303a15a74146b738d12453088e662880";
 
   private static final double DOUBLE_ERROR_MARGIN = 1e-10;
 
@@ -180,7 +182,7 @@ public class BuildStepsIntegrationTest {
     BuildResult image1 =
         BuildSteps.forBuildToDockerRegistry(
                 getBuildConfigurationBuilder(
-                        ImageReference.of("gcr.io", "distroless/java", "latest"),
+                        ImageReference.of("gcr.io", "distroless/java", DISTROLESS_DIGEST),
                         ImageReference.of("localhost:5000", "testimage", "testtag"))
                     .setEventDispatcher(
                         new DefaultEventDispatcher(
@@ -190,8 +192,6 @@ public class BuildStepsIntegrationTest {
                     .build())
             .run();
     progressChecker.checkCompletion();
-    // TODO: Layer count event test depends on the number of layers in distroless; use a specific
-    // TODO: digest instead of "latest"?
     Assert.assertEquals(
         layerCounts,
         ImmutableMap.of(
@@ -210,7 +210,7 @@ public class BuildStepsIntegrationTest {
     BuildResult image2 =
         BuildSteps.forBuildToDockerRegistry(
                 getBuildConfigurationBuilder(
-                        ImageReference.of("gcr.io", "distroless/java", "latest"),
+                        ImageReference.of("gcr.io", "distroless/java", DISTROLESS_DIGEST),
                         ImageReference.of("localhost:5000", "testimage", "testtag"))
                     .build())
             .run();
@@ -238,7 +238,7 @@ public class BuildStepsIntegrationTest {
     BuildSteps buildImageSteps =
         BuildSteps.forBuildToDockerRegistry(
             getBuildConfigurationBuilder(
-                    ImageReference.of("gcr.io", "distroless/java", "latest"),
+                    ImageReference.of("gcr.io", "distroless/java", DISTROLESS_DIGEST),
                     ImageReference.of("localhost:5000", "testimage", "testtag"))
                 .setAdditionalTargetImageTags(ImmutableSet.of("testtag2", "testtag3"))
                 .build());
@@ -294,7 +294,7 @@ public class BuildStepsIntegrationTest {
 
     BuildConfiguration buildConfiguration =
         getBuildConfigurationBuilder(
-                ImageReference.of("gcr.io", "distroless/java", "latest"),
+                ImageReference.of("gcr.io", "distroless/java", DISTROLESS_DIGEST),
                 ImageReference.of(null, "testdocker", null))
             .setEventDispatcher(
                 new DefaultEventDispatcher(
@@ -324,7 +324,7 @@ public class BuildStepsIntegrationTest {
     String imageReference = "testdocker";
     BuildConfiguration buildConfiguration =
         getBuildConfigurationBuilder(
-                ImageReference.of("gcr.io", "distroless/java", "latest"),
+                ImageReference.of("gcr.io", "distroless/java", DISTROLESS_DIGEST),
                 ImageReference.of(null, imageReference, null))
             .setAdditionalTargetImageTags(ImmutableSet.of("testtag2", "testtag3"))
             .build();
@@ -350,7 +350,7 @@ public class BuildStepsIntegrationTest {
 
     BuildConfiguration buildConfiguration =
         getBuildConfigurationBuilder(
-                ImageReference.of("gcr.io", "distroless/java", "latest"),
+                ImageReference.of("gcr.io", "distroless/java", DISTROLESS_DIGEST),
                 ImageReference.of(null, "testtar", null))
             .setEventDispatcher(
                 new DefaultEventDispatcher(

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -150,14 +150,16 @@ public class BuildStepsIntegrationTest {
 
   private ImmutableList<LayerConfiguration> fakeLayerConfigurations;
 
-  private Map<BuildStepType, Integer> layerCounts = new HashMap<>();
+  private final Map<BuildStepType, Integer> layerCounts = new HashMap<>();
   private final Consumer<LayerCountEvent> layerCountConsumer =
       layerCountEvent -> {
-        BuildStepType stepType = layerCountEvent.getBuildStepType();
-        if (layerCounts.containsKey(stepType)) {
-          layerCounts.put(stepType, layerCounts.get(stepType) + layerCountEvent.getCount());
-        } else {
-          layerCounts.put(stepType, layerCountEvent.getCount());
+        synchronized (layerCounts) {
+          BuildStepType stepType = layerCountEvent.getBuildStepType();
+          if (layerCounts.containsKey(stepType)) {
+            layerCounts.put(stepType, layerCounts.get(stepType) + layerCountEvent.getCount());
+          } else {
+            layerCounts.put(stepType, layerCountEvent.getCount());
+          }
         }
       };
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/builder/BuildStepsIntegrationTest.java
@@ -152,11 +152,11 @@ public class BuildStepsIntegrationTest {
 
   private final Map<BuildStepType, Integer> layerCounts = new ConcurrentHashMap<>();
   private final Consumer<LayerCountEvent> layerCountConsumer =
-      layerCountEvent -> {
-        BuildStepType stepType = layerCountEvent.getBuildStepType();
-        layerCounts.merge(
-            stepType, layerCountEvent.getCount(), (oldValue, count) -> oldValue + count);
-      };
+      layerCountEvent ->
+          layerCounts.merge(
+              layerCountEvent.getBuildStepType(),
+              layerCountEvent.getCount(),
+              (oldValue, count) -> oldValue + count);
 
   @Before
   public void setUp() throws IOException, URISyntaxException {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildStepType.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/BuildStepType.java
@@ -46,8 +46,11 @@ public enum BuildStepType {
   /** Step for pushing the image manifest to the target registry. */
   PUSH_IMAGE,
 
-  /** Step for pushing the image layers to the target registry. */
-  PUSH_LAYERS,
+  /** Step for pushing the application image layers to the target registry. */
+  PUSH_APPLICATION_LAYERS,
+
+  /** Step for pushing the base image layers to the target registry. */
+  PUSH_BASE_LAYERS,
 
   /** Step for retrieving credentials for the base image registry. */
   RETRIEVE_REGISTRY_CREDENTIALS_BASE,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
@@ -26,6 +26,7 @@ import com.google.cloud.tools.jib.cache.CacheCorruptedException;
 import com.google.cloud.tools.jib.cache.CachedLayer;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.configuration.LayerConfiguration;
+import com.google.cloud.tools.jib.event.events.LayerCountEvent;
 import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.image.ReproducibleLayerBuilder;
 import com.google.common.collect.ImmutableList;
@@ -73,7 +74,13 @@ class BuildAndCacheApplicationLayerStep implements AsyncStep<CachedLayer>, Calla
                 layerConfiguration.getName(),
                 layerConfiguration));
       }
-      return buildAndCacheApplicationLayerSteps.build();
+      ImmutableList<BuildAndCacheApplicationLayerStep> steps =
+          buildAndCacheApplicationLayerSteps.build();
+      buildConfiguration
+          .getEventDispatcher()
+          .dispatch(
+              new LayerCountEvent(BuildStepType.BUILD_AND_CACHE_APPLICATION_LAYER, steps.size()));
+      return steps;
     }
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayersStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayersStep.java
@@ -24,6 +24,7 @@ import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.builder.steps.PullBaseImageStep.BaseImageWithAuthorization;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
+import com.google.cloud.tools.jib.event.events.LayerCountEvent;
 import com.google.cloud.tools.jib.image.Layer;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.common.collect.ImmutableList;
@@ -83,6 +84,11 @@ class PullAndCacheBaseImageLayersStep
             new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), DESCRIPTION)) {
       ImmutableList.Builder<PullAndCacheBaseImageLayerStep> pullAndCacheBaseImageLayerStepsBuilder =
           ImmutableList.builderWithExpectedSize(baseImageLayers.size());
+      buildConfiguration
+          .getEventDispatcher()
+          .dispatch(
+              new LayerCountEvent(
+                  BuildStepType.PULL_AND_CACHE_BASE_IMAGE_LAYER, baseImageLayers.size()));
       for (Layer layer : baseImageLayers) {
         pullAndCacheBaseImageLayerStepsBuilder.add(
             new PullAndCacheBaseImageLayerStep(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.async.AsyncStep;
 import com.google.cloud.tools.jib.async.AsyncSteps;
+import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.docker.DockerClient;
@@ -145,7 +146,8 @@ public class StepsRunner {
                     buildConfiguration,
                     Preconditions.checkNotNull(rootProgressEventDispatcher).newChildProducer(),
                     Preconditions.checkNotNull(steps.authenticatePushStep),
-                    Preconditions.checkNotNull(steps.pullAndCacheBaseImageLayersStep)));
+                    Preconditions.checkNotNull(steps.pullAndCacheBaseImageLayersStep),
+                    BuildStepType.PUSH_BASE_LAYERS));
   }
 
   public StepsRunner buildAndCacheApplicationLayers() {
@@ -193,7 +195,8 @@ public class StepsRunner {
                     Preconditions.checkNotNull(rootProgressEventDispatcher).newChildProducer(),
                     Preconditions.checkNotNull(steps.authenticatePushStep),
                     AsyncSteps.immediate(
-                        Preconditions.checkNotNull(steps.buildAndCacheApplicationLayerSteps))));
+                        Preconditions.checkNotNull(steps.buildAndCacheApplicationLayerSteps)),
+                    BuildStepType.PUSH_APPLICATION_LAYERS));
   }
 
   public StepsRunner pushImage() {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/JibEventType.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/JibEventType.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.event;
 
+import com.google.cloud.tools.jib.event.events.LayerCountEvent;
 import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.event.events.ProgressEvent;
 import com.google.cloud.tools.jib.event.events.TimerEvent;
@@ -39,6 +40,10 @@ public class JibEventType<E extends JibEvent> {
   /** Event indicating progress for tasks in Jib's execution. */
   public static final JibEventType<ProgressEvent> PROGRESS =
       new JibEventType<>(ProgressEvent.class);
+
+  /** Event used for counting layers processed during a build step. */
+  public static final JibEventType<LayerCountEvent> LAYER_COUNT =
+      new JibEventType<>(LayerCountEvent.class);
 
   // TODO: Add entries for all JibEvent types.
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/LayerCountEvent.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/LayerCountEvent.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.event.events;
+
+import com.google.cloud.tools.jib.builder.BuildStepType;
+import com.google.cloud.tools.jib.event.JibEvent;
+
+/** Event used for counting layers processed during a build step. */
+public class LayerCountEvent implements JibEvent {
+
+  private final BuildStepType buildStepType;
+  private final int count;
+
+  /**
+   * Creates a new {@link LayerCountEvent}. For internal use only.
+   *
+   * @param buildStepType the build step associated with the event
+   * @param count the number of layers counted
+   */
+  public LayerCountEvent(BuildStepType buildStepType, int count) {
+    this.buildStepType = buildStepType;
+    this.count = count;
+  }
+
+  /**
+   * Gets the type of build step that fired the event.
+   *
+   * @return the type of build step that fired the event
+   */
+  public BuildStepType getBuildStepType() {
+    return buildStepType;
+  }
+
+  /**
+   * Gets the number of layers.
+   *
+   * @return the number of layers
+   */
+  public int getCount() {
+    return count;
+  }
+}


### PR DESCRIPTION
Adds a new `LayerCountEvent` that indicates the number of layers being processed during:
- `BuildAndCacheApplicationLayerStep`s
- `PullAndCacheBaseImageLayersStep`
- `PushLayersStep`

This is probably enough events for now, so fixes #1054.