### PR TITLE
Rethrow ExecutionException's cause in jib-core

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `JibContainerBuilder#containerize()` throws multiple sub-types of `RegistryException` rather than wrapping them in an `ExecutionException` ([#1440](https://github.com/GoogleContainerTools/jib/issues/1440))
+
 ### Fixed
 
 - `MainClassFinder` failure when main method is defined using varargs (i.e. `public static void main(String... args)`) ([#1456](https://github.com/GoogleContainerTools/jib/issues/1456))

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
@@ -22,6 +22,7 @@ import com.google.cloud.tools.jib.configuration.credentials.Credential;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.registry.LocalRegistry;
+import com.google.cloud.tools.jib.registry.RegistryException;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
@@ -65,8 +66,8 @@ public class JibIntegrationTest {
 
   @Test
   public void testBasic_helloWorld()
-      throws InvalidImageReferenceException, InterruptedException, ExecutionException,
-          CacheDirectoryCreationException, IOException {
+      throws InvalidImageReferenceException, InterruptedException, CacheDirectoryCreationException,
+          IOException, RegistryException, ExecutionException {
     ImageReference targetImageReference =
         ImageReference.of("localhost:5000", "jib-core", "basic-helloworld");
     JibContainer jibContainer =
@@ -89,8 +90,8 @@ public class JibIntegrationTest {
   /** Ensure that a provided executor is not disposed. */
   @Test
   public void testProvidedExecutorNotDisposed()
-      throws InvalidImageReferenceException, InterruptedException, ExecutionException,
-          CacheDirectoryCreationException, IOException {
+      throws InvalidImageReferenceException, InterruptedException, CacheDirectoryCreationException,
+          IOException, RegistryException, ExecutionException {
     ImageReference targetImageReference =
         ImageReference.of("localhost:5000", "jib-core", "basic-helloworld");
     Containerizer containerizer =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
@@ -40,7 +40,6 @@ public class Containerizer {
    * The default directory for caching the base image layers, in {@code [user cache
    * home]/google-cloud-tools-java/jib}.
    */
-  // TODO: Reduce scope once plugins are migrated to use the new Jib Core API.
   public static final Path DEFAULT_BASE_CACHE_DIRECTORY =
       UserCacheHome.getCacheHome().resolve("google-cloud-tools-java").resolve("jib");
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticationFailedException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticationFailedException.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.jib.registry;
 import java.text.MessageFormat;
 
 /** Thrown because registry authentication failed. */
-public class RegistryAuthenticationFailedException extends Exception {
+public class RegistryAuthenticationFailedException extends RegistryException {
 
   private static final String REASON = "Failed to authenticate with registry {0}/{1} because: {2}";
   private final String serverUrl;

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
@@ -242,7 +242,11 @@ public class BuildStepsRunner {
             new RegistryUnauthorizedException(
                 ex.getServerUrl(), ex.getImageName(), (HttpResponseException) ex.getCause()),
             helpfulSuggestions);
+      } else {
+        // Unknown cause
+        throw new BuildStepsExecutionException(helpfulSuggestions.none(), ex);
       }
+
     } catch (UnknownHostException ex) {
       throw new BuildStepsExecutionException(helpfulSuggestions.forUnknownHost(), ex);
 

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
@@ -31,7 +31,7 @@ import com.google.cloud.tools.jib.image.LayerEntry;
 import com.google.cloud.tools.jib.registry.InsecureRegistryException;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticationFailedException;
 import com.google.cloud.tools.jib.registry.RegistryCredentialsNotSentException;
-import com.google.cloud.tools.jib.registry.RegistryErrorException;
+import com.google.cloud.tools.jib.registry.RegistryException;
 import com.google.cloud.tools.jib.registry.RegistryUnauthorizedException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Verify;
@@ -226,53 +226,36 @@ public class BuildStepsRunner {
 
       return jibContainer;
 
-    } catch (ExecutionException executionException) {
-      Throwable exceptionDuringBuildSteps = executionException.getCause();
+    } catch (HttpHostConnectException ex) {
+      // Failed to connect to registry.
+      throw new BuildStepsExecutionException(helpfulSuggestions.forHttpHostConnect(), ex);
 
-      if (exceptionDuringBuildSteps instanceof HttpHostConnectException) {
-        // Failed to connect to registry.
-        throw new BuildStepsExecutionException(
-            helpfulSuggestions.forHttpHostConnect(), exceptionDuringBuildSteps);
+    } catch (RegistryUnauthorizedException ex) {
+      handleRegistryUnauthorizedException(ex, helpfulSuggestions);
 
-      } else if (exceptionDuringBuildSteps instanceof RegistryUnauthorizedException) {
-        handleRegistryUnauthorizedException(
-            (RegistryUnauthorizedException) exceptionDuringBuildSteps, helpfulSuggestions);
+    } catch (RegistryCredentialsNotSentException ex) {
+      throw new BuildStepsExecutionException(helpfulSuggestions.forCredentialsNotSent(), ex);
 
-      } else if (exceptionDuringBuildSteps instanceof RegistryCredentialsNotSentException) {
-        throw new BuildStepsExecutionException(
-            helpfulSuggestions.forCredentialsNotSent(), exceptionDuringBuildSteps);
-
-      } else if (exceptionDuringBuildSteps instanceof RegistryAuthenticationFailedException
-          && exceptionDuringBuildSteps.getCause() instanceof HttpResponseException) {
-        RegistryAuthenticationFailedException failureException =
-            (RegistryAuthenticationFailedException) exceptionDuringBuildSteps;
+    } catch (RegistryAuthenticationFailedException ex) {
+      if (ex.getCause() instanceof HttpResponseException) {
         handleRegistryUnauthorizedException(
             new RegistryUnauthorizedException(
-                failureException.getServerUrl(),
-                failureException.getImageName(),
-                (HttpResponseException) exceptionDuringBuildSteps.getCause()),
+                ex.getServerUrl(), ex.getImageName(), (HttpResponseException) ex.getCause()),
             helpfulSuggestions);
-
-      } else if (exceptionDuringBuildSteps instanceof UnknownHostException) {
-        throw new BuildStepsExecutionException(
-            helpfulSuggestions.forUnknownHost(), exceptionDuringBuildSteps);
-
-      } else if (exceptionDuringBuildSteps instanceof InsecureRegistryException) {
-        throw new BuildStepsExecutionException(
-            helpfulSuggestions.forInsecureRegistry(), exceptionDuringBuildSteps);
-
-      } else if (exceptionDuringBuildSteps instanceof RegistryErrorException) {
-        // RegistryErrorExceptions have good messages
-        RegistryErrorException registryErrorException =
-            (RegistryErrorException) exceptionDuringBuildSteps;
-        String message =
-            Verify.verifyNotNull(registryErrorException.getMessage()); // keep null-away happy
-        throw new BuildStepsExecutionException(message, exceptionDuringBuildSteps);
-
-      } else {
-        throw new BuildStepsExecutionException(
-            helpfulSuggestions.none(), executionException.getCause());
       }
+    } catch (UnknownHostException ex) {
+      throw new BuildStepsExecutionException(helpfulSuggestions.forUnknownHost(), ex);
+
+    } catch (InsecureRegistryException ex) {
+      throw new BuildStepsExecutionException(helpfulSuggestions.forInsecureRegistry(), ex);
+
+    } catch (RegistryException ex) {
+      String message = Verify.verifyNotNull(ex.getMessage()); // keep null-away happy
+      throw new BuildStepsExecutionException(message, ex);
+
+    } catch (ExecutionException ex) {
+      String message = Verify.verifyNotNull(ex.getCause().getMessage()); // keep null-away happy
+      throw new BuildStepsExecutionException(message, ex.getCause());
 
     } catch (InterruptedException ex) {
       // TODO: Add more suggestions for various build failures.


### PR DESCRIPTION
Fixes #1440 

Originally, it was up to the library user to catch an `ExecutionException`, and determine what kind of execution caused it using a series of `if (ex instanceof ...)` statements for more fine-grained exception handling. With this PR, `ExecutionException`s' causes are re-thrown if they are `RegistryException`s, which makes jib-core error handling/documentation much more straightforward.