### PR TITLE
Add cache methods for saving manifest and container config

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blobs.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blobs.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /** Static methods for {@link Blob}. */
@@ -71,6 +72,20 @@ public class Blobs {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     blob.writeTo(byteArrayOutputStream);
     return byteArrayOutputStream.toByteArray();
+  }
+
+  /**
+   * Writes the BLOB to a file.
+   *
+   * @param blob the BLOB to to write
+   * @param blobFile the file to write to
+   * @return the {@link BlobDescriptor} of the written BLOB
+   * @throws IOException if writing the BLOB fails
+   */
+  public static BlobDescriptor writeToFile(Blob blob, Path blobFile) throws IOException {
+    try (OutputStream outputStream = Files.newOutputStream(blobFile)) {
+      return blob.writeTo(outputStream);
+    }
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
@@ -18,7 +18,10 @@ package com.google.cloud.tools.jib.cache;
 
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
+import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.LayerEntry;
+import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
+import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -53,6 +56,22 @@ public class Cache {
 
   private Cache(CacheStorage cacheStorage) {
     this.cacheStorage = cacheStorage;
+  }
+
+  /**
+   * Saves an image manifest and container configuration.
+   *
+   * @param imageReference the image reference the save the manifest and container configuration for
+   * @param manifestTemplate the manifest
+   * @param containerConfigurationTemplate the container configuration
+   * @throws IOException if an I/O exception occurs
+   */
+  public void writeMetadata(
+      ImageReference imageReference,
+      ManifestTemplate manifestTemplate,
+      ContainerConfigurationTemplate containerConfigurationTemplate)
+      throws IOException {
+    cacheStorage.writeMetadata(imageReference, manifestTemplate, containerConfigurationTemplate);
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
@@ -20,8 +20,9 @@ import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.LayerEntry;
+import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
-import com.google.cloud.tools.jib.image.json.ManifestTemplate;
+import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -62,16 +63,28 @@ public class Cache {
    * Saves an image manifest and container configuration.
    *
    * @param imageReference the image reference the save the manifest and container configuration for
-   * @param manifestTemplate the manifest
+   * @param manifestTemplate the V2.2 or OCI manifest
    * @param containerConfigurationTemplate the container configuration
    * @throws IOException if an I/O exception occurs
    */
   public void writeMetadata(
       ImageReference imageReference,
-      ManifestTemplate manifestTemplate,
+      BuildableManifestTemplate manifestTemplate,
       ContainerConfigurationTemplate containerConfigurationTemplate)
       throws IOException {
     cacheStorage.writeMetadata(imageReference, manifestTemplate, containerConfigurationTemplate);
+  }
+
+  /**
+   * Saves a V2.1 image manifest.
+   *
+   * @param imageReference the image reference the save the manifest and container configuration for
+   * @param manifestTemplate the V2.1 manifest
+   * @throws IOException if an I/O exception occurs
+   */
+  public void writeMetadata(ImageReference imageReference, V21ManifestTemplate manifestTemplate)
+      throws IOException {
+    cacheStorage.writeMetadata(imageReference, manifestTemplate);
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
@@ -60,9 +60,9 @@ public class Cache {
   }
 
   /**
-   * Saves an image manifest and container configuration.
+   * Saves a manifest and container configuration for a V2.2 or OCI image.
    *
-   * @param imageReference the image reference the save the manifest and container configuration for
+   * @param imageReference the image reference to save the manifest and container configuration for
    * @param manifestTemplate the V2.2 or OCI manifest
    * @param containerConfigurationTemplate the container configuration
    * @throws IOException if an I/O exception occurs
@@ -78,7 +78,7 @@ public class Cache {
   /**
    * Saves a V2.1 image manifest.
    *
-   * @param imageReference the image reference the save the manifest and container configuration for
+   * @param imageReference the image reference to save the manifest and container configuration for
    * @param manifestTemplate the V2.1 manifest
    * @throws IOException if an I/O exception occurs
    */

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorage.java
@@ -19,8 +19,9 @@ package com.google.cloud.tools.jib.cache;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.ImageReference;
+import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
-import com.google.cloud.tools.jib.image.json.ManifestTemplate;
+import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
@@ -97,7 +98,17 @@ interface CacheStorage {
    */
   void writeMetadata(
       ImageReference imageReference,
-      ManifestTemplate manifestTemplate,
+      BuildableManifestTemplate manifestTemplate,
       ContainerConfigurationTemplate containerConfigurationTemplate)
+      throws IOException;
+
+  /**
+   * Saves a V2.1 manifest.
+   *
+   * @param imageReference the image reference to store the metadata for
+   * @param manifestTemplate the image's manifest
+   * @throws IOException if an I/O exception occurs
+   */
+  void writeMetadata(ImageReference imageReference, V21ManifestTemplate manifestTemplate)
       throws IOException;
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorage.java
@@ -93,6 +93,7 @@ interface CacheStorage {
    * @param imageReference the image reference to store the metadata for
    * @param manifestTemplate the image's manifest
    * @param containerConfigurationTemplate the image's container configuration
+   * @throws IOException if an I/O exception occurs
    */
   void writeMetadata(
       ImageReference imageReference,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorage.java
@@ -89,7 +89,7 @@ interface CacheStorage {
       throws IOException, CacheCorruptedException;
 
   /**
-   * Saves the manifest and container configuration.
+   * Saves the manifest and container configuration for a V2.2 or OCI image.
    *
    * @param imageReference the image reference to store the metadata for
    * @param manifestTemplate the image's manifest

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorage.java
@@ -18,6 +18,9 @@ package com.google.cloud.tools.jib.cache;
 
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
+import com.google.cloud.tools.jib.image.ImageReference;
+import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
+import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.Set;
@@ -83,4 +86,17 @@ interface CacheStorage {
    */
   Optional<DescriptorDigest> select(DescriptorDigest selector)
       throws IOException, CacheCorruptedException;
+
+  /**
+   * Saves the manifest and container configuration.
+   *
+   * @param imageReference the image reference to store the metadata for
+   * @param manifestTemplate the image's manifest
+   * @param containerConfigurationTemplate the image's container configuration
+   */
+  void writeMetadata(
+      ImageReference imageReference,
+      ManifestTemplate manifestTemplate,
+      ContainerConfigurationTemplate containerConfigurationTemplate)
+      throws IOException;
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorage.java
@@ -18,6 +18,9 @@ package com.google.cloud.tools.jib.cache;
 
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
+import com.google.cloud.tools.jib.image.ImageReference;
+import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
+import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -89,5 +92,15 @@ class DefaultCacheStorage implements CacheStorage {
   public Optional<DescriptorDigest> select(DescriptorDigest selector)
       throws IOException, CacheCorruptedException {
     return defaultCacheStorageReader.select(selector);
+  }
+
+  @Override
+  public void writeMetadata(
+      ImageReference imageReference,
+      ManifestTemplate manifestTemplate,
+      ContainerConfigurationTemplate containerConfiguration)
+      throws IOException {
+    defaultCacheStorageWriter.writeMetadata(
+        imageReference, manifestTemplate, containerConfiguration);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorage.java
@@ -19,8 +19,9 @@ package com.google.cloud.tools.jib.cache;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.ImageReference;
+import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
-import com.google.cloud.tools.jib.image.json.ManifestTemplate;
+import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -97,10 +98,16 @@ class DefaultCacheStorage implements CacheStorage {
   @Override
   public void writeMetadata(
       ImageReference imageReference,
-      ManifestTemplate manifestTemplate,
-      ContainerConfigurationTemplate containerConfiguration)
+      BuildableManifestTemplate manifestTemplate,
+      ContainerConfigurationTemplate containerConfigurationTemplate)
       throws IOException {
     defaultCacheStorageWriter.writeMetadata(
-        imageReference, manifestTemplate, containerConfiguration);
+        imageReference, manifestTemplate, containerConfigurationTemplate);
+  }
+
+  @Override
+  public void writeMetadata(ImageReference imageReference, V21ManifestTemplate manifestTemplate)
+      throws IOException {
+    defaultCacheStorageWriter.writeMetadata(imageReference, manifestTemplate);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageFiles.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageFiles.java
@@ -130,12 +130,14 @@ class DefaultCacheStorageFiles {
    *
    * @param imageReference the image reference
    * @return a path in the form of {@code
-   *     (jib-cache)/images/registry[/port]/repository/(tag|digest-type/digest)}
+   *     (jib-cache)/images/registry[!port]/repository!(tag|digest-type!digest)}
    */
   Path getImageDirectory(ImageReference imageReference) {
-    // Split image reference on '/', ':', and '@' to build directory structure
-    Iterable<String> directories =
-        Splitter.onPattern("\\/|:|@").split(imageReference.toStringWithTag());
+    // Replace ':' and '@' with '!' to avoid directory-naming restrictions
+    String replacedReference = imageReference.toStringWithTag().replace(':', '!').replace('@', '!');
+
+    // Split image reference on '/' to build directory structure
+    Iterable<String> directories = Splitter.on('/').split(replacedReference);
     Path destination = getImagesDirectory();
     for (String dir : directories) {
       destination = destination.resolve(dir);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageFiles.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageFiles.java
@@ -17,6 +17,8 @@
 package com.google.cloud.tools.jib.cache;
 
 import com.google.cloud.tools.jib.image.DescriptorDigest;
+import com.google.cloud.tools.jib.image.ImageReference;
+import com.google.common.base.Splitter;
 import java.nio.file.Path;
 import java.security.DigestException;
 
@@ -24,6 +26,7 @@ import java.security.DigestException;
 class DefaultCacheStorageFiles {
 
   private static final String LAYERS_DIRECTORY = "layers";
+  private static final String IMAGES_DIRECTORY = "images";
   private static final String SELECTORS_DIRECTORY = "selectors";
   private static final String TEMPORARY_DIRECTORY = "tmp";
   private static final String TEMPORARY_LAYER_FILE_NAME = ".tmp.layer";
@@ -111,6 +114,33 @@ class DefaultCacheStorageFiles {
    */
   Path getLayerDirectory(DescriptorDigest layerDigest) {
     return getLayersDirectory().resolve(layerDigest.getHash());
+  }
+
+  /**
+   * Gets the directory to store the image manifest and configuration.
+   *
+   * @return the directory for the image manifest and configuration
+   */
+  Path getImagesDirectory() {
+    return cacheDirectory.resolve(IMAGES_DIRECTORY);
+  }
+
+  /**
+   * Gets the directory corresponding to the given image reference.
+   *
+   * @param imageReference the image reference
+   * @return a path in the form of {@code
+   *     (jib-cache)/images/registry[/port]/repository/(tag|digest-type/digest)}
+   */
+  Path getImageDirectory(ImageReference imageReference) {
+    // Split image reference on '/', ':', and '@' to build directory structure
+    Iterable<String> directories =
+        Splitter.onPattern("\\/|:|@").split(imageReference.toStringWithTag());
+    Path destination = getImagesDirectory();
+    for (String dir : directories) {
+      destination = destination.resolve(dir);
+    }
+    return destination;
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
@@ -27,7 +27,6 @@ import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
 import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
-import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.common.base.Preconditions;
 import com.google.common.io.ByteStreams;
@@ -110,18 +109,16 @@ class DefaultCacheStorageWriter {
   }
 
   /**
-   * Writes a json template to the destination path by writing to a temporary file then moving the
-   * file.
+   * Writes a blob to the destination path by writing to a temporary file then moving the file.
    *
-   * @param jsonTemplate the json template
+   * @param blob the blob
    * @param destination the destination path
    * @throws IOException if an I/O exception occurs
    */
-  private static void writeMetadata(JsonTemplate jsonTemplate, Path destination)
-      throws IOException {
+  private static void writeBlob(Blob blob, Path destination) throws IOException {
     Path temporaryFile = Files.createTempFile(destination.getParent(), null, null);
     temporaryFile.toFile().deleteOnExit();
-    Blobs.writeToFile(JsonTemplateMapper.toBlob(jsonTemplate), temporaryFile);
+    Blobs.writeToFile(blob, temporaryFile);
 
     // Attempts an atomic move first, and falls back to non-atomic if the file system does not
     // support atomic moves.
@@ -259,8 +256,10 @@ class DefaultCacheStorageWriter {
     Files.createDirectories(imageDirectory);
 
     try (LockFile ignored1 = LockFile.lock(imageDirectory.resolve("lock"))) {
-      writeMetadata(manifestTemplate, imageDirectory.resolve("manifest.json"));
-      writeMetadata(containerConfiguration, imageDirectory.resolve("config.json"));
+      writeBlob(
+          JsonTemplateMapper.toBlob(manifestTemplate), imageDirectory.resolve("manifest.json"));
+      writeBlob(
+          JsonTemplateMapper.toBlob(containerConfiguration), imageDirectory.resolve("config.json"));
     }
   }
 
@@ -276,7 +275,8 @@ class DefaultCacheStorageWriter {
     Files.createDirectories(imageDirectory);
 
     try (LockFile ignored1 = LockFile.lock(imageDirectory.resolve("lock"))) {
-      writeMetadata(manifestTemplate, imageDirectory.resolve("manifest.json"));
+      writeBlob(
+          JsonTemplateMapper.toBlob(manifestTemplate), imageDirectory.resolve("manifest.json"));
     }
   }
 
@@ -361,22 +361,6 @@ class DefaultCacheStorageWriter {
     // Creates the selectors directory if it doesn't exist.
     Files.createDirectories(selectorFile.getParent());
 
-    // Writes the selector to a temporary file and then moves the file to the intended location.
-    Path temporarySelectorFile = Files.createTempFile(null, null);
-    temporarySelectorFile.toFile().deleteOnExit();
-    Blobs.writeToFileWithLock(Blobs.from(layerDigest.getHash()), temporarySelectorFile);
-
-    // Attempts an atomic move first, and falls back to non-atomic if the file system does not
-    // support atomic moves.
-    try {
-      Files.move(
-          temporarySelectorFile,
-          selectorFile,
-          StandardCopyOption.ATOMIC_MOVE,
-          StandardCopyOption.REPLACE_EXISTING);
-
-    } catch (AtomicMoveNotSupportedException ignored) {
-      Files.move(temporarySelectorFile, selectorFile, StandardCopyOption.REPLACE_EXISTING);
-    }
+    writeBlob(Blobs.from(layerDigest.getHash()), selectorFile);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
@@ -258,12 +258,9 @@ class DefaultCacheStorageWriter {
     Preconditions.checkNotNull(manifestTemplate.getContainerConfiguration());
     Preconditions.checkNotNull(manifestTemplate.getContainerConfiguration().getDigest());
 
-    // Create the images directory
     Path imageDirectory = defaultCacheStorageFiles.getImageDirectory(imageReference);
     Files.createDirectories(imageDirectory);
 
-    // TODO: Lock properly
-    // Write manifest and configuration
     writeMetadata(manifestTemplate, imageDirectory.resolve("manifest.json"));
     writeMetadata(containerConfiguration, imageDirectory.resolve("config.json"));
   }
@@ -276,12 +273,9 @@ class DefaultCacheStorageWriter {
    */
   void writeMetadata(ImageReference imageReference, V21ManifestTemplate manifestTemplate)
       throws IOException {
-    // Create the images directory
     Path imageDirectory = defaultCacheStorageFiles.getImageDirectory(imageReference);
     Files.createDirectories(imageDirectory);
 
-    // TODO: Lock properly
-    // Write manifest
     writeMetadata(manifestTemplate, imageDirectory.resolve("manifest.json"));
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
@@ -107,6 +107,14 @@ class DefaultCacheStorageWriter {
     }
   }
 
+  /**
+   * Writes a json template to the destination path by writing to a temporary file then moving the
+   * file.
+   *
+   * @param jsonTemplate the json template
+   * @param destination the destination path
+   * @throws IOException if an I/O exception occurs
+   */
   private static void writeMetadata(JsonTemplate jsonTemplate, Path destination)
       throws IOException {
     Path temporaryFile = Files.createTempFile(destination.getParent(), null, null);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
@@ -28,6 +28,7 @@ import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
 import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
+import com.google.common.base.Preconditions;
 import com.google.common.io.ByteStreams;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -250,21 +251,26 @@ class DefaultCacheStorageWriter {
       BuildableManifestTemplate manifestTemplate,
       ContainerConfigurationTemplate containerConfiguration)
       throws IOException {
+    Preconditions.checkNotNull(manifestTemplate.getContainerConfiguration());
+    Preconditions.checkNotNull(manifestTemplate.getContainerConfiguration().getDigest());
+
     // Create the images directory
     Path imageDirectory = defaultCacheStorageFiles.getImageDirectory(imageReference);
     Files.createDirectories(imageDirectory);
 
-    String destinationSuffix =
-        "."
+    String manifestFilename =
+        "manifest."
             + containerConfiguration.getArchitecture()
             + "."
             + containerConfiguration.getOs()
             + ".json";
+    String configFilename =
+        manifestTemplate.getContainerConfiguration().getDigest().getHash() + ".json";
 
     // TODO: Lock properly
     // Write manifest and configuration
-    writeMetadata(manifestTemplate, imageDirectory.resolve("manifest" + destinationSuffix));
-    writeMetadata(containerConfiguration, imageDirectory.resolve("config" + destinationSuffix));
+    writeMetadata(manifestTemplate, imageDirectory.resolve(manifestFilename));
+    writeMetadata(containerConfiguration, imageDirectory.resolve(configFilename));
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
@@ -123,7 +123,7 @@ class DefaultCacheStorageWriter {
     try (LockFile ignored1 = LockFile.lock(Paths.get(destination.toString() + ".lock"))) {
       Path temporaryFile = Files.createTempFile(destination.getParent(), null, null);
       temporaryFile.toFile().deleteOnExit();
-      Blobs.writeToFileWithLock(JsonTemplateMapper.toBlob(jsonTemplate), temporaryFile);
+      Blobs.writeToFile(JsonTemplateMapper.toBlob(jsonTemplate), temporaryFile);
 
       // Attempts an atomic move first, and falls back to non-atomic if the file system does not
       // support atomic moves.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
@@ -120,24 +120,24 @@ class DefaultCacheStorageWriter {
    */
   private static void writeMetadata(JsonTemplate jsonTemplate, Path destination)
       throws IOException {
-    LockFile lock = LockFile.lock(Paths.get(destination.toString() + ".lock"));
-    Path temporaryFile = Files.createTempFile(destination.getParent(), null, null);
-    temporaryFile.toFile().deleteOnExit();
-    Blobs.writeToFileWithLock(JsonTemplateMapper.toBlob(jsonTemplate), temporaryFile);
+    try (LockFile ignored1 = LockFile.lock(Paths.get(destination.toString() + ".lock"))) {
+      Path temporaryFile = Files.createTempFile(destination.getParent(), null, null);
+      temporaryFile.toFile().deleteOnExit();
+      Blobs.writeToFileWithLock(JsonTemplateMapper.toBlob(jsonTemplate), temporaryFile);
 
-    // Attempts an atomic move first, and falls back to non-atomic if the file system does not
-    // support atomic moves.
-    try {
-      Files.move(
-          temporaryFile,
-          destination,
-          StandardCopyOption.ATOMIC_MOVE,
-          StandardCopyOption.REPLACE_EXISTING);
+      // Attempts an atomic move first, and falls back to non-atomic if the file system does not
+      // support atomic moves.
+      try {
+        Files.move(
+            temporaryFile,
+            destination,
+            StandardCopyOption.ATOMIC_MOVE,
+            StandardCopyOption.REPLACE_EXISTING);
 
-    } catch (AtomicMoveNotSupportedException ignored) {
-      Files.move(temporaryFile, destination, StandardCopyOption.REPLACE_EXISTING);
+      } catch (AtomicMoveNotSupportedException ignored2) {
+        Files.move(temporaryFile, destination, StandardCopyOption.REPLACE_EXISTING);
+      }
     }
-    lock.release();
   }
 
   private final DefaultCacheStorageFiles defaultCacheStorageFiles;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.cache;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.blob.Blobs;
+import com.google.cloud.tools.jib.filesystem.LockFile;
 import com.google.cloud.tools.jib.filesystem.TemporaryDirectory;
 import com.google.cloud.tools.jib.hash.CountingDigestOutputStream;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
@@ -39,6 +40,7 @@ import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.FileSystemException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -118,6 +120,7 @@ class DefaultCacheStorageWriter {
    */
   private static void writeMetadata(JsonTemplate jsonTemplate, Path destination)
       throws IOException {
+    LockFile lock = LockFile.lock(Paths.get(destination.toString() + ".lock"));
     Path temporaryFile = Files.createTempFile(destination.getParent(), null, null);
     temporaryFile.toFile().deleteOnExit();
     Blobs.writeToFileWithLock(JsonTemplateMapper.toBlob(jsonTemplate), temporaryFile);
@@ -134,6 +137,7 @@ class DefaultCacheStorageWriter {
     } catch (AtomicMoveNotSupportedException ignored) {
       Files.move(temporaryFile, destination, StandardCopyOption.REPLACE_EXISTING);
     }
+    lock.release();
   }
 
   private final DefaultCacheStorageFiles defaultCacheStorageFiles;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriter.java
@@ -258,19 +258,10 @@ class DefaultCacheStorageWriter {
     Path imageDirectory = defaultCacheStorageFiles.getImageDirectory(imageReference);
     Files.createDirectories(imageDirectory);
 
-    String manifestFilename =
-        "manifest."
-            + containerConfiguration.getArchitecture()
-            + "."
-            + containerConfiguration.getOs()
-            + ".json";
-    String configFilename =
-        manifestTemplate.getContainerConfiguration().getDigest().getHash() + ".json";
-
     // TODO: Lock properly
     // Write manifest and configuration
-    writeMetadata(manifestTemplate, imageDirectory.resolve(manifestFilename));
-    writeMetadata(containerConfiguration, imageDirectory.resolve(configFilename));
+    writeMetadata(manifestTemplate, imageDirectory.resolve("manifest.json"));
+    writeMetadata(containerConfiguration, imageDirectory.resolve("config.json"));
   }
 
   /**
@@ -285,20 +276,9 @@ class DefaultCacheStorageWriter {
     Path imageDirectory = defaultCacheStorageFiles.getImageDirectory(imageReference);
     Files.createDirectories(imageDirectory);
 
-    ContainerConfigurationTemplate containerConfiguration =
-        manifestTemplate.getContainerConfiguration().orElse(null);
-    String fileName =
-        containerConfiguration == null
-            ? "manifest.amd64.linux.json"
-            : "manifest."
-                + containerConfiguration.getArchitecture()
-                + "."
-                + containerConfiguration.getOs()
-                + ".json";
-
     // TODO: Lock properly
     // Write manifest
-    writeMetadata(manifestTemplate, imageDirectory.resolve(fileName));
+    writeMetadata(manifestTemplate, imageDirectory.resolve("manifest.json"));
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.filesystem;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileLock;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/** Creates and deletes lock files. */
+public class LockFile {
+
+  private final Path lockFile;
+  private final FileLock lock;
+
+  private LockFile(Path lockFile, FileLock lock) {
+    this.lockFile = lockFile;
+    this.lock = lock;
+  }
+
+  /**
+   * Creates a lock file.
+   *
+   * @param lockFile the path of the lock file
+   * @return a new {@link LockFile} that can be released later
+   * @throws IOException if creating the lock file fails
+   */
+  public static LockFile lock(Path lockFile) throws IOException {
+    Files.createDirectories(lockFile.getParent());
+    while (true) {
+      try {
+        FileLock fileLock = new FileOutputStream(lockFile.toFile()).getChannel().tryLock();
+        if (fileLock != null) {
+          return new LockFile(lockFile, fileLock);
+        }
+      } catch (Exception ignored) {
+      }
+
+      try {
+        Thread.sleep(500);
+      } catch (InterruptedException ignored) {
+      }
+    }
+  }
+
+  /** Releases the lock file. */
+  public void release() {
+    try {
+      lock.release();
+      Files.delete(lockFile);
+    } catch (IOException ex) {
+      throw new IllegalStateException("Unable to release lock", ex);
+    }
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
@@ -63,8 +63,8 @@ public class LockFile {
     try {
       lock.release();
       Files.delete(lockFile);
-    } catch (IOException ex) {
-      throw new IllegalStateException("Unable to release lock", ex);
+    } catch (IOException ignored) {
+
     }
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
@@ -33,10 +33,12 @@ public class LockFile implements Closeable {
 
   private final Path lockFile;
   private final FileLock fileLock;
+  private final Lock lock;
 
-  private LockFile(Path lockFile, FileLock fileLock) {
+  private LockFile(Path lockFile, FileLock fileLock, Lock lock) {
     this.lockFile = lockFile;
     this.fileLock = fileLock;
+    this.lock = lock;
   }
 
   /**
@@ -55,7 +57,7 @@ public class LockFile implements Closeable {
     lock.lock();
     Files.createDirectories(lockFile.getParent());
     FileLock fileLock = new FileOutputStream(lockFile.toFile()).getChannel().lock();
-    return new LockFile(lockFile, fileLock);
+    return new LockFile(lockFile, fileLock, lock);
   }
 
   /** Releases the lock file. */
@@ -71,9 +73,6 @@ public class LockFile implements Closeable {
       Files.delete(lockFile);
     } catch (IOException ignored) {
     }
-    Lock lock = LOCK_MAP.get(lockFile);
-    if (lock != null) {
-      lock.unlock();
-    }
+    lock.unlock();
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.filesystem;
 
+import java.io.Closeable;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileLock;
@@ -23,7 +24,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 /** Creates and deletes lock files. */
-public class LockFile {
+public class LockFile implements Closeable {
 
   private final Path lockFile;
   private final FileLock lock;
@@ -59,7 +60,8 @@ public class LockFile {
   }
 
   /** Releases the lock file. */
-  public void release() {
+  @Override
+  public void close() {
     try {
       lock.release();
     } catch (IOException ex) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
@@ -62,9 +62,13 @@ public class LockFile {
   public void release() {
     try {
       lock.release();
+    } catch (IOException ex) {
+      throw new IllegalStateException("Unable to release lock", ex);
+    }
+
+    try {
       Files.delete(lockFile);
     } catch (IOException ignored) {
-
     }
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
@@ -80,9 +80,9 @@ public class JsonToImageTranslator {
       imageBuilder.addLayer(new DigestOnlyLayer(digest));
     }
 
-    if (manifestTemplate.getContainerConfiguration() != null) {
+    if (manifestTemplate.getContainerConfiguration().isPresent()) {
       configureBuilderWithContainerConfiguration(
-          imageBuilder, manifestTemplate.getContainerConfiguration());
+          imageBuilder, manifestTemplate.getContainerConfiguration().get());
     }
     return imageBuilder.build();
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/V21ManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/V21ManifestTemplate.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /**
@@ -118,21 +119,21 @@ public class V21ManifestTemplate implements ManifestTemplate {
    *
    * @return container configuration if the first history string holds it; {@code null} otherwise
    */
-  @Nullable
-  public ContainerConfigurationTemplate getContainerConfiguration() {
+  public Optional<ContainerConfigurationTemplate> getContainerConfiguration() {
     try {
       if (history.isEmpty()) {
-        return null;
+        return Optional.empty();
       }
       String v1Compatibility = history.get(0).v1Compatibility;
       if (v1Compatibility == null) {
-        return null;
+        return Optional.empty();
       }
 
-      return JsonTemplateMapper.readJson(v1Compatibility, ContainerConfigurationTemplate.class);
+      return Optional.of(
+          JsonTemplateMapper.readJson(v1Compatibility, ContainerConfigurationTemplate.class));
     } catch (IOException ex) {
       // not a container configuration; ignore and continue
-      return null;
+      return Optional.empty();
     }
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageFilesTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageFilesTest.java
@@ -17,6 +17,9 @@
 package com.google.cloud.tools.jib.cache;
 
 import com.google.cloud.tools.jib.image.DescriptorDigest;
+import com.google.cloud.tools.jib.image.ImageReference;
+import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.DigestException;
 import org.hamcrest.CoreMatchers;
@@ -155,5 +158,21 @@ public class DefaultCacheStorageFilesTest {
   public void testGetTemporaryDirectory() {
     Assert.assertEquals(
         Paths.get("cache/directory/tmp"), testDefaultCacheStorageFiles.getTemporaryDirectory());
+  }
+
+  @Test
+  public void testGetImageDirectory() throws InvalidImageReferenceException {
+    Path imagesDirectory = Paths.get("cache", "directory", "images");
+    Assert.assertEquals(imagesDirectory, testDefaultCacheStorageFiles.getImagesDirectory());
+    Assert.assertEquals(
+        imagesDirectory.resolve("reg.istry/repo/sitory/tag"),
+        testDefaultCacheStorageFiles.getImageDirectory(
+            ImageReference.parse("reg.istry/repo/sitory:tag")));
+    Assert.assertEquals(
+        imagesDirectory.resolve(
+            "reg.istry/repo/sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        testDefaultCacheStorageFiles.getImageDirectory(
+            ImageReference.parse(
+                "reg.istry/repo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")));
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageFilesTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageFilesTest.java
@@ -164,15 +164,20 @@ public class DefaultCacheStorageFilesTest {
   public void testGetImageDirectory() throws InvalidImageReferenceException {
     Path imagesDirectory = Paths.get("cache", "directory", "images");
     Assert.assertEquals(imagesDirectory, testDefaultCacheStorageFiles.getImagesDirectory());
+
     Assert.assertEquals(
-        imagesDirectory.resolve("reg.istry/repo/sitory/tag"),
+        imagesDirectory.resolve("reg.istry/repo/sitory!tag"),
         testDefaultCacheStorageFiles.getImageDirectory(
             ImageReference.parse("reg.istry/repo/sitory:tag")));
     Assert.assertEquals(
         imagesDirectory.resolve(
-            "reg.istry/repo/sha256/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            "reg.istry/repo!sha256!aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
         testDefaultCacheStorageFiles.getImageDirectory(
             ImageReference.parse(
                 "reg.istry/repo@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")));
+    Assert.assertEquals(
+        imagesDirectory.resolve("reg.istry!5000/repo/sitory!tag"),
+        testDefaultCacheStorageFiles.getImageDirectory(
+            ImageReference.parse("reg.istry:5000/repo/sitory:tag")));
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageFilesTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageFilesTest.java
@@ -161,6 +161,12 @@ public class DefaultCacheStorageFilesTest {
   }
 
   @Test
+  public void testGetImagesDirectory() {
+    Assert.assertEquals(
+        Paths.get("cache/directory/images"), testDefaultCacheStorageFiles.getImagesDirectory());
+  }
+
+  @Test
   public void testGetImageDirectory() throws InvalidImageReferenceException {
     Path imagesDirectory = Paths.get("cache", "directory", "images");
     Assert.assertEquals(imagesDirectory, testDefaultCacheStorageFiles.getImagesDirectory());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriterTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriterTest.java
@@ -133,8 +133,8 @@ public class DefaultCacheStorageWriterTest {
                 .resolve("manifest.amd64.linux.json"),
             V21ManifestTemplate.class);
     Assert.assertEquals(
-        expectedManifest.getContainerConfiguration().getArchitecture(),
-        manifestTemplate.getContainerConfiguration().getArchitecture());
+        expectedManifest.getContainerConfiguration().get().getArchitecture(),
+        manifestTemplate.getContainerConfiguration().get().getArchitecture());
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriterTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriterTest.java
@@ -152,7 +152,8 @@ public class DefaultCacheStorageWriterTest {
     Path savedManifestPath =
         cacheRoot.resolve("images/image.reference/project/thing!tag/manifest.wasm.js.json");
     Path savedConfigPath =
-        cacheRoot.resolve("images/image.reference/project/thing!tag/config.wasm.js.json");
+        cacheRoot.resolve(
+            "images/image.reference/project/thing!tag/8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad.json");
     Assert.assertTrue(Files.exists(savedManifestPath));
     Assert.assertTrue(Files.exists(savedConfigPath));
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriterTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/DefaultCacheStorageWriterTest.java
@@ -123,7 +123,7 @@ public class DefaultCacheStorageWriterTest {
         .writeMetadata(imageReference, manifestTemplate);
 
     Path savedManifestPath =
-        cacheRoot.resolve("images/image.reference/project/thing!tag/manifest.amd64.linux.json");
+        cacheRoot.resolve("images/image.reference/project/thing!tag/manifest.json");
     Assert.assertTrue(Files.exists(savedManifestPath));
 
     V21ManifestTemplate savedManifest =
@@ -150,10 +150,9 @@ public class DefaultCacheStorageWriterTest {
         .writeMetadata(imageReference, manifestTemplate, containerConfigurationTemplate);
 
     Path savedManifestPath =
-        cacheRoot.resolve("images/image.reference/project/thing!tag/manifest.wasm.js.json");
+        cacheRoot.resolve("images/image.reference/project/thing!tag/manifest.json");
     Path savedConfigPath =
-        cacheRoot.resolve(
-            "images/image.reference/project/thing!tag/8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad.json");
+        cacheRoot.resolve("images/image.reference/project/thing!tag/config.json");
     Assert.assertTrue(Files.exists(savedManifestPath));
     Assert.assertTrue(Files.exists(savedConfigPath));
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
@@ -45,8 +45,6 @@ public class LockFileTest {
             intPointer[0] = valueBeforeSleep + 1;
 
             lockFile.release();
-            Assert.assertFalse(
-                Files.exists(temporaryFolder.getRoot().toPath().resolve("testLock")));
 
           } catch (InterruptedException | IOException ex) {
             throw new AssertionError(ex);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
@@ -29,22 +29,19 @@ public class LockFileTest {
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
-  public void testLockAndRelease() throws InterruptedException {
+  public void testLockAndRelease() throws InterruptedException, IOException {
     int[] intPointer = {0};
 
     // Runnable that would produce a race condition without a lock file
     Runnable procedure =
         () -> {
-          try {
-            LockFile lockFile =
-                LockFile.lock(temporaryFolder.getRoot().toPath().resolve("testLock"));
+          try (LockFile ignored =
+              LockFile.lock(temporaryFolder.getRoot().toPath().resolve("testLock"))) {
             Assert.assertTrue(Files.exists(temporaryFolder.getRoot().toPath().resolve("testLock")));
 
             int valueBeforeSleep = intPointer[0];
             Thread.sleep(100);
             intPointer[0] = valueBeforeSleep + 1;
-
-            lockFile.release();
 
           } catch (InterruptedException | IOException ex) {
             throw new AssertionError(ex);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.filesystem;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,7 +31,7 @@ public class LockFileTest {
 
   @Test
   public void testLockAndRelease() throws InterruptedException {
-    int[] intPointer = {0};
+    AtomicInteger atomicInt = new AtomicInteger(0);
 
     // Runnable that would produce a race condition without a lock file
     Runnable procedure =
@@ -39,9 +40,9 @@ public class LockFileTest {
               LockFile.lock(temporaryFolder.getRoot().toPath().resolve("testLock"))) {
             Assert.assertTrue(Files.exists(temporaryFolder.getRoot().toPath().resolve("testLock")));
 
-            int valueBeforeSleep = intPointer[0];
+            int valueBeforeSleep = atomicInt.intValue();
             Thread.sleep(100);
-            intPointer[0] = valueBeforeSleep + 1;
+            atomicInt.set(valueBeforeSleep + 1);
 
           } catch (InterruptedException | IOException ex) {
             throw new AssertionError(ex);
@@ -55,6 +56,6 @@ public class LockFileTest {
     thread.join();
 
     // Assert no overlap while lock was in place
-    Assert.assertEquals(2, intPointer[0]);
+    Assert.assertEquals(2, atomicInt.intValue());
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
@@ -29,7 +29,7 @@ public class LockFileTest {
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
-  public void testLockAndRelease() throws InterruptedException, IOException {
+  public void testLockAndRelease() throws InterruptedException {
     int[] intPointer = {0};
 
     // Runnable that would produce a race condition without a lock file

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.filesystem;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+/** Tests for {@link LockFile}. */
+public class LockFileTest {
+
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Test
+  public void testLockAndRelease() throws InterruptedException {
+    int[] intPointer = {0};
+
+    // Runnable that would produce a race condition without a lock file
+    Runnable procedure =
+        () -> {
+          try {
+            LockFile lockFile =
+                LockFile.lock(temporaryFolder.getRoot().toPath().resolve("testLock"));
+            Assert.assertTrue(Files.exists(temporaryFolder.getRoot().toPath().resolve("testLock")));
+
+            int valueBeforeSleep = intPointer[0];
+            Thread.sleep(100);
+            intPointer[0] = valueBeforeSleep + 1;
+
+            lockFile.release();
+            Assert.assertFalse(
+                Files.exists(temporaryFolder.getRoot().toPath().resolve("testLock")));
+
+          } catch (InterruptedException | IOException ex) {
+            throw new AssertionError(ex);
+          }
+        };
+
+    // Run the runnable once in this thread + once in the main thread
+    Thread thread = new Thread(procedure);
+    thread.start();
+    procedure.run();
+    thread.join();
+
+    // Assert no overlap while lock was in place
+    Assert.assertEquals(2, intPointer[0]);
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/V21ManifestTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/V21ManifestTemplateTest.java
@@ -46,7 +46,7 @@ public class V21ManifestTemplateTest {
         manifestJson.getFsLayers().get(0).getDigest());
 
     ContainerConfigurationTemplate containerConfiguration =
-        manifestJson.getContainerConfiguration();
+        manifestJson.getContainerConfiguration().orElse(null);
     Assert.assertEquals(
         Arrays.asList("JAVA_HOME=/opt/openjdk", "PATH=/opt/openjdk/bin"),
         containerConfiguration.getContainerEnvironment());


### PR DESCRIPTION
Towards #718.

Adds `writeMetadata` methods to `Cache`, `CacheStorage`, and `DefaultCacheStorageWriter`, as well as helpers for getting the image metadata directory in `DefaultCacheStorageFiles`.

Mostly ignored file-locking for now; I did reuse some methods which involve file locking, but I'll probably need to take another look in the future when the locking design is nailed down.