### PR TITLE
Adds examples to Jib Core.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,8 @@
 
 Please [file an issue](/../../issues/new) if you find any problems with the examples or would like to request other examples.
 
+For examples on using Jib Core, see [jib-core/examples](/../../jib-core/examples).
+
 ### Simple example
 
 See [helloworld](helloworld) for containerizing a simple `Hello World` application.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@
 
 Please [file an issue](/../../issues/new) if you find any problems with the examples or would like to request other examples.
 
-For examples on using Jib Core, see [jib-core/examples](/../../jib-core/examples).
+For examples on using Jib Core, see [jib-core/examples](../jib-core/examples).
 
 ### Simple example
 

--- a/jib-core/examples/README.md
+++ b/jib-core/examples/README.md
@@ -1,0 +1,9 @@
+# Jib Core examples
+
+Please [file an issue](/../../issues/new) if you find any problems with the examples or would like to request other examples.
+
+For examples on using Jib plugins, see [examples](/../../examples).
+
+### Using Jib Core in Gradle builds
+
+See [build.gradle](build.gradle) for examples using Jib Core to build and manipulate container images within a `build.gradle` script.

--- a/jib-core/examples/README.md
+++ b/jib-core/examples/README.md
@@ -2,7 +2,7 @@
 
 Please [file an issue](/../../issues/new) if you find any problems with the examples or would like to request other examples.
 
-For examples on using Jib plugins, see [examples](/../../examples).
+For examples on using Jib plugins, see [examples](../examples).
 
 ### Using Jib Core in Gradle builds
 

--- a/jib-core/examples/README.md
+++ b/jib-core/examples/README.md
@@ -2,7 +2,7 @@
 
 Please [file an issue](/../../issues/new) if you find any problems with the examples or would like to request other examples.
 
-For examples on using Jib plugins, see [examples](../examples).
+For examples on using Jib plugins, see [examples](../../examples).
 
 ### Using Jib Core in Gradle builds
 

--- a/jib-core/examples/build.gradle/README.md
+++ b/jib-core/examples/build.gradle/README.md
@@ -1,0 +1,51 @@
+# Examples using Jib Core in Gradle builds
+
+Jib Core is a containerization library for JVM languages, so it works well in Groovy as well. You can use Jib Core directly within a Gradle `build.gradle` to make tasks that build and manipulate container images.
+
+For example, the following snippet is a simple example that creates a Gradle task that adds an environment variable to an existing image:
+
+`build.gradle`:
+
+```groovy
+// Imports Jib Core as a library to use in this build script.
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+  dependencies {
+    classpath 'com.google.cloud.tools:jib-core:0.1.1'
+  }
+}
+
+import com.google.cloud.tools.jib.api.Jib
+import com.google.cloud.tools.jib.api.Containerizer
+import com.google.cloud.tools.jib.api.RegistryImage
+import com.google.cloud.tools.jib.frontend.CredentialRetrieverFactory
+import com.google.cloud.tools.jib.image.ImageReference
+
+// Creates a task called 'dojib'.
+task('dojib') {
+  doLast { 
+    def targetImage = '<target image reference>'
+    Jib
+        // Starts with the existing image.
+        .from('<existing image reference')
+        // Adds an environment variable.
+        .addEnvironmentVariable('ENV_NAME', 'ENV_VALUE')
+        // Performs the containerization.
+        .containerize(
+            Containerizer.to(
+                // Tells Jib to containerize to targetImage's registry. 
+                RegistryImage
+                    .named(targetImage)
+                    // Tells Jib to get registry credentials from a Docker config.
+                    .addCredentialRetriever(
+                        CredentialRetrieverFactory
+                            .forImage(ImageReference.parse(targetImage))
+                            .dockerConfig())))
+    println 'done'
+  }
+}
+```
+
+


### PR DESCRIPTION
Adds a single `build.gradle` example for now.

Ported from https://github.com/GoogleContainerTools/jib/issues/1452#issuecomment-458598641

Preview at https://github.com/GoogleContainerTools/jib/tree/jib-core-examples/jib-core/examples/build.gradle