### PR TITLE
Allow setting scratch base image in jib-core

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - `JavaContainerBuilder#setAppRoot()` and `JavaContainerBuilder#fromDistrolessJetty()` for building WAR containers ([#1464](https://github.com/GoogleContainerTools/jib/issues/1464))
+- `Jib#fromScratch()` to start building from an empty base image ([#1471](https://github.com/GoogleContainerTools/jib/issues/1471))
 
 ### Changed
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/Jib.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/Jib.java
@@ -60,5 +60,14 @@ public class Jib {
     return new JibContainerBuilder(registryImage);
   }
 
+  /**
+   * Starts building the container from an empty base image.
+   *
+   * @return a new {@link JibContainerBuilder} to continue building the container
+   */
+  public static JibContainerBuilder fromScratch() {
+    return from(ImageReference.ofScratch());
+  }
+
   private Jib() {}
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/Jib.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/Jib.java
@@ -66,7 +66,7 @@ public class Jib {
    * @return a new {@link JibContainerBuilder} to continue building the container
    */
   public static JibContainerBuilder fromScratch() {
-    return from(ImageReference.ofScratch());
+    return from(ImageReference.scratch());
   }
 
   private Jib() {}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
@@ -175,7 +175,7 @@ public class ImageReference {
    * @return an {@link ImageReference} with an empty registry and tag component, and repository set
    *     to "scratch"
    */
-  public static ImageReference ofScratch() {
+  public static ImageReference scratch() {
     return new ImageReference("", "scratch", "");
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageReference.java
@@ -169,6 +169,17 @@ public class ImageReference {
   }
 
   /**
+   * Constructs an {@link ImageReference} with an empty registry and tag component, and repository
+   * set to "scratch".
+   *
+   * @return an {@link ImageReference} with an empty registry and tag component, and repository set
+   *     to "scratch"
+   */
+  public static ImageReference ofScratch() {
+    return new ImageReference("", "scratch", "");
+  }
+
+  /**
    * Returns {@code true} if {@code registry} is a valid registry string. For example, a valid
    * registry could be {@code gcr.io} or {@code localhost:5000}.
    *
@@ -269,6 +280,15 @@ public class ImageReference {
    */
   public boolean isTagDigest() {
     return tag.matches(DescriptorDigest.DIGEST_REGEX);
+  }
+
+  /**
+   * Returns {@code true} if the {@link ImageReference} is a scratch image; {@code false} if not.
+   *
+   * @return {@code true} if the {@link ImageReference} is a scratch image; {@code false} if not
+   */
+  public boolean isScratch() {
+    return "".equals(registry) && "scratch".equals(repository) && "".equals(tag);
   }
 
   /**

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageReferenceTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageReferenceTest.java
@@ -180,6 +180,13 @@ public class ImageReferenceTest {
             .isTagDigest());
   }
 
+  @Test
+  public void testIsScratch() {
+    Assert.assertTrue(ImageReference.scratch().isScratch());
+    Assert.assertFalse(ImageReference.of("", "scratch", "").isScratch());
+    Assert.assertFalse(ImageReference.of(null, "scratch", null).isScratch());
+  }
+
   private void verifyParse(String registry, String repository, String tagSeparator, String tag)
       throws InvalidImageReferenceException {
     // Gets the expected parsed components.


### PR DESCRIPTION
Adds `Jib.fromScratch()`, which signals most of `PullBaseImageStep` to be skipped (and effectively skips `PullAndCacheBaseImageLayersStep` and `PushLayersStep` for the base image as a result, since there are no layers to process).

Part of #1471. Should we support this in the plugins, or does that start to stray too much from being a "Java" image builder?