### PR TITLE
Remove END JIB JSON string from files task/mojo

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/FilesTaskV2.java
@@ -104,7 +104,6 @@ public class FilesTaskV2 extends DefaultTask {
     // Print files
     System.out.println("\nBEGIN JIB JSON");
     System.out.println(skaffoldFilesOutput.getJsonString());
-    System.out.println("END JIB JSON");
   }
 
   /**

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/FilesTaskV2Test.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/FilesTaskV2Test.java
@@ -54,10 +54,9 @@ public class FilesTaskV2Test {
     Assert.assertEquals(TaskOutcome.SUCCESS, jibTask.getOutcome());
     String output = buildResult.getOutput().trim();
     Assert.assertThat(output, CoreMatchers.startsWith("BEGIN JIB JSON"));
-    Assert.assertThat(output, CoreMatchers.endsWith("END JIB JSON"));
 
-    // Return task output with header/footer removed
-    return output.replace("BEGIN JIB JSON", "").replace("END JIB JSON", "").trim();
+    // Return task output with header removed
+    return output.replace("BEGIN JIB JSON", "").trim();
   }
 
   /**

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2.java
@@ -160,7 +160,6 @@ public class FilesMojoV2 extends AbstractMojo {
       // Print JSON string
       System.out.println("\nBEGIN JIB JSON");
       System.out.println(skaffoldFilesOutput.getJsonString());
-      System.out.println("END JIB JSON");
     } catch (IOException ex) {
       throw new MojoExecutionException(ex.getMessage(), ex);
     }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2Test.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2Test.java
@@ -65,10 +65,6 @@ public class FilesMojoV2Test {
 
     int begin = log.indexOf("BEGIN JIB JSON");
     Assert.assertTrue(begin > -1);
-    Assert.assertTrue(
-        "log.size() is " + log.size() + ", but begin + 2 is " + begin + 2, log.size() > begin + 2);
-    Assert.assertEquals("END JIB JSON", log.get(begin + 2));
-
     SkaffoldFilesOutput output = new SkaffoldFilesOutput(log.get(begin + 1));
     Assert.assertEquals(buildFiles, output.getBuild());
     Assert.assertEquals(inputFiles, output.getInputs());


### PR DESCRIPTION
Since the JSON string will always only be on one line, the "END JIB JSON" footer isn't necessary.