### PR TITLE
Rename from Credential.basic() to Credential.from()

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
@@ -77,7 +77,7 @@ public class JibIntegrationTest {
                 Containerizer.to(
                         RegistryImage.named(targetImageReference)
                             .addCredentialRetriever(
-                                () -> Optional.of(Credential.basic("username", "password"))))
+                                () -> Optional.of(Credential.from("username", "password"))))
                     .setAllowInsecureRegistries(true));
 
     Assert.assertEquals("Hello World\n", pullAndRunBuiltImage(targetImageReference.toString()));
@@ -98,7 +98,7 @@ public class JibIntegrationTest {
             Containerizer.to(
                     RegistryImage.named(targetImageReference)
                         .addCredentialRetriever(
-                            () -> Optional.of(Credential.basic("username", "password"))))
+                            () -> Optional.of(Credential.from("username", "password"))))
                 .setAllowInsecureRegistries(true));
 
     // Check that resulting image has no layers
@@ -120,7 +120,7 @@ public class JibIntegrationTest {
         Containerizer.to(
                 RegistryImage.named(targetImageReference)
                     .addCredentialRetriever(
-                        () -> Optional.of(Credential.basic("username", "password"))))
+                        () -> Optional.of(Credential.from("username", "password"))))
             .setAllowInsecureRegistries(true);
 
     ExecutorService executorService = Executors.newCachedThreadPool();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/RegistryImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/RegistryImage.java
@@ -82,7 +82,7 @@ public class RegistryImage implements SourceImage, TargetImage {
    * @return this
    */
   public RegistryImage addCredential(String username, String password) {
-    addCredentialRetriever(() -> Optional.of(Credential.basic(username, password)));
+    addCredentialRetriever(() -> Optional.of(Credential.from(username, password)));
     return this;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/credentials/Credential.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/credentials/Credential.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.jib.configuration.credentials;
 
 import java.util.Objects;
 
-// TODO: Move to lower-level package - probably at same level as Authorization.
 /** Holds credentials (username and password). */
 public class Credential {
   // If the username is set to <token>, the secret would be a refresh token.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/credentials/Credential.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/credentials/Credential.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 // TODO: Move to lower-level package - probably at same level as Authorization.
 /** Holds credentials (username and password). */
 public class Credential {
-  // if the username is set to <token> the secret would be an refresh token, see details at
+  // If the username is set to <token>, the secret would be a refresh token.
   // https://github.com/docker/cli/blob/master/docs/reference/commandline/login.md#credential-helper-protocol
   private static final String OAUTH2_TOKEN_USER_NAME = "<token>";
 
@@ -32,7 +32,7 @@ public class Credential {
    * @param password the password
    * @return a new {@link Credential}
    */
-  public static Credential basic(String username, String password) {
+  public static Credential from(String username, String password) {
     return new Credential(username, password);
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
@@ -98,7 +98,7 @@ public class DockerConfigCredentialRetriever {
             new String(Base64.decodeBase64(auth), StandardCharsets.UTF_8);
         String username = usernameColonPassword.substring(0, usernameColonPassword.indexOf(":"));
         String password = usernameColonPassword.substring(usernameColonPassword.indexOf(":") + 1);
-        return Optional.of(Credential.basic(username, password));
+        return Optional.of(Credential.from(username, password));
       }
 
       // Then, tries to use a defined credHelpers credential helper.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
@@ -119,7 +119,7 @@ public class DockerCredentialHelper {
                 credentialHelper, serverUrl, output);
           }
 
-          return Credential.basic(dockerCredentials.Username, dockerCredentials.Secret);
+          return Credential.from(dockerCredentials.Username, dockerCredentials.Secret);
 
         } catch (JsonProcessingException ex) {
           throw new CredentialHelperUnhandledServerUrlException(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
@@ -176,7 +176,7 @@ public class JibContainerBuilderTest {
     Assert.assertEquals(
         1, buildConfiguration.getTargetImageConfiguration().getCredentialRetrievers().size());
     Assert.assertEquals(
-        Credential.basic("username", "password"),
+        Credential.from("username", "password"),
         buildConfiguration
             .getTargetImageConfiguration()
             .getCredentialRetrievers()

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/RegistryImageTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/RegistryImageTest.java
@@ -49,7 +49,7 @@ public class RegistryImageTest {
     Assert.assertEquals(2, imageConfiguration.getCredentialRetrievers().size());
     Assert.assertSame(mockCredentialRetriever, imageConfiguration.getCredentialRetrievers().get(0));
     Assert.assertEquals(
-        Credential.basic("username", "password"),
+        Credential.from("username", "password"),
         imageConfiguration
             .getCredentialRetrievers()
             .get(1)

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
@@ -54,13 +54,13 @@ public class RetrieveRegistryCredentialsStepTest {
         makeFakeBuildConfiguration(
             Arrays.asList(
                 Optional::empty,
-                () -> Optional.of(Credential.basic("baseusername", "basepassword"))),
+                () -> Optional.of(Credential.from("baseusername", "basepassword"))),
             Arrays.asList(
-                () -> Optional.of(Credential.basic("targetusername", "targetpassword")),
-                () -> Optional.of(Credential.basic("ignored", "ignored"))));
+                () -> Optional.of(Credential.from("targetusername", "targetpassword")),
+                () -> Optional.of(Credential.from("ignored", "ignored"))));
 
     Assert.assertEquals(
-        Credential.basic("baseusername", "basepassword"),
+        Credential.from("baseusername", "basepassword"),
         RetrieveRegistryCredentialsStep.forBaseImage(
                 mockListeningExecutorService,
                 buildConfiguration,
@@ -68,7 +68,7 @@ public class RetrieveRegistryCredentialsStepTest {
                     .newChildProducer())
             .call());
     Assert.assertEquals(
-        Credential.basic("targetusername", "targetpassword"),
+        Credential.from("targetusername", "targetpassword"),
         RetrieveRegistryCredentialsStep.forTargetImage(
                 mockListeningExecutorService,
                 buildConfiguration,

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
@@ -54,7 +54,7 @@ public class BuildConfigurationTest {
     Set<String> additionalTargetImageTags = ImmutableSet.of("tag1", "tag2", "tag3");
     Set<String> expectedTargetImageTags = ImmutableSet.of("targettag", "tag1", "tag2", "tag3");
     List<CredentialRetriever> credentialRetrievers =
-        Collections.singletonList(() -> Optional.of(Credential.basic("username", "password")));
+        Collections.singletonList(() -> Optional.of(Credential.from("username", "password")));
     Instant expectedCreationTime = Instant.ofEpochSecond(10000);
     List<String> expectedEntrypoint = Arrays.asList("some", "entrypoint");
     List<String> expectedProgramArguments = Arrays.asList("arg1", "arg2");
@@ -126,7 +126,7 @@ public class BuildConfigurationTest {
         expectedTargetTag, buildConfiguration.getTargetImageConfiguration().getImageTag());
     Assert.assertEquals(expectedTargetImageTags, buildConfiguration.getAllTargetImageTags());
     Assert.assertEquals(
-        Credential.basic("username", "password"),
+        Credential.from("username", "password"),
         buildConfiguration
             .getTargetImageConfiguration()
             .getCredentialRetrievers()

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/credentials/CredentialTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/credentials/CredentialTest.java
@@ -27,10 +27,10 @@ public class CredentialTest {
 
   @Test
   public void testCredentialsHash() {
-    Credential credentialA1 = Credential.basic("username", "password");
-    Credential credentialA2 = Credential.basic("username", "password");
-    Credential credentialB1 = Credential.basic("", "");
-    Credential credentialB2 = Credential.basic("", "");
+    Credential credentialA1 = Credential.from("username", "password");
+    Credential credentialA2 = Credential.from("username", "password");
+    Credential credentialB1 = Credential.from("", "");
+    Credential credentialB2 = Credential.from("", "");
 
     Assert.assertEquals(credentialA1, credentialA2);
     Assert.assertEquals(credentialB1, credentialB2);
@@ -44,7 +44,7 @@ public class CredentialTest {
 
   @Test
   public void testCredentialsOAuth2RefreshToken() {
-    Credential oauth2Credential = Credential.basic("<token>", "eyJhbGciOi...3gw");
+    Credential oauth2Credential = Credential.from("<token>", "eyJhbGciOi...3gw");
     Assert.assertTrue(
         "Credential should be an auth2 token when username is <token>",
         oauth2Credential.isOAuth2RefreshToken());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactoryTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactoryTest.java
@@ -42,7 +42,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class CredentialRetrieverFactoryTest {
 
-  private static final Credential FAKE_CREDENTIALS = Credential.basic("username", "password");
+  private static final Credential FAKE_CREDENTIALS = Credential.from("username", "password");
 
   /**
    * Returns a {@link DockerCredentialHelperFactory} that checks given parameters upon creating a

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
@@ -67,7 +67,7 @@ public class RegistryAuthenticatorTest {
 
   @Test
   public void testAuthRequestParameters_oauth2() {
-    registryAuthenticator.setCredential(Credential.basic("<token>", "oauth2_access_token"));
+    registryAuthenticator.setCredential(Credential.from("<token>", "oauth2_access_token"));
     Assert.assertEquals(
         "service=someservice&scope=repository:someimage:scope"
             + "&client_id=jib.da031fe481a93ac107a95a96462358f9"
@@ -82,13 +82,13 @@ public class RegistryAuthenticatorTest {
 
   @Test
   public void isOAuth2Auth_basicAuth() {
-    registryAuthenticator.setCredential(Credential.basic("name", "password"));
+    registryAuthenticator.setCredential(Credential.from("name", "password"));
     Assert.assertFalse(registryAuthenticator.isOAuth2Auth());
   }
 
   @Test
   public void isOAuth2Auth_oauth2() {
-    registryAuthenticator.setCredential(Credential.basic("<token>", "oauth2_token"));
+    registryAuthenticator.setCredential(Credential.from("<token>", "oauth2_token"));
     Assert.assertTrue(registryAuthenticator.isOAuth2Auth());
   }
 
@@ -101,7 +101,7 @@ public class RegistryAuthenticatorTest {
 
   @Test
   public void istAuthenticationUrl_oauth2() throws MalformedURLException {
-    registryAuthenticator.setCredential(Credential.basic("<token>", "oauth2_token"));
+    registryAuthenticator.setCredential(Credential.from("<token>", "oauth2_token"));
     Assert.assertEquals(
         new URL("https://somerealm"), registryAuthenticator.getAuthenticationUrl("scope"));
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
@@ -35,7 +35,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class DockerConfigCredentialRetrieverTest {
 
-  private static final Credential FAKE_CREDENTIAL = Credential.basic("username", "password");
+  private static final Credential FAKE_CREDENTIAL = Credential.from("username", "password");
 
   @Mock private DockerCredentialHelper mockDockerCredentialHelper;
   @Mock private DockerConfig mockDockerConfig;

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidator.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidator.java
@@ -63,7 +63,7 @@ public class ConfigurationPropertyValidator {
     String commandlinePassword = rawConfiguration.getProperty(passwordProperty).orElse(null);
     if (!Strings.isNullOrEmpty(commandlineUsername)
         && !Strings.isNullOrEmpty(commandlinePassword)) {
-      return Optional.of(Credential.basic(commandlineUsername, commandlinePassword));
+      return Optional.of(Credential.from(commandlineUsername, commandlinePassword));
     }
 
     // Warn if a system property is missing
@@ -103,7 +103,7 @@ public class ConfigurationPropertyValidator {
       return Optional.empty();
     }
 
-    return Optional.of(Credential.basic(auth.getUsername(), auth.getPassword()));
+    return Optional.of(Credential.from(auth.getUsername(), auth.getPassword()));
   }
 
   /**

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -407,7 +407,7 @@ public class PluginConfigurationProcessor {
         AuthProperty auth = optionalInferredAuth.get();
         String username = Verify.verifyNotNull(auth.getUsername());
         String password = Verify.verifyNotNull(auth.getPassword());
-        Credential credential = Credential.basic(username, password);
+        Credential credential = Credential.from(username, password);
         defaultCredentialRetrievers.setInferredCredential(credential, auth.getAuthDescriptor());
       }
     }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidatorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidatorTest.java
@@ -52,7 +52,7 @@ public class ConfigurationPropertyValidatorTest {
         .thenReturn(Optional.of("abcde"));
     Mockito.when(mockConfiguration.getProperty("jib.test.auth.pass"))
         .thenReturn(Optional.of("12345"));
-    Credential expected = Credential.basic("abcde", "12345");
+    Credential expected = Credential.from("abcde", "12345");
     Optional<Credential> actual =
         ConfigurationPropertyValidator.getImageCredential(
             mockEventDispatcher,
@@ -66,7 +66,7 @@ public class ConfigurationPropertyValidatorTest {
     // Auth set in configuration
     Mockito.when(mockConfiguration.getProperty("jib.test.auth.user")).thenReturn(Optional.empty());
     Mockito.when(mockConfiguration.getProperty("jib.test.auth.pass")).thenReturn(Optional.empty());
-    expected = Credential.basic("vwxyz", "98765");
+    expected = Credential.from("vwxyz", "98765");
     actual =
         ConfigurationPropertyValidator.getImageCredential(
             mockEventDispatcher,

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
@@ -48,8 +48,8 @@ public class DefaultCredentialRetrieversTest {
   @Mock private CredentialRetriever mockInferCredentialHelperCredentialRetriever;
   @Mock private CredentialRetriever mockDockerConfigCredentialRetriever;
 
-  private final Credential knownCredential = Credential.basic("username", "password");
-  private final Credential inferredCredential = Credential.basic("username2", "password2");
+  private final Credential knownCredential = Credential.from("username", "password");
+  private final Credential inferredCredential = Credential.from("username2", "password2");
 
   @Before
   public void setUp() {


### PR DESCRIPTION
Fixes #1526. Simple renaming.