### PR TITLE
Add helper LogEvent#toString()

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/LogEvent.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/LogEvent.java
@@ -118,4 +118,9 @@ public class LogEvent implements JibEvent {
   public int hashCode() {
     return Objects.hash(level, message);
   }
+
+  @Override
+  public String toString() {
+    return "LogEvent [level=" + level + ", message=" + message + "]";
+  }
 }


### PR DESCRIPTION
Helpful to identify errors reported in tests involving logging.