### PR TITLE
Let test web server write only after reading first HTTP request

### DIFF
--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
@@ -17,9 +17,11 @@
 package com.google.cloud.tools.jib.http;
 
 import com.google.common.io.Resources;
+import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URISyntaxException;
@@ -43,7 +45,7 @@ public class TestWebServer implements Closeable {
   private final ServerSocket serverSocket;
   private final ExecutorService executorService = Executors.newSingleThreadExecutor();
   private final Semaphore threadStarted = new Semaphore(0);
-  private final StringBuffer inputRead = new StringBuffer();
+  private final StringBuilder inputRead = new StringBuilder();
 
   public TestWebServer(boolean https)
       throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException {
@@ -89,14 +91,18 @@ public class TestWebServer implements Closeable {
   private Void serve200() throws IOException {
     threadStarted.release();
     try (Socket socket = serverSocket.accept()) {
+
+      InputStream in = socket.getInputStream();
+      BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+      for (String line = reader.readLine();
+          line != null && !line.isEmpty(); // An empty line marks the end of an HTTP request.
+          line = reader.readLine()) {
+        inputRead.append(line + "\n");
+      }
+
       String response = "HTTP/1.1 200 OK\nContent-Length:12\n\nHello World!";
       socket.getOutputStream().write(response.getBytes(StandardCharsets.UTF_8));
       socket.getOutputStream().flush();
-
-      InputStream in = socket.getInputStream();
-      for (int ch = in.read(); ch != -1; ch = in.read()) {
-        inputRead.append((char) ch);
-      }
     }
     return null;
   }


### PR DESCRIPTION
Fixes #1621, hopefully.

From various logs, I think the reason is that the server writes response first and then tries to read, causing the client side to shut down connection early before reading all the input. Now the server will be more compliant to the HTTP protocol.