### PR TITLE
Do not crash on inaccurate progress reporting

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcher.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcher.java
@@ -61,11 +61,8 @@ public class ProgressEventDispatcher implements Closeable {
    */
   public static ProgressEventDispatcher newRoot(
       EventDispatcher eventDispatcher, String description, long allocationUnits) {
-    long allocationUnitsChecked = allocationUnits < 0 ? 0 : allocationUnits;
     return newProgressEventDispatcher(
-        eventDispatcher,
-        Allocation.newRoot(description, allocationUnitsChecked),
-        BuildStepType.ALL);
+        eventDispatcher, Allocation.newRoot(description, allocationUnits), BuildStepType.ALL);
   }
 
   /**
@@ -119,11 +116,8 @@ public class ProgressEventDispatcher implements Closeable {
           BuildStepType buildStepType, String description, long allocationUnits) {
         Preconditions.checkState(!used);
         used = true;
-        long allocationUnitsChecked = allocationUnits < 0 ? 0 : allocationUnits;
         return newProgressEventDispatcher(
-            eventDispatcher,
-            allocation.newChild(description, allocationUnitsChecked),
-            buildStepType);
+            eventDispatcher, allocation.newChild(description, allocationUnits), buildStepType);
       }
     };
   }
@@ -148,6 +142,14 @@ public class ProgressEventDispatcher implements Closeable {
     eventDispatcher.dispatch(new ProgressEvent(allocation, unitsDecremented, buildStepType));
   }
 
+  /**
+   * Decrements remaining allocation units by {@code units} but no more than the remaining
+   * allocation units (which may be 0). Returns the actual units decremented, which never exceeds
+   * {@code units}.
+   *
+   * @param units units to decrement
+   * @return units actually decremented
+   */
   private long decrementRemainingAllocationUnits(long units) {
     Preconditions.checkState(!closed);
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/Allocation.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/Allocation.java
@@ -65,7 +65,7 @@ public class Allocation {
 
   private Allocation(String description, long allocationUnits, @Nullable Allocation parent) {
     this.description = description;
-    this.allocationUnits = allocationUnits;
+    this.allocationUnits = allocationUnits < 0 ? 0 : allocationUnits;
     this.parent = parent;
 
     this.fractionOfRoot = (parent == null ? 1.0 : parent.fractionOfRoot) / allocationUnits;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcherTest.java
@@ -101,7 +101,9 @@ public class ProgressEventDispatcherTest {
     Assert.assertEquals(5, progressEvents.get(1).getAllocation().getAllocationUnits());
     Assert.assertEquals(4, progressEvents.get(2).getAllocation().getAllocationUnits());
 
+    // child1 (of allocation 5) opening and closing
     Assert.assertSame(progressEvents.get(1).getAllocation(), progressEvents.get(4).getAllocation());
+    // child1 (of allocation 4) opening and closing
     Assert.assertSame(progressEvents.get(2).getAllocation(), progressEvents.get(3).getAllocation());
 
     Assert.assertEquals(0, progressEvents.get(0).getUnits()); // 0-progress sent when root creation

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcherTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.jib.builder;
 
 import com.google.cloud.tools.jib.event.EventDispatcher;
 import com.google.cloud.tools.jib.event.events.ProgressEvent;
-import com.google.common.base.VerifyException;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
@@ -59,37 +58,56 @@ public class ProgressEventDispatcherTest {
   }
 
   @Test
-  public void testDispatch_tooMuchProgress() {
+  public void testDispatch_safeWithtooMuchProgress() {
     try (ProgressEventDispatcher progressEventDispatcher =
         ProgressEventDispatcher.newRoot(mockEventDispatcher, "allocation description", 10)) {
-      progressEventDispatcher.dispatchProgress(10);
-      try {
-        progressEventDispatcher.dispatchProgress(10);
-        Assert.fail();
-
-      } catch (VerifyException ex) {
-        Assert.assertEquals(
-            "Remaining allocation units less than 0 for 'allocation description': -10",
-            ex.getMessage());
-      }
+      progressEventDispatcher.dispatchProgress(6);
+      progressEventDispatcher.dispatchProgress(8);
+      progressEventDispatcher.dispatchProgress(1);
     }
+
+    ArgumentCaptor<ProgressEvent> eventsCaptor = ArgumentCaptor.forClass(ProgressEvent.class);
+    Mockito.verify(mockEventDispatcher, Mockito.times(4)).dispatch(eventsCaptor.capture());
+    List<ProgressEvent> progressEvents = eventsCaptor.getAllValues();
+
+    Assert.assertSame(progressEvents.get(0).getAllocation(), progressEvents.get(1).getAllocation());
+    Assert.assertSame(progressEvents.get(1).getAllocation(), progressEvents.get(2).getAllocation());
+    Assert.assertSame(progressEvents.get(2).getAllocation(), progressEvents.get(3).getAllocation());
+
+    Assert.assertEquals(10, progressEvents.get(0).getAllocation().getAllocationUnits());
+
+    Assert.assertEquals(0, progressEvents.get(0).getUnits());
+    Assert.assertEquals(6, progressEvents.get(1).getUnits());
+    Assert.assertEquals(4, progressEvents.get(2).getUnits());
+    Assert.assertEquals(0, progressEvents.get(3).getUnits());
   }
 
   @Test
-  public void testDispatch_tooManyChildren() {
+  public void testDispatch_safeWithTooManyChildren() {
     try (ProgressEventDispatcher progressEventDispatcher =
-        ProgressEventDispatcher.newRoot(mockEventDispatcher, "allocation description", 1)) {
-      progressEventDispatcher.newChildProducer();
-
-      try {
-        progressEventDispatcher.newChildProducer();
-        Assert.fail();
-
-      } catch (VerifyException ex) {
-        Assert.assertEquals(
-            "Remaining allocation units less than 0 for 'allocation description': -1",
-            ex.getMessage());
-      }
+            ProgressEventDispatcher.newRoot(mockEventDispatcher, "allocation description", 1);
+        ProgressEventDispatcher ignored1 =
+            progressEventDispatcher.newChildProducer().create(BuildStepType.ALL, "ignored", 5);
+        ProgressEventDispatcher ignored2 =
+            progressEventDispatcher.newChildProducer().create(BuildStepType.ALL, "ignored", 4)) {
+      // empty
     }
+
+    ArgumentCaptor<ProgressEvent> eventsCaptor = ArgumentCaptor.forClass(ProgressEvent.class);
+    Mockito.verify(mockEventDispatcher, Mockito.times(5)).dispatch(eventsCaptor.capture());
+    List<ProgressEvent> progressEvents = eventsCaptor.getAllValues();
+
+    Assert.assertEquals(1, progressEvents.get(0).getAllocation().getAllocationUnits());
+    Assert.assertEquals(5, progressEvents.get(1).getAllocation().getAllocationUnits());
+    Assert.assertEquals(4, progressEvents.get(2).getAllocation().getAllocationUnits());
+
+    Assert.assertSame(progressEvents.get(1).getAllocation(), progressEvents.get(4).getAllocation());
+    Assert.assertSame(progressEvents.get(2).getAllocation(), progressEvents.get(3).getAllocation());
+
+    Assert.assertEquals(0, progressEvents.get(0).getUnits()); // 0-progress sent when root creation
+    Assert.assertEquals(0, progressEvents.get(1).getUnits()); // when child1 creation
+    Assert.assertEquals(0, progressEvents.get(2).getUnits()); // when child2 creation
+    Assert.assertEquals(4, progressEvents.get(3).getUnits()); // when child2 closes
+    Assert.assertEquals(5, progressEvents.get(4).getUnits()); // when child1 closes
   }
 }

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed an issue where setting `allowInsecureRegistries` may fail to try HTTP. ([#1517](https://github.com/GoogleContainerTools/jib/issues/1517))
-- Crash on talking to servers that do not set or send incorrect `Content-Length` HTTP header value. ([#1512](https://github.com/GoogleContainerTools/jib/issues/1512))
+- Crash on talking to servers that do not set the `Content-Length` HTTP header or send an incorrect value. ([#1512](https://github.com/GoogleContainerTools/jib/issues/1512))
 
 ## 1.0.1
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Crash on talking to servers that do not set or send incorrect `Content-Length` HTTP header value. ([#1512](https://github.com/GoogleContainerTools/jib/issues/1512))  
+
 ## 1.0.1
 
 ### Added

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -12,7 +12,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed an issue where setting `<allowInsecureRegistries>` may fail to try HTTP. ([#1517](https://github.com/GoogleContainerTools/jib/issues/1517))
-- Crash on talking to servers that do not set or send incorrect `Content-Length` HTTP header value. ([#1512](https://github.com/GoogleContainerTools/jib/issues/1512))
+- Crash on talking to servers that do not set the `Content-Length` HTTP header or send an incorrect value. ([#1512](https://github.com/GoogleContainerTools/jib/issues/1512))
 
 ## 1.0.1
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Crash on talking to servers that do not set or send incorrect `Content-Length` HTTP header value. ([#1512](https://github.com/GoogleContainerTools/jib/issues/1512))  
+
 ## 1.0.1
 
 ### Added


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/jib/issues/1512#issuecomment-468333807, where the root cause is believed to be an inaccurate or missing `Content-Length` value. (The log shows that `remainingAllocationUnits` is -1 when the `Verify` statement is violated.)

Closes #1512.