### PR TITLE
Define mainClassName in Micronaut example

### DIFF
--- a/examples/micronaut/build.gradle
+++ b/examples/micronaut/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'groovy'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
     id 'net.ltgt.apt-idea' version '0.18'
-    id 'com.google.cloud.tools.jib' version '1.0.0'
+    id 'com.google.cloud.tools.jib' version '1.0.1'
 }
 
 version '0.1'
@@ -43,6 +43,3 @@ mainClassName = 'example.micronaut.Application'
 
 /** CHANGE THIS TO THE IMAGE YOU WANT TO PUSH TO */
 // jib.to.image = 'gcr.io/PROJECT_ID/micronaut-jib'
-
-// not needed once https://github.com/GoogleContainerTools/jib/issues/1501 is fixed
-jib.container.mainClass = mainClassName

--- a/examples/micronaut/build.gradle
+++ b/examples/micronaut/build.gradle
@@ -43,4 +43,6 @@ mainClassName = 'example.micronaut.Application'
 
 /** CHANGE THIS TO THE IMAGE YOU WANT TO PUSH TO */
 // jib.to.image = 'gcr.io/PROJECT_ID/micronaut-jib'
+
+// not needed once https://github.com/GoogleContainerTools/jib/issues/1501 is fixed
 jib.container.mainClass = mainClassName

--- a/examples/micronaut/build.gradle
+++ b/examples/micronaut/build.gradle
@@ -39,7 +39,8 @@ dependencies {
 
 compileJava.options.compilerArgs += '-parameters'
 compileTestJava.options.compilerArgs += '-parameters'
-run.main = 'example.micronaut.Application'
+mainClassName = 'example.micronaut.Application'
 
 /** CHANGE THIS TO THE IMAGE YOU WANT TO PUSH TO */
 // jib.to.image = 'gcr.io/PROJECT_ID/micronaut-jib'
+jib.container.mainClass = mainClassName


### PR DESCRIPTION
Fixes #1495.

#1243 added `run.main` to fix `./gradlew run` back then. But I couldn't find any documentation about `run.main`.

OTOH, [the use of `mainClassName` is documented in the Micronaunt doc](https://docs.micronaut.io/latest/guide/index.html#groovyFunctions). It makes the sample work again.

~~I had to add `jib.container.mainClass`. This might be due to #1501.~~ UPDATE: #1501 fixed in Jib 1.0.1.