### PR TITLE
Restart docker as workaround to fix clock skew

### DIFF
--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -10,6 +10,17 @@ export PATH=$PATH:/usr/local/Caskroom/google-cloud-sdk/latest/google-cloud-sdk/b
 docker stop $(docker ps --all --quiet) || true
 docker kill $(docker ps --all --quiet) || true
 
+# Restarting Docker for Mac to get around the certificate expiration issue:
+# b/112707824
+# https://github.com/GoogleContainerTools/jib/issues/730#issuecomment-413603874
+# https://github.com/moby/moby/issues/11534
+# TODO: remove this temporary fix once b/112707824 is permanently fixed.
+if [ "${KOKORO_JOB_CLUSTER}" = "MACOS_EXTERNAL" ]; then
+  osascript -e 'quit app "Docker"'
+  open -a Docker
+  while ! docker info > /dev/null 2>&1; do sleep 1; done
+fi
+
 cd github/jib
 
 # Workaround for issue with calling 'docker login'. It defaults to using docker-credential-osxkeychain and errors with:


### PR DESCRIPTION
Recently, the degree of flakiness has well crossed the tolerance threshold.

![selection_001](https://user-images.githubusercontent.com/10523105/53263520-a0fec400-36a7-11e9-892f-84880024e54c.png)

Then I just noticed we weren't applying the same workaround to restart Docker on presubmit builds. Hopefully this resolves the issue.