### PR TITLE
Add _jibSkaffoldFilesV2 task

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.gradle;
+
+import com.google.cloud.tools.jib.plugins.common.SkaffoldFilesOutput;
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ProjectDependency;
+import org.gradle.api.artifacts.PublishArtifact;
+import org.gradle.api.initialization.Settings;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * Print out changing source dependencies on a project.
+ *
+ * <p>Expected use: {@code ./gradlew _jibSkaffoldFiles -q} or {@code ./gradlew
+ * :<subproject>:_jibSkaffoldFiles -q}
+ */
+public class FilesTaskV2 extends DefaultTask {
+
+  private final SkaffoldFilesOutput skaffoldFilesOutput = new SkaffoldFilesOutput();
+
+  @Nullable private JibExtension jibExtension;
+
+  public FilesTaskV2 setJibExtension(JibExtension jibExtension) {
+    this.jibExtension = jibExtension;
+    return this;
+  }
+
+  @TaskAction
+  public void listFiles() throws IOException {
+    Preconditions.checkNotNull(jibExtension);
+    Project project = getProject();
+
+    // If this is not the root project, add the root project's build.gradle and settings.gradle
+    if (project != project.getRootProject()) {
+      addGradleFiles(project.getRootProject());
+    }
+
+    addProjectFiles(project);
+
+    // Add extra layer
+    if (Files.exists(jibExtension.getExtraDirectory().getPath())) {
+      skaffoldFilesOutput.addInput(jibExtension.getExtraDirectory().getPath());
+    }
+
+    // Find project dependencies
+    Set<ProjectDependency> projectDependencies = findProjectDependencies(project);
+
+    Set<File> projectDependencyJars = new HashSet<>();
+    for (ProjectDependency projectDependency : projectDependencies) {
+      addProjectFiles(projectDependency.getDependencyProject());
+
+      // Keep track of project dependency jars for filtering out later
+      String configurationName = projectDependency.getTargetConfiguration();
+      if (configurationName == null) {
+        configurationName = "default";
+      }
+      Project dependencyProject = projectDependency.getDependencyProject();
+      for (Configuration targetConfiguration :
+          dependencyProject.getConfigurations().getByName(configurationName).getHierarchy()) {
+        for (PublishArtifact artifact : targetConfiguration.getArtifacts()) {
+          projectDependencyJars.add(artifact.getFile());
+        }
+      }
+    }
+
+    // Add SNAPSHOT, non-project dependency jars
+    for (File file : project.getConfigurations().getByName("runtime")) {
+      if (!projectDependencyJars.contains(file) && file.toString().contains("SNAPSHOT")) {
+        skaffoldFilesOutput.addInput(file.toPath());
+        projectDependencyJars.add(file); // Add to set to avoid printing the same files twice
+      }
+    }
+
+    // Print files
+    System.out.println(skaffoldFilesOutput.getJsonString());
+  }
+
+  /**
+   * Prints the locations of a project's build.gradle, settings.gradle, and gradle.properties.
+   *
+   * @param project the project
+   */
+  private void addGradleFiles(Project project) {
+    Path projectPath = project.getProjectDir().toPath();
+
+    // Print build.gradle
+    skaffoldFilesOutput.addBuild(project.getBuildFile().toPath());
+
+    // Print settings.gradle
+    if (project.getGradle().getStartParameter().getSettingsFile() != null) {
+      skaffoldFilesOutput.addBuild(
+          project.getGradle().getStartParameter().getSettingsFile().toPath());
+    } else if (Files.exists(projectPath.resolve(Settings.DEFAULT_SETTINGS_FILE))) {
+      skaffoldFilesOutput.addBuild(projectPath.resolve(Settings.DEFAULT_SETTINGS_FILE));
+    }
+
+    // Print gradle.properties
+    if (Files.exists(projectPath.resolve("gradle.properties"))) {
+      skaffoldFilesOutput.addBuild(projectPath.resolve("gradle.properties"));
+    }
+  }
+
+  /**
+   * Prints build files, sources, and resources associated with a project.
+   *
+   * @param project the project
+   */
+  private void addProjectFiles(Project project) {
+    JavaPluginConvention javaConvention =
+        project.getConvention().getPlugin(JavaPluginConvention.class);
+    SourceSet mainSourceSet =
+        javaConvention.getSourceSets().findByName(SourceSet.MAIN_SOURCE_SET_NAME);
+    if (mainSourceSet == null) {
+      return;
+    }
+
+    // Print build config, settings, etc.
+    addGradleFiles(project);
+
+    // Print sources + resources
+    mainSourceSet
+        .getAllSource()
+        .getSourceDirectories()
+        .forEach(
+            sourceDirectory -> {
+              if (sourceDirectory.exists()) {
+                skaffoldFilesOutput.addInput(sourceDirectory.toPath());
+              }
+            });
+  }
+
+  /**
+   * Collects a project's project dependencies, including all transitive project dependencies.
+   *
+   * @param project the project to find the project dependencies for
+   * @return the set of project dependencies
+   */
+  private Set<ProjectDependency> findProjectDependencies(Project project) {
+    Set<ProjectDependency> projectDependencies = new HashSet<>();
+    Deque<Project> projects = new ArrayDeque<>();
+    projects.push(project);
+
+    while (!projects.isEmpty()) {
+      Project currentProject = projects.pop();
+
+      // Search through all dependencies
+      for (Configuration configuration :
+          currentProject.getConfigurations().getByName("runtime").getHierarchy()) {
+        for (Dependency dependency : configuration.getDependencies()) {
+          if (dependency instanceof ProjectDependency) {
+            // If this is a project dependency, save it
+            ProjectDependency projectDependency = (ProjectDependency) dependency;
+            if (!projectDependencies.contains(projectDependency)) {
+              projects.push(projectDependency.getDependencyProject());
+              projectDependencies.add(projectDependency);
+            }
+          }
+        }
+      }
+    }
+    return projectDependencies;
+  }
+}

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
@@ -136,27 +136,25 @@ public class FilesTaskV2 extends DefaultTask {
    * @param project the project
    */
   private void addProjectFiles(Project project) {
+    // Add build config, settings, etc.
+    addGradleFiles(project);
+
+    // Add sources + resources
     JavaPluginConvention javaConvention =
         project.getConvention().getPlugin(JavaPluginConvention.class);
     SourceSet mainSourceSet =
         javaConvention.getSourceSets().findByName(SourceSet.MAIN_SOURCE_SET_NAME);
-    if (mainSourceSet == null) {
-      return;
+    if (mainSourceSet != null) {
+      mainSourceSet
+          .getAllSource()
+          .getSourceDirectories()
+          .forEach(
+              sourceDirectory -> {
+                if (sourceDirectory.exists()) {
+                  skaffoldFilesOutput.addInput(sourceDirectory.toPath());
+                }
+              });
     }
-
-    // Print build config, settings, etc.
-    addGradleFiles(project);
-
-    // Print sources + resources
-    mainSourceSet
-        .getAllSource()
-        .getSourceDirectories()
-        .forEach(
-            sourceDirectory -> {
-              if (sourceDirectory.exists()) {
-                skaffoldFilesOutput.addInput(sourceDirectory.toPath());
-              }
-            });
   }
 
   /**

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC.
+ * Copyright 2019 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
@@ -39,7 +39,7 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskAction;
 
 /**
- * Print out changing source dependencies on a project.
+ * Prints out changing source dependencies on a project.
  *
  * <p>Expected use: {@code ./gradlew _jibSkaffoldFiles -q} or {@code ./gradlew
  * :<subproject>:_jibSkaffoldFiles -q}
@@ -106,17 +106,17 @@ public class FilesTaskV2 extends DefaultTask {
   }
 
   /**
-   * Prints the locations of a project's build.gradle, settings.gradle, and gradle.properties.
+   * Adds the locations of a project's build.gradle, settings.gradle, and gradle.properties.
    *
    * @param project the project
    */
   private void addGradleFiles(Project project) {
     Path projectPath = project.getProjectDir().toPath();
 
-    // Print build.gradle
+    // Add build.gradle
     skaffoldFilesOutput.addBuild(project.getBuildFile().toPath());
 
-    // Print settings.gradle
+    // Add settings.gradle
     if (project.getGradle().getStartParameter().getSettingsFile() != null) {
       skaffoldFilesOutput.addBuild(
           project.getGradle().getStartParameter().getSettingsFile().toPath());
@@ -124,7 +124,7 @@ public class FilesTaskV2 extends DefaultTask {
       skaffoldFilesOutput.addBuild(projectPath.resolve(Settings.DEFAULT_SETTINGS_FILE));
     }
 
-    // Print gradle.properties
+    // Add gradle.properties
     if (Files.exists(projectPath.resolve("gradle.properties"))) {
       skaffoldFilesOutput.addBuild(projectPath.resolve("gradle.properties"));
     }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -40,6 +40,7 @@ public class JibPlugin implements Plugin<Project> {
   @VisibleForTesting static final String BUILD_TAR_TASK_NAME = "jibBuildTar";
   @VisibleForTesting static final String BUILD_DOCKER_TASK_NAME = "jibDockerBuild";
   @VisibleForTesting static final String FILES_TASK_NAME = "_jibSkaffoldFiles";
+  @VisibleForTesting static final String FILES_TASK_V2_NAME = "_jibSkaffoldFilesV2";
   @VisibleForTesting static final String EXPLODED_WAR_TASK_NAME = "jibExplodedWar";
 
   /**
@@ -100,6 +101,7 @@ public class JibPlugin implements Plugin<Project> {
             .create(BUILD_TAR_TASK_NAME, BuildTarTask.class)
             .setJibExtension(jibExtension);
     project.getTasks().create(FILES_TASK_NAME, FilesTask.class).setJibExtension(jibExtension);
+    project.getTasks().create(FILES_TASK_V2_NAME, FilesTaskV2.class).setJibExtension(jibExtension);
 
     project.afterEvaluate(
         projectAfterEvaluation -> {

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/FilesTaskV2Test.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/FilesTaskV2Test.java
@@ -137,5 +137,6 @@ public class FilesTaskV2Test {
         result.getInputs().get(result.getInputs().size() - 1),
         CoreMatchers.endsWith("guava-HEAD-jre-SNAPSHOT.jar"));
     Assert.assertEquals(7, result.getInputs().size());
+    Assert.assertEquals(result.getIgnore().size(), 0);
   }
 }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/FilesTaskV2Test.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/FilesTaskV2Test.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google LLC.
+ * Copyright 2019 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/FilesTaskV2Test.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/FilesTaskV2Test.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.gradle;
+
+import com.google.cloud.tools.jib.plugins.common.SkaffoldFilesOutput;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/** Tests for {@link FilesTaskV2}. */
+public class FilesTaskV2Test {
+
+  @ClassRule public static final TestProject simpleTestProject = new TestProject("simple");
+
+  @ClassRule public static final TestProject multiTestProject = new TestProject("multi-service");
+
+  /**
+   * Verifies that the files task succeeded and returns the list of paths it prints out.
+   *
+   * @param project the project to run the task on
+   * @param moduleName the name of the sub-project, or {@code null} if no sub-project
+   * @return the list of paths printed by the task
+   */
+  private static String verifyTaskSuccess(TestProject project, @Nullable String moduleName) {
+    String taskName =
+        ":" + (moduleName == null ? "" : moduleName + ":") + JibPlugin.FILES_TASK_V2_NAME;
+    BuildResult buildResult = project.build(taskName, "-q");
+    BuildTask jibTask = buildResult.task(taskName);
+    Assert.assertNotNull(jibTask);
+    Assert.assertEquals(TaskOutcome.SUCCESS, jibTask.getOutcome());
+
+    return buildResult.getOutput().trim();
+  }
+
+  /**
+   * Asserts that two lists contain the same paths. Required to avoid Mac's /var/ vs. /private/var/
+   * symlink issue.
+   *
+   * @param expected the expected list of paths
+   * @param actual the actual list of paths
+   * @throws IOException if checking if two files are the same fails
+   */
+  private static void assertPathListsAreEqual(List<Path> expected, List<String> actual)
+      throws IOException {
+    Assert.assertEquals(expected.size(), actual.size());
+    for (int index = 0; index < expected.size(); index++) {
+      Assert.assertEquals(
+          expected.get(index).toRealPath(), Paths.get(actual.get(index)).toRealPath());
+    }
+  }
+
+  @Test
+  public void testFilesTask_singleProject() throws IOException {
+    Path projectRoot = simpleTestProject.getProjectRoot();
+    SkaffoldFilesOutput result =
+        new SkaffoldFilesOutput(verifyTaskSuccess(simpleTestProject, null));
+    assertPathListsAreEqual(
+        ImmutableList.of(projectRoot.resolve("build.gradle")), result.getBuild());
+    assertPathListsAreEqual(
+        ImmutableList.of(
+            projectRoot.resolve("src/main/resources"),
+            projectRoot.resolve("src/main/java"),
+            projectRoot.resolve("src/main/custom-extra-dir")),
+        result.getInputs());
+    Assert.assertEquals(result.getIgnore().size(), 0);
+  }
+
+  @Test
+  public void testFilesTask_multiProjectSimpleService() throws IOException {
+    Path projectRoot = multiTestProject.getProjectRoot();
+    Path simpleServiceRoot = projectRoot.resolve("simple-service");
+    SkaffoldFilesOutput result =
+        new SkaffoldFilesOutput(verifyTaskSuccess(multiTestProject, "simple-service"));
+    assertPathListsAreEqual(
+        ImmutableList.of(
+            projectRoot.resolve("build.gradle"),
+            projectRoot.resolve("settings.gradle"),
+            projectRoot.resolve("gradle.properties"),
+            simpleServiceRoot.resolve("build.gradle")),
+        result.getBuild());
+    assertPathListsAreEqual(
+        ImmutableList.of(simpleServiceRoot.resolve("src/main/java")), result.getInputs());
+    Assert.assertEquals(result.getIgnore().size(), 0);
+  }
+
+  @Test
+  public void testFilesTask_multiProjectComplexService() throws IOException {
+    Path projectRoot = multiTestProject.getProjectRoot();
+    Path complexServiceRoot = projectRoot.resolve("complex-service");
+    Path libRoot = projectRoot.resolve("lib");
+    SkaffoldFilesOutput result =
+        new SkaffoldFilesOutput(verifyTaskSuccess(multiTestProject, "complex-service"));
+    assertPathListsAreEqual(
+        ImmutableList.of(
+            projectRoot.resolve("build.gradle"),
+            projectRoot.resolve("settings.gradle"),
+            projectRoot.resolve("gradle.properties"),
+            complexServiceRoot.resolve("build.gradle"),
+            libRoot.resolve("build.gradle")),
+        result.getBuild());
+    assertPathListsAreEqual(
+        ImmutableList.of(
+            complexServiceRoot.resolve("src/main/extra-resources-1"),
+            complexServiceRoot.resolve("src/main/extra-resources-2"),
+            complexServiceRoot.resolve("src/main/java"),
+            complexServiceRoot.resolve("src/main/other-jib"),
+            libRoot.resolve("src/main/resources"),
+            libRoot.resolve("src/main/java")),
+        result.getInputs().subList(0, 6));
+    // guava jar is in a temporary-looking directory, so we need to do some extra processing to
+    // match this
+    Assert.assertThat(
+        result.getInputs().get(result.getInputs().size() - 1),
+        CoreMatchers.endsWith("guava-HEAD-jre-SNAPSHOT.jar"));
+    Assert.assertEquals(7, result.getInputs().size());
+  }
+}

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutput.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutput.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.plugins.common;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -69,7 +70,23 @@ public class SkaffoldFilesOutput {
     private final List<String> ignore = new ArrayList<>();
   }
 
-  private final SkaffoldFilesTemplate skaffoldFilesTemplate = new SkaffoldFilesTemplate();
+  private final SkaffoldFilesTemplate skaffoldFilesTemplate;
+
+  /** Creates an empty {@link SkaffoldFilesOutput}. */
+  public SkaffoldFilesOutput() {
+    skaffoldFilesTemplate = new SkaffoldFilesTemplate();
+  }
+
+  /**
+   * Creates a {@link SkaffoldFilesOutput} from a JSON string.
+   *
+   * @param json the JSON string
+   * @throws IOException if reading the JSON string fails
+   */
+  @VisibleForTesting
+  public SkaffoldFilesOutput(String json) throws IOException {
+    this.skaffoldFilesTemplate = new ObjectMapper().readValue(json, SkaffoldFilesTemplate.class);
+  }
 
   /**
    * Adds a build file/directory.
@@ -96,6 +113,21 @@ public class SkaffoldFilesOutput {
    */
   public void addIgnore(Path ignoreFile) {
     skaffoldFilesTemplate.ignore.add(ignoreFile.toString());
+  }
+
+  @VisibleForTesting
+  public List<String> getBuild() {
+    return skaffoldFilesTemplate.build;
+  }
+
+  @VisibleForTesting
+  public List<String> getInputs() {
+    return skaffoldFilesTemplate.inputs;
+  }
+
+  @VisibleForTesting
+  public List<String> getIgnore() {
+    return skaffoldFilesTemplate.ignore;
   }
 
   /**

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutputTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutputTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.plugins.common;
 
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.nio.file.Paths;
 import org.junit.Assert;
@@ -23,6 +24,9 @@ import org.junit.Test;
 
 /** Tests for {@link SkaffoldFilesOutput}. */
 public class SkaffoldFilesOutputTest {
+
+  private static final String TEST_JSON =
+      "{\"build\":[\"buildFile1\",\"buildFile2\"],\"inputs\":[\"input1\",\"input2\"],\"ignore\":[\"ignore1\",\"ignore2\"]}";
 
   @Test
   public void testGetJsonString() throws IOException {
@@ -33,9 +37,7 @@ public class SkaffoldFilesOutputTest {
     skaffoldFilesOutput.addInput(Paths.get("input2"));
     skaffoldFilesOutput.addIgnore(Paths.get("ignore1"));
     skaffoldFilesOutput.addIgnore(Paths.get("ignore2"));
-    Assert.assertEquals(
-        "{\"build\":[\"buildFile1\",\"buildFile2\"],\"inputs\":[\"input1\",\"input2\"],\"ignore\":[\"ignore1\",\"ignore2\"]}",
-        skaffoldFilesOutput.getJsonString());
+    Assert.assertEquals(TEST_JSON, skaffoldFilesOutput.getJsonString());
   }
 
   @Test
@@ -43,5 +45,14 @@ public class SkaffoldFilesOutputTest {
     SkaffoldFilesOutput skaffoldFilesOutput = new SkaffoldFilesOutput();
     Assert.assertEquals(
         "{\"build\":[],\"inputs\":[],\"ignore\":[]}", skaffoldFilesOutput.getJsonString());
+  }
+
+  @Test
+  public void testConstructor_json() throws IOException {
+    SkaffoldFilesOutput skaffoldFilesOutput = new SkaffoldFilesOutput(TEST_JSON);
+    Assert.assertEquals(
+        ImmutableList.of("buildFile1", "buildFile2"), skaffoldFilesOutput.getBuild());
+    Assert.assertEquals(ImmutableList.of("input1", "input2"), skaffoldFilesOutput.getInputs());
+    Assert.assertEquals(ImmutableList.of("ignore1", "ignore2"), skaffoldFilesOutput.getIgnore());
   }
 }


### PR DESCRIPTION
Part of #1484. The logic is very similar to the original `_jibSkaffoldFiles` (actually almost completely copy-pasted), but it categorizes the files and prints them out in a JSON string instead of just a list.