### PR TITLE
Allow setting approot any time during JavaContainerBuilder construction

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JavaContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JavaContainerBuilder.java
@@ -363,10 +363,7 @@ public class JavaContainerBuilder {
               + "JavaContainerBuilder#setMainClass(String), or consider using a "
               + "jib.frontend.MainClassFinder to infer the main class");
     }
-    if (addedClasses.isEmpty()
-        && addedResources.isEmpty()
-        && addedDependencies.isEmpty()
-        && addedOthers.isEmpty()) {
+    if (classpath.isEmpty()) {
       throw new IllegalStateException(
           "Failed to construct entrypoint because no files were added to the JavaContainerBuilder");
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JavaContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JavaContainerBuilder.java
@@ -369,7 +369,6 @@ public class JavaContainerBuilder {
           appRoot.resolve(JavaEntrypointConstructor.DEFAULT_RELATIVE_RESOURCES_PATH_ON_IMAGE));
     }
 
-    // Add dependencies to layer configuration
     // Detect duplicate filenames and rename with filesize to avoid collisions
     List<String> duplicates =
         addedDependencies
@@ -383,6 +382,7 @@ public class JavaContainerBuilder {
             .map(Entry::getKey)
             .collect(Collectors.toList());
     for (Path file : addedDependencies) {
+      // Add dependencies to layer configuration
       layerConfigurationsBuilder.addFile(
           file.getFileName().toString().contains("SNAPSHOT")
               ? LayerType.SNAPSHOT_DEPENDENCIES


### PR DESCRIPTION
This changes `JavaContainerBuilder` to not build the layer configuration until `toContainerBuilder()` is called, allowing people who use `JavaContainerBuilder` to change the app root even after files have been added.

Fixes #1476.