### PR TITLE
Choose Base Distroless Java version based on project version

### DIFF
--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/DefaultTargetProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/DefaultTargetProjectIntegrationTest.java
@@ -82,7 +82,9 @@ public class DefaultTargetProjectIntegrationTest {
     Assert.assertEquals(
         "Hello, world. An argument.\n",
         JibRunHelper.buildToDockerDaemonAndRun(
-            defaultTargetTestProject, "default-target-name:default-target-version"));
+            defaultTargetTestProject,
+            "default-target-name:default-target-version",
+            "build.gradle"));
     assertDockerInspect("default-target-name:default-target-version");
   }
 }

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/EmptyProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/EmptyProjectIntegrationTest.java
@@ -87,7 +87,8 @@ public class EmptyProjectIntegrationTest {
   @Test
   public void testDockerDaemon_empty() throws IOException, InterruptedException, DigestException {
     String targetImage = "emptyimage:gradle" + System.nanoTime();
-    Assert.assertEquals("", JibRunHelper.buildToDockerDaemonAndRun(emptyTestProject, targetImage));
+    Assert.assertEquals(
+        "", JibRunHelper.buildToDockerDaemonAndRun(emptyTestProject, targetImage, "build.gradle"));
     Assert.assertEquals(
         "1970-01-01T00:00:00Z",
         new Command("docker", "inspect", "-f", "{{.Created}}", targetImage).run().trim());

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibRunHelper.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibRunHelper.java
@@ -53,6 +53,7 @@ public class JibRunHelper {
             "clean",
             "jib",
             "-Djib.useOnlyProjectCache=true",
+            "-Djib.console=plain",
             "-D_TARGET_IMAGE=" + imageReference,
             "-b=" + gradleBuildFile);
     assertBuildSuccess(buildResult, "jib", "Built and pushed image as ");
@@ -70,6 +71,7 @@ public class JibRunHelper {
             "clean",
             "jib",
             "-Djib.useOnlyProjectCache=true",
+            "-Djib.console=plain",
             "-D_TARGET_IMAGE=" + imageReference,
             "-D_ADDITIONAL_TAG=" + additionalTag);
     assertBuildSuccess(buildResult, "jib", "Built and pushed image as ");
@@ -95,6 +97,7 @@ public class JibRunHelper {
             "clean",
             "jibDockerBuild",
             "-Djib.useOnlyProjectCache=true",
+            "-Djib.console=plain",
             "-D_TARGET_IMAGE=" + imageReference,
             "-b=" + gradleBuildFile);
     assertBuildSuccess(buildResult, "jibDockerBuild", "Built image to Docker daemon as ");
@@ -105,9 +108,10 @@ public class JibRunHelper {
     Assert.assertThat(history, CoreMatchers.containsString("jib-gradle-plugin"));
   }
 
-  static String buildToDockerDaemonAndRun(TestProject testProject, String imageReference)
+  static String buildToDockerDaemonAndRun(
+      TestProject testProject, String imageReference, String gradleBuildFile)
       throws IOException, InterruptedException, DigestException {
-    buildToDockerDaemon(testProject, imageReference, "build.gradle");
+    buildToDockerDaemon(testProject, imageReference, gradleBuildFile);
     return new Command("docker", "run", "--rm", imageReference).run();
   }
 

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -19,10 +19,10 @@ package com.google.cloud.tools.jib.gradle;
 import com.google.cloud.tools.jib.Command;
 import com.google.cloud.tools.jib.IntegrationTestingConfiguration;
 import com.google.cloud.tools.jib.registry.LocalRegistry;
+import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.security.DigestException;
 import java.time.Instant;
-import org.gradle.internal.impldep.com.google.api.client.repackaged.com.google.common.base.Splitter;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.UnexpectedBuildFailure;
 import org.hamcrest.CoreMatchers;
@@ -183,7 +183,7 @@ public class SingleProjectIntegrationTest {
       throws DigestException, IOException, InterruptedException {
     Assume.assumeTrue(isJava11RuntimeOrHigher());
 
-    String targetImage = "localhost:6000/compleximage:gradle" + System.nanoTime();
+    String targetImage = "localhost:6000/simpleimage:gradle" + System.nanoTime();
     Assert.assertEquals(
         "Hello, world. \n",
         JibRunHelper.buildToDockerDaemonAndRun(
@@ -204,7 +204,7 @@ public class SingleProjectIntegrationTest {
       Assert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
-              "The base image uses Java 8, but project is using Java 11; perhaps you should "
+              "The base image uses Java 8, but project is using Java 11, perhaps you should "
                   + "configure a Java 11-compatible base image using the 'jib.from.image' "
                   + "parameter, or set targetCompatibility = 8 or below in your build "
                   + "configuration"));

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -204,7 +204,7 @@ public class SingleProjectIntegrationTest {
       Assert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
-              "The base image uses Java 8, but project is using Java 11, perhaps you should "
+              "Your project is using Java 11 but the base image is for Java 8, perhaps you should "
                   + "configure a Java 11-compatible base image using the 'jib.from.image' "
                   + "parameter, or set targetCompatibility = 8 or below in your build "
                   + "configuration"));

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -22,6 +22,7 @@ import com.google.cloud.tools.jib.registry.LocalRegistry;
 import java.io.IOException;
 import java.security.DigestException;
 import java.time.Instant;
+import org.gradle.internal.impldep.com.google.api.client.repackaged.com.google.common.base.Splitter;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.UnexpectedBuildFailure;
 import org.hamcrest.CoreMatchers;
@@ -43,6 +44,11 @@ public class SingleProjectIntegrationTest {
       new LocalRegistry(6000, "testuser2", "testpassword2");
 
   @ClassRule public static final TestProject simpleTestProject = new TestProject("simple");
+
+  private static boolean isJava11RuntimeOrHigher() {
+    Iterable<String> split = Splitter.on(".").split(System.getProperty("java.version"));
+    return Integer.valueOf(split.iterator().next()) >= 11;
+  }
 
   /**
    * Asserts that the creation time of the simple test project is set. If the time parsed from the
@@ -114,6 +120,7 @@ public class SingleProjectIntegrationTest {
             "clean",
             "jib",
             "-Djib.useOnlyProjectCache=true",
+            "-Djib.console=plain",
             "-D_TARGET_IMAGE=" + imageReference,
             "-D_TARGET_USERNAME=" + username,
             "-D_TARGET_PASSWORD=" + password,
@@ -150,6 +157,7 @@ public class SingleProjectIntegrationTest {
           "clean",
           "jib",
           "-Djib.useOnlyProjectCache=true",
+          "-Djib.console=plain",
           "-x=classes",
           "-D_TARGET_IMAGE=" + targetImage);
       Assert.fail();
@@ -168,6 +176,39 @@ public class SingleProjectIntegrationTest {
     assertDockerInspect(targetImage);
     assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);
     assertWorkingDirectory("/home", targetImage);
+  }
+
+  @Test
+  public void testDockerDaemon_simpleOnJava11()
+      throws DigestException, IOException, InterruptedException {
+    Assume.assumeTrue(isJava11RuntimeOrHigher());
+
+    String targetImage = "localhost:6000/compleximage:gradle" + System.nanoTime();
+    Assert.assertEquals(
+        "Hello, world. \n",
+        JibRunHelper.buildToDockerDaemonAndRun(
+            simpleTestProject, targetImage, "build-java11.gradle"));
+  }
+
+  @Test
+  public void testDockerDaemon_simpleWithIncompatibleJava11()
+      throws DigestException, IOException, InterruptedException {
+    Assume.assumeTrue(isJava11RuntimeOrHigher());
+
+    try {
+      JibRunHelper.buildToDockerDaemonAndRun(
+          simpleTestProject, "willnotbuild", "build-java11-incompatible.gradle");
+      Assert.fail();
+
+    } catch (UnexpectedBuildFailure ex) {
+      Assert.assertThat(
+          ex.getMessage(),
+          CoreMatchers.containsString(
+              "The base image uses Java 8, but project is using Java 11; perhaps you should "
+                  + "configure a Java 11-compatible base image using the 'jib.from.image' "
+                  + "parameter, or set targetCompatibility = 8 or below in your build "
+                  + "configuration"));
+    }
   }
 
   @Test
@@ -198,7 +239,7 @@ public class SingleProjectIntegrationTest {
     Instant beforeBuild = Instant.now();
     Assert.assertEquals(
         "Hello, world. An argument.\nrw-r--r--\nrw-r--r--\nfoo\ncat\n",
-        JibRunHelper.buildToDockerDaemonAndRun(simpleTestProject, targetImage));
+        JibRunHelper.buildToDockerDaemonAndRun(simpleTestProject, targetImage, "build.gradle"));
     assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);
     assertDockerInspect(targetImage);
     assertWorkingDirectory("/home", targetImage);
@@ -218,6 +259,7 @@ public class SingleProjectIntegrationTest {
             "clean",
             "jibDockerBuild",
             "-Djib.useOnlyProjectCache=true",
+            "-Djib.console=plain",
             "-D_TARGET_IMAGE=" + targetImage,
             "-b=build-dockerclient.gradle",
             "--debug");
@@ -241,6 +283,7 @@ public class SingleProjectIntegrationTest {
             "clean",
             "jibBuildTar",
             "-Djib.useOnlyProjectCache=true",
+            "-Djib.console=plain",
             "-D_TARGET_IMAGE=" + targetImage);
 
     JibRunHelper.assertBuildSuccess(buildResult, "jibBuildTar", "Built image tarball at ");

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-java11-incompatible.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-java11-incompatible.gradle
@@ -1,0 +1,18 @@
+plugins {
+  id 'java'
+  id 'com.google.cloud.tools.jib'
+}
+
+sourceCompatibility = 11
+targetCompatibility = 11
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compile files('libs/dependency-1.0.0.jar')
+}
+
+jib.from.image = 'gcr.io/distroless/java'
+jib.to.image = System.getProperty("_TARGET_IMAGE")

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-java11.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-java11.gradle
@@ -1,0 +1,17 @@
+plugins {
+  id 'java'
+  id 'com.google.cloud.tools.jib'
+}
+
+sourceCompatibility = 11
+targetCompatibility = 11
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compile files('libs/dependency-1.0.0.jar')
+}
+
+jib.to.image = System.getProperty("_TARGET_IMAGE")

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
+import com.google.cloud.tools.jib.plugins.common.IncompatibleBaseImageJavaVersionException;
 import com.google.cloud.tools.jib.plugins.common.InferredAuthRetrievalException;
 import com.google.cloud.tools.jib.plugins.common.InvalidAppRootException;
 import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException;
@@ -113,7 +114,6 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
               jibExtension.getExtraDirectory().getPath(),
               jibExtension.getExtraDirectory().getPermissions(),
               appRoot);
-      projectProperties.validateAgainstDefaultBaseImageVersion(jibExtension.getFrom().getImage());
 
       GradleHelpfulSuggestionsBuilder gradleHelpfulSuggestionsBuilder =
           new GradleHelpfulSuggestionsBuilder(HELPFUL_SUGGESTIONS_PREFIX, jibExtension);
@@ -168,6 +168,19 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
     } catch (InvalidContainerVolumeException ex) {
       throw new GradleException(
           "container.volumes is not an absolute Unix-style path: " + ex.getInvalidVolume(), ex);
+
+    } catch (IncompatibleBaseImageJavaVersionException ex) {
+      throw new GradleException(
+          "The base image uses Java "
+              + ex.getBaseImageJavaMajorVersion()
+              + ", but project is using Java "
+              + ex.getProjectJavaMajorVersion()
+              + "; perhaps you should configure a Java "
+              + ex.getProjectJavaMajorVersion()
+              + "-compatible base image using the 'jib.from.image' parameter, or set "
+              + "targetCompatibility = "
+              + ex.getBaseImageJavaMajorVersion()
+              + " or below in your build configuration");
     }
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -171,16 +171,7 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new GradleException(
-          "The base image uses Java "
-              + ex.getBaseImageMajorJavaVersion()
-              + ", but project is using Java "
-              + ex.getProjectMajorJavaVersion()
-              + "; perhaps you should configure a Java "
-              + ex.getProjectMajorJavaVersion()
-              + "-compatible base image using the 'jib.from.image' parameter, or set "
-              + "targetCompatibility = "
-              + ex.getBaseImageMajorJavaVersion()
-              + " or below in your build configuration");
+          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(8, 11));
     }
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -172,14 +172,14 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new GradleException(
           "The base image uses Java "
-              + ex.getBaseImageJavaMajorVersion()
+              + ex.getBaseImageMajorJavaVersion()
               + ", but project is using Java "
-              + ex.getProjectJavaMajorVersion()
+              + ex.getProjectMajorJavaVersion()
               + "; perhaps you should configure a Java "
-              + ex.getProjectJavaMajorVersion()
+              + ex.getProjectMajorJavaVersion()
               + "-compatible base image using the 'jib.from.image' parameter, or set "
               + "targetCompatibility = "
-              + ex.getBaseImageJavaMajorVersion()
+              + ex.getBaseImageMajorJavaVersion()
               + " or below in your build configuration");
     }
   }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -171,7 +171,8 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new GradleException(
-          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(8, 11));
+          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(
+              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()));
     }
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -172,7 +172,8 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new GradleException(
           HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(
-              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()));
+              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()),
+          ex);
     }
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -24,6 +24,7 @@ import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
+import com.google.cloud.tools.jib.plugins.common.IncompatibleBaseImageJavaVersionException;
 import com.google.cloud.tools.jib.plugins.common.InferredAuthRetrievalException;
 import com.google.cloud.tools.jib.plugins.common.InvalidAppRootException;
 import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException;
@@ -89,7 +90,6 @@ public class BuildImageTask extends DefaultTask implements JibTask {
               jibExtension.getExtraDirectory().getPath(),
               jibExtension.getExtraDirectory().getPermissions(),
               appRoot);
-      projectProperties.validateAgainstDefaultBaseImageVersion(jibExtension.getFrom().getImage());
 
       if (Strings.isNullOrEmpty(jibExtension.getTo().getImage())) {
         throw new GradleException(
@@ -148,6 +148,19 @@ public class BuildImageTask extends DefaultTask implements JibTask {
     } catch (InvalidContainerVolumeException ex) {
       throw new GradleException(
           "container.volumes is not an absolute Unix-style path: " + ex.getInvalidVolume(), ex);
+
+    } catch (IncompatibleBaseImageJavaVersionException ex) {
+      throw new GradleException(
+          "The base image uses Java "
+              + ex.getBaseImageJavaMajorVersion()
+              + ", but project is using Java "
+              + ex.getProjectJavaMajorVersion()
+              + "; perhaps you should configure a Java "
+              + ex.getProjectJavaMajorVersion()
+              + "-compatible base image using the 'jib.from.image' parameter, or set "
+              + "targetCompatibility = "
+              + ex.getBaseImageJavaMajorVersion()
+              + " or below in your build configuration");
     }
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -152,7 +152,8 @@ public class BuildImageTask extends DefaultTask implements JibTask {
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new GradleException(
           HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(
-              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()));
+              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()),
+          ex);
     }
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -151,7 +151,8 @@ public class BuildImageTask extends DefaultTask implements JibTask {
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new GradleException(
-          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(8, 11));
+          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(
+              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()));
     }
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -151,16 +151,7 @@ public class BuildImageTask extends DefaultTask implements JibTask {
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new GradleException(
-          "The base image uses Java "
-              + ex.getBaseImageMajorJavaVersion()
-              + ", but project is using Java "
-              + ex.getProjectMajorJavaVersion()
-              + "; perhaps you should configure a Java "
-              + ex.getProjectMajorJavaVersion()
-              + "-compatible base image using the 'jib.from.image' parameter, or set "
-              + "targetCompatibility = "
-              + ex.getBaseImageMajorJavaVersion()
-              + " or below in your build configuration");
+          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(8, 11));
     }
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -152,14 +152,14 @@ public class BuildImageTask extends DefaultTask implements JibTask {
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new GradleException(
           "The base image uses Java "
-              + ex.getBaseImageJavaMajorVersion()
+              + ex.getBaseImageMajorJavaVersion()
               + ", but project is using Java "
-              + ex.getProjectJavaMajorVersion()
+              + ex.getProjectMajorJavaVersion()
               + "; perhaps you should configure a Java "
-              + ex.getProjectJavaMajorVersion()
+              + ex.getProjectMajorJavaVersion()
               + "-compatible base image using the 'jib.from.image' parameter, or set "
               + "targetCompatibility = "
-              + ex.getBaseImageJavaMajorVersion()
+              + ex.getBaseImageMajorJavaVersion()
               + " or below in your build configuration");
     }
   }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -168,16 +168,7 @@ public class BuildTarTask extends DefaultTask implements JibTask {
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new GradleException(
-          "The base image uses Java "
-              + ex.getBaseImageMajorJavaVersion()
-              + ", but project is using Java "
-              + ex.getProjectMajorJavaVersion()
-              + "; perhaps you should configure a Java "
-              + ex.getProjectMajorJavaVersion()
-              + "-compatible base image using the 'jib.from.image' parameter, or set "
-              + "targetCompatibility = "
-              + ex.getBaseImageMajorJavaVersion()
-              + " or below in your build configuration");
+          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(8, 11));
     }
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -169,14 +169,14 @@ public class BuildTarTask extends DefaultTask implements JibTask {
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new GradleException(
           "The base image uses Java "
-              + ex.getBaseImageJavaMajorVersion()
+              + ex.getBaseImageMajorJavaVersion()
               + ", but project is using Java "
-              + ex.getProjectJavaMajorVersion()
+              + ex.getProjectMajorJavaVersion()
               + "; perhaps you should configure a Java "
-              + ex.getProjectJavaMajorVersion()
+              + ex.getProjectMajorJavaVersion()
               + "-compatible base image using the 'jib.from.image' parameter, or set "
               + "targetCompatibility = "
-              + ex.getBaseImageJavaMajorVersion()
+              + ex.getBaseImageMajorJavaVersion()
               + " or below in your build configuration");
     }
   }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -168,7 +168,8 @@ public class BuildTarTask extends DefaultTask implements JibTask {
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new GradleException(
-          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(8, 11));
+          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(
+              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()));
     }
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -169,7 +169,8 @@ public class BuildTarTask extends DefaultTask implements JibTask {
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new GradleException(
           HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(
-              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()));
+              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()),
+          ex);
     }
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
+import com.google.cloud.tools.jib.plugins.common.IncompatibleBaseImageJavaVersionException;
 import com.google.cloud.tools.jib.plugins.common.InferredAuthRetrievalException;
 import com.google.cloud.tools.jib.plugins.common.InvalidAppRootException;
 import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException;
@@ -112,7 +113,6 @@ public class BuildTarTask extends DefaultTask implements JibTask {
               jibExtension.getExtraDirectory().getPath(),
               jibExtension.getExtraDirectory().getPermissions(),
               appRoot);
-      projectProperties.validateAgainstDefaultBaseImageVersion(jibExtension.getFrom().getImage());
 
       GradleHelpfulSuggestionsBuilder gradleHelpfulSuggestionsBuilder =
           new GradleHelpfulSuggestionsBuilder(HELPFUL_SUGGESTIONS_PREFIX, jibExtension);
@@ -165,6 +165,19 @@ public class BuildTarTask extends DefaultTask implements JibTask {
     } catch (InvalidContainerVolumeException ex) {
       throw new GradleException(
           "container.volumes is not an absolute Unix-style path: " + ex.getInvalidVolume(), ex);
+
+    } catch (IncompatibleBaseImageJavaVersionException ex) {
+      throw new GradleException(
+          "The base image uses Java "
+              + ex.getBaseImageJavaMajorVersion()
+              + ", but project is using Java "
+              + ex.getProjectJavaMajorVersion()
+              + "; perhaps you should configure a Java "
+              + ex.getProjectJavaMajorVersion()
+              + "-compatible base image using the 'jib.from.image' parameter, or set "
+              + "targetCompatibility = "
+              + ex.getBaseImageJavaMajorVersion()
+              + " or below in your build configuration");
     }
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -257,6 +257,11 @@ class GradleProjectProperties implements ProjectProperties {
     return project.getVersion().toString();
   }
 
+  @Override
+  public int getMajorJavaVersion() {
+    throw new RuntimeException("bug");
+  }
+
   void validateAgainstDefaultBaseImageVersion(@Nullable String baseImage) {
     if (!PluginConfigurationProcessor.usingDefaultBaseImage(baseImage)) {
       return;

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -267,19 +267,6 @@ class GradleProjectProperties implements ProjectProperties {
     return Integer.valueOf(version.getMajorVersion());
   }
 
-  void validateAgainstDefaultBaseImageVersion(@Nullable String baseImage) {
-    int version = getMajorJavaVersion();
-    if (version > 11) {
-      throw new GradleException(
-          "Jib's default base image uses Java 8 or 11, but project is using Java "
-              + version
-              + "; perhaps you should configure a Java "
-              + version
-              + "-compatible base image using the 'jib.from.image' parameter, or set "
-              + "targetCompatibility = 11 or below in your build configuration");
-    }
-  }
-
   /**
    * Validates and converts a {@code String->String} file-path-to-file-permissions map to an
    * equivalent {@code AbsoluteUnixPath->FilePermission} map.

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -162,17 +162,7 @@ public class BuildDockerMojo extends JibPluginConfiguration {
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new MojoExecutionException(
-          "The base image uses Java "
-              + ex.getBaseImageMajorJavaVersion()
-              + ", but project is using Java "
-              + ex.getProjectMajorJavaVersion()
-              + "; perhaps you should configure a Java "
-              + ex.getProjectMajorJavaVersion()
-              + "-compatible base image using the "
-              + "'<from><image>' parameter, or set maven-compiler-plugin's '<target>' or "
-              + "'<release>' version to "
-              + ex.getBaseImageMajorJavaVersion()
-              + " or below in your build configuration");
+          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForMaven(8, 11));
 
     } catch (InvalidImageReferenceException
         | IOException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -163,15 +163,15 @@ public class BuildDockerMojo extends JibPluginConfiguration {
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new MojoExecutionException(
           "The base image uses Java "
-              + ex.getBaseImageJavaMajorVersion()
+              + ex.getBaseImageMajorJavaVersion()
               + ", but project is using Java "
-              + ex.getProjectJavaMajorVersion()
+              + ex.getProjectMajorJavaVersion()
               + "; perhaps you should configure a Java "
-              + ex.getProjectJavaMajorVersion()
+              + ex.getProjectMajorJavaVersion()
               + "-compatible base image using the "
               + "'<from><image>' parameter, or set maven-compiler-plugin's '<target>' or "
               + "'<release>' version to "
-              + ex.getBaseImageJavaMajorVersion()
+              + ex.getBaseImageMajorJavaVersion()
               + " or below in your build configuration");
 
     } catch (InvalidImageReferenceException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -27,6 +27,7 @@ import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
 import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
+import com.google.cloud.tools.jib.plugins.common.IncompatibleBaseImageJavaVersionException;
 import com.google.cloud.tools.jib.plugins.common.InferredAuthRetrievalException;
 import com.google.cloud.tools.jib.plugins.common.InvalidAppRootException;
 import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException;
@@ -98,7 +99,6 @@ public class BuildDockerMojo extends JibPluginConfiguration {
               MojoCommon.getExtraDirectoryPath(this),
               MojoCommon.convertPermissionsList(getExtraDirectoryPermissions()),
               appRoot);
-      projectProperties.validateAgainstDefaultBaseImageVersion(getBaseImage());
       EventDispatcher eventDispatcher =
           new DefaultEventDispatcher(projectProperties.getEventHandlers());
 
@@ -159,6 +159,8 @@ public class BuildDockerMojo extends JibPluginConfiguration {
     } catch (InvalidContainerVolumeException ex) {
       throw new MojoExecutionException(
           "<container><volumes> is not an absolute Unix-style path: " + ex.getInvalidVolume(), ex);
+
+    } catch (IncompatibleBaseImageJavaVersionException ex) {
 
     } catch (InvalidImageReferenceException
         | IOException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -161,6 +161,18 @@ public class BuildDockerMojo extends JibPluginConfiguration {
           "<container><volumes> is not an absolute Unix-style path: " + ex.getInvalidVolume(), ex);
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
+      throw new MojoExecutionException(
+          "The base image uses Java "
+              + ex.getBaseImageJavaMajorVersion()
+              + ", but project is using Java "
+              + ex.getProjectJavaMajorVersion()
+              + "; perhaps you should configure a Java "
+              + ex.getProjectJavaMajorVersion()
+              + "-compatible base image using the "
+              + "'<from><image>' parameter, or set maven-compiler-plugin's '<target>' or "
+              + "'<release>' version to "
+              + ex.getBaseImageJavaMajorVersion()
+              + " or below in your build configuration");
 
     } catch (InvalidImageReferenceException
         | IOException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -162,7 +162,8 @@ public class BuildDockerMojo extends JibPluginConfiguration {
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new MojoExecutionException(
-          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForMaven(8, 11));
+          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForMaven(
+              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()));
 
     } catch (InvalidImageReferenceException
         | IOException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -163,7 +163,8 @@ public class BuildDockerMojo extends JibPluginConfiguration {
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new MojoExecutionException(
           HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForMaven(
-              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()));
+              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()),
+          ex);
 
     } catch (InvalidImageReferenceException
         | IOException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -154,7 +154,8 @@ public class BuildImageMojo extends JibPluginConfiguration {
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new MojoExecutionException(
-          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForMaven(8, 11));
+          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForMaven(
+              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()));
 
     } catch (InvalidImageReferenceException
         | IOException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -154,17 +154,7 @@ public class BuildImageMojo extends JibPluginConfiguration {
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new MojoExecutionException(
-          "The base image uses Java "
-              + ex.getBaseImageMajorJavaVersion()
-              + ", but project is using Java "
-              + ex.getProjectMajorJavaVersion()
-              + "; perhaps you should configure a Java "
-              + ex.getProjectMajorJavaVersion()
-              + "-compatible base image using the "
-              + "'<from><image>' parameter, or set maven-compiler-plugin's '<target>' or "
-              + "'<release>' version to "
-              + ex.getBaseImageMajorJavaVersion()
-              + " or below in your build configuration");
+          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForMaven(8, 11));
 
     } catch (InvalidImageReferenceException
         | IOException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -155,15 +155,15 @@ public class BuildImageMojo extends JibPluginConfiguration {
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new MojoExecutionException(
           "The base image uses Java "
-              + ex.getBaseImageJavaMajorVersion()
+              + ex.getBaseImageMajorJavaVersion()
               + ", but project is using Java "
-              + ex.getProjectJavaMajorVersion()
+              + ex.getProjectMajorJavaVersion()
               + "; perhaps you should configure a Java "
-              + ex.getProjectJavaMajorVersion()
+              + ex.getProjectMajorJavaVersion()
               + "-compatible base image using the "
               + "'<from><image>' parameter, or set maven-compiler-plugin's '<target>' or "
               + "'<release>' version to "
-              + ex.getBaseImageJavaMajorVersion()
+              + ex.getBaseImageMajorJavaVersion()
               + " or below in your build configuration");
 
     } catch (InvalidImageReferenceException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -155,7 +155,8 @@ public class BuildImageMojo extends JibPluginConfiguration {
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new MojoExecutionException(
           HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForMaven(
-              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()));
+              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()),
+          ex);
 
     } catch (InvalidImageReferenceException
         | IOException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -132,17 +132,7 @@ public class BuildTarMojo extends JibPluginConfiguration {
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new MojoExecutionException(
-          "The base image uses Java "
-              + ex.getBaseImageMajorJavaVersion()
-              + ", but project is using Java "
-              + ex.getProjectMajorJavaVersion()
-              + "; perhaps you should configure a Java "
-              + ex.getProjectMajorJavaVersion()
-              + "-compatible base image using the "
-              + "'<from><image>' parameter, or set maven-compiler-plugin's '<target>' or "
-              + "'<release>' version to "
-              + ex.getBaseImageMajorJavaVersion()
-              + " or below in your build configuration");
+          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForMaven(8, 11));
 
     } catch (InvalidImageReferenceException
         | IOException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -133,7 +133,8 @@ public class BuildTarMojo extends JibPluginConfiguration {
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new MojoExecutionException(
           HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForMaven(
-              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()));
+              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()),
+          ex);
 
     } catch (InvalidImageReferenceException
         | IOException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -132,7 +132,8 @@ public class BuildTarMojo extends JibPluginConfiguration {
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new MojoExecutionException(
-          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForMaven(8, 11));
+          HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForMaven(
+              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()));
 
     } catch (InvalidImageReferenceException
         | IOException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -131,6 +131,18 @@ public class BuildTarMojo extends JibPluginConfiguration {
           "<container><volumes> is not an absolute Unix-style path: " + ex.getInvalidVolume(), ex);
 
     } catch (IncompatibleBaseImageJavaVersionException ex) {
+      throw new MojoExecutionException(
+          "The base image uses Java "
+              + ex.getBaseImageJavaMajorVersion()
+              + ", but project is using Java "
+              + ex.getProjectJavaMajorVersion()
+              + "; perhaps you should configure a Java "
+              + ex.getProjectJavaMajorVersion()
+              + "-compatible base image using the "
+              + "'<from><image>' parameter, or set maven-compiler-plugin's '<target>' or "
+              + "'<release>' version to "
+              + ex.getBaseImageJavaMajorVersion()
+              + " or below in your build configuration");
 
     } catch (InvalidImageReferenceException
         | IOException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -133,15 +133,15 @@ public class BuildTarMojo extends JibPluginConfiguration {
     } catch (IncompatibleBaseImageJavaVersionException ex) {
       throw new MojoExecutionException(
           "The base image uses Java "
-              + ex.getBaseImageJavaMajorVersion()
+              + ex.getBaseImageMajorJavaVersion()
               + ", but project is using Java "
-              + ex.getProjectJavaMajorVersion()
+              + ex.getProjectMajorJavaVersion()
               + "; perhaps you should configure a Java "
-              + ex.getProjectJavaMajorVersion()
+              + ex.getProjectMajorJavaVersion()
               + "-compatible base image using the "
               + "'<from><image>' parameter, or set maven-compiler-plugin's '<target>' or "
               + "'<release>' version to "
-              + ex.getBaseImageJavaMajorVersion()
+              + ex.getBaseImageMajorJavaVersion()
               + " or below in your build configuration");
 
     } catch (InvalidImageReferenceException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -24,6 +24,7 @@ import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsRunner;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
+import com.google.cloud.tools.jib.plugins.common.IncompatibleBaseImageJavaVersionException;
 import com.google.cloud.tools.jib.plugins.common.InferredAuthRetrievalException;
 import com.google.cloud.tools.jib.plugins.common.InvalidAppRootException;
 import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException;
@@ -71,7 +72,6 @@ public class BuildTarMojo extends JibPluginConfiguration {
               MojoCommon.getExtraDirectoryPath(this),
               MojoCommon.convertPermissionsList(getExtraDirectoryPermissions()),
               appRoot);
-      projectProperties.validateAgainstDefaultBaseImageVersion(getBaseImage());
       EventDispatcher eventDispatcher =
           new DefaultEventDispatcher(projectProperties.getEventHandlers());
 
@@ -129,6 +129,8 @@ public class BuildTarMojo extends JibPluginConfiguration {
     } catch (InvalidContainerVolumeException ex) {
       throw new MojoExecutionException(
           "<container><volumes> is not an absolute Unix-style path: " + ex.getInvalidVolume(), ex);
+
+    } catch (IncompatibleBaseImageJavaVersionException ex) {
 
     } catch (InvalidImageReferenceException
         | IOException

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -265,24 +265,24 @@ public class MavenProjectProperties implements ProjectProperties {
     // Check properties for version
     if (project.getProperties().getProperty("maven.compiler.target") != null) {
       return getVersionFromString(project.getProperties().getProperty("maven.compiler.target"));
-    } else if (project.getProperties().getProperty("maven.compiler.release") != null) {
+    }
+    if (project.getProperties().getProperty("maven.compiler.release") != null) {
       return getVersionFromString(project.getProperties().getProperty("maven.compiler.release"));
-    } else {
-      // Check maven-compiler-plugin for version
-      Plugin mavenCompilerPlugin =
-          project.getPlugin("org.apache.maven.plugins:maven-compiler-plugin");
-      if (mavenCompilerPlugin != null) {
-        Xpp3Dom pluginConfiguration = (Xpp3Dom) mavenCompilerPlugin.getConfiguration();
-        if (pluginConfiguration != null) {
-          Xpp3Dom target = pluginConfiguration.getChild("target");
-          if (target != null) {
-            return getVersionFromString(target.getValue());
-          } else {
-            Xpp3Dom release = pluginConfiguration.getChild("release");
-            if (release != null) {
-              return getVersionFromString(release.getValue());
-            }
-          }
+    }
+
+    // Check maven-compiler-plugin for version
+    Plugin mavenCompilerPlugin =
+        project.getPlugin("org.apache.maven.plugins:maven-compiler-plugin");
+    if (mavenCompilerPlugin != null) {
+      Xpp3Dom pluginConfiguration = (Xpp3Dom) mavenCompilerPlugin.getConfiguration();
+      if (pluginConfiguration != null) {
+        Xpp3Dom target = pluginConfiguration.getChild("target");
+        if (target != null) {
+          return getVersionFromString(target.getValue());
+        }
+        Xpp3Dom release = pluginConfiguration.getChild("release");
+        if (release != null) {
+          return getVersionFromString(release.getValue());
         }
       }
     }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.Os;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -23,7 +23,6 @@ import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.event.progress.ProgressEventHandler;
 import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.frontend.JavaLayerConfigurations;
-import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.cloud.tools.jib.plugins.common.ProjectProperties;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.cloud.tools.jib.plugins.common.TimerEventHandler;
@@ -289,23 +288,5 @@ public class MavenProjectProperties implements ProjectProperties {
       }
     }
     return 6; // maven-compiler-plugin default is 1.6
-  }
-
-  void validateAgainstDefaultBaseImageVersion(@Nullable String baseImage)
-      throws MojoFailureException {
-    if (!PluginConfigurationProcessor.usingDefaultBaseImage(baseImage)) {
-      return;
-    }
-
-    int version = getMajorJavaVersion();
-    if (version > 11) {
-      throw new MojoFailureException(
-          "Jib's default base image uses Java 8 or 11, but project is using Java "
-              + version
-              + "; perhaps you should configure a Java "
-              + version
-              + "-compatible base image using the '<from><image>' parameter, or set maven-compiler-plugin's "
-              + "'<target>' or '<release>' version to 11 or below in your build configuration");
-    }
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -22,6 +22,7 @@ import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.registry.LocalRegistry;
+import com.google.common.base.Splitter;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
@@ -93,7 +94,8 @@ public class BuildImageMojoIntegrationTest {
   }
 
   private static boolean isJava11RuntimeOrHigher() {
-    return Integer.valueOf(System.getProperty("java.version").split("\\.")[0]) >= 11;
+    Iterable<String> split = Splitter.on(".").split(System.getProperty("java.version"));
+    return Integer.valueOf(split.iterator().next()) >= 11;
   }
 
   /**
@@ -360,10 +362,9 @@ public class BuildImageMojoIntegrationTest {
       throws DigestException, IOException, InterruptedException {
     Assume.assumeTrue(isJava11RuntimeOrHigher());
 
-    String targetImage = getGcrImageReference("simpleimage:maven");
     try {
       buildAndRun(
-          simpleTestProject.getProjectRoot(), targetImage, "pom-java11-incompatible.xml", false);
+          simpleTestProject.getProjectRoot(), "willnotbuild", "pom-java11-incompatible.xml", false);
       Assert.fail();
     } catch (VerificationException ex) {
       Assert.assertThat(

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -370,7 +370,7 @@ public class BuildImageMojoIntegrationTest {
       Assert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
-              "The base image uses Java 8, but project is using Java 11; perhaps you should "
+              "The base image uses Java 8, but project is using Java 11, perhaps you should "
                   + "configure a Java 11-compatible base image using the '<from><image>' "
                   + "parameter, or set maven-compiler-plugin's '<target>' or '<release>' version "
                   + "to 8 or below in your build configuration"));

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -370,7 +370,7 @@ public class BuildImageMojoIntegrationTest {
       Assert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
-              "The base image uses Java 8, but project is using Java 11, perhaps you should "
+              "Your project is using Java 11 but the base image is for Java 8, perhaps you should "
                   + "configure a Java 11-compatible base image using the '<from><image>' "
                   + "parameter, or set maven-compiler-plugin's '<target>' or '<release>' version "
                   + "to 8 or below in your build configuration"));

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -351,7 +351,7 @@ public class BuildImageMojoIntegrationTest {
 
     String targetImage = getGcrImageReference("simpleimage:maven");
     Assert.assertEquals(
-        "Hello, world. An argument.\nrw-r--r--\nrw-r--r--\nfoo\ncat\n",
+        "Hello, world. An argument.\n",
         buildAndRun(simpleTestProject.getProjectRoot(), targetImage, "pom-java11.xml", false));
   }
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -356,6 +356,27 @@ public class BuildImageMojoIntegrationTest {
   }
 
   @Test
+  public void testExecute_simpleWithIncomptiableJava11()
+      throws DigestException, IOException, InterruptedException {
+    Assume.assumeTrue(isJava11RuntimeOrHigher());
+
+    String targetImage = getGcrImageReference("simpleimage:maven");
+    try {
+      buildAndRun(
+          simpleTestProject.getProjectRoot(), targetImage, "pom-java11-incompatible.xml", false);
+      Assert.fail();
+    } catch (VerificationException ex) {
+      Assert.assertThat(
+          ex.getMessage(),
+          CoreMatchers.containsString(
+              "The base image uses Java 8, but project is using Java 11; perhaps you should "
+                  + "configure a Java 11-compatible base image using the '<from><image>' "
+                  + "parameter, or set maven-compiler-plugin's '<target>' or '<release>' version "
+                  + "to 8 or below in your build configuration"));
+    }
+  }
+
+  @Test
   public void testExecute_empty()
       throws InterruptedException, IOException, VerificationException, DigestException {
     String targetImage = getGcrImageReference("emptyimage:maven");

--- a/jib-maven-plugin/src/test/resources/maven/projects/default-target/pom.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/default-target/pom.xml
@@ -8,7 +8,6 @@
   <version>default-target-version</version>
 
   <properties>
-    <java.target.version>1.8</java.target.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>

--- a/jib-maven-plugin/src/test/resources/maven/projects/empty/pom.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/empty/pom.xml
@@ -8,7 +8,6 @@
   <version>1</version>
 
   <properties>
-    <java.target.version>1.8</java.target.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex-properties.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex-properties.xml
@@ -8,7 +8,6 @@
   <version>1</version>
 
   <properties>
-    <java.target.version>1.8</java.target.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex.xml
@@ -8,7 +8,6 @@
   <version>1</version>
 
   <properties>
-    <java.target.version>1.8</java.target.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-dockerclient.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-dockerclient.xml
@@ -1,4 +1,6 @@
-<project>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.test</groupId>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-java11-incompatible.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-java11-incompatible.xml
@@ -39,6 +39,9 @@
         <artifactId>jib-maven-plugin</artifactId>
         <version>${jib-maven-plugin.version}</version>
         <configuration>
+          <from>
+            <image>gcr.io/distroless/java</image>
+          </from>
           <to>
             <image>${_TARGET_IMAGE}</image>
           </to>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-java11.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-java11.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.test</groupId>
-  <artifactId>empty</artifactId>
+  <artifactId>my-artifact-id</artifactId>
   <version>1</version>
 
   <properties>
@@ -13,14 +13,24 @@
     <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>
   </properties>
 
+  <dependencies>
+    <dependency>
+      <groupId>com.test</groupId>
+      <artifactId>dependency</artifactId>
+      <version>1.0.0</version>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/libs/dependency-1.0.0.jar</systemPath>
+    </dependency>
+  </dependencies>
+
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>11</source>
+          <target>11</target>
         </configuration>
       </plugin>
 
@@ -28,14 +38,6 @@
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
         <version>${jib-maven-plugin.version}</version>
-        <configuration>
-          <to>
-            <image>${_TARGET_IMAGE}</image>
-          </to>
-          <container>
-            <user>myuser:mygroup</user>
-          </container>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-java11.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-java11.xml
@@ -38,6 +38,22 @@
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
         <version>${jib-maven-plugin.version}</version>
+        <configuration>
+          <to>
+            <image>${_TARGET_IMAGE}</image>
+          </to>
+          <container>
+            <args>An argument.</args>
+            <ports>
+              <port>1000/tcp</port>
+              <port>2000-2003/udp</port>
+            </ports>
+            <labels>
+              <key1>value1</key1>
+              <key2>value2</key2>
+            </labels>
+          </container>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-no-to-image.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-no-to-image.xml
@@ -10,7 +10,6 @@
   <name>Name not Usable as Image Reference</name>
   
   <properties>
-    <java.target.version>1.8</java.target.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom.xml
@@ -8,7 +8,6 @@
   <version>1</version>
 
   <properties>
-    <java.target.version>1.8</java.target.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>

--- a/jib-maven-plugin/src/test/resources/maven/projects/war_servlet25/pom-tomcat.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/war_servlet25/pom-tomcat.xml
@@ -9,7 +9,6 @@
   <packaging>war</packaging>
 
   <properties>
-    <java.target.version>1.8</java.target.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>

--- a/jib-maven-plugin/src/test/resources/maven/projects/war_servlet25/pom.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/war_servlet25/pom.xml
@@ -9,7 +9,6 @@
   <packaging>war</packaging>
 
   <properties>
-    <java.target.version>1.8</java.target.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/HelpfulSuggestions.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/HelpfulSuggestions.java
@@ -54,10 +54,25 @@ public class HelpfulSuggestions {
     return suggest(messagePrefix, "add a `mainClass` configuration to " + pluginName);
   }
 
-  public static String forDockerContextInsecureRecursiveDelete(
-      String messagePrefix, String directory) {
-    return suggest(
-        messagePrefix, "clear " + directory + " manually before creating the Docker context");
+  public static String forIncompatibleBaseImageJavaVesionForGradle(
+      int baseImageMajorJavaVersion, int projectMajorJavaVersion) {
+    return forIncompatibleBaseImageJavaVesion(
+        baseImageMajorJavaVersion,
+        projectMajorJavaVersion,
+        "using the 'jib.from.image' parameter, or set targetCompatibility = "
+            + baseImageMajorJavaVersion
+            + " or below");
+  }
+
+  public static String forIncompatibleBaseImageJavaVesionForMaven(
+      int baseImageMajorJavaVersion, int projectMajorJavaVersion) {
+    return forIncompatibleBaseImageJavaVesion(
+        baseImageMajorJavaVersion,
+        projectMajorJavaVersion,
+        "using the '<from><image>' parameter, or set maven-compiler-plugin's '<target>' or "
+            + "'<release>' version to "
+            + baseImageMajorJavaVersion
+            + " or below");
   }
 
   /**
@@ -67,6 +82,20 @@ public class HelpfulSuggestions {
    */
   public static String suggest(String messagePrefix, String suggestion) {
     return messagePrefix + ", perhaps you should " + suggestion;
+  }
+
+  private static String forIncompatibleBaseImageJavaVesion(
+      int baseImageMajorJavaVersion, int projectMajorJavaVersion, String parameterInstructions) {
+    return suggest(
+        "The base image uses Java "
+            + baseImageMajorJavaVersion
+            + ", but project is using Java "
+            + projectMajorJavaVersion,
+        "configure a Java "
+            + projectMajorJavaVersion
+            + "-compatible base image "
+            + parameterInstructions
+            + " in your build configuration");
   }
 
   private final String messagePrefix;

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/HelpfulSuggestions.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/HelpfulSuggestions.java
@@ -87,10 +87,10 @@ public class HelpfulSuggestions {
   private static String forIncompatibleBaseImageJavaVesion(
       int baseImageMajorJavaVersion, int projectMajorJavaVersion, String parameterInstructions) {
     return suggest(
-        "The base image uses Java "
-            + baseImageMajorJavaVersion
-            + ", but project is using Java "
-            + projectMajorJavaVersion,
+        "Your project is using Java "
+            + projectMajorJavaVersion
+            + " but the base image is for Java "
+            + baseImageMajorJavaVersion,
         "configure a Java "
             + projectMajorJavaVersion
             + "-compatible base image "

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/IncompatibleBaseImageJavaVersionException.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/IncompatibleBaseImageJavaVersionException.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.plugins.common;
+
+public class IncompatibleBaseImageJavaVersionException extends Exception {
+
+  private final int baseImageJavaMajorVersion;
+  private final int projectJavaMajorVersion;
+
+  public IncompatibleBaseImageJavaVersionException(
+      int baseImageJavaMajorVersion, int projectJavaMajorVersion) {
+    this.baseImageJavaMajorVersion = baseImageJavaMajorVersion;
+    this.projectJavaMajorVersion = projectJavaMajorVersion;
+  }
+
+  public int getBaseImageJavaMajorVersion() {
+    return baseImageJavaMajorVersion;
+  }
+
+  public int getProjectJavaMajorVersion() {
+    return projectJavaMajorVersion;
+  }
+}

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/IncompatibleBaseImageJavaVersionException.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/IncompatibleBaseImageJavaVersionException.java
@@ -18,20 +18,20 @@ package com.google.cloud.tools.jib.plugins.common;
 
 public class IncompatibleBaseImageJavaVersionException extends Exception {
 
-  private final int baseImageJavaMajorVersion;
-  private final int projectJavaMajorVersion;
+  private final int baseImageMajorJavaVersion;
+  private final int projectMajorJavaVersion;
 
   public IncompatibleBaseImageJavaVersionException(
-      int baseImageJavaMajorVersion, int projectJavaMajorVersion) {
-    this.baseImageJavaMajorVersion = baseImageJavaMajorVersion;
-    this.projectJavaMajorVersion = projectJavaMajorVersion;
+      int baseImageMajorJavaVersion, int projectMajorJavaVersion) {
+    this.baseImageMajorJavaVersion = baseImageMajorJavaVersion;
+    this.projectMajorJavaVersion = projectMajorJavaVersion;
   }
 
-  public int getBaseImageJavaMajorVersion() {
-    return baseImageJavaMajorVersion;
+  public int getBaseImageMajorJavaVersion() {
+    return baseImageMajorJavaVersion;
   }
 
-  public int getProjectJavaMajorVersion() {
-    return projectJavaMajorVersion;
+  public int getProjectMajorJavaVersion() {
+    return projectMajorJavaVersion;
   }
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/IncompatibleBaseImageJavaVersionException.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/IncompatibleBaseImageJavaVersionException.java
@@ -16,6 +16,11 @@
 
 package com.google.cloud.tools.jib.plugins.common;
 
+/**
+ * Exception when the Java version in the base image is incompatible with the Java version of the
+ * application to be containerized. For example, when the project is Java 11 but the base image is
+ * {@code gcr.io/distroless/java:8}.
+ */
 public class IncompatibleBaseImageJavaVersionException extends Exception {
 
   private final int baseImageMajorJavaVersion;

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -477,42 +477,41 @@ public class PluginConfigurationProcessor {
   }
 
   /**
-   * Checks whether or not the known default Java 8 distroless base image is being used. Checking
-   * against only images known to Java 8, the method may to return {@code false} for Java 8
-   * distroless unknown to it.
+   * Checks if the given image is a known Java 8 distroless image. Checking against only images
+   * known to Java 8, the method may to return {@code false} for Java 8 distroless unknown to it.
    *
-   * @param baseImage the configured base image
-   * @return {@code true} if the base image is equal to one of the known Java 8 distroless images,
-   *     else {@code false}
+   * @param imageReference the image reference
+   * @return {@code true} if the image is equal to one of the known Java 8 distroless images, else
+   *     {@code false}
    */
-  private static boolean isKnownDistrolessJava8Image(String baseImage) {
-    // TODO: drop "latest" and the likes once it no longer points to Java 8.
-    return baseImage.equals("gcr.io/distroless/java")
-        || baseImage.equals("gcr.io/distroless/java:latest")
-        || baseImage.equals("gcr.io/distroless/java:debug")
-        || baseImage.equals("gcr.io/distroless/java:8")
-        || baseImage.equals("gcr.io/distroless/java:8-debug")
-        || baseImage.equals("gcr.io/distroless/java/jetty")
-        || baseImage.equals("gcr.io/distroless/java/jetty:debug")
-        || baseImage.equals("gcr.io/distroless/java/jetty:java8")
-        || baseImage.equals("gcr.io/distroless/java/jetty:java8-debug");
+  private static boolean isKnownDistrolessJava8Image(String imageReference) {
+    // TODO: drop "latest", "debug", and the like once they no longer point to Java 8.
+    return imageReference.equals("gcr.io/distroless/java")
+        || imageReference.equals("gcr.io/distroless/java:latest")
+        || imageReference.equals("gcr.io/distroless/java:debug")
+        || imageReference.equals("gcr.io/distroless/java:8")
+        || imageReference.equals("gcr.io/distroless/java:8-debug")
+        || imageReference.equals("gcr.io/distroless/java/jetty")
+        || imageReference.equals("gcr.io/distroless/java/jetty:latest")
+        || imageReference.equals("gcr.io/distroless/java/jetty:debug")
+        || imageReference.equals("gcr.io/distroless/java/jetty:java8")
+        || imageReference.equals("gcr.io/distroless/java/jetty:java8-debug");
   }
 
   /**
-   * Checks whether or not the known default Java 11 distroless base image is being used. Checking
-   * against only images known to Java 11, the method may to return {@code false} for Java 11
-   * distroless unknown to it.
+   * Checks if the given image is a known Java 11 distroless image. Checking against only images
+   * known to Java 11, the method may to return {@code false} for Java 11 distroless unknown to it.
    *
-   * @param baseImage the configured base image
-   * @return {@code true} if the base image is equal to one of the known Java 11 distroless images,
-   *     else {@code false}
+   * @param imageReference the image reference
+   * @return {@code true} if the image is equal to one of the known Java 11 distroless images, else
+   *     {@code false}
    */
-  private static boolean isKnownDistrolessJava11Image(String baseImage) {
-    // TODO: add "latest" and the likes once it points to Java 11.
-    return baseImage.equals("gcr.io/distroless/java:11")
-        || baseImage.equals("gcr.io/distroless/java:11-debug")
-        || baseImage.equals("gcr.io/distroless/java/jetty:java11")
-        || baseImage.equals("gcr.io/distroless/java/jetty:java11-debug");
+  private static boolean isKnownDistrolessJava11Image(String imageReference) {
+    // TODO: add "latest", "debug", and the like to this list once they point to Java 11.
+    return imageReference.equals("gcr.io/distroless/java:11")
+        || imageReference.equals("gcr.io/distroless/java:11-debug")
+        || imageReference.equals("gcr.io/distroless/java/jetty:java11")
+        || imageReference.equals("gcr.io/distroless/java/jetty:java11-debug");
   }
 
   private final JibContainerBuilder jibContainerBuilder;

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -55,45 +55,6 @@ import javax.annotation.Nullable;
  */
 public class PluginConfigurationProcessor {
 
-  /**
-   * Checks whether or not the known default Java 8 distroless base image is being used. Checking
-   * against only images known to Java 8, the method may to return {@code false} for Java 8
-   * distroless unknown to it.
-   *
-   * @param baseImageConfiguration the configured base image
-   * @return {@code true} if the base image is equal to one of the known Java 8 distroless images,
-   *     else {@code false}
-   */
-  private static boolean knownDistrolessJava8Image(String baseImageConfiguration) {
-    // TODO: drop "latest" and the likes once it no longer points to Java 8.
-    return baseImageConfiguration.equals("gcr.io/distroless/java")
-        || baseImageConfiguration.equals("gcr.io/distroless/java:latest")
-        || baseImageConfiguration.equals("gcr.io/distroless/java:debug")
-        || baseImageConfiguration.equals("gcr.io/distroless/java:8")
-        || baseImageConfiguration.equals("gcr.io/distroless/java:8-debug")
-        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty")
-        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:debug")
-        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java8")
-        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java8-debug");
-  }
-
-  /**
-   * Checks whether or not the known default Java 11 distroless base image is being used. Checking
-   * against only images known to Java 11, the method may to return {@code false} for Java 11
-   * distroless unknown to it.
-   *
-   * @param baseImageConfiguration the configured base image
-   * @return {@code true} if the base image is equal to one of the known Java 11 distroless images,
-   *     else {@code false}
-   */
-  private static boolean knownDistrolessJava11Image(String baseImageConfiguration) {
-    // TODO: add "latest" and the likes once it points to Java 11.
-    return baseImageConfiguration.equals("gcr.io/distroless/java:11")
-        || baseImageConfiguration.equals("gcr.io/distroless/java:11-debug")
-        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java11")
-        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java11-debug");
-  }
-
   public static PluginConfigurationProcessor processCommonConfigurationForDockerDaemonImage(
       RawConfiguration rawConfiguration,
       InferredAuthProvider inferredAuthProvider,
@@ -510,6 +471,45 @@ public class PluginConfigurationProcessor {
       return Paths.get(System.getProperty(property));
     }
     return defaultPath;
+  }
+
+  /**
+   * Checks whether or not the known default Java 8 distroless base image is being used. Checking
+   * against only images known to Java 8, the method may to return {@code false} for Java 8
+   * distroless unknown to it.
+   *
+   * @param baseImageConfiguration the configured base image
+   * @return {@code true} if the base image is equal to one of the known Java 8 distroless images,
+   *     else {@code false}
+   */
+  private static boolean knownDistrolessJava8Image(String baseImageConfiguration) {
+    // TODO: drop "latest" and the likes once it no longer points to Java 8.
+    return baseImageConfiguration.equals("gcr.io/distroless/java")
+        || baseImageConfiguration.equals("gcr.io/distroless/java:latest")
+        || baseImageConfiguration.equals("gcr.io/distroless/java:debug")
+        || baseImageConfiguration.equals("gcr.io/distroless/java:8")
+        || baseImageConfiguration.equals("gcr.io/distroless/java:8-debug")
+        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty")
+        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:debug")
+        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java8")
+        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java8-debug");
+  }
+
+  /**
+   * Checks whether or not the known default Java 11 distroless base image is being used. Checking
+   * against only images known to Java 11, the method may to return {@code false} for Java 11
+   * distroless unknown to it.
+   *
+   * @param baseImageConfiguration the configured base image
+   * @return {@code true} if the base image is equal to one of the known Java 11 distroless images,
+   *     else {@code false}
+   */
+  private static boolean knownDistrolessJava11Image(String baseImageConfiguration) {
+    // TODO: add "latest" and the likes once it points to Java 11.
+    return baseImageConfiguration.equals("gcr.io/distroless/java:11")
+        || baseImageConfiguration.equals("gcr.io/distroless/java:11-debug")
+        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java11")
+        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java11-debug");
   }
 
   private final JibContainerBuilder jibContainerBuilder;

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -273,7 +273,8 @@ public class PluginConfigurationProcessor {
    * @param rawConfiguration raw configuration data
    * @param projectProperties used for providing additional information
    * @return the base image
-   * @throws IncompatibleBaseImageJavaVersionException
+   * @throws IncompatibleBaseImageJavaVersionException when the Java version in the base image is
+   *     incompatible with the Java version of the application to be containerized
    */
   @VisibleForTesting
   static String getBaseImage(RawConfiguration rawConfiguration, ProjectProperties projectProperties)
@@ -283,9 +284,10 @@ public class PluginConfigurationProcessor {
     if (rawConfiguration.getFromImage().isPresent()) {
       String baseImage = rawConfiguration.getFromImage().get();
 
-      if (knownDistrolessJava8Image(baseImage) && javaVersion > 8) {
+      if (isKnownDistrolessJava8Image(baseImage) && javaVersion > 8) {
         throw new IncompatibleBaseImageJavaVersionException(8, javaVersion);
-      } else if (knownDistrolessJava11Image(baseImage) && javaVersion > 11) {
+      }
+      if (isKnownDistrolessJava11Image(baseImage) && javaVersion > 11) {
         throw new IncompatibleBaseImageJavaVersionException(11, javaVersion);
       }
       return baseImage;
@@ -294,13 +296,14 @@ public class PluginConfigurationProcessor {
     // Base image not configured; auto-pick Distroless.
     if (projectProperties.isWarProject()) {
       return "gcr.io/distroless/java/jetty";
-    } else if (javaVersion <= 8) {
-      return "gcr.io/distroless/java:8";
-    } else if (javaVersion <= 11) {
-      return "gcr.io/distroless/java:11";
-    } else {
-      throw new IncompatibleBaseImageJavaVersionException(11, javaVersion);
     }
+    if (javaVersion <= 8) {
+      return "gcr.io/distroless/java:8";
+    }
+    if (javaVersion <= 11) {
+      return "gcr.io/distroless/java:11";
+    }
+    throw new IncompatibleBaseImageJavaVersionException(11, javaVersion);
   }
 
   /**
@@ -478,21 +481,21 @@ public class PluginConfigurationProcessor {
    * against only images known to Java 8, the method may to return {@code false} for Java 8
    * distroless unknown to it.
    *
-   * @param baseImageConfiguration the configured base image
+   * @param baseImage the configured base image
    * @return {@code true} if the base image is equal to one of the known Java 8 distroless images,
    *     else {@code false}
    */
-  private static boolean knownDistrolessJava8Image(String baseImageConfiguration) {
+  private static boolean isKnownDistrolessJava8Image(String baseImage) {
     // TODO: drop "latest" and the likes once it no longer points to Java 8.
-    return baseImageConfiguration.equals("gcr.io/distroless/java")
-        || baseImageConfiguration.equals("gcr.io/distroless/java:latest")
-        || baseImageConfiguration.equals("gcr.io/distroless/java:debug")
-        || baseImageConfiguration.equals("gcr.io/distroless/java:8")
-        || baseImageConfiguration.equals("gcr.io/distroless/java:8-debug")
-        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty")
-        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:debug")
-        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java8")
-        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java8-debug");
+    return baseImage.equals("gcr.io/distroless/java")
+        || baseImage.equals("gcr.io/distroless/java:latest")
+        || baseImage.equals("gcr.io/distroless/java:debug")
+        || baseImage.equals("gcr.io/distroless/java:8")
+        || baseImage.equals("gcr.io/distroless/java:8-debug")
+        || baseImage.equals("gcr.io/distroless/java/jetty")
+        || baseImage.equals("gcr.io/distroless/java/jetty:debug")
+        || baseImage.equals("gcr.io/distroless/java/jetty:java8")
+        || baseImage.equals("gcr.io/distroless/java/jetty:java8-debug");
   }
 
   /**
@@ -500,16 +503,16 @@ public class PluginConfigurationProcessor {
    * against only images known to Java 11, the method may to return {@code false} for Java 11
    * distroless unknown to it.
    *
-   * @param baseImageConfiguration the configured base image
+   * @param baseImage the configured base image
    * @return {@code true} if the base image is equal to one of the known Java 11 distroless images,
    *     else {@code false}
    */
-  private static boolean knownDistrolessJava11Image(String baseImageConfiguration) {
+  private static boolean isKnownDistrolessJava11Image(String baseImage) {
     // TODO: add "latest" and the likes once it points to Java 11.
-    return baseImageConfiguration.equals("gcr.io/distroless/java:11")
-        || baseImageConfiguration.equals("gcr.io/distroless/java:11-debug")
-        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java11")
-        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java11-debug");
+    return baseImage.equals("gcr.io/distroless/java:11")
+        || baseImage.equals("gcr.io/distroless/java:11-debug")
+        || baseImage.equals("gcr.io/distroless/java/jetty:java11")
+        || baseImage.equals("gcr.io/distroless/java/jetty:java11-debug");
   }
 
   private final JibContainerBuilder jibContainerBuilder;

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -64,13 +64,15 @@ public class PluginConfigurationProcessor {
    * @return {@code true} if the base image is equal to one of the known Java 8 distroless images,
    *     else {@code false}
    */
-  public static boolean knownDistrolessJava8Image(String baseImageConfiguration) {
+  private static boolean knownDistrolessJava8Image(String baseImageConfiguration) {
     // TODO: drop "latest" and the likes once it no longer points to Java 8.
     return baseImageConfiguration.equals("gcr.io/distroless/java")
         || baseImageConfiguration.equals("gcr.io/distroless/java:latest")
         || baseImageConfiguration.equals("gcr.io/distroless/java:debug")
         || baseImageConfiguration.equals("gcr.io/distroless/java:8")
         || baseImageConfiguration.equals("gcr.io/distroless/java:8-debug")
+        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty")
+        || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:debug")
         || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java8")
         || baseImageConfiguration.equals("gcr.io/distroless/java/jetty:java8-debug");
   }
@@ -84,7 +86,7 @@ public class PluginConfigurationProcessor {
    * @return {@code true} if the base image is equal to one of the known Java 11 distroless images,
    *     else {@code false}
    */
-  public static boolean knownDistrolessJava11Image(String baseImageConfiguration) {
+  private static boolean knownDistrolessJava11Image(String baseImageConfiguration) {
     // TODO: add "latest" and the likes once it points to Java 11.
     return baseImageConfiguration.equals("gcr.io/distroless/java:11")
         || baseImageConfiguration.equals("gcr.io/distroless/java:11-debug")

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
@@ -58,4 +58,6 @@ public interface ProjectProperties {
   String getName();
 
   String getVersion();
+
+  int getMajorJavaVersion();
 }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/HelpfulSuggestionsTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/HelpfulSuggestionsTest.java
@@ -71,13 +71,13 @@ public class HelpfulSuggestionsTest {
         HelpfulSuggestions.forToNotConfigured(
             "messagePrefix", "parameter", "buildFile", "command"));
     Assert.assertEquals(
-        "The base image uses Java 8, but project is using Java 11, perhaps you should "
+        "Your project is using Java 11 but the base image is for Java 8, perhaps you should "
             + "configure a Java 11-compatible base image using the 'jib.from.image' "
             + "parameter, or set targetCompatibility = 8 or below in your build "
             + "configuration",
         HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(8, 11));
     Assert.assertEquals(
-        "The base image uses Java 8, but project is using Java 11, perhaps you should "
+        "Your project is using Java 11 but the base image is for Java 8, perhaps you should "
             + "configure a Java 11-compatible base image using the '<from><image>' "
             + "parameter, or set maven-compiler-plugin's '<target>' or '<release>' version "
             + "to 8 or below in your build configuration",

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/HelpfulSuggestionsTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/HelpfulSuggestionsTest.java
@@ -64,15 +64,24 @@ public class HelpfulSuggestionsTest {
         "messagePrefix, perhaps you should make sure your credentials for 'targetregistry' are set up correctly",
         TEST_HELPFUL_SUGGESTIONS.forNoCredentialsDefined("targetregistry", "targetrepository"));
     Assert.assertEquals(
-        "messagePrefix, perhaps you should clear directory manually before creating the Docker context",
-        HelpfulSuggestions.forDockerContextInsecureRecursiveDelete("messagePrefix", "directory"));
-    Assert.assertEquals(
         "messagePrefix, perhaps you should add a `mainClass` configuration to plugin",
         HelpfulSuggestions.forMainClassNotFound("messagePrefix", "plugin"));
     Assert.assertEquals(
         "messagePrefix, perhaps you should add a parameter configuration parameter to your buildFile or set the parameter via the commandline (e.g. 'command').",
         HelpfulSuggestions.forToNotConfigured(
             "messagePrefix", "parameter", "buildFile", "command"));
+    Assert.assertEquals(
+        "The base image uses Java 8, but project is using Java 11, perhaps you should "
+            + "configure a Java 11-compatible base image using the 'jib.from.image' "
+            + "parameter, or set targetCompatibility = 8 or below in your build "
+            + "configuration",
+        HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForGradle(8, 11));
+    Assert.assertEquals(
+        "The base image uses Java 8, but project is using Java 11, perhaps you should "
+            + "configure a Java 11-compatible base image using the '<from><image>' "
+            + "parameter, or set maven-compiler-plugin's '<target>' or '<release>' version "
+            + "to 8 or below in your build configuration",
+        HelpfulSuggestions.forIncompatibleBaseImageJavaVesionForMaven(8, 11));
     Assert.assertEquals("messagePrefix", TEST_HELPFUL_SUGGESTIONS.none());
     Assert.assertEquals(
         "messagePrefix, perhaps you should use a registry that supports HTTPS so credentials can be sent safely, or set the 'sendCredentialsOverHttp' system property to true",

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -434,6 +434,97 @@ public class PluginConfigurationProcessorTest {
   }
 
   @Test
+  public void testGetBaseImage_chooseJava8Distroless()
+      throws IncompatibleBaseImageJavaVersionException {
+    Mockito.when(projectProperties.getMajorJavaVersion()).thenReturn(6);
+    Assert.assertEquals(
+        "gcr.io/distroless/java:8",
+        PluginConfigurationProcessor.getBaseImage(rawConfiguration, projectProperties));
+
+    Mockito.when(projectProperties.getMajorJavaVersion()).thenReturn(7);
+    Assert.assertEquals(
+        "gcr.io/distroless/java:8",
+        PluginConfigurationProcessor.getBaseImage(rawConfiguration, projectProperties));
+
+    Mockito.when(projectProperties.getMajorJavaVersion()).thenReturn(8);
+    Assert.assertEquals(
+        "gcr.io/distroless/java:8",
+        PluginConfigurationProcessor.getBaseImage(rawConfiguration, projectProperties));
+  }
+
+  @Test
+  public void testGetBaseImage_chooseJava11Distroless()
+      throws IncompatibleBaseImageJavaVersionException {
+    Mockito.when(projectProperties.getMajorJavaVersion()).thenReturn(9);
+    Assert.assertEquals(
+        "gcr.io/distroless/java:11",
+        PluginConfigurationProcessor.getBaseImage(rawConfiguration, projectProperties));
+
+    Mockito.when(projectProperties.getMajorJavaVersion()).thenReturn(10);
+    Assert.assertEquals(
+        "gcr.io/distroless/java:11",
+        PluginConfigurationProcessor.getBaseImage(rawConfiguration, projectProperties));
+
+    Mockito.when(projectProperties.getMajorJavaVersion()).thenReturn(11);
+    Assert.assertEquals(
+        "gcr.io/distroless/java:11",
+        PluginConfigurationProcessor.getBaseImage(rawConfiguration, projectProperties));
+  }
+
+  @Test
+  public void testGetBaseImage_projectHigherThanJava11() {
+    Mockito.when(projectProperties.getMajorJavaVersion()).thenReturn(12);
+
+    try {
+      PluginConfigurationProcessor.getBaseImage(rawConfiguration, projectProperties);
+      Assert.fail();
+    } catch (IncompatibleBaseImageJavaVersionException ex) {
+      Assert.assertEquals(11, ex.getBaseImageMajorJavaVersion());
+      Assert.assertEquals(12, ex.getProjectMajorJavaVersion());
+    }
+  }
+
+  @Test
+  public void testGetBaseImage_incompatibleJava8BaseImage() {
+    Mockito.when(projectProperties.getMajorJavaVersion()).thenReturn(11);
+
+    Mockito.when(rawConfiguration.getFromImage())
+        .thenReturn(Optional.of("gcr.io/distroless/java:8"));
+    try {
+      PluginConfigurationProcessor.getBaseImage(rawConfiguration, projectProperties);
+      Assert.fail();
+    } catch (IncompatibleBaseImageJavaVersionException ex) {
+      Assert.assertEquals(8, ex.getBaseImageMajorJavaVersion());
+      Assert.assertEquals(11, ex.getProjectMajorJavaVersion());
+    }
+
+    Mockito.when(rawConfiguration.getFromImage())
+        .thenReturn(Optional.of("gcr.io/distroless/java:latest"));
+    try {
+      PluginConfigurationProcessor.getBaseImage(rawConfiguration, projectProperties);
+      Assert.fail();
+    } catch (IncompatibleBaseImageJavaVersionException ex) {
+      Assert.assertEquals(8, ex.getBaseImageMajorJavaVersion());
+      Assert.assertEquals(11, ex.getProjectMajorJavaVersion());
+    }
+  }
+
+  @Test
+  public void testGetBaseImage_incompatibleJava11BaseImage() {
+    Mockito.when(projectProperties.getMajorJavaVersion()).thenReturn(15);
+
+    Mockito.when(rawConfiguration.getFromImage())
+        .thenReturn(Optional.of("gcr.io/distroless/java:11"));
+    try {
+      PluginConfigurationProcessor.getBaseImage(rawConfiguration, projectProperties);
+      Assert.fail();
+    } catch (IncompatibleBaseImageJavaVersionException ex) {
+      Assert.assertEquals(11, ex.getBaseImageMajorJavaVersion());
+      Assert.assertEquals(15, ex.getProjectMajorJavaVersion());
+    }
+  }
+
+  @Test
   public void testGetBaseImage_defaultNonWarPackaging()
       throws IncompatibleBaseImageJavaVersionException {
     Mockito.when(projectProperties.isWarProject()).thenReturn(false);

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -92,7 +92,8 @@ public class PluginConfigurationProcessorTest {
   public void testPluginConfigurationProcessor_defaults()
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException,
           MainClassInferenceException, InvalidAppRootException, InferredAuthRetrievalException,
-          InvalidWorkingDirectoryException, InvalidContainerVolumeException {
+          InvalidWorkingDirectoryException, InvalidContainerVolumeException,
+          IncompatibleBaseImageJavaVersionException {
     PluginConfigurationProcessor processor = createPluginConfigurationProcessor();
     BuildConfiguration buildConfiguration =
         getBuildConfiguration(processor.getJibContainerBuilder());
@@ -114,7 +115,8 @@ public class PluginConfigurationProcessorTest {
   public void testPluginConfigurationProcessor_cacheDirectorySystemProperties()
       throws InferredAuthRetrievalException, InvalidContainerVolumeException,
           MainClassInferenceException, InvalidAppRootException, IOException,
-          InvalidWorkingDirectoryException, InvalidImageReferenceException {
+          InvalidWorkingDirectoryException, InvalidImageReferenceException,
+          IncompatibleBaseImageJavaVersionException {
     System.setProperty(PropertyNames.BASE_IMAGE_CACHE, "new/base/cache");
     System.setProperty(PropertyNames.APPLICATION_CACHE, "/new/application/cache");
 
@@ -131,7 +133,7 @@ public class PluginConfigurationProcessorTest {
   public void testPluginConfigurationProcessor_warProjectBaseImage()
       throws InvalidImageReferenceException, MainClassInferenceException, InvalidAppRootException,
           InferredAuthRetrievalException, IOException, InvalidWorkingDirectoryException,
-          InvalidContainerVolumeException {
+          InvalidContainerVolumeException, IncompatibleBaseImageJavaVersionException {
     Mockito.when(projectProperties.isWarProject()).thenReturn(true);
 
     PluginConfigurationProcessor processor = createPluginConfigurationProcessor();
@@ -146,7 +148,8 @@ public class PluginConfigurationProcessorTest {
   public void testEntrypoint()
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException,
           MainClassInferenceException, InvalidAppRootException, InferredAuthRetrievalException,
-          InvalidWorkingDirectoryException, InvalidContainerVolumeException {
+          InvalidWorkingDirectoryException, InvalidContainerVolumeException,
+          IncompatibleBaseImageJavaVersionException {
     Mockito.when(rawConfiguration.getEntrypoint())
         .thenReturn(Optional.of(Arrays.asList("custom", "entrypoint")));
 
@@ -185,7 +188,8 @@ public class PluginConfigurationProcessorTest {
   public void testEntrypoint_defaultWarPackaging()
       throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException,
           MainClassInferenceException, InvalidAppRootException, InferredAuthRetrievalException,
-          InvalidWorkingDirectoryException, InvalidContainerVolumeException {
+          InvalidWorkingDirectoryException, InvalidContainerVolumeException,
+          IncompatibleBaseImageJavaVersionException {
     Mockito.when(rawConfiguration.getEntrypoint()).thenReturn(Optional.empty());
     Mockito.when(projectProperties.isWarProject()).thenReturn(true);
 
@@ -202,7 +206,8 @@ public class PluginConfigurationProcessorTest {
   public void testEntrypoint_defaulNonWarPackaging()
       throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException,
           MainClassInferenceException, InvalidAppRootException, InferredAuthRetrievalException,
-          InvalidWorkingDirectoryException, InvalidContainerVolumeException {
+          InvalidWorkingDirectoryException, InvalidContainerVolumeException,
+          IncompatibleBaseImageJavaVersionException {
     Mockito.when(rawConfiguration.getEntrypoint()).thenReturn(Optional.empty());
     Mockito.when(projectProperties.isWarProject()).thenReturn(false);
 
@@ -223,7 +228,8 @@ public class PluginConfigurationProcessorTest {
   public void testUser()
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException,
           MainClassInferenceException, InvalidAppRootException, InferredAuthRetrievalException,
-          InvalidWorkingDirectoryException, InvalidContainerVolumeException {
+          InvalidWorkingDirectoryException, InvalidContainerVolumeException,
+          IncompatibleBaseImageJavaVersionException {
     Mockito.when(rawConfiguration.getUser()).thenReturn(Optional.of("customUser"));
 
     PluginConfigurationProcessor processor = createPluginConfigurationProcessor();
@@ -238,7 +244,8 @@ public class PluginConfigurationProcessorTest {
   public void testUser_null()
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException,
           MainClassInferenceException, InvalidAppRootException, InferredAuthRetrievalException,
-          InvalidWorkingDirectoryException, InvalidContainerVolumeException {
+          InvalidWorkingDirectoryException, InvalidContainerVolumeException,
+          IncompatibleBaseImageJavaVersionException {
     PluginConfigurationProcessor processor = createPluginConfigurationProcessor();
     BuildConfiguration buildConfiguration =
         getBuildConfiguration(processor.getJibContainerBuilder());
@@ -251,7 +258,8 @@ public class PluginConfigurationProcessorTest {
   public void testEntrypoint_warningOnJvmFlags()
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException,
           MainClassInferenceException, InvalidAppRootException, InferredAuthRetrievalException,
-          InvalidWorkingDirectoryException, InvalidContainerVolumeException {
+          InvalidWorkingDirectoryException, InvalidContainerVolumeException,
+          IncompatibleBaseImageJavaVersionException {
     Mockito.when(rawConfiguration.getEntrypoint())
         .thenReturn(Optional.of(Arrays.asList("custom", "entrypoint")));
     Mockito.when(rawConfiguration.getJvmFlags()).thenReturn(Collections.singletonList("jvmFlag"));
@@ -272,7 +280,8 @@ public class PluginConfigurationProcessorTest {
   public void testEntrypoint_warningOnMainclass()
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException,
           MainClassInferenceException, InvalidAppRootException, InferredAuthRetrievalException,
-          InvalidWorkingDirectoryException, InvalidContainerVolumeException {
+          InvalidWorkingDirectoryException, InvalidContainerVolumeException,
+          IncompatibleBaseImageJavaVersionException {
     Mockito.when(rawConfiguration.getEntrypoint())
         .thenReturn(Optional.of(Arrays.asList("custom", "entrypoint")));
     Mockito.when(rawConfiguration.getMainClass()).thenReturn(Optional.of("java.util.Object"));
@@ -293,7 +302,8 @@ public class PluginConfigurationProcessorTest {
   public void testEntrypointClasspath_nonDefaultAppRoot()
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException,
           MainClassInferenceException, InvalidAppRootException, InferredAuthRetrievalException,
-          InvalidWorkingDirectoryException, InvalidContainerVolumeException {
+          InvalidWorkingDirectoryException, InvalidContainerVolumeException,
+          IncompatibleBaseImageJavaVersionException {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("/my/app");
 
     PluginConfigurationProcessor processor = createPluginConfigurationProcessor();
@@ -315,7 +325,8 @@ public class PluginConfigurationProcessorTest {
   public void testWebAppEntrypoint_inheritedFromBaseImage()
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException,
           MainClassInferenceException, InvalidAppRootException, InferredAuthRetrievalException,
-          InvalidWorkingDirectoryException, InvalidContainerVolumeException {
+          InvalidWorkingDirectoryException, InvalidContainerVolumeException,
+          IncompatibleBaseImageJavaVersionException {
     Mockito.when(projectProperties.isWarProject()).thenReturn(true);
 
     PluginConfigurationProcessor processor = createPluginConfigurationProcessor();
@@ -423,16 +434,18 @@ public class PluginConfigurationProcessorTest {
   }
 
   @Test
-  public void testGetBaseImage_defaultNonWarPackaging() {
+  public void testGetBaseImage_defaultNonWarPackaging()
+      throws IncompatibleBaseImageJavaVersionException {
     Mockito.when(projectProperties.isWarProject()).thenReturn(false);
 
     Assert.assertEquals(
-        "gcr.io/distroless/java",
+        "gcr.io/distroless/java:8",
         PluginConfigurationProcessor.getBaseImage(rawConfiguration, projectProperties));
   }
 
   @Test
-  public void testGetBaseImage_defaultWarProject() {
+  public void testGetBaseImage_defaultWarProject()
+      throws IncompatibleBaseImageJavaVersionException {
     Mockito.when(projectProperties.isWarProject()).thenReturn(true);
 
     Assert.assertEquals(
@@ -441,7 +454,7 @@ public class PluginConfigurationProcessorTest {
   }
 
   @Test
-  public void testGetBaseImage_nonDefault() {
+  public void testGetBaseImage_nonDefault() throws IncompatibleBaseImageJavaVersionException {
     Mockito.when(rawConfiguration.getFromImage()).thenReturn(Optional.of("tomcat"));
 
     Assert.assertEquals(
@@ -473,7 +486,7 @@ public class PluginConfigurationProcessorTest {
   private PluginConfigurationProcessor createPluginConfigurationProcessor()
       throws InvalidImageReferenceException, MainClassInferenceException, InvalidAppRootException,
           InferredAuthRetrievalException, IOException, InvalidWorkingDirectoryException,
-          InvalidContainerVolumeException {
+          InvalidContainerVolumeException, IncompatibleBaseImageJavaVersionException {
     return PluginConfigurationProcessor.processCommonConfiguration(
         rawConfiguration,
         ignored -> Optional.empty(),


### PR DESCRIPTION
Fixes #1279.

I've spent a lot of time contemplating where would be the ideal place to do the validation if the user is using an incompatible base image. I ended up doing the check in the place where we have the logic to choose the base image, because otherwise, I thought we would be prone to miss updating both the image-choosing logic and the validation logic in a synchronized manner in the future when, e.g., Java 15 is introduced. That resulted in throwing an "incompatible base image" exception from `PluginConfigurationProgressor.getBaseImage()`.