### PR TITLE
Propagate labels from base image / propagate container config in case of V2.1 manifest

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
@@ -143,10 +143,7 @@ public class JsonToImageTranslator {
       ContainerConfigurationTemplate containerConfigurationTemplate)
       throws BadContainerConfigurationFormatException {
 
-    List<HistoryEntry> historyObjects = containerConfigurationTemplate.getHistory();
-    for (HistoryEntry historyObject : historyObjects) {
-      imageBuilder.addHistory(historyObject);
-    }
+    containerConfigurationTemplate.getHistory().forEach(imageBuilder::addHistory);
 
     if (containerConfigurationTemplate.getCreated() != null) {
       try {
@@ -164,13 +161,8 @@ public class JsonToImageTranslator {
       imageBuilder.setOs(containerConfigurationTemplate.getOs());
     }
 
-    if (containerConfigurationTemplate.getContainerEntrypoint() != null) {
-      imageBuilder.setEntrypoint(containerConfigurationTemplate.getContainerEntrypoint());
-    }
-
-    if (containerConfigurationTemplate.getContainerCmd() != null) {
-      imageBuilder.setProgramArguments(containerConfigurationTemplate.getContainerCmd());
-    }
+    imageBuilder.setEntrypoint(containerConfigurationTemplate.getContainerEntrypoint());
+    imageBuilder.setProgramArguments(containerConfigurationTemplate.getContainerCmd());
 
     List<String> baseHealthCheckCommand = containerConfigurationTemplate.getContainerHealthTest();
     if (baseHealthCheckCommand != null) {
@@ -213,10 +205,7 @@ public class JsonToImageTranslator {
       }
     }
 
-    if (containerConfigurationTemplate.getContainerLabels() != null) {
-      imageBuilder.addLabels(containerConfigurationTemplate.getContainerLabels());
-    }
-
+    imageBuilder.addLabels(containerConfigurationTemplate.getContainerLabels());
     imageBuilder.setWorkingDirectory(containerConfigurationTemplate.getContainerWorkingDir());
     imageBuilder.setUser(containerConfigurationTemplate.getContainerUser());
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
@@ -81,7 +81,7 @@ public class JsonToImageTranslator {
     }
 
     if (manifestTemplate.getContainerConfiguration() != null) {
-      configureImageBuilderWithContainerConfiguration(
+      configureBuilderWithContainerConfiguration(
           imageBuilder, manifestTemplate.getContainerConfiguration());
     }
     return imageBuilder.build();
@@ -134,11 +134,11 @@ public class JsonToImageTranslator {
       imageBuilder.addLayer(new ReferenceLayer(noDiffIdLayer.getBlobDescriptor(), diffId));
     }
 
-    configureImageBuilderWithContainerConfiguration(imageBuilder, containerConfigurationTemplate);
+    configureBuilderWithContainerConfiguration(imageBuilder, containerConfigurationTemplate);
     return imageBuilder.build();
   }
 
-  private static void configureImageBuilderWithContainerConfiguration(
+  private static void configureBuilderWithContainerConfiguration(
       Image.Builder<Layer> imageBuilder,
       ContainerConfigurationTemplate containerConfigurationTemplate)
       throws BadContainerConfigurationFormatException {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
@@ -114,7 +114,7 @@ public class JsonToImageTranslatorTest {
   }
 
   @Test
-  public void testvolumeMapToList() throws BadContainerConfigurationFormatException {
+  public void testVolumeMapToList() throws BadContainerConfigurationFormatException {
     ImmutableSortedMap<String, Map<?, ?>> input =
         ImmutableSortedMap.of(
             "/var/job-result-data", ImmutableMap.of(), "/var/log/my-app-logs", ImmutableMap.of());
@@ -222,5 +222,8 @@ public class JsonToImageTranslatorTest {
             AbsoluteUnixPath.get("/var/log/my-app-logs")),
         image.getVolumes());
     Assert.assertEquals("tomcat", image.getUser());
+    Assert.assertEquals("value1", image.getLabels().get("key1"));
+    Assert.assertEquals("value2", image.getLabels().get("key2"));
+    Assert.assertEquals(2, image.getLabels().size());
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
@@ -47,7 +47,8 @@ public class JsonToImageTranslatorTest {
 
   @Test
   public void testToImage_v21()
-      throws IOException, LayerPropertyNotFoundException, DigestException, URISyntaxException {
+      throws IOException, LayerPropertyNotFoundException, DigestException, URISyntaxException,
+          BadContainerConfigurationFormatException {
     // Loads the JSON string.
     Path jsonFile =
         Paths.get(getClass().getClassLoader().getResource("core/json/v21manifest.json").toURI());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/V21ManifestTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/V21ManifestTemplateTest.java
@@ -24,6 +24,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.DigestException;
+import java.util.Arrays;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -44,6 +45,13 @@ public class V21ManifestTemplateTest {
             "sha256:8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad"),
         manifestJson.getFsLayers().get(0).getDigest());
 
-    Assert.assertEquals("some v1-compatible object", manifestJson.getV1Compatibility(0));
+    ContainerConfigurationTemplate containerConfiguration =
+        manifestJson.getContainerConfiguration();
+    Assert.assertEquals(
+        Arrays.asList("JAVA_HOME=/opt/openjdk", "PATH=/opt/openjdk/bin"),
+        containerConfiguration.getContainerEnvironment());
+    Assert.assertEquals(
+        Arrays.asList("/opt/openjdk/bin/java"), containerConfiguration.getContainerEntrypoint());
+    // Assert.assertEquals("some v1-compatible object", manifestJson.getV1Compatibility(0));
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/V21ManifestTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/V21ManifestTemplateTest.java
@@ -52,6 +52,5 @@ public class V21ManifestTemplateTest {
         containerConfiguration.getContainerEnvironment());
     Assert.assertEquals(
         Arrays.asList("/opt/openjdk/bin/java"), containerConfiguration.getContainerEntrypoint());
-    // Assert.assertEquals("some v1-compatible object", manifestJson.getV1Compatibility(0));
   }
 }

--- a/jib-core/src/test/resources/core/json/v21manifest.json
+++ b/jib-core/src/test/resources/core/json/v21manifest.json
@@ -5,7 +5,7 @@
     {"blobSum":"sha256:5bd451067f9ab05e97cda8476c82f86d9b69c2dffb60a8ad2fe3723942544ab3"}
   ],
   "history": [
-    {"v1Compatibility":"some v1-compatible object"},
+    {"v1Compatibility": "{\"architecture\":\"amd64\",\"config\":{\"Env\":[\"JAVA_HOME=/opt/openjdk\",\"PATH=/opt/openjdk/bin\"],\"Entrypoint\":[\"/opt/openjdk/bin/java\"],\"Cmd\":[\"-version\"]},\"created\":\"2019-04-17T14:02:34.79404123Z\"}"},
     {"v1Compatibility":"another v1-compatible object"}
   ]
 }


### PR DESCRIPTION
Fixes #1643.
Fixes #1641.

Travis is failing to install OpenJDK 11, so ignore that for the moment.