### PR TITLE
Add default timestamp to not-yet-existant parent dirs

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/LayerEntry.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/LayerEntry.java
@@ -46,9 +46,10 @@ public class LayerEntry {
                   ? FilePermissions.DEFAULT_FOLDER_PERMISSIONS
                   : FilePermissions.DEFAULT_FILE_PERMISSIONS;
 
+  public static final Instant DEFAULT_MODIFIED_TIME = Instant.ofEpochSecond(1);
   /** Provider that returns default file modification time (EPOCH + 1 second). */
   public static final BiFunction<Path, AbsoluteUnixPath, Instant> DEFAULT_MODIFIED_TIME_PROVIDER =
-      (sourcePath, destinationPath) -> Instant.ofEpochSecond(1);
+      (sourcePath, destinationPath) -> DEFAULT_MODIFIED_TIME;
 
   private final Path sourceFile;
   private final AbsoluteUnixPath extractionPath;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
@@ -55,7 +55,8 @@ public class ReproducibleLayerBuilder {
 
     /**
      * Adds a {@link TarArchiveEntry} if its extraction path does not exist yet. Also adds all of
-     * the parent directories on the extraction path.
+     * the parent directories on the extraction path, if the parent does not exist. Parent will have
+     * modified time to set to {@link LayerEntry#DEFAULT_MODIFIED_TIME}.
      *
      * @param tarArchiveEntry the {@link TarArchiveEntry}
      */
@@ -68,7 +69,9 @@ public class ReproducibleLayerBuilder {
       // directories.
       Path namePath = Paths.get(tarArchiveEntry.getName());
       if (namePath.getParent() != namePath.getRoot()) {
-        add(new TarArchiveEntry(DIRECTORY_FILE, namePath.getParent().toString()));
+        TarArchiveEntry dir = new TarArchiveEntry(DIRECTORY_FILE, namePath.getParent().toString());
+        dir.setModTime(LayerEntry.DEFAULT_MODIFIED_TIME.toEpochMilli());
+        add(dir);
       }
 
       entries.add(tarArchiveEntry);
@@ -121,6 +124,7 @@ public class ReproducibleLayerBuilder {
     TarStreamBuilder tarStreamBuilder = new TarStreamBuilder();
     for (TarArchiveEntry entry : sortedFilesystemEntries) {
       // Strips out all non-reproducible elements from tar archive entries.
+      // Modified time is configured per entry
       entry.setGroupId(0);
       entry.setUserId(0);
       entry.setUserName("");

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
@@ -193,8 +193,7 @@ public class ReproducibleLayerBuilderTest {
     Path ignoredParent = Files.createDirectories(testRoot.resolve("bbb-ignored"));
     Path fileB = Files.createFile(ignoredParent.resolve("fileB"));
     Path fileC =
-        Files.createFile(
-            Files.createDirectories(testRoot.resolve("ccc-absent")).resolve("fileC"));
+        Files.createFile(Files.createDirectories(testRoot.resolve("ccc-absent")).resolve("fileC"));
 
     Blob layer =
         new ReproducibleLayerBuilder(
@@ -260,7 +259,6 @@ public class ReproducibleLayerBuilderTest {
 
       // we don't care about fileC
     }
-
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
@@ -246,8 +246,9 @@ public class ReproducibleLayerBuilderTest {
 
       // parentBBB (default permissions - ignored custom permissions, since fileB added first)
       TarArchiveEntry rootParentBBB = in.getNextTarEntry();
+      // TODO (#1650): we want 040444 here.
       Assert.assertEquals(040755, rootParentBBB.getMode());
-      // TODO (#1650): The behavior we WANT is that that we get Instant.ofEpochSecond(40) here.
+      // TODO (#1650): we want Instant.ofEpochSecond(40) here.
       Assert.assertEquals(Instant.ofEpochSecond(1), root.getModTime().toInstant());
 
       // skip over fileB

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
@@ -247,6 +247,7 @@ public class ReproducibleLayerBuilderTest {
       // parentBBB (default permissions - ignored custom permissions, since fileB added first)
       TarArchiveEntry rootParentBBB = in.getNextTarEntry();
       Assert.assertEquals(040755, rootParentBBB.getMode());
+      // TODO (#1650): The behavior we WANT is that that we get Instant.ofEpochSecond(40) here.
       Assert.assertEquals(Instant.ofEpochSecond(1), root.getModTime().toInstant());
 
       // skip over fileB


### PR DESCRIPTION
So this defines a strong behavior for parents that don't exist in the layer yet.
1. order matters, a directory can only be configured if it's added to the layer before any of its children
2. for a file with parent(s) that doesn't exist yet, a default modified time is applied.

fixes #1648 

NOTE: This *does not* fix the out of order issue for defining directory permissions. That should be fixed in a followup (#1650)