### PR TITLE
Hide internal classes and methods

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
@@ -53,7 +53,8 @@ public class Containerizer {
    * @return a new {@link Containerizer}
    */
   public static Containerizer to(RegistryImage registryImage) {
-    return new Containerizer(registryImage);
+    Preconditions.checkArgument(registryImage instanceof TargetImage);
+    return new Containerizer((TargetImage) registryImage);
   }
 
   /**
@@ -63,7 +64,8 @@ public class Containerizer {
    * @return a new {@link Containerizer}
    */
   public static Containerizer to(DockerDaemonImage dockerDaemonImage) {
-    return new Containerizer(dockerDaemonImage);
+    Preconditions.checkArgument(dockerDaemonImage instanceof TargetImage);
+    return new Containerizer((TargetImage) dockerDaemonImage);
   }
 
   /**
@@ -73,7 +75,8 @@ public class Containerizer {
    * @return a new {@link Containerizer}
    */
   public static Containerizer to(TarImage tarImage) {
-    return new Containerizer(tarImage);
+    Preconditions.checkArgument(tarImage instanceof TargetImage);
+    return new Containerizer((TargetImage) tarImage);
   }
 
   private final TargetImage targetImage;
@@ -133,6 +136,7 @@ public class Containerizer {
     baseImageLayersCacheDirectory = cacheDirectory;
     return this;
   }
+
   /**
    * Sets the directory to use for caching application layers. This cache can be shared between
    * multiple images. If not set, a temporary directory will be used as the application layers

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/DockerDaemonImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/DockerDaemonImage.java
@@ -1,4 +1,21 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package com.google.cloud.tools.jib.api;
+// TODO: Move to com.google.cloud.tools.jib once that package is cleaned up.
 
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/DockerDaemonImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/DockerDaemonImage.java
@@ -1,36 +1,11 @@
-/*
- * Copyright 2018 Google LLC.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
-
 package com.google.cloud.tools.jib.api;
-// TODO: Move to com.google.cloud.tools.jib once that package is cleaned up.
 
-import com.google.cloud.tools.jib.builder.BuildSteps;
-import com.google.cloud.tools.jib.configuration.BuildConfiguration;
-import com.google.cloud.tools.jib.configuration.ImageConfiguration;
-import com.google.cloud.tools.jib.docker.DockerClient;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
-import com.google.common.collect.ImmutableMap;
 import java.nio.file.Path;
 import java.util.Map;
-import javax.annotation.Nullable;
 
-/** Builds to the Docker daemon. */
-// TODO: Add tests once JibContainerBuilder#containerize() is added.
-public class DockerDaemonImage implements TargetImage {
+public interface DockerDaemonImage {
 
   /**
    * Instantiate with the image reference to tag the built image with. This is the name that shows
@@ -39,8 +14,8 @@ public class DockerDaemonImage implements TargetImage {
    * @param imageReference the image reference
    * @return a new {@link DockerDaemonImage}
    */
-  public static DockerDaemonImage named(ImageReference imageReference) {
-    return new DockerDaemonImage(imageReference);
+  static DockerDaemonImage named(ImageReference imageReference) {
+    return new DockerDaemonTargetImage(imageReference);
   }
 
   /**
@@ -51,18 +26,8 @@ public class DockerDaemonImage implements TargetImage {
    * @return a new {@link DockerDaemonImage}
    * @throws InvalidImageReferenceException if {@code imageReference} is not a valid image reference
    */
-  public static DockerDaemonImage named(String imageReference)
-      throws InvalidImageReferenceException {
+  static DockerDaemonImage named(String imageReference) throws InvalidImageReferenceException {
     return named(ImageReference.parse(imageReference));
-  }
-
-  private final ImageReference imageReference;
-  @Nullable private Path dockerExecutable;
-  @Nullable private Map<String, String> dockerEnvironment;
-
-  /** Instantiate with {@link #named}. */
-  private DockerDaemonImage(ImageReference imageReference) {
-    this.imageReference = imageReference;
   }
 
   /**
@@ -71,10 +36,7 @@ public class DockerDaemonImage implements TargetImage {
    * @param dockerExecutable the path to the {@code docker} CLI
    * @return this
    */
-  public DockerDaemonImage setDockerExecutable(Path dockerExecutable) {
-    this.dockerExecutable = dockerExecutable;
-    return this;
-  }
+  public DockerDaemonImage setDockerExecutable(Path dockerExecutable);
 
   /**
    * Sets the additional environment variables to use when running {@link #dockerExecutable docker}.
@@ -82,25 +44,5 @@ public class DockerDaemonImage implements TargetImage {
    * @param dockerEnvironment additional environment variables
    * @return this
    */
-  public DockerDaemonImage setDockerEnvironment(Map<String, String> dockerEnvironment) {
-    this.dockerEnvironment = dockerEnvironment;
-    return this;
-  }
-
-  @Override
-  public ImageConfiguration toImageConfiguration() {
-    return ImageConfiguration.builder(imageReference).build();
-  }
-
-  @Override
-  public BuildSteps toBuildSteps(BuildConfiguration buildConfiguration) {
-    DockerClient.Builder dockerClientBuilder = DockerClient.builder();
-    if (dockerExecutable != null) {
-      dockerClientBuilder.setDockerExecutable(dockerExecutable);
-    }
-    if (dockerEnvironment != null) {
-      dockerClientBuilder.setDockerEnvironment(ImmutableMap.copyOf(dockerEnvironment));
-    }
-    return BuildSteps.forBuildToDockerDaemon(dockerClientBuilder.build(), buildConfiguration);
-  }
+  public DockerDaemonImage setDockerEnvironment(Map<String, String> dockerEnvironment);
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/DockerDaemonTargetImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/DockerDaemonTargetImage.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.api;
+// TODO: Move to com.google.cloud.tools.jib once that package is cleaned up.
+
+import com.google.cloud.tools.jib.builder.BuildSteps;
+import com.google.cloud.tools.jib.configuration.BuildConfiguration;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
+import com.google.cloud.tools.jib.docker.DockerClient;
+import com.google.cloud.tools.jib.image.ImageReference;
+import com.google.common.collect.ImmutableMap;
+import java.nio.file.Path;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/** Builds to the Docker daemon. */
+// TODO: Add tests once JibContainerBuilder#containerize() is added.
+class DockerDaemonTargetImage implements DockerDaemonImage, TargetImage {
+
+  private final ImageReference imageReference;
+  @Nullable private Path dockerExecutable;
+  @Nullable private Map<String, String> dockerEnvironment;
+
+  DockerDaemonTargetImage(ImageReference imageReference) {
+    this.imageReference = imageReference;
+  }
+
+  @Override
+  public DockerDaemonTargetImage setDockerExecutable(Path dockerExecutable) {
+    this.dockerExecutable = dockerExecutable;
+    return this;
+  }
+
+  @Override
+  public DockerDaemonTargetImage setDockerEnvironment(Map<String, String> dockerEnvironment) {
+    this.dockerEnvironment = dockerEnvironment;
+    return this;
+  }
+
+  @Override
+  public ImageConfiguration toImageConfiguration() {
+    return ImageConfiguration.builder(imageReference).build();
+  }
+
+  @Override
+  public BuildSteps toBuildSteps(BuildConfiguration buildConfiguration) {
+    DockerClient.Builder dockerClientBuilder = DockerClient.builder();
+    if (dockerExecutable != null) {
+      dockerClientBuilder.setDockerExecutable(dockerExecutable);
+    }
+    if (dockerEnvironment != null) {
+      dockerClientBuilder.setDockerEnvironment(ImmutableMap.copyOf(dockerEnvironment));
+    }
+    return BuildSteps.forBuildToDockerDaemon(dockerClientBuilder.build(), buildConfiguration);
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/DockerDaemonTargetImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/DockerDaemonTargetImage.java
@@ -27,8 +27,6 @@ import java.nio.file.Path;
 import java.util.Map;
 import javax.annotation.Nullable;
 
-/** Builds to the Docker daemon. */
-// TODO: Add tests once JibContainerBuilder#containerize() is added.
 class DockerDaemonTargetImage implements DockerDaemonImage, TargetImage {
 
   private final ImageReference imageReference;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/Jib.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/Jib.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.api;
 
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
+import com.google.common.base.Preconditions;
 
 /** Build containers with Jib. */
 // TODO: Add tests once JibContainerBuilder#containerize() is added.
@@ -46,7 +47,7 @@ public class Jib {
    * @return a new {@link JibContainerBuilder} to continue building the container
    */
   public static JibContainerBuilder from(ImageReference baseImageReference) {
-    return new JibContainerBuilder(RegistryImage.named(baseImageReference));
+    return new JibContainerBuilder(new RegistrySourceTargetImage(baseImageReference));
   }
 
   /**
@@ -57,7 +58,8 @@ public class Jib {
    * @return a new {@link JibContainerBuilder} to continue building the container
    */
   public static JibContainerBuilder from(RegistryImage registryImage) {
-    return new JibContainerBuilder(registryImage);
+    Preconditions.checkArgument(registryImage instanceof SourceImage);
+    return new JibContainerBuilder((SourceImage) registryImage);
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/RegistrySourceTargetImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/RegistrySourceTargetImage.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.api;
+// TODO: Move to com.google.cloud.tools.jib once that package is cleaned up.
+
+import com.google.cloud.tools.jib.builder.BuildSteps;
+import com.google.cloud.tools.jib.configuration.BuildConfiguration;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
+import com.google.cloud.tools.jib.configuration.credentials.Credential;
+import com.google.cloud.tools.jib.configuration.credentials.CredentialRetriever;
+import com.google.cloud.tools.jib.image.ImageReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Defines an image on a container registry that can be used as either a source or target image.
+ *
+ * <p>The registry portion of the image reference determines which registry to the image lives (or
+ * should live) on. The repository portion is the namespace within the registry. The tag is a label
+ * to easily identify an image among all the images in the repository. See {@link ImageReference}
+ * for more details.
+ *
+ * <p>When configuring credentials (via {@link #addCredential} for example), make sure the
+ * credentials are valid push (for using this as a target image) or pull (for using this as a source
+ * image) credentials for the repository specified via the image reference.
+ */
+// TODO: Add tests once JibContainerBuilder#containerize() is added.
+public class RegistrySourceTargetImage implements RegistryImage, SourceImage, TargetImage {
+
+  private final ImageReference imageReference;
+  private final List<CredentialRetriever> credentialRetrievers = new ArrayList<>();
+
+  RegistrySourceTargetImage(ImageReference imageReference) {
+    this.imageReference = imageReference;
+  }
+
+  @Override
+  public RegistrySourceTargetImage addCredential(String username, String password) {
+    addCredentialRetriever(() -> Optional.of(Credential.from(username, password)));
+    return this;
+  }
+
+  @Override
+  public RegistrySourceTargetImage addCredentialRetriever(CredentialRetriever credentialRetriever) {
+    credentialRetrievers.add(credentialRetriever);
+    return this;
+  }
+
+  @Override
+  public ImageConfiguration toImageConfiguration() {
+    return ImageConfiguration.builder(imageReference)
+        .setCredentialRetrievers(credentialRetrievers)
+        .build();
+  }
+
+  @Override
+  public BuildSteps toBuildSteps(BuildConfiguration buildConfiguration) {
+    return BuildSteps.forBuildToDockerRegistry(buildConfiguration);
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/RegistrySourceTargetImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/RegistrySourceTargetImage.java
@@ -27,20 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-/**
- * Defines an image on a container registry that can be used as either a source or target image.
- *
- * <p>The registry portion of the image reference determines which registry to the image lives (or
- * should live) on. The repository portion is the namespace within the registry. The tag is a label
- * to easily identify an image among all the images in the repository. See {@link ImageReference}
- * for more details.
- *
- * <p>When configuring credentials (via {@link #addCredential} for example), make sure the
- * credentials are valid push (for using this as a target image) or pull (for using this as a source
- * image) credentials for the repository specified via the image reference.
- */
-// TODO: Add tests once JibContainerBuilder#containerize() is added.
-public class RegistrySourceTargetImage implements RegistryImage, SourceImage, TargetImage {
+class RegistrySourceTargetImage implements RegistryImage, SourceImage, TargetImage {
 
   private final ImageReference imageReference;
   private final List<CredentialRetriever> credentialRetrievers = new ArrayList<>();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarImage.java
@@ -17,9 +17,6 @@
 package com.google.cloud.tools.jib.api;
 // TODO: Move to com.google.cloud.tools.jib once that package is cleaned up.
 
-import com.google.cloud.tools.jib.builder.BuildSteps;
-import com.google.cloud.tools.jib.configuration.BuildConfiguration;
-import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import java.nio.file.Path;
@@ -35,9 +32,9 @@ import java.nio.file.Path;
  * }</pre>
  */
 // TODO: Add tests once JibContainerBuilder#containerize() is added.
-public class TarImage implements TargetImage {
+public interface TarImage {
 
-  /** Finishes constructing a {@link TarImage}. */
+  /** Finishes constructing a {@link TarTargetImage}. */
   public static class Builder {
 
     private final ImageReference imageReference;
@@ -50,10 +47,10 @@ public class TarImage implements TargetImage {
      * Sets the output file to save the tarball archive to.
      *
      * @param outputFile the output file
-     * @return a new {@link TarImage}
+     * @return a new {@link TarTargetImage}
      */
     public TarImage saveTo(Path outputFile) {
-      return new TarImage(imageReference, outputFile);
+      return new TarTargetImage(imageReference, outputFile);
     }
   }
 
@@ -62,7 +59,7 @@ public class TarImage implements TargetImage {
    * name of the image if loaded into the Docker daemon.
    *
    * @param imageReference the image reference
-   * @return a {@link Builder} to finish constructing a new {@link TarImage}
+   * @return a {@link Builder} to finish constructing a new {@link TarTargetImage}
    */
   public static Builder named(ImageReference imageReference) {
     return new Builder(imageReference);
@@ -72,38 +69,10 @@ public class TarImage implements TargetImage {
    * Configures the output tarball archive with an image reference to set as its tag.
    *
    * @param imageReference the image reference
-   * @return a {@link Builder} to finish constructing a new {@link TarImage}
+   * @return a {@link Builder} to finish constructing a new {@link TarTargetImage}
    * @throws InvalidImageReferenceException if {@code imageReference} is not a valid image reference
    */
   public static Builder named(String imageReference) throws InvalidImageReferenceException {
     return named(ImageReference.parse(imageReference));
-  }
-
-  private final ImageReference imageReference;
-  private final Path outputFile;
-
-  /** Instantiate with {@link #named}. */
-  private TarImage(ImageReference imageReference, Path outputFile) {
-    this.imageReference = imageReference;
-    this.outputFile = outputFile;
-  }
-
-  @Override
-  public ImageConfiguration toImageConfiguration() {
-    return ImageConfiguration.builder(imageReference).build();
-  }
-
-  @Override
-  public BuildSteps toBuildSteps(BuildConfiguration buildConfiguration) {
-    return BuildSteps.forBuildToTar(outputFile, buildConfiguration);
-  }
-
-  /**
-   * Gets the output file to save the tarball archive to.
-   *
-   * @return the output file
-   */
-  Path getOutputFile() {
-    return outputFile;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarImage.java
@@ -34,7 +34,7 @@ import java.nio.file.Path;
 // TODO: Add tests once JibContainerBuilder#containerize() is added.
 public interface TarImage {
 
-  /** Finishes constructing a {@link TarTargetImage}. */
+  /** Finishes constructing a {@link TarImage}. */
   public static class Builder {
 
     private final ImageReference imageReference;
@@ -59,7 +59,7 @@ public interface TarImage {
    * name of the image if loaded into the Docker daemon.
    *
    * @param imageReference the image reference
-   * @return a {@link Builder} to finish constructing a new {@link TarTargetImage}
+   * @return a {@link Builder} to finish constructing a new {@link TarImage}
    */
   public static Builder named(ImageReference imageReference) {
     return new Builder(imageReference);
@@ -69,7 +69,7 @@ public interface TarImage {
    * Configures the output tarball archive with an image reference to set as its tag.
    *
    * @param imageReference the image reference
-   * @return a {@link Builder} to finish constructing a new {@link TarTargetImage}
+   * @return a {@link Builder} to finish constructing a new {@link TarImage}
    * @throws InvalidImageReferenceException if {@code imageReference} is not a valid image reference
    */
   public static Builder named(String imageReference) throws InvalidImageReferenceException {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarTargetImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarTargetImage.java
@@ -23,17 +23,6 @@ import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.image.ImageReference;
 import java.nio.file.Path;
 
-/**
- * Builds to a tarball archive.
- *
- * <p>Usage example:
- *
- * <pre>{@code
- * TarImage tarImage = TarImage.named("myimage")
- *                             .saveTo(Paths.get("image.tar"));
- * }</pre>
- */
-// TODO: Add tests once JibContainerBuilder#containerize() is added.
 class TarTargetImage implements TarImage, TargetImage {
 
   private final ImageReference imageReference;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarTargetImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarTargetImage.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.api;
+// TODO: Move to com.google.cloud.tools.jib once that package is cleaned up.
+
+import com.google.cloud.tools.jib.builder.BuildSteps;
+import com.google.cloud.tools.jib.configuration.BuildConfiguration;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
+import com.google.cloud.tools.jib.image.ImageReference;
+import java.nio.file.Path;
+
+/**
+ * Builds to a tarball archive.
+ *
+ * <p>Usage example:
+ *
+ * <pre>{@code
+ * TarImage tarImage = TarImage.named("myimage")
+ *                             .saveTo(Paths.get("image.tar"));
+ * }</pre>
+ */
+// TODO: Add tests once JibContainerBuilder#containerize() is added.
+class TarTargetImage implements TarImage, TargetImage {
+
+  private final ImageReference imageReference;
+  private final Path outputFile;
+
+  TarTargetImage(ImageReference imageReference, Path outputFile) {
+    this.imageReference = imageReference;
+    this.outputFile = outputFile;
+  }
+
+  @Override
+  public ImageConfiguration toImageConfiguration() {
+    return ImageConfiguration.builder(imageReference).build();
+  }
+
+  @Override
+  public BuildSteps toBuildSteps(BuildConfiguration buildConfiguration) {
+    return BuildSteps.forBuildToTar(outputFile, buildConfiguration);
+  }
+
+  /**
+   * Gets the output file to save the tarball archive to.
+   *
+   * @return the output file
+   */
+  Path getOutputFile() {
+    return outputFile;
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/TargetImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/TargetImage.java
@@ -24,18 +24,7 @@ import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 /** Represents a destination for the Jib-built image. */
 interface TargetImage {
 
-  /**
-   * Converts into an {@link ImageConfiguration}. For internal use only.
-   *
-   * @return an {@link ImageConfiguration}
-   */
   ImageConfiguration toImageConfiguration();
 
-  /**
-   * Converts into {@link BuildSteps}. For internal use only.
-   *
-   * @param buildConfiguration the {@link BuildConfiguration} to use
-   * @return {@link BuildSteps}
-   */
   BuildSteps toBuildSteps(BuildConfiguration buildConfiguration);
 }


### PR DESCRIPTION
Up for discussion.

I've looked into the classes in `.api`, and the situation is not so grim if we get rid of the two internal methods `toImageConfiguration()` and `toBuildSteps()`. It would then hide `BuildConfiguration`, `ImageConfiguration`, and `BuildSteps`, the biggest offenders. I tried to explore what can be done to remove them at this stage with little refactoring.

The idea here is to have `TarImage`, `DockerDaemonImage`, etc as interfaces, not mandating them to implement the two internal methods. Instead, internal classes implementing the interfaces will carry them. (Note `SourceImage` and `TargetImage` are already invisible.)

If you have other ideas, throw them here.