### PR TITLE
Move layer file info logging to containerize()

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -150,7 +150,6 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
                 pluginConfigurationProcessor.getJibContainerBuilder(),
                 pluginConfigurationProcessor.getContainerizer(),
                 new DefaultEventDispatcher(projectProperties.getEventHandlers()),
-                projectProperties.getJavaLayerConfigurations().getLayerConfigurations(),
                 helpfulSuggestions);
 
       } finally {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -129,7 +129,6 @@ public class BuildImageTask extends DefaultTask implements JibTask {
                 pluginConfigurationProcessor.getJibContainerBuilder(),
                 pluginConfigurationProcessor.getContainerizer(),
                 new DefaultEventDispatcher(projectProperties.getEventHandlers()),
-                projectProperties.getJavaLayerConfigurations().getLayerConfigurations(),
                 helpfulSuggestions);
 
       } finally {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -147,7 +147,6 @@ public class BuildTarTask extends DefaultTask implements JibTask {
                 pluginConfigurationProcessor.getJibContainerBuilder(),
                 pluginConfigurationProcessor.getContainerizer(),
                 new DefaultEventDispatcher(projectProperties.getEventHandlers()),
-                projectProperties.getJavaLayerConfigurations().getLayerConfigurations(),
                 helpfulSuggestions);
 
       } finally {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -141,7 +141,6 @@ public class BuildDockerMojo extends JibPluginConfiguration {
                 pluginConfigurationProcessor.getJibContainerBuilder(),
                 pluginConfigurationProcessor.getContainerizer(),
                 eventDispatcher,
-                projectProperties.getJavaLayerConfigurations().getLayerConfigurations(),
                 helpfulSuggestions);
 
       } finally {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -133,7 +133,6 @@ public class BuildImageMojo extends JibPluginConfiguration {
                 pluginConfigurationProcessor.getJibContainerBuilder(),
                 pluginConfigurationProcessor.getContainerizer(),
                 eventDispatcher,
-                projectProperties.getJavaLayerConfigurations().getLayerConfigurations(),
                 helpfulSuggestions);
 
       } finally {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -111,7 +111,6 @@ public class BuildTarMojo extends JibPluginConfiguration {
                 pluginConfigurationProcessor.getJibContainerBuilder(),
                 pluginConfigurationProcessor.getContainerizer(),
                 eventDispatcher,
-                projectProperties.getJavaLayerConfigurations().getLayerConfigurations(),
                 helpfulSuggestions);
 
       } finally {

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunner.java
@@ -23,11 +23,9 @@ import com.google.cloud.tools.jib.api.JibContainer;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.builder.BuildSteps;
 import com.google.cloud.tools.jib.configuration.CacheDirectoryCreationException;
-import com.google.cloud.tools.jib.configuration.LayerConfiguration;
 import com.google.cloud.tools.jib.event.EventDispatcher;
 import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.image.ImageReference;
-import com.google.cloud.tools.jib.image.LayerEntry;
 import com.google.cloud.tools.jib.registry.InsecureRegistryException;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticationFailedException;
 import com.google.cloud.tools.jib.registry.RegistryCredentialsNotSentException;
@@ -40,7 +38,6 @@ import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.concurrent.ExecutionException;
@@ -150,13 +147,6 @@ public class BuildStepsRunner {
     }
   }
 
-  private static String capitalizeFirstLetter(String string) {
-    if (string.length() == 0) {
-      return string;
-    }
-    return Character.toUpperCase(string.charAt(0)) + string.substring(1);
-  }
-
   private final String startupMessage;
   private final String successMessage;
   @Nullable private Path imageDigestOutputPath;
@@ -174,7 +164,6 @@ public class BuildStepsRunner {
    * @param jibContainerBuilder the {@link JibContainerBuilder}
    * @param containerizer the {@link Containerizer}
    * @param eventDispatcher the {@link EventDispatcher}
-   * @param layerConfigurations the list of {@link LayerConfiguration}s
    * @param helpfulSuggestions suggestions to use in help messages for exceptions
    * @return the built {@link JibContainer}
    * @throws BuildStepsExecutionException if another exception is thrown during the build
@@ -185,29 +174,11 @@ public class BuildStepsRunner {
       JibContainerBuilder jibContainerBuilder,
       Containerizer containerizer,
       EventDispatcher eventDispatcher,
-      List<LayerConfiguration> layerConfigurations,
       HelpfulSuggestions helpfulSuggestions)
       throws BuildStepsExecutionException, IOException, CacheDirectoryCreationException {
     try {
       eventDispatcher.dispatch(LogEvent.lifecycle(""));
       eventDispatcher.dispatch(LogEvent.lifecycle(startupMessage));
-
-      // Logs the different source files used.
-      eventDispatcher.dispatch(
-          LogEvent.info("Containerizing application with the following files:"));
-
-      for (LayerConfiguration layerConfiguration : layerConfigurations) {
-        if (layerConfiguration.getLayerEntries().isEmpty()) {
-          continue;
-        }
-
-        eventDispatcher.dispatch(
-            LogEvent.info("\t" + capitalizeFirstLetter(layerConfiguration.getName()) + ":"));
-
-        for (LayerEntry layerEntry : layerConfiguration.getLayerEntries()) {
-          eventDispatcher.dispatch(LogEvent.info("\t\t" + layerEntry.getSourceFile()));
-        }
-      }
 
       JibContainer jibContainer = jibContainerBuilder.containerize(containerizer);
 

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunnerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/BuildStepsRunnerTest.java
@@ -29,7 +29,6 @@ import com.google.cloud.tools.jib.registry.RegistryException;
 import com.google.cloud.tools.jib.registry.RegistryUnauthorizedException;
 import java.io.IOException;
 import java.net.UnknownHostException;
-import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import org.apache.http.conn.HttpHostConnectException;
 import org.junit.Assert;
@@ -82,11 +81,7 @@ public class BuildStepsRunnerTest {
   public void testBuildImage_pass()
       throws BuildStepsExecutionException, IOException, CacheDirectoryCreationException {
     testBuildImageStepsRunner.build(
-        mockJibContainerBuilder,
-        mockContainerizer,
-        mockEventDispatcher,
-        Collections.emptyList(),
-        TEST_HELPFUL_SUGGESTIONS);
+        mockJibContainerBuilder, mockContainerizer, mockEventDispatcher, TEST_HELPFUL_SUGGESTIONS);
   }
 
   @Test
@@ -104,7 +99,6 @@ public class BuildStepsRunnerTest {
           mockJibContainerBuilder,
           mockContainerizer,
           mockEventDispatcher,
-          Collections.emptyList(),
           TEST_HELPFUL_SUGGESTIONS);
       Assert.fail("buildImage should have thrown an exception");
 
@@ -127,7 +121,6 @@ public class BuildStepsRunnerTest {
           mockJibContainerBuilder,
           mockContainerizer,
           mockEventDispatcher,
-          Collections.emptyList(),
           TEST_HELPFUL_SUGGESTIONS);
       Assert.fail("buildImage should have thrown an exception");
 
@@ -151,7 +144,6 @@ public class BuildStepsRunnerTest {
           mockJibContainerBuilder,
           mockContainerizer,
           mockEventDispatcher,
-          Collections.emptyList(),
           TEST_HELPFUL_SUGGESTIONS);
       Assert.fail("buildImage should have thrown an exception");
 
@@ -180,7 +172,6 @@ public class BuildStepsRunnerTest {
           mockJibContainerBuilder,
           mockContainerizer,
           mockEventDispatcher,
-          Collections.emptyList(),
           TEST_HELPFUL_SUGGESTIONS);
       Assert.fail("buildImage should have thrown an exception");
 
@@ -210,7 +201,6 @@ public class BuildStepsRunnerTest {
           mockJibContainerBuilder,
           mockContainerizer,
           mockEventDispatcher,
-          Collections.emptyList(),
           TEST_HELPFUL_SUGGESTIONS);
       Assert.fail("buildImage should have thrown an exception");
 
@@ -234,7 +224,6 @@ public class BuildStepsRunnerTest {
           mockJibContainerBuilder,
           mockContainerizer,
           mockEventDispatcher,
-          Collections.emptyList(),
           TEST_HELPFUL_SUGGESTIONS);
       Assert.fail("buildImage should have thrown an exception");
 
@@ -257,7 +246,6 @@ public class BuildStepsRunnerTest {
           mockJibContainerBuilder,
           mockContainerizer,
           mockEventDispatcher,
-          Collections.emptyList(),
           TEST_HELPFUL_SUGGESTIONS);
       Assert.fail("buildImage should have thrown an exception");
 


### PR DESCRIPTION
Slight cleanup by moving some logging events into jib core, which removes an extra `layerConfigurations` parameter being passed around.