### PR TITLE
Consolidate getAppRootChecked()

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -31,6 +31,7 @@ import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException
 import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
+import com.google.cloud.tools.jib.plugins.common.RawConfiguration;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -104,8 +105,10 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
     TaskCommon.disableHttpLogging();
 
     try {
-      AbsoluteUnixPath appRoot = TaskCommon.getAppRootChecked(jibExtension, getProject());
-
+      RawConfiguration gradleRawConfiguration = new GradleRawConfiguration(jibExtension);
+      AbsoluteUnixPath appRoot =
+          PluginConfigurationProcessor.getAppRootChecked(
+              gradleRawConfiguration, TaskCommon.isWarProject(getProject()));
       GradleProjectProperties projectProperties =
           GradleProjectProperties.getForProject(
               getProject(),
@@ -120,7 +123,7 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
 
       PluginConfigurationProcessor pluginConfigurationProcessor =
           PluginConfigurationProcessor.processCommonConfigurationForDockerDaemonImage(
-              new GradleRawConfiguration(jibExtension),
+              gradleRawConfiguration,
               ignored -> java.util.Optional.empty(),
               projectProperties,
               dockerClientParameters.getExecutablePath(),

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -30,6 +30,7 @@ import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException
 import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
+import com.google.cloud.tools.jib.plugins.common.RawConfiguration;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import java.io.IOException;
@@ -81,7 +82,10 @@ public class BuildImageTask extends DefaultTask implements JibTask {
     TaskCommon.disableHttpLogging();
 
     try {
-      AbsoluteUnixPath appRoot = TaskCommon.getAppRootChecked(jibExtension, getProject());
+      RawConfiguration gradleRawConfiguration = new GradleRawConfiguration(jibExtension);
+      AbsoluteUnixPath appRoot =
+          PluginConfigurationProcessor.getAppRootChecked(
+              gradleRawConfiguration, TaskCommon.isWarProject(getProject()));
       GradleProjectProperties projectProperties =
           GradleProjectProperties.getForProject(
               getProject(),
@@ -102,9 +106,7 @@ public class BuildImageTask extends DefaultTask implements JibTask {
 
       PluginConfigurationProcessor pluginConfigurationProcessor =
           PluginConfigurationProcessor.processCommonConfigurationForRegistryImage(
-              new GradleRawConfiguration(jibExtension),
-              ignored -> Optional.empty(),
-              projectProperties);
+              gradleRawConfiguration, ignored -> Optional.empty(), projectProperties);
 
       ImageReference targetImageReference = pluginConfigurationProcessor.getTargetImageReference();
       HelpfulSuggestions helpfulSuggestions =

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -29,6 +29,7 @@ import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException
 import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
+import com.google.cloud.tools.jib.plugins.common.RawConfiguration;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -103,8 +104,10 @@ public class BuildTarTask extends DefaultTask implements JibTask {
     TaskCommon.disableHttpLogging();
 
     try {
-      AbsoluteUnixPath appRoot = TaskCommon.getAppRootChecked(jibExtension, getProject());
-
+      RawConfiguration gradleRawConfiguration = new GradleRawConfiguration(jibExtension);
+      AbsoluteUnixPath appRoot =
+          PluginConfigurationProcessor.getAppRootChecked(
+              gradleRawConfiguration, TaskCommon.isWarProject(getProject()));
       GradleProjectProperties projectProperties =
           GradleProjectProperties.getForProject(
               getProject(),
@@ -120,7 +123,7 @@ public class BuildTarTask extends DefaultTask implements JibTask {
       Path tarOutputPath = getTargetPath();
       PluginConfigurationProcessor pluginConfigurationProcessor =
           PluginConfigurationProcessor.processCommonConfigurationForTarImage(
-              new GradleRawConfiguration(jibExtension),
+              gradleRawConfiguration,
               ignored -> Optional.empty(),
               projectProperties,
               tarOutputPath,

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurations.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleLayerConfigurations.java
@@ -61,7 +61,7 @@ class GradleLayerConfigurations {
       Map<AbsoluteUnixPath, FilePermissions> extraDirectoryPermissions,
       AbsoluteUnixPath appRoot)
       throws IOException {
-    if (GradleProjectProperties.getWarTask(project) != null) {
+    if (TaskCommon.getWarTask(project) != null) {
       logger.info("WAR project identified, creating WAR image: " + project.getDisplayName());
       return getForWarProject(project, extraDirectory, extraDirectoryPermissions, appRoot);
     } else {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -51,8 +51,6 @@ import org.gradle.api.Task;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.plugins.WarPluginConvention;
-import org.gradle.api.tasks.bundling.War;
 import org.gradle.jvm.tasks.Jar;
 
 /** Obtains information about a Gradle {@link Project} that uses Jib. */
@@ -84,16 +82,6 @@ class GradleProjectProperties implements ProjectProperties {
     } catch (IOException ex) {
       throw new GradleException("Obtaining project build output files failed", ex);
     }
-  }
-
-  @Nullable
-  static War getWarTask(Project project) {
-    WarPluginConvention warPluginConvention =
-        project.getConvention().findPlugin(WarPluginConvention.class);
-    if (warPluginConvention == null) {
-      return null;
-    }
-    return (War) warPluginConvention.getProject().getTasks().findByName("war");
   }
 
   static Path getExplodedWarDirectory(Project project) {
@@ -141,7 +129,6 @@ class GradleProjectProperties implements ProjectProperties {
   }
 
   private static boolean isProgressFooterEnabled(Project project) {
-    // TODO: Consolidate with MavenProjectProperties?
     if ("plain".equals(System.getProperty(PropertyNames.CONSOLE))) {
       return false;
     }
@@ -220,7 +207,7 @@ class GradleProjectProperties implements ProjectProperties {
 
   @Override
   public boolean isWarProject() {
-    return getWarTask(project) != null;
+    return TaskCommon.isWarProject(project);
   }
 
   /**

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -106,7 +106,7 @@ public class JibPlugin implements Plugin<Project> {
     project.afterEvaluate(
         projectAfterEvaluation -> {
           try {
-            War warTask = GradleProjectProperties.getWarTask(project);
+            War warTask = TaskCommon.getWarTask(project);
             Task dependsOnTask;
             if (warTask != null) {
               ExplodedWarTask explodedWarTask =

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -113,21 +113,21 @@ public class GradleProjectPropertiesTest {
 
   @Test
   public void testGetWar_warProject() {
-    Assert.assertNotNull(GradleProjectProperties.getWarTask(mockProject));
+    Assert.assertNotNull(TaskCommon.getWarTask(mockProject));
   }
 
   @Test
   public void testGetWar_noWarPlugin() {
     Mockito.when(mockConvention.findPlugin(WarPluginConvention.class)).thenReturn(null);
 
-    Assert.assertNull(GradleProjectProperties.getWarTask(mockProject));
+    Assert.assertNull(TaskCommon.getWarTask(mockProject));
   }
 
   @Test
   public void testGetWar_noWarTask() {
     Mockito.when(mockTaskContainer.findByName("war")).thenReturn(null);
 
-    Assert.assertNull(GradleProjectProperties.getWarTask(mockProject));
+    Assert.assertNull(TaskCommon.getWarTask(mockProject));
   }
 
   @Test

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -34,6 +34,7 @@ import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryExceptio
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
+import com.google.cloud.tools.jib.plugins.common.RawConfiguration;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.IOException;
@@ -90,7 +91,10 @@ public class BuildDockerMojo extends JibPluginConfiguration {
     }
 
     try {
-      AbsoluteUnixPath appRoot = MojoCommon.getAppRootChecked(this);
+      RawConfiguration mavenRawConfiguration = new MavenRawConfiguration(this);
+      AbsoluteUnixPath appRoot =
+          PluginConfigurationProcessor.getAppRootChecked(
+              mavenRawConfiguration, MojoCommon.isWarProject(getProject()));
       MavenProjectProperties projectProperties =
           MavenProjectProperties.getForProject(
               getProject(),
@@ -107,7 +111,7 @@ public class BuildDockerMojo extends JibPluginConfiguration {
 
       PluginConfigurationProcessor pluginConfigurationProcessor =
           PluginConfigurationProcessor.processCommonConfigurationForDockerDaemonImage(
-              new MavenRawConfiguration(this),
+              mavenRawConfiguration,
               new MavenSettingsServerCredentials(
                   getSession().getSettings(), getSettingsDecrypter(), eventDispatcher),
               projectProperties,

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -32,6 +32,7 @@ import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException
 import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
+import com.google.cloud.tools.jib.plugins.common.RawConfiguration;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import java.io.IOException;
@@ -87,7 +88,10 @@ public class BuildImageMojo extends JibPluginConfiguration {
     }
 
     try {
-      AbsoluteUnixPath appRoot = MojoCommon.getAppRootChecked(this);
+      RawConfiguration mavenRawConfiguration = new MavenRawConfiguration(this);
+      AbsoluteUnixPath appRoot =
+          PluginConfigurationProcessor.getAppRootChecked(
+              mavenRawConfiguration, MojoCommon.isWarProject(getProject()));
       MavenProjectProperties projectProperties =
           MavenProjectProperties.getForProject(
               getProject(),
@@ -101,7 +105,7 @@ public class BuildImageMojo extends JibPluginConfiguration {
 
       PluginConfigurationProcessor pluginConfigurationProcessor =
           PluginConfigurationProcessor.processCommonConfigurationForRegistryImage(
-              new MavenRawConfiguration(this),
+              mavenRawConfiguration,
               new MavenSettingsServerCredentials(
                   getSession().getSettings(), getSettingsDecrypter(), eventDispatcher),
               projectProperties);

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -30,6 +30,7 @@ import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException
 import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
+import com.google.cloud.tools.jib.plugins.common.RawConfiguration;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -63,7 +64,10 @@ public class BuildTarMojo extends JibPluginConfiguration {
     }
 
     try {
-      AbsoluteUnixPath appRoot = MojoCommon.getAppRootChecked(this);
+      RawConfiguration mavenRawConfiguration = new MavenRawConfiguration(this);
+      AbsoluteUnixPath appRoot =
+          PluginConfigurationProcessor.getAppRootChecked(
+              mavenRawConfiguration, MojoCommon.isWarProject(getProject()));
       MavenProjectProperties projectProperties =
           MavenProjectProperties.getForProject(
               getProject(),
@@ -82,7 +86,7 @@ public class BuildTarMojo extends JibPluginConfiguration {
       Path tarOutputPath = buildOutput.resolve("jib-image.tar");
       PluginConfigurationProcessor pluginConfigurationProcessor =
           PluginConfigurationProcessor.processCommonConfigurationForTarImage(
-              new MavenRawConfiguration(this),
+              mavenRawConfiguration,
               new MavenSettingsServerCredentials(
                   getSession().getSettings(), getSettingsDecrypter(), eventDispatcher),
               projectProperties,

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -129,7 +129,6 @@ public class MavenProjectProperties implements ProjectProperties {
   }
 
   private static boolean isProgressFooterEnabled() {
-    // TODO: Consolidate with GradleProjectProperties?
     if ("plain".equals(System.getProperty(PropertyNames.CONSOLE))) {
       return false;
     }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
@@ -18,9 +18,7 @@ package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.configuration.FilePermissions;
 import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
-import com.google.cloud.tools.jib.frontend.JavaLayerConfigurations;
 import com.google.cloud.tools.jib.maven.JibPluginConfiguration.PermissionConfiguration;
-import com.google.cloud.tools.jib.plugins.common.InvalidAppRootException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.nio.file.Path;
@@ -42,33 +40,6 @@ class MojoCommon {
   static boolean isWarProject(MavenProject project) {
     String packaging = project.getPackaging();
     return "war".equals(packaging) || "gwt-app".equals(packaging);
-  }
-
-  /**
-   * Gets the value of the {@code <container><appRoot>} parameter. If the parameter is empty,
-   * returns {@link JavaLayerConfigurations#DEFAULT_WEB_APP_ROOT} for project with WAR packaging or
-   * {@link JavaLayerConfigurations#DEFAULT_APP_ROOT} for other packaging.
-   *
-   * @param jibPluginConfiguration the Jib plugin configuration
-   * @return the app root value
-   * @throws InvalidAppRootException if the app root is not an absolute path in Unix-style
-   */
-  // TODO: find a way to use PluginConfigurationProcessor.getAppRootChecked() instead
-  static AbsoluteUnixPath getAppRootChecked(JibPluginConfiguration jibPluginConfiguration)
-      throws InvalidAppRootException {
-    String appRoot = jibPluginConfiguration.getAppRoot();
-    if (appRoot.isEmpty()) {
-      boolean isWarProject = isWarProject(jibPluginConfiguration.getProject());
-      appRoot =
-          isWarProject
-              ? JavaLayerConfigurations.DEFAULT_WEB_APP_ROOT
-              : JavaLayerConfigurations.DEFAULT_APP_ROOT;
-    }
-    try {
-      return AbsoluteUnixPath.get(appRoot);
-    } catch (IllegalArgumentException ex) {
-      throw new InvalidAppRootException(appRoot, appRoot, ex);
-    }
   }
 
   /**

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -273,7 +273,8 @@ public class PluginConfigurationProcessor {
       return null;
     }
 
-    AbsoluteUnixPath appRoot = getAppRootChecked(rawConfiguration, projectProperties);
+    AbsoluteUnixPath appRoot =
+        getAppRootChecked(rawConfiguration, projectProperties.isWarProject());
     String mainClass =
         MainClassResolver.resolveMainClass(
             rawConfiguration.getMainClass().orElse(null), projectProperties);
@@ -330,18 +331,17 @@ public class PluginConfigurationProcessor {
    * JavaLayerConfigurations#DEFAULT_APP_ROOT} for other projects.
    *
    * @param rawConfiguration raw configuration data
-   * @param projectProperties used for providing additional information
+   * @param isWarProject whether or not the project is a WAR project
    * @return the app root value
    * @throws InvalidAppRootException if {@code appRoot} value is not an absolute Unix path
    */
   @VisibleForTesting
-  static AbsoluteUnixPath getAppRootChecked(
-      RawConfiguration rawConfiguration, ProjectProperties projectProperties)
-      throws InvalidAppRootException {
+  public static AbsoluteUnixPath getAppRootChecked(
+      RawConfiguration rawConfiguration, boolean isWarProject) throws InvalidAppRootException {
     String appRoot = rawConfiguration.getAppRoot();
     if (appRoot.isEmpty()) {
       appRoot =
-          projectProperties.isWarProject()
+          isWarProject
               ? JavaLayerConfigurations.DEFAULT_WEB_APP_ROOT
               : JavaLayerConfigurations.DEFAULT_APP_ROOT;
     }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -332,7 +332,7 @@ public class PluginConfigurationProcessorTest {
 
     Assert.assertEquals(
         AbsoluteUnixPath.get("/some/root"),
-        PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties));
+        PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, false));
   }
 
   @Test
@@ -340,7 +340,7 @@ public class PluginConfigurationProcessorTest {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("relative/path");
 
     try {
-      PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties);
+      PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, false);
       Assert.fail();
     } catch (InvalidAppRootException ex) {
       Assert.assertEquals("relative/path", ex.getMessage());
@@ -352,7 +352,7 @@ public class PluginConfigurationProcessorTest {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("\\windows\\path");
 
     try {
-      PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties);
+      PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, false);
       Assert.fail();
     } catch (InvalidAppRootException ex) {
       Assert.assertEquals("\\windows\\path", ex.getMessage());
@@ -364,7 +364,7 @@ public class PluginConfigurationProcessorTest {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("C:\\windows\\path");
 
     try {
-      PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties);
+      PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, false);
       Assert.fail();
     } catch (InvalidAppRootException ex) {
       Assert.assertEquals("C:\\windows\\path", ex.getMessage());
@@ -374,21 +374,19 @@ public class PluginConfigurationProcessorTest {
   @Test
   public void testGetAppRootChecked_defaultNonWarProject() throws InvalidAppRootException {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("");
-    Mockito.when(projectProperties.isWarProject()).thenReturn(false);
 
     Assert.assertEquals(
         AbsoluteUnixPath.get("/app"),
-        PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties));
+        PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, false));
   }
 
   @Test
   public void testGetAppRootChecked_defaultWarProject() throws InvalidAppRootException {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("");
-    Mockito.when(projectProperties.isWarProject()).thenReturn(true);
 
     Assert.assertEquals(
         AbsoluteUnixPath.get("/jetty/webapps/ROOT"),
-        PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties));
+        PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, true));
   }
 
   @Test


### PR DESCRIPTION
Small cleanup, uses `getAppRootChecked()` from `PluginConfigurationProcessor` instead of `MojoCommon`/`TaskCommon`.