### PR TITLE
No need for checking null Maven settings.xml Decryptor

### DIFF
--- a/jib-maven-plugin/pom.xml
+++ b/jib-maven-plugin/pom.xml
@@ -368,7 +368,7 @@
               </annotationProcessorPaths>
               <compilerArgs>
                 <arg>-XDcompilePolicy=simple</arg>
-                <arg>-Xplugin:ErrorProne -Xep:NullAway:ERROR -XepOpt:NullAway:AnnotatedPackages=com.google.cloud.tools</arg>
+                <arg>-Xplugin:ErrorProne -Xep:NullAway:ERROR -XepOpt:NullAway:ExcludedFieldAnnotations=org.apache.maven.plugins.annotations.Component -XepOpt:NullAway:AnnotatedPackages=com.google.cloud.tools</arg>
               </compilerArgs>
             </configuration>
           </execution>

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -114,7 +114,7 @@ public class BuildDockerMojo extends JibPluginConfiguration {
           PluginConfigurationProcessor.processCommonConfigurationForDockerDaemonImage(
               mavenRawConfiguration,
               new MavenSettingsServerCredentials(
-                  getSession().getSettings(), getSettingsDecrypter(), eventDispatcher),
+                  getSession().getSettings(), getSettingsDecrypter()),
               projectProperties,
               dockerExecutable,
               getDockerClientEnvironment(),

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -108,7 +108,7 @@ public class BuildImageMojo extends JibPluginConfiguration {
           PluginConfigurationProcessor.processCommonConfigurationForRegistryImage(
               mavenRawConfiguration,
               new MavenSettingsServerCredentials(
-                  getSession().getSettings(), getSettingsDecrypter(), eventDispatcher),
+                  getSession().getSettings(), getSettingsDecrypter()),
               projectProperties);
       ProxyProvider.init(getSession().getSettings());
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -89,7 +89,7 @@ public class BuildTarMojo extends JibPluginConfiguration {
           PluginConfigurationProcessor.processCommonConfigurationForTarImage(
               mavenRawConfiguration,
               new MavenSettingsServerCredentials(
-                  getSession().getSettings(), getSettingsDecrypter(), eventDispatcher),
+                  getSession().getSettings(), getSettingsDecrypter()),
               projectProperties,
               tarOutputPath,
               mavenHelpfulSuggestionsBuilder.build());

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -232,8 +232,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   @Parameter(defaultValue = "false", property = PropertyNames.SKIP)
   private boolean skip;
 
-  // @Nullable to suppress NullAway complaining a non-null field uninitialized; not null in practice
-  @Nullable @Component protected SettingsDecrypter settingsDecrypter;
+  @Component protected SettingsDecrypter settingsDecrypter;
 
   MavenSession getSession() {
     return Preconditions.checkNotNull(session);

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -544,7 +544,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   }
 
   SettingsDecrypter getSettingsDecrypter() {
-    return Preconditions.checkNotNull(settingsDecrypter);
+    return settingsDecrypter;
   }
 
   @VisibleForTesting

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -232,7 +232,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   @Parameter(defaultValue = "false", property = PropertyNames.SKIP)
   private boolean skip;
 
-  @Nullable @Component protected SettingsDecrypter settingsDecrypter;
+  @Component protected SettingsDecrypter settingsDecrypter;
 
   MavenSession getSession() {
     return Preconditions.checkNotNull(session);
@@ -544,7 +544,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   }
 
   SettingsDecrypter getSettingsDecrypter() {
-    return Preconditions.checkNotNull(settingsDecrypter);
+    return settingsDecrypter;
   }
 
   @VisibleForTesting

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -232,7 +232,8 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   @Parameter(defaultValue = "false", property = PropertyNames.SKIP)
   private boolean skip;
 
-  @Component protected SettingsDecrypter settingsDecrypter;
+  // @Nullable to suppress NullAway complaining a non-null field uninitialized; not null in practice
+  @Nullable @Component protected SettingsDecrypter settingsDecrypter;
 
   MavenSession getSession() {
     return Preconditions.checkNotNull(session);
@@ -544,7 +545,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   }
 
   SettingsDecrypter getSettingsDecrypter() {
-    return settingsDecrypter;
+    return Preconditions.checkNotNull(settingsDecrypter);
   }
 
   @VisibleForTesting

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentials.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentials.java
@@ -16,16 +16,10 @@
 
 package com.google.cloud.tools.jib.maven;
 
-import com.google.cloud.tools.jib.event.EventDispatcher;
-import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
 import com.google.cloud.tools.jib.plugins.common.InferredAuthProvider;
 import com.google.cloud.tools.jib.plugins.common.InferredAuthRetrievalException;
-import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import javax.annotation.Nullable;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.building.SettingsProblem;
@@ -42,25 +36,8 @@ class MavenSettingsServerCredentials implements InferredAuthProvider {
 
   static final String CREDENTIAL_SOURCE = "Maven settings";
 
-  // pattern cribbed directly from
-  // https://github.com/sonatype/plexus-cipher/blob/master/src/main/java/org/sonatype/plexus/components/cipher/DefaultPlexusCipher.java
-  private static final Pattern ENCRYPTED_STRING_PATTERN =
-      Pattern.compile(".*?[^\\\\]?\\{(.*?[^\\\\])\\}.*");
-
-  /**
-   * Return true if the given string appears to have been encrypted with the <a
-   * href="https://maven.apache.org/guides/mini/guide-encryption.html#How_to_encrypt_server_passwords">Maven
-   * password encryption</a>. Such passwords appear between unescaped braces.
-   */
-  @VisibleForTesting
-  static boolean isEncrypted(String password) {
-    Matcher matcher = ENCRYPTED_STRING_PATTERN.matcher(password);
-    return matcher.matches() || matcher.find();
-  }
-
   private final Settings settings;
-  @Nullable private final SettingsDecrypter settingsDecrypter;
-  private final EventDispatcher eventDispatcher;
+  private final SettingsDecrypter settingsDecrypter;
 
   /**
    * Create new instance.
@@ -69,13 +46,9 @@ class MavenSettingsServerCredentials implements InferredAuthProvider {
    * @param settingsDecrypter the Maven decrypter component
    * @param eventDispatcher the Jib event dispatcher
    */
-  MavenSettingsServerCredentials(
-      Settings settings,
-      @Nullable SettingsDecrypter settingsDecrypter,
-      EventDispatcher eventDispatcher) {
+  MavenSettingsServerCredentials(Settings settings, SettingsDecrypter settingsDecrypter) {
     this.settings = settings;
     this.settingsDecrypter = settingsDecrypter;
-    this.eventDispatcher = eventDispatcher;
   }
 
   /**
@@ -92,31 +65,23 @@ class MavenSettingsServerCredentials implements InferredAuthProvider {
       return Optional.empty();
     }
 
-    if (settingsDecrypter != null) {
-      // SettingsDecrypter and SettingsDecryptionResult do not document the meanings of the return
-      // results. SettingsDecryptionResult#getServers() does note that the list of decrypted servers
-      // can be empty.  We handle the results as follows:
-      //    - if there are any ERROR or FATAL problems reported, then decryption failed
-      //    - if no decrypted servers returned then treat as if no decryption was required
-      SettingsDecryptionRequest request = new DefaultSettingsDecryptionRequest(registryServer);
-      SettingsDecryptionResult result = settingsDecrypter.decrypt(request);
-      // un-encrypted passwords are passed through, so a problem indicates a real issue
-      for (SettingsProblem problem : result.getProblems()) {
-        if (problem.getSeverity() == SettingsProblem.Severity.ERROR
-            || problem.getSeverity() == SettingsProblem.Severity.FATAL) {
-          throw new InferredAuthRetrievalException(
-              "Unable to decrypt password for " + registry + ": " + problem);
-        }
+    // SettingsDecrypter and SettingsDecryptionResult do not document the meanings of the return
+    // results. SettingsDecryptionResult#getServers() does note that the list of decrypted servers
+    // can be empty.  We handle the results as follows:
+    //    - if there are any ERROR or FATAL problems reported, then decryption failed
+    //    - if no decrypted servers returned then treat as if no decryption was required
+    SettingsDecryptionRequest request = new DefaultSettingsDecryptionRequest(registryServer);
+    SettingsDecryptionResult result = settingsDecrypter.decrypt(request);
+    // un-encrypted passwords are passed through, so a problem indicates a real issue
+    for (SettingsProblem problem : result.getProblems()) {
+      if (problem.getSeverity() == SettingsProblem.Severity.ERROR
+          || problem.getSeverity() == SettingsProblem.Severity.FATAL) {
+        throw new InferredAuthRetrievalException(
+            "Unable to decrypt password for " + registry + ": " + problem);
       }
-      if (result.getServer() != null) {
-        registryServer = result.getServer();
-      }
-    } else if (isEncrypted(registryServer.getPassword())) {
-      eventDispatcher.dispatch(
-          LogEvent.warn(
-              "Server password for registry "
-                  + registry
-                  + " appears to be encrypted, but there is no decrypter available"));
+    }
+    if (result.getServer() != null) {
+      registryServer = result.getServer();
     }
 
     String username = registryServer.getUsername();

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentialsTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentialsTest.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.tools.jib.maven;
 
-import com.google.cloud.tools.jib.event.EventDispatcher;
-import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
 import com.google.cloud.tools.jib.plugins.common.InferredAuthRetrievalException;
 import java.util.Collections;
@@ -41,14 +39,20 @@ public class MavenSettingsServerCredentialsTest {
 
   @Mock private Settings mockSettings;
   @Mock private Server mockServer1;
-  @Mock private EventDispatcher mockEventDispatcher;
+  @Mock private SettingsDecrypter mockSettingsDecrypter;
+  @Mock private SettingsDecryptionResult mockSettingsDecryptionResult;
 
   private MavenSettingsServerCredentials testMavenSettingsServerCredentials;
 
   @Before
   public void setUp() {
+    Mockito.when(mockSettingsDecryptionResult.getProblems()).thenReturn(Collections.emptyList());
+    Mockito.when(mockSettingsDecryptionResult.getServer()).thenReturn(mockServer1);
+    Mockito.when(mockSettingsDecrypter.decrypt(Mockito.any()))
+        .thenReturn(mockSettingsDecryptionResult);
+
     testMavenSettingsServerCredentials =
-        new MavenSettingsServerCredentials(mockSettings, null, mockEventDispatcher);
+        new MavenSettingsServerCredentials(mockSettings, mockSettingsDecrypter);
   }
 
   @Test
@@ -62,8 +66,6 @@ public class MavenSettingsServerCredentialsTest {
     Assert.assertTrue(auth.isPresent());
     Assert.assertEquals("server1 username", auth.get().getUsername());
     Assert.assertEquals("server1 password", auth.get().getPassword());
-
-    Mockito.verifyZeroInteractions(mockEventDispatcher);
   }
 
   @Test
@@ -77,32 +79,9 @@ public class MavenSettingsServerCredentialsTest {
   }
 
   @Test
-  public void testRetrieve_withNullDecrypter_encrypted() throws InferredAuthRetrievalException {
-    Mockito.when(mockSettings.getServer("server1")).thenReturn(mockServer1);
-    Mockito.when(mockServer1.getUsername()).thenReturn("server1 username");
-    Mockito.when(mockServer1.getPassword()).thenReturn("{COQLCE6DU6GtcS5P=}");
-
-    Optional<AuthProperty> auth = testMavenSettingsServerCredentials.getAuth("server1");
-    Assert.assertTrue(auth.isPresent());
-    Assert.assertEquals("server1 username", auth.get().getUsername());
-    Assert.assertEquals("{COQLCE6DU6GtcS5P=}", auth.get().getPassword());
-    String expectedWarning =
-        "Server password for registry server1 appears to be encrypted, but there is no decrypter"
-            + " available";
-    Mockito.verify(mockEventDispatcher).dispatch(LogEvent.warn(expectedWarning));
-  }
-
-  @Test
   public void testRetrieve_withDecrypter_success() throws InferredAuthRetrievalException {
-    SettingsDecryptionResult mockResult = Mockito.mock(SettingsDecryptionResult.class);
-    Mockito.when(mockResult.getProblems()).thenReturn(Collections.emptyList());
-    Mockito.when(mockResult.getServer()).thenReturn(mockServer1);
-
-    // don't actually perform encryption/decryption
-    SettingsDecrypter mockDecrypter = Mockito.mock(SettingsDecrypter.class);
-    Mockito.when(mockDecrypter.decrypt(Mockito.any())).thenReturn(mockResult);
     testMavenSettingsServerCredentials =
-        new MavenSettingsServerCredentials(mockSettings, mockDecrypter, mockEventDispatcher);
+        new MavenSettingsServerCredentials(mockSettings, mockSettingsDecrypter);
 
     // essentially the same as testRetrieve_found()
     Mockito.when(mockSettings.getServer("server1")).thenReturn(mockServer1);
@@ -114,9 +93,9 @@ public class MavenSettingsServerCredentialsTest {
     Assert.assertEquals("server1 username", auth.get().getUsername());
     Assert.assertEquals("server1 password", auth.get().getPassword());
 
-    Mockito.verify(mockDecrypter).decrypt(Mockito.any());
-    Mockito.verify(mockResult).getProblems();
-    Mockito.verify(mockResult, Mockito.atLeastOnce()).getServer();
+    Mockito.verify(mockSettingsDecrypter).decrypt(Mockito.any());
+    Mockito.verify(mockSettingsDecryptionResult).getProblems();
+    Mockito.verify(mockSettingsDecryptionResult, Mockito.atLeastOnce()).getServer();
   }
 
   @Test
@@ -126,15 +105,11 @@ public class MavenSettingsServerCredentialsTest {
     Mockito.when(mockProblem.getSeverity()).thenReturn(SettingsProblem.Severity.ERROR);
     // Maven's SettingsProblem has a more structured toString, but irrelevant here
     Mockito.when(mockProblem.toString()).thenReturn("MockProblemText");
+    Mockito.when(mockSettingsDecryptionResult.getProblems())
+        .thenReturn(Collections.singletonList(mockProblem));
 
-    SettingsDecryptionResult mockResult = Mockito.mock(SettingsDecryptionResult.class);
-    Mockito.when(mockResult.getProblems()).thenReturn(Collections.singletonList(mockProblem));
-
-    // return an result with problems
-    SettingsDecrypter mockDecrypter = Mockito.mock(SettingsDecrypter.class);
-    Mockito.when(mockDecrypter.decrypt(Mockito.any())).thenReturn(mockResult);
     testMavenSettingsServerCredentials =
-        new MavenSettingsServerCredentials(mockSettings, mockDecrypter, mockEventDispatcher);
+        new MavenSettingsServerCredentials(mockSettings, mockSettingsDecrypter);
 
     // essentially the same as testRetrieve_found()
     Mockito.when(mockSettings.getServer("server1")).thenReturn(mockServer1);
@@ -145,26 +120,10 @@ public class MavenSettingsServerCredentialsTest {
     } catch (InferredAuthRetrievalException ex) {
       Assert.assertEquals(
           ex.getMessage(), "Unable to decrypt password for server1: MockProblemText");
-      Mockito.verify(mockDecrypter).decrypt(Mockito.any());
-      Mockito.verify(mockResult).getProblems();
-      Mockito.verifyNoMoreInteractions(mockResult); // getServer() should never be called
-    }
-  }
-
-  @Test
-  public void testIsEncrypted_plaintext() {
-    Assert.assertFalse(MavenSettingsServerCredentials.isEncrypted("plain text"));
-  }
-
-  @Test
-  public void testIsEncrypted_encryptedPayload() {
-    String examples[] = {
-      "{COQLCE6DU6GtcS5P=}",
-      "expires on 2009-04-11 {COQLCE6DU6GtcS5P=}", // with note
-      "{jSMOWnoPFgsHVpMvz5VrIt5kRbzGpI8u+\\{EF1iFQyJQ=}" // with escaped brace
-    };
-    for (String payload : examples) {
-      Assert.assertTrue(MavenSettingsServerCredentials.isEncrypted(payload));
+      Mockito.verify(mockSettingsDecrypter).decrypt(Mockito.any());
+      Mockito.verify(mockSettingsDecryptionResult).getProblems();
+      Mockito.verifyNoMoreInteractions(
+          mockSettingsDecryptionResult); // getServer() should never be called
     }
   }
 }


### PR DESCRIPTION
Toward #1369.

Probably we initially considered the possibility that the decryptor could be null, but so far, no one has reported the violation of this:

```java
  SettingsDecrypter getSettingsDecrypter() {
    return Preconditions.checkNotNull(settingsDecrypter);
  }
```

After all, `getSettingsDecrypter()` has not been `@Nullable`. I don't think we need to take out the `checkNotNull()`.