### PR TITLE
Send client_id for OAuth2 registry auth

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
@@ -269,7 +269,7 @@ public class RegistryAuthenticator {
     String serviceScope = getServiceScopeRequestParameters(scope);
     return isOAuth2Auth()
         ? serviceScope
-            + "&grant_type=refresh_token&refresh_token="
+            + "&client_id=jib&grant_type=refresh_token&refresh_token="
             // If OAuth2, credential.getPassword() is a refresh token.
             + Verify.verifyNotNull(credential).getPassword()
         : serviceScope;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
@@ -270,7 +270,7 @@ public class RegistryAuthenticator {
     return isOAuth2Auth()
         ? serviceScope
             // https://github.com/GoogleContainerTools/jib/pull/1545
-            + "&client_id=da031fe481a93ac107a95a96462358f9"
+            + "&client_id=jib.da031fe481a93ac107a95a96462358f9"
             + "&grant_type=refresh_token&refresh_token="
             // If OAuth2, credential.getPassword() is a refresh token.
             + Verify.verifyNotNull(credential).getPassword()

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
@@ -269,7 +269,9 @@ public class RegistryAuthenticator {
     String serviceScope = getServiceScopeRequestParameters(scope);
     return isOAuth2Auth()
         ? serviceScope
-            + "&client_id=jib&grant_type=refresh_token&refresh_token="
+            // https://github.com/GoogleContainerTools/jib/pull/1545
+            + "&client_id=da031fe481a93ac107a95a96462358f9"
+            + "&grant_type=refresh_token&refresh_token="
             // If OAuth2, credential.getPassword() is a refresh token.
             + Verify.verifyNotNull(credential).getPassword()
         : serviceScope;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
@@ -70,7 +70,7 @@ public class RegistryAuthenticatorTest {
     registryAuthenticator.setCredential(Credential.basic("<token>", "oauth2_access_token"));
     Assert.assertEquals(
         "service=someservice&scope=repository:someimage:scope"
-            + "&grant_type=refresh_token&refresh_token=oauth2_access_token",
+            + "&client_id=jib&grant_type=refresh_token&refresh_token=oauth2_access_token",
         registryAuthenticator.getAuthRequestParameters("scope"));
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
@@ -70,7 +70,7 @@ public class RegistryAuthenticatorTest {
     registryAuthenticator.setCredential(Credential.basic("<token>", "oauth2_access_token"));
     Assert.assertEquals(
         "service=someservice&scope=repository:someimage:scope"
-            + "&client_id=da031fe481a93ac107a95a96462358f9"
+            + "&client_id=jib.da031fe481a93ac107a95a96462358f9"
             + "&grant_type=refresh_token&refresh_token=oauth2_access_token",
         registryAuthenticator.getAuthRequestParameters("scope"));
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
@@ -70,7 +70,8 @@ public class RegistryAuthenticatorTest {
     registryAuthenticator.setCredential(Credential.basic("<token>", "oauth2_access_token"));
     Assert.assertEquals(
         "service=someservice&scope=repository:someimage:scope"
-            + "&client_id=jib&grant_type=refresh_token&refresh_token=oauth2_access_token",
+            + "&client_id=da031fe481a93ac107a95a96462358f9"
+            + "&grant_type=refresh_token&refresh_token=oauth2_access_token",
         registryAuthenticator.getAuthRequestParameters("scope"));
   }
 


### PR DESCRIPTION
Fixes #1545. `client_id` is a required parameter.