### PR TITLE
Add jib:_skaffold-files-v2 goal

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
@@ -102,7 +102,9 @@ public class FilesTaskV2 extends DefaultTask {
     }
 
     // Print files
+    System.out.println("BEGIN JIB JSON");
     System.out.println(skaffoldFilesOutput.getJsonString());
+    System.out.println("END JIB JSON");
   }
 
   /**

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
@@ -102,7 +102,7 @@ public class FilesTaskV2 extends DefaultTask {
     }
 
     // Print files
-    System.out.println("BEGIN JIB JSON");
+    System.out.println("\nBEGIN JIB JSON");
     System.out.println(skaffoldFilesOutput.getJsonString());
     System.out.println("END JIB JSON");
   }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/FilesTaskV2Test.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/FilesTaskV2Test.java
@@ -52,8 +52,12 @@ public class FilesTaskV2Test {
     BuildTask jibTask = buildResult.task(taskName);
     Assert.assertNotNull(jibTask);
     Assert.assertEquals(TaskOutcome.SUCCESS, jibTask.getOutcome());
+    String output = buildResult.getOutput().trim();
+    Assert.assertThat(output, CoreMatchers.startsWith("BEGIN JIB JSON"));
+    Assert.assertThat(output, CoreMatchers.endsWith("END JIB JSON"));
 
-    return buildResult.getOutput().trim();
+    // Return task output with header/footer removed
+    return output.replace("BEGIN JIB JSON", "").replace("END JIB JSON", "").trim();
   }
 
   /**

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/FilesTaskV2Test.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/FilesTaskV2Test.java
@@ -43,7 +43,7 @@ public class FilesTaskV2Test {
    *
    * @param project the project to run the task on
    * @param moduleName the name of the sub-project, or {@code null} if no sub-project
-   * @return the list of paths printed by the task
+   * @return the JSON string printed by the task
    */
   private static String verifyTaskSuccess(TestProject project, @Nullable String moduleName) {
     String taskName =

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -548,21 +548,8 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
     this.project = project;
   }
 
-  /**
-   * Gets a system property with the given name. First checks for a -D commandline argument, then
-   * checks for a property defined in the POM, then returns null if neither are defined.
-   *
-   * @param propertyName the name of the system property
-   * @return the value of the system property, or null if not defined
-   */
   @Nullable
-  public String getProperty(String propertyName) {
-    if (session != null && session.getSystemProperties().containsKey(propertyName)) {
-      return session.getSystemProperties().getProperty(propertyName);
-    }
-    if (project != null && project.getProperties().containsKey(propertyName)) {
-      return project.getProperties().getProperty(propertyName);
-    }
-    return null;
+  String getProperty(String propertyName) {
+    return MavenProjectProperties.getProperty(propertyName, project, session);
   }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -89,6 +90,25 @@ public class MavenProjectProperties implements ProjectProperties {
               + "jib:build\" instead of \"mvn clean compile jib:build\"?)",
           ex);
     }
+  }
+
+  /**
+   * Gets a system property with the given name. First checks for a -D commandline argument, then
+   * checks for a property defined in the POM, then returns null if neither are defined.
+   *
+   * @param propertyName the name of the system property
+   * @return the value of the system property, or null if not defined
+   */
+  @Nullable
+  public static String getProperty(
+      String propertyName, @Nullable MavenProject project, @Nullable MavenSession session) {
+    if (session != null && session.getSystemProperties().containsKey(propertyName)) {
+      return session.getSystemProperties().getProperty(propertyName);
+    }
+    if (project != null && project.getProperties().containsKey(propertyName)) {
+      return project.getProperties().getProperty(propertyName);
+    }
+    return null;
   }
 
   private static EventHandlers makeEventHandlers(

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2.java
@@ -158,7 +158,7 @@ public class FilesMojoV2 extends AbstractMojo {
 
     try {
       // Print JSON string
-      System.out.println("BEGIN JIB JSON");
+      System.out.println("\nBEGIN JIB JSON");
       System.out.println(skaffoldFilesOutput.getJsonString());
       System.out.println("END JIB JSON");
     } catch (IOException ex) {
@@ -168,13 +168,10 @@ public class FilesMojoV2 extends AbstractMojo {
 
   private Path resolveExtraDirectory(MavenProject project) {
     // Try getting extra directory from project/session properties
-    if (project.getProperties().containsKey(PropertyNames.EXTRA_DIRECTORY_PATH)) {
-      return Paths.get(project.getProperties().getProperty(PropertyNames.EXTRA_DIRECTORY_PATH));
-    }
-    if (session != null
-        && session.getSystemProperties().containsKey(PropertyNames.EXTRA_DIRECTORY_PATH)) {
-      return Paths.get(
-          session.getSystemProperties().getProperty(PropertyNames.EXTRA_DIRECTORY_PATH));
+    String extraDirectoryProperty =
+        MavenProjectProperties.getProperty(PropertyNames.EXTRA_DIRECTORY_PATH, project, session);
+    if (extraDirectoryProperty != null) {
+      return Paths.get(extraDirectoryProperty);
     }
 
     // Try getting extra directory from project pom

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven.skaffold;
+
+import com.google.cloud.tools.jib.maven.JibPluginConfiguration.ExtraDirectoryParameters;
+import com.google.cloud.tools.jib.maven.MavenProjectProperties;
+import com.google.cloud.tools.jib.plugins.common.SkaffoldFilesOutput;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.maven.artifact.Artifact;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.FileSet;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.DefaultDependencyResolutionRequest;
+import org.apache.maven.project.DependencyResolutionException;
+import org.apache.maven.project.DependencyResolutionResult;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.project.ProjectDependenciesResolver;
+import org.eclipse.aether.graph.DependencyFilter;
+
+/**
+ * Print out changing source dependencies on a module. In multimodule applications it should be run
+ * by activating a single module and its dependent modules. Dependency collection will ignore
+ * project level snapshots (sub-modules) unless the user has explicitly installed them (by only
+ * requiring dependencyCollection). For use only within skaffold.
+ *
+ * <p>Expected use: "./mvnw jib:_skaffold-files-v2 -q" or "./mvnw jib:_skaffold-files-v2 -pl module
+ * -am -q"
+ */
+@Mojo(
+    name = FilesMojoV2.GOAL_NAME,
+    requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
+    aggregator = true)
+public class FilesMojoV2 extends AbstractMojo {
+
+  @VisibleForTesting static final String GOAL_NAME = "_skaffold-files-v2";
+
+  @Nullable
+  @Parameter(defaultValue = "${session}", required = true, readonly = true)
+  private MavenSession session;
+
+  @Nullable
+  @Parameter(defaultValue = "${project}", required = true, readonly = true)
+  private MavenProject project;
+
+  @Nullable
+  @Parameter(defaultValue = "${reactorProjects}", required = true, readonly = true)
+  private List<MavenProject> projects;
+
+  // TODO: This is internal maven, we should find a better way to do this
+  @Nullable @Component private ProjectDependenciesResolver projectDependenciesResolver;
+
+  // This parameter is cloned from JibPluginConfiguration
+  @Parameter private ExtraDirectoryParameters extraDirectory = new ExtraDirectoryParameters();
+
+  private final SkaffoldFilesOutput skaffoldFilesOutput = new SkaffoldFilesOutput();
+
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    Preconditions.checkNotNull(project);
+    Preconditions.checkNotNull(projects);
+    Preconditions.checkNotNull(session);
+    Preconditions.checkNotNull(projectDependenciesResolver);
+
+    // Add pom configuration files
+    skaffoldFilesOutput.addBuild(project.getFile().toPath());
+    project.getPlugin("com.google.cloud.tools:jib-maven-plugin").getKey()
+    if ("pom".equals(project.getPackaging())) {
+      // done if <packaging>pom</packaging>
+      return;
+    }
+
+    // Add sources directory (resolved by maven to be an absolute path)
+    skaffoldFilesOutput.addInput(Paths.get(project.getBuild().getSourceDirectory()));
+
+    // Add resources directory (resolved by maven to be an absolute path)
+    ImmutableSet.copyOf(project.getBuild().getResources())
+        .stream()
+        .map(FileSet::getDirectory)
+        .map(Paths::get)
+        .forEach(skaffoldFilesOutput::addInput);
+
+    // This seems weird, but we will only print out the jib "extraFiles" directory on projects where
+    // the plugin is explicitly configured (even though _skaffold-files-v2 is a jib-maven-plugin
+    // goal and is expected to run on all projects irrespective of their configuring of the jib
+    // plugin).
+    if (project.getPlugin(MavenProjectProperties.PLUGIN_KEY) != null) {
+      // Add extra directory
+      skaffoldFilesOutput.addInput(resolveExtraDirectory());
+    }
+
+    // Grab non-project SNAPSHOT dependencies for this project
+    // TODO: this whole sections relies on internal maven API, it could break. We need to explore
+    // TODO: better ways to resolve dependencies using the public maven API.
+    Set<String> projectArtifacts =
+        projects
+            .stream()
+            .map(MavenProject::getArtifact)
+            .map(Artifact::toString)
+            .collect(Collectors.toSet());
+
+    DependencyFilter ignoreProjectDependenciesFilter =
+        (node, parents) -> {
+          if (node == null || node.getDependency() == null) {
+            // if nothing, then ignore
+            return false;
+          }
+          if (projectArtifacts.contains(node.getArtifact().toString())) {
+            // ignore project dependency artifacts
+            return false;
+          }
+          // we only want compile/runtime deps
+          return Artifact.SCOPE_COMPILE_PLUS_RUNTIME.contains(node.getDependency().getScope());
+        };
+
+    try {
+      DependencyResolutionResult resolutionResult =
+          projectDependenciesResolver.resolve(
+              new DefaultDependencyResolutionRequest(project, session.getRepositorySession())
+                  .setResolutionFilter(ignoreProjectDependenciesFilter));
+      resolutionResult
+          .getDependencies()
+          .stream()
+          .map(org.eclipse.aether.graph.Dependency::getArtifact)
+          .filter(org.eclipse.aether.artifact.Artifact::isSnapshot)
+          .map(org.eclipse.aether.artifact.Artifact::getFile)
+          .map(File::toPath)
+          .forEach(skaffoldFilesOutput::addInput);
+
+      // Print JSON files
+      System.out.println("BEGIN JIB JSON");
+      System.out.println(skaffoldFilesOutput.getJsonString());
+      System.out.println("END JIB JSON");
+
+    } catch (DependencyResolutionException ex) {
+      throw new MojoExecutionException("Failed to resolve dependencies", ex);
+    } catch (IOException ex) {
+      throw new MojoExecutionException(ex.getMessage(), ex);
+    }
+  }
+
+  private Path resolveExtraDirectory() {
+    if (extraDirectory.getPath() == null) {
+      return Preconditions.checkNotNull(project)
+          .getBasedir()
+          .getAbsoluteFile()
+          .toPath()
+          .resolve("src")
+          .resolve("main")
+          .resolve("jib");
+    }
+    return extraDirectory.getPath().getAbsoluteFile().toPath();
+  }
+}

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2.java
@@ -21,7 +21,6 @@ import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.cloud.tools.jib.plugins.common.SkaffoldFilesOutput;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -97,7 +96,9 @@ public class FilesMojoV2 extends AbstractMojo {
       skaffoldFilesOutput.addInput(Paths.get(project.getBuild().getSourceDirectory()));
 
       // Add resources directory (resolved by maven to be an absolute path)
-      ImmutableSet.copyOf(project.getBuild().getResources())
+      project
+          .getBuild()
+          .getResources()
           .stream()
           .map(FileSet::getDirectory)
           .map(Paths::get)
@@ -183,13 +184,13 @@ public class FilesMojoV2 extends AbstractMojo {
       if (pluginConfiguration != null) {
         Xpp3Dom extraDirectoryConfiguration = pluginConfiguration.getChild("extraDirectory");
         if (extraDirectoryConfiguration != null) {
-          // May be configured via <extraDirectory> or <extraDirectory><path>
           Xpp3Dom child = extraDirectoryConfiguration.getChild("path");
           if (child != null) {
+            // <extraDirectory><path>...</path></extraDirectory>
             return Paths.get(child.getValue());
-          } else {
-            return Paths.get(extraDirectoryConfiguration.getValue());
           }
+          // <extraDirectory>...</extraDirectory>
+          return Paths.get(extraDirectoryConfiguration.getValue());
         }
       }
     }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2Test.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2Test.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven.skaffold;
+
+import com.google.cloud.tools.jib.maven.TestPlugin;
+import com.google.cloud.tools.jib.maven.TestProject;
+import com.google.cloud.tools.jib.plugins.common.SkaffoldFilesOutput;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/** Tests for {@link FilesMojoV2}. */
+public class FilesMojoV2Test {
+
+  @ClassRule public static final TestPlugin testPlugin = new TestPlugin();
+
+  @ClassRule
+  public static final TestProject simpleTestProject = new TestProject(testPlugin, "simple");
+
+  @ClassRule
+  public static final TestProject multiTestProject = new TestProject(testPlugin, "multi");
+
+  private static void verifyFiles(
+      Path projectRoot, String module, List<Path> buildFiles, List<Path> inputFiles)
+      throws VerificationException, IOException {
+
+    Verifier verifier = new Verifier(projectRoot.toString());
+    verifier.setAutoclean(false);
+    verifier.addCliOption("-q");
+    if (!Strings.isNullOrEmpty(module)) {
+      verifier.addCliOption("-pl");
+      verifier.addCliOption(module);
+      verifier.addCliOption("-am");
+    }
+    verifier.executeGoal("jib:" + FilesMojoV2.GOAL_NAME);
+
+    verifier.verifyErrorFreeLog();
+    Path logFile = Paths.get(verifier.getBasedir()).resolve(verifier.getLogFileName());
+    List<String> log = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+
+    int begin = log.indexOf("BEGIN JIB JSON");
+    Assert.assertTrue(log.size() > begin + 2);
+    Assert.assertEquals("END JIB JSON", log.get(begin + 2));
+
+    Assert.fail(log.get(begin + 1));
+
+    SkaffoldFilesOutput output = new SkaffoldFilesOutput(log.get(begin + 1));
+    assertPathListsAreEqual(buildFiles, output.getBuild());
+    assertPathListsAreEqual(inputFiles, output.getInputs());
+    Assert.assertEquals(0, output.getIgnore().size());
+  }
+
+  /**
+   * Asserts that two lists contain the same paths. Required to avoid Mac's /var/ vs. /private/var/
+   * symlink issue.
+   *
+   * @param expected the expected list of paths
+   * @param actual the actual list of paths
+   * @throws IOException if checking if two files are the same fails
+   */
+  private static void assertPathListsAreEqual(List<Path> expected, List<String> actual)
+      throws IOException {
+    Assert.assertEquals(expected.size(), actual.size());
+    for (int index = 0; index < expected.size(); index++) {
+      Assert.assertEquals(
+          expected.get(index).toRealPath(), Paths.get(actual.get(index)).toRealPath());
+    }
+  }
+
+  @Test
+  public void testFilesMojo_singleModule() throws VerificationException, IOException {
+    Path projectRoot = simpleTestProject.getProjectRoot();
+
+    verifyFiles(
+        projectRoot,
+        null,
+        ImmutableList.of(projectRoot.resolve("pom.xml")),
+        ImmutableList.of(
+            projectRoot.resolve("src/main/java"),
+            projectRoot.resolve("src/main/resources"),
+            projectRoot.resolve("src/main/jib-custom")));
+  }
+
+  @Test
+  public void testFilesMojo_multiModuleSimpleService() throws VerificationException, IOException {
+    Path projectRoot = multiTestProject.getProjectRoot();
+    Path simpleServiceRoot = projectRoot.resolve("simple-service");
+
+    verifyFiles(
+        projectRoot,
+        "simple-service",
+        ImmutableList.of(projectRoot.resolve("pom.xml"), simpleServiceRoot.resolve("pom.xml")),
+        ImmutableList.of(
+            simpleServiceRoot.resolve("src/main/java"),
+            simpleServiceRoot.resolve("src/main/resources"),
+            simpleServiceRoot.resolve("src/main/jib")));
+  }
+
+  @Test
+  public void testFilesMojo_multiModuleComplexService() throws VerificationException, IOException {
+    Path projectRoot = multiTestProject.getProjectRoot();
+    Path complexServiceRoot = projectRoot.resolve("complex-service");
+    Path libRoot = projectRoot.resolve("lib");
+
+    verifyFiles(
+        projectRoot,
+        "complex-service",
+        ImmutableList.of(
+            projectRoot.resolve("pom.xml"),
+            libRoot.resolve("pom.xml"),
+            complexServiceRoot.resolve("pom.xml")),
+        ImmutableList.of(
+            libRoot.resolve("src/main/java"),
+            libRoot.resolve("src/main/resources"),
+            complexServiceRoot.resolve("src/main/java"),
+            complexServiceRoot.resolve("src/main/resources1"),
+            complexServiceRoot.resolve("src/main/resources2"),
+            complexServiceRoot.resolve("src/main/other-jib"),
+            // this test expects standard .m2 locations
+            Paths.get(System.getProperty("user.home"))
+                .resolve(
+                    ".m2/repository/com/google/guava/guava/HEAD-jre-SNAPSHOT/guava-HEAD-jre-SNAPSHOT.jar")));
+  }
+}

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2Test.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2Test.java
@@ -45,7 +45,7 @@ public class FilesMojoV2Test {
   public static final TestProject multiTestProject = new TestProject(testPlugin, "multi");
 
   private static void verifyFiles(
-      Path projectRoot, String module, List<Path> buildFiles, List<Path> inputFiles)
+      Path projectRoot, String module, List<String> buildFiles, List<String> inputFiles)
       throws VerificationException, IOException {
 
     Verifier verifier = new Verifier(projectRoot.toString());
@@ -66,29 +66,10 @@ public class FilesMojoV2Test {
     Assert.assertTrue(log.size() > begin + 2);
     Assert.assertEquals("END JIB JSON", log.get(begin + 2));
 
-    Assert.fail(log.get(begin + 1));
-
     SkaffoldFilesOutput output = new SkaffoldFilesOutput(log.get(begin + 1));
-    assertPathListsAreEqual(buildFiles, output.getBuild());
-    assertPathListsAreEqual(inputFiles, output.getInputs());
+    Assert.assertEquals(buildFiles, output.getBuild());
+    Assert.assertEquals(inputFiles, output.getInputs());
     Assert.assertEquals(0, output.getIgnore().size());
-  }
-
-  /**
-   * Asserts that two lists contain the same paths. Required to avoid Mac's /var/ vs. /private/var/
-   * symlink issue.
-   *
-   * @param expected the expected list of paths
-   * @param actual the actual list of paths
-   * @throws IOException if checking if two files are the same fails
-   */
-  private static void assertPathListsAreEqual(List<Path> expected, List<String> actual)
-      throws IOException {
-    Assert.assertEquals(expected.size(), actual.size());
-    for (int index = 0; index < expected.size(); index++) {
-      Assert.assertEquals(
-          expected.get(index).toRealPath(), Paths.get(actual.get(index)).toRealPath());
-    }
   }
 
   @Test
@@ -98,11 +79,11 @@ public class FilesMojoV2Test {
     verifyFiles(
         projectRoot,
         null,
-        ImmutableList.of(projectRoot.resolve("pom.xml")),
+        ImmutableList.of(projectRoot.resolve("pom.xml").toString()),
         ImmutableList.of(
-            projectRoot.resolve("src/main/java"),
-            projectRoot.resolve("src/main/resources"),
-            projectRoot.resolve("src/main/jib-custom")));
+            projectRoot.resolve("src/main/java").toString(),
+            projectRoot.resolve("src/main/resources").toString(),
+            projectRoot.resolve("src/main/jib-custom").toString()));
   }
 
   @Test
@@ -113,11 +94,13 @@ public class FilesMojoV2Test {
     verifyFiles(
         projectRoot,
         "simple-service",
-        ImmutableList.of(projectRoot.resolve("pom.xml"), simpleServiceRoot.resolve("pom.xml")),
         ImmutableList.of(
-            simpleServiceRoot.resolve("src/main/java"),
-            simpleServiceRoot.resolve("src/main/resources"),
-            simpleServiceRoot.resolve("src/main/jib")));
+            projectRoot.resolve("pom.xml").toString(),
+            simpleServiceRoot.resolve("pom.xml").toString()),
+        ImmutableList.of(
+            simpleServiceRoot.resolve("src/main/java").toString(),
+            simpleServiceRoot.resolve("src/main/resources").toString(),
+            simpleServiceRoot.resolve("src/main/jib").toString()));
   }
 
   @Test
@@ -130,19 +113,20 @@ public class FilesMojoV2Test {
         projectRoot,
         "complex-service",
         ImmutableList.of(
-            projectRoot.resolve("pom.xml"),
-            libRoot.resolve("pom.xml"),
-            complexServiceRoot.resolve("pom.xml")),
+            projectRoot.resolve("pom.xml").toString(),
+            libRoot.resolve("pom.xml").toString(),
+            complexServiceRoot.resolve("pom.xml").toString()),
         ImmutableList.of(
-            libRoot.resolve("src/main/java"),
-            libRoot.resolve("src/main/resources"),
-            complexServiceRoot.resolve("src/main/java"),
-            complexServiceRoot.resolve("src/main/resources1"),
-            complexServiceRoot.resolve("src/main/resources2"),
-            complexServiceRoot.resolve("src/main/other-jib"),
+            libRoot.resolve("src/main/java").toString(),
+            libRoot.resolve("src/main/resources").toString(),
+            complexServiceRoot.resolve("src/main/java").toString(),
+            complexServiceRoot.resolve("src/main/resources1").toString(),
+            complexServiceRoot.resolve("src/main/resources2").toString(),
+            complexServiceRoot.resolve("src/main/other-jib").toString(),
             // this test expects standard .m2 locations
             Paths.get(System.getProperty("user.home"))
                 .resolve(
-                    ".m2/repository/com/google/guava/guava/HEAD-jre-SNAPSHOT/guava-HEAD-jre-SNAPSHOT.jar")));
+                    ".m2/repository/com/google/guava/guava/HEAD-jre-SNAPSHOT/guava-HEAD-jre-SNAPSHOT.jar")
+                .toString()));
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2Test.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2Test.java
@@ -20,12 +20,13 @@ import com.google.cloud.tools.jib.maven.TestPlugin;
 import com.google.cloud.tools.jib.maven.TestProject;
 import com.google.cloud.tools.jib.plugins.common.SkaffoldFilesOutput;
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
@@ -63,7 +64,9 @@ public class FilesMojoV2Test {
     List<String> log = Files.readAllLines(logFile, StandardCharsets.UTF_8);
 
     int begin = log.indexOf("BEGIN JIB JSON");
-    Assert.assertTrue(log.size() > begin + 2);
+    Assert.assertTrue(begin > -1);
+    Assert.assertTrue(
+        "log.size() is " + log.size() + ", but begin + 2 is " + begin + 2, log.size() > begin + 2);
     Assert.assertEquals("END JIB JSON", log.get(begin + 2));
 
     SkaffoldFilesOutput output = new SkaffoldFilesOutput(log.get(begin + 1));
@@ -79,8 +82,8 @@ public class FilesMojoV2Test {
     verifyFiles(
         projectRoot,
         null,
-        ImmutableList.of(projectRoot.resolve("pom.xml").toString()),
-        ImmutableList.of(
+        Collections.singletonList(projectRoot.resolve("pom.xml").toString()),
+        Arrays.asList(
             projectRoot.resolve("src/main/java").toString(),
             projectRoot.resolve("src/main/resources").toString(),
             projectRoot.resolve("src/main/jib-custom").toString()));
@@ -94,10 +97,10 @@ public class FilesMojoV2Test {
     verifyFiles(
         projectRoot,
         "simple-service",
-        ImmutableList.of(
+        Arrays.asList(
             projectRoot.resolve("pom.xml").toString(),
             simpleServiceRoot.resolve("pom.xml").toString()),
-        ImmutableList.of(
+        Arrays.asList(
             simpleServiceRoot.resolve("src/main/java").toString(),
             simpleServiceRoot.resolve("src/main/resources").toString(),
             simpleServiceRoot.resolve("src/main/jib").toString()));
@@ -112,11 +115,11 @@ public class FilesMojoV2Test {
     verifyFiles(
         projectRoot,
         "complex-service",
-        ImmutableList.of(
+        Arrays.asList(
             projectRoot.resolve("pom.xml").toString(),
             libRoot.resolve("pom.xml").toString(),
             complexServiceRoot.resolve("pom.xml").toString()),
-        ImmutableList.of(
+        Arrays.asList(
             libRoot.resolve("src/main/java").toString(),
             libRoot.resolve("src/main/resources").toString(),
             complexServiceRoot.resolve("src/main/java").toString(),

--- a/jib-maven-plugin/src/test/resources/maven/projects/multi/complex-service/pom.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/multi/complex-service/pom.xml
@@ -18,7 +18,7 @@
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
         <configuration>
-          <extraDirectory>src/main/other-jib</extraDirectory>
+          <extraDirectory>${project.basedir}/src/main/other-jib</extraDirectory>
         </configuration>
       </plugin>
     </plugins>

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutput.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutput.java
@@ -85,7 +85,7 @@ public class SkaffoldFilesOutput {
    */
   @VisibleForTesting
   public SkaffoldFilesOutput(String json) throws IOException {
-    this.skaffoldFilesTemplate = new ObjectMapper().readValue(json, SkaffoldFilesTemplate.class);
+    skaffoldFilesTemplate = new ObjectMapper().readValue(json, SkaffoldFilesTemplate.class);
   }
 
   /**


### PR DESCRIPTION
Fixes #1484. Adds new goal that lists the files skaffold should watch, in JSON format.

There may be more to do resolving the extra directory, but I'm not sure. Let me know if there are test cases I should add.