### PR TITLE
Don't add empty layers in JavaLayerConfigurations

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaLayerConfigurations.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaLayerConfigurations.java
@@ -164,7 +164,6 @@ public class JavaLayerConfigurations {
         AbsoluteUnixPath basePathInContainer,
         Map<AbsoluteUnixPath, FilePermissions> permissionsMap)
         throws IOException {
-
       if (layerBuilders.get(layerType) == null) {
         layerBuilders.put(layerType, LayerConfiguration.builder());
       }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaLayerConfigurations.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaLayerConfigurations.java
@@ -22,7 +22,6 @@ import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.filesystem.DirectoryWalker;
 import com.google.cloud.tools.jib.image.LayerEntry;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.io.IOException;
@@ -68,11 +67,7 @@ public class JavaLayerConfigurations {
     private final Map<LayerType, LayerConfiguration.Builder> layerBuilders =
         new EnumMap<>(LayerType.class);
 
-    private Builder() {
-      for (LayerType layerType : LayerType.values()) {
-        layerBuilders.put(layerType, LayerConfiguration.builder());
-      }
-    }
+    private Builder() {}
 
     /**
      * Adds a file to a layer. Only adds the single source file to the exact path in the container
@@ -111,8 +106,10 @@ public class JavaLayerConfigurations {
         Path sourceFile,
         AbsoluteUnixPath pathInContainer,
         @Nullable FilePermissions permissions) {
-      Preconditions.checkNotNull(layerBuilders.get(layerType))
-          .addEntry(sourceFile, pathInContainer, permissions);
+      if (layerBuilders.get(layerType) == null) {
+        layerBuilders.put(layerType, LayerConfiguration.builder());
+      }
+      layerBuilders.get(layerType).addEntry(sourceFile, pathInContainer, permissions);
       return this;
     }
 
@@ -167,7 +164,11 @@ public class JavaLayerConfigurations {
         AbsoluteUnixPath basePathInContainer,
         Map<AbsoluteUnixPath, FilePermissions> permissionsMap)
         throws IOException {
-      LayerConfiguration.Builder builder = Preconditions.checkNotNull(layerBuilders.get(layerType));
+
+      if (layerBuilders.get(layerType) == null) {
+        layerBuilders.put(layerType, LayerConfiguration.builder());
+      }
+      LayerConfiguration.Builder builder = layerBuilders.get(layerType);
 
       new DirectoryWalker(sourceRoot)
           .filterRoot()
@@ -240,6 +241,9 @@ public class JavaLayerConfigurations {
   }
 
   private ImmutableList<LayerEntry> getLayerEntries(LayerType layerType) {
-    return Preconditions.checkNotNull(layerConfigurationMap.get(layerType)).getLayerEntries();
+    if (layerConfigurationMap.get(layerType) == null) {
+      return ImmutableList.of();
+    }
+    return layerConfigurationMap.get(layerType).getLayerEntries();
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaLayerConfigurations.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/JavaLayerConfigurations.java
@@ -106,7 +106,7 @@ public class JavaLayerConfigurations {
         Path sourceFile,
         AbsoluteUnixPath pathInContainer,
         @Nullable FilePermissions permissions) {
-      if (layerBuilders.get(layerType) == null) {
+      if (!layerBuilders.containsKey(layerType)) {
         layerBuilders.put(layerType, LayerConfiguration.builder());
       }
       layerBuilders.get(layerType).addEntry(sourceFile, pathInContainer, permissions);
@@ -164,7 +164,7 @@ public class JavaLayerConfigurations {
         AbsoluteUnixPath basePathInContainer,
         Map<AbsoluteUnixPath, FilePermissions> permissionsMap)
         throws IOException {
-      if (layerBuilders.get(layerType) == null) {
+      if (!layerBuilders.containsKey(layerType)) {
         layerBuilders.put(layerType, LayerConfiguration.builder());
       }
       LayerConfiguration.Builder builder = layerBuilders.get(layerType);
@@ -240,7 +240,7 @@ public class JavaLayerConfigurations {
   }
 
   private ImmutableList<LayerEntry> getLayerEntries(LayerType layerType) {
-    if (layerConfigurationMap.get(layerType) == null) {
+    if (!layerConfigurationMap.containsKey(layerType)) {
       return ImmutableList.of();
     }
     return layerConfigurationMap.get(layerType).getLayerEntries();

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/JavaLayerConfigurationsTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/JavaLayerConfigurationsTest.java
@@ -264,6 +264,11 @@ public class JavaLayerConfigurationsTest {
         Collections.singletonList(
             new LayerEntry(sourceRoot.resolve("file"), basePath.resolve("file"), null)),
         configurations.getExtraFilesLayerEntries());
+    Assert.assertEquals(Collections.emptyList(), configurations.getClassLayerEntries());
+    Assert.assertEquals(Collections.emptyList(), configurations.getResourceLayerEntries());
+    Assert.assertEquals(Collections.emptyList(), configurations.getDependencyLayerEntries());
+    Assert.assertEquals(
+        Collections.emptyList(), configurations.getSnapshotDependencyLayerEntries());
   }
 
   @Test
@@ -281,6 +286,11 @@ public class JavaLayerConfigurationsTest {
         Collections.singletonList(
             new LayerEntry(sourceRoot.resolve("leaf"), basePath.resolve("leaf"), null)),
         configurations.getClassLayerEntries());
+    Assert.assertEquals(Collections.emptyList(), configurations.getResourceLayerEntries());
+    Assert.assertEquals(Collections.emptyList(), configurations.getDependencyLayerEntries());
+    Assert.assertEquals(
+        Collections.emptyList(), configurations.getSnapshotDependencyLayerEntries());
+    Assert.assertEquals(Collections.emptyList(), configurations.getExtraFilesLayerEntries());
   }
 
   @Test


### PR DESCRIPTION
Before this PR, in `JavaLayerConfigurations`, all 5 java layers (classes, resources, dependencies, snapshot dependencies, and extra files) are added automatically, whether there are files in the layers or not. This PR skips the empty layers.

Small bit towards #1373.