### PR TITLE
add lasttimestamp to LayerEntry to ensure the timestamp can be controlled for key files

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/LayerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/LayerConfiguration.java
@@ -80,13 +80,36 @@ public class LayerConfiguration {
      *     sourceFile}
      * @param permissions the file permissions on the container. If null, then default permissions
      *     are used (644 for files, 755 for directories)
+     * @param lastModified file last modified value, default to 1 second since the epoch
+     *     (https://github.com/GoogleContainerTools/jib/issues/1079)
+     * @return this
+     * @see Builder#addEntry(Path, AbsoluteUnixPath)
+     */
+    public Builder addEntry(
+        Path sourceFile,
+        AbsoluteUnixPath pathInContainer,
+        @Nullable FilePermissions permissions,
+        long lastModified) {
+      layerEntries.add(new LayerEntry(sourceFile, pathInContainer, permissions, lastModified));
+      return this;
+    }
+
+    /**
+     * Adds an entry to the layer with the given permissions. Only adds the single source file to
+     * the exact path in the container file system. See {@link Builder#addEntry(Path,
+     * AbsoluteUnixPath)} for more information.
+     *
+     * @param sourceFile the source file to add to the layer
+     * @param pathInContainer the path in the container file system corresponding to the {@code
+     *     sourceFile}
+     * @param permissions the file permissions on the container. If null, then default permissions
+     *     are used (644 for files, 755 for directories)
      * @return this
      * @see Builder#addEntry(Path, AbsoluteUnixPath)
      */
     public Builder addEntry(
         Path sourceFile, AbsoluteUnixPath pathInContainer, @Nullable FilePermissions permissions) {
-      layerEntries.add(new LayerEntry(sourceFile, pathInContainer, permissions));
-      return this;
+      return addEntry(sourceFile, pathInContainer, permissions, -1);
     }
 
     /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/LayerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/LayerConfiguration.java
@@ -80,8 +80,7 @@ public class LayerConfiguration {
      *     sourceFile}
      * @param permissions the file permissions on the container. If null, then default permissions
      *     are used (644 for files, 755 for directories)
-     * @param lastModified file last modified value, default to 1 second since the epoch
-     *     (https://github.com/GoogleContainerTools/jib/issues/1079)
+     * @param lastModified the modification time of the file
      * @return this
      * @see Builder#addEntry(Path, AbsoluteUnixPath)
      */
@@ -109,7 +108,7 @@ public class LayerConfiguration {
      */
     public Builder addEntry(
         Path sourceFile, AbsoluteUnixPath pathInContainer, @Nullable FilePermissions permissions) {
-      return addEntry(sourceFile, pathInContainer, permissions, -1);
+      return addEntry(sourceFile, pathInContainer, permissions, 1000);
     }
 
     /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/LayerEntry.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/LayerEntry.java
@@ -75,7 +75,7 @@ public class LayerEntry {
                 ? FilePermissions.DEFAULT_FOLDER_PERMISSIONS
                 : FilePermissions.DEFAULT_FILE_PERMISSIONS
             : permissions;
-    this.lastModifiedTime = Math.max(lastModifiedTime, 1000);
+    this.lastModifiedTime = lastModifiedTime;
   }
 
   /**
@@ -90,7 +90,7 @@ public class LayerEntry {
    */
   public LayerEntry(
       Path sourceFile, AbsoluteUnixPath extractionPath, @Nullable FilePermissions permissions) {
-    this(sourceFile, extractionPath, permissions, -1);
+    this(sourceFile, extractionPath, permissions, 1000);
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/LayerEntry.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/LayerEntry.java
@@ -79,7 +79,8 @@ public class LayerEntry {
   }
 
   /**
-   * Backward compatible constructor.
+   * Instantiates with a source file and the path to place the source file in the container file
+   * system.
    *
    * @param sourceFile the source file to add to the layer
    * @param extractionPath the path in the container file system corresponding to the {@code
@@ -93,9 +94,9 @@ public class LayerEntry {
   }
 
   /**
-   * The timestamp of the entry.
+   * Returns the modification time of the file in the entry.
    *
-   * @return the modTime to set on the tar entry in the docker layer.
+   * @return the modification time
    */
   public long getLastModifiedTime() {
     return lastModifiedTime;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/LayerEntry.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/LayerEntry.java
@@ -40,6 +40,7 @@ public class LayerEntry {
   private final Path sourceFile;
   private final AbsoluteUnixPath extractionPath;
   private final FilePermissions permissions;
+  private final long lastModifiedTime;
 
   /**
    * Instantiates with a source file and the path to place the source file in the container file
@@ -58,9 +59,14 @@ public class LayerEntry {
    *     sourceFile}
    * @param permissions the file permissions on the container. Use {@code null} to use defaults (644
    *     for files, 755 for directories)
+   * @param lastModifiedTime the file modification time, default to 1 second since the epoch
+   *     (https://github.com/GoogleContainerTools/jib/issues/1079)
    */
   public LayerEntry(
-      Path sourceFile, AbsoluteUnixPath extractionPath, @Nullable FilePermissions permissions) {
+      Path sourceFile,
+      AbsoluteUnixPath extractionPath,
+      @Nullable FilePermissions permissions,
+      long lastModifiedTime) {
     this.sourceFile = sourceFile;
     this.extractionPath = extractionPath;
     this.permissions =
@@ -69,6 +75,30 @@ public class LayerEntry {
                 ? FilePermissions.DEFAULT_FOLDER_PERMISSIONS
                 : FilePermissions.DEFAULT_FILE_PERMISSIONS
             : permissions;
+    this.lastModifiedTime = Math.max(lastModifiedTime, 1000);
+  }
+
+  /**
+   * Backward compatible constructor.
+   *
+   * @param sourceFile the source file to add to the layer
+   * @param extractionPath the path in the container file system corresponding to the {@code
+   *     sourceFile}
+   * @param permissions the file permissions on the container. Use {@code null} to use defaults (644
+   *     for files, 755 for directories)
+   */
+  public LayerEntry(
+      Path sourceFile, AbsoluteUnixPath extractionPath, @Nullable FilePermissions permissions) {
+    this(sourceFile, extractionPath, permissions, -1);
+  }
+
+  /**
+   * The timestamp of the entry.
+   *
+   * @return the modTime to set on the tar entry in the docker layer.
+   */
+  public long getLastModifiedTime() {
+    return lastModifiedTime;
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
@@ -107,6 +107,7 @@ public class ReproducibleLayerBuilder {
       // Sets the entry's permissions by masking out the permission bits from the entry's mode (the
       // lowest 9 bits) then using a bitwise OR to set them to the layerEntry's permissions.
       entry.setMode((entry.getMode() & ~0777) | layerEntry.getPermissions().getPermissionBits());
+      entry.setModTime(layerEntry.getLastModifiedTime());
 
       uniqueTarArchiveEntries.add(entry);
     }
@@ -120,8 +121,6 @@ public class ReproducibleLayerBuilder {
     TarStreamBuilder tarStreamBuilder = new TarStreamBuilder();
     for (TarArchiveEntry entry : sortedFilesystemEntries) {
       // Strips out all non-reproducible elements from tar archive entries.
-      // 1 second since the epoch (https://github.com/GoogleContainerTools/jib/issues/1079)
-      entry.setModTime(1000);
       entry.setGroupId(0);
       entry.setUserId(0);
       entry.setUserName("");


### PR DESCRIPTION
I assume this is close to the issue https://github.com/GoogleContainerTools/jib/issues/1079 so I didn't recreate a ticket but my use case is a bit different.
I have a dockerized app using libraries relying on file lastModifiedDate to create a kind of "testable timestamp" to check if some caching should be invalidated or not.
Current impl of jib-core setModTime to 1s after epoch which breaks that usage.
To ensure it is reproducable I propose to add the timestamp in the API of addEntry(file), with a minimum of 1s after the epoch. 
This way people can choose to hardcode it or use a custom version if they know - like using maven metadata if the file comes from a maven release.

Hope it makes sense.