### PR TITLE
Add offline mode to jib-core

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -6,12 +6,14 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Container configurations in the base image are now propagated when registry uses the old V2 image manifest, schema version 1 (such as Quay) ([#1641](https://github.com/GoogleContainerTools/jib/issues/1641))
+- `Containerizer#setOfflineMode` to retrieve the base image from Jib's cache rather than a container registry ([#718](https://github.com/GoogleContainerTools/jib/issues/718))
 
 ### Changed
 
 ### Fixed
 
 - Labels in the base image are now propagated ([#1643](https://github.com/GoogleContainerTools/jib/issues/1643))
+- Fixed an issue with using OCI base images ([#1683](https://github.com/GoogleContainerTools/jib/issues/1683))
 
 ## 0.9.1
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
@@ -118,9 +118,9 @@ public class JibIntegrationTest {
   public void testOffline()
       throws IOException, InterruptedException, InvalidImageReferenceException, ExecutionException,
           RegistryException, CacheDirectoryCreationException {
-    LocalRegistry offlineRegistry = new LocalRegistry(5001);
-    offlineRegistry.start();
-    offlineRegistry.pullAndPushToLocal("busybox", "busybox");
+    LocalRegistry tempRegistry = new LocalRegistry(5001);
+    tempRegistry.start();
+    tempRegistry.pullAndPushToLocal("busybox", "busybox");
     Path cacheDirectory = cacheFolder.getRoot().toPath();
 
     ImageReference targetImageReferenceOnline =
@@ -148,7 +148,6 @@ public class JibIntegrationTest {
               .setOfflineMode(true));
       Assert.fail();
     } catch (ExecutionException ex) {
-      Assert.assertTrue(ex.getCause() instanceof IOException);
       Assert.assertEquals(
           "Cannot run Jib in offline mode; localhost:5001/busybox not found in cache",
           ex.getCause().getMessage());
@@ -161,7 +160,7 @@ public class JibIntegrationTest {
             .setAllowInsecureRegistries(true));
 
     // Run again in offline mode, should succeed this time
-    offlineRegistry.stop();
+    tempRegistry.stop();
     jibContainerBuilder.containerize(
         Containerizer.to(DockerDaemonImage.named(targetImageReferenceOffline))
             .setBaseImageLayersCache(cacheDirectory)

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
@@ -119,7 +119,7 @@ public class JibIntegrationTest {
       throws IOException, InterruptedException, InvalidImageReferenceException, ExecutionException,
           RegistryException, CacheDirectoryCreationException {
     LocalRegistry tempRegistry = new LocalRegistry(5001);
-    tempRegistry.start();
+    tempRegistry.startLocalRegistry();
     tempRegistry.pullAndPushToLocal("busybox", "busybox");
     Path cacheDirectory = cacheFolder.getRoot().toPath();
 
@@ -149,7 +149,7 @@ public class JibIntegrationTest {
       Assert.fail();
     } catch (ExecutionException ex) {
       Assert.assertEquals(
-          "Cannot run Jib in offline mode; localhost:5001/busybox not found in cache",
+          "Cannot run Jib in offline mode; localhost:5001/busybox not found in local Jib cache",
           ex.getCause().getMessage());
     }
 
@@ -160,7 +160,7 @@ public class JibIntegrationTest {
             .setAllowInsecureRegistries(true));
 
     // Run again in offline mode, should succeed this time
-    tempRegistry.stop();
+    tempRegistry.stopLocalRegistry();
     jibContainerBuilder.containerize(
         Containerizer.to(DockerDaemonImage.named(targetImageReferenceOffline))
             .setBaseImageLayersCache(cacheDirectory)

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
@@ -24,6 +24,7 @@ import com.google.cloud.tools.jib.image.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.registry.LocalRegistry;
 import com.google.cloud.tools.jib.registry.RegistryException;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -32,13 +33,17 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /** Integration tests for {@link Jib}. */
 public class JibIntegrationTest {
 
   @ClassRule
   public static final LocalRegistry localRegistry = new LocalRegistry(5000, "username", "password");
+
+  @Rule public final TemporaryFolder cacheFolder = new TemporaryFolder();
 
   /**
    * Pulls a built image and attempts to run it.
@@ -107,6 +112,65 @@ public class JibIntegrationTest {
     Assert.assertFalse(
         "docker inspect output contained layers: " + inspectOutput,
         inspectOutput.contains("\"Layers\": ["));
+  }
+
+  @Test
+  public void testOffline()
+      throws IOException, InterruptedException, InvalidImageReferenceException, ExecutionException,
+          RegistryException, CacheDirectoryCreationException {
+    LocalRegistry offlineRegistry = new LocalRegistry(5001);
+    offlineRegistry.start();
+    offlineRegistry.pullAndPushToLocal("busybox", "busybox");
+    Path cacheDirectory = cacheFolder.getRoot().toPath();
+
+    ImageReference targetImageReferenceOnline =
+        ImageReference.of("localhost:5001", "jib-core", "basic-online");
+    ImageReference targetImageReferenceOffline =
+        ImageReference.of("localhost:5001", "jib-core", "basic-offline");
+
+    JibContainerBuilder jibContainerBuilder =
+        Jib.from("localhost:5001/busybox").setEntrypoint("echo", "Hello World");
+
+    // Should fail since Jib can't build to registry offline
+    try {
+      jibContainerBuilder.containerize(
+          Containerizer.to(RegistryImage.named(targetImageReferenceOffline)).setOfflineMode(true));
+      Assert.fail();
+    } catch (IllegalStateException ex) {
+      Assert.assertEquals("Cannot build to a container registry in offline mode", ex.getMessage());
+    }
+
+    // Should fail since Jib hasn't cached the base image yet
+    try {
+      jibContainerBuilder.containerize(
+          Containerizer.to(DockerDaemonImage.named(targetImageReferenceOffline))
+              .setBaseImageLayersCache(cacheDirectory)
+              .setOfflineMode(true));
+      Assert.fail();
+    } catch (ExecutionException ex) {
+      Assert.assertTrue(ex.getCause() instanceof IOException);
+      Assert.assertEquals(
+          "Cannot run Jib in offline mode; localhost:5001/busybox not found in cache",
+          ex.getCause().getMessage());
+    }
+
+    // Run online to cache the base image
+    jibContainerBuilder.containerize(
+        Containerizer.to(DockerDaemonImage.named(targetImageReferenceOnline))
+            .setBaseImageLayersCache(cacheDirectory)
+            .setAllowInsecureRegistries(true));
+
+    // Run again in offline mode, should succeed this time
+    offlineRegistry.stop();
+    jibContainerBuilder.containerize(
+        Containerizer.to(DockerDaemonImage.named(targetImageReferenceOffline))
+            .setBaseImageLayersCache(cacheDirectory)
+            .setOfflineMode(true));
+
+    // Verify output
+    Assert.assertEquals(
+        "Hello World\n",
+        new Command("docker", "run", "--rm", targetImageReferenceOffline.toString()).run());
   }
 
   /** Ensure that a provided executor is not disposed. */

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
@@ -119,7 +119,7 @@ public class JibIntegrationTest {
       throws IOException, InterruptedException, InvalidImageReferenceException, ExecutionException,
           RegistryException, CacheDirectoryCreationException {
     LocalRegistry tempRegistry = new LocalRegistry(5001);
-    tempRegistry.startLocalRegistry();
+    tempRegistry.start();
     tempRegistry.pullAndPushToLocal("busybox", "busybox");
     Path cacheDirectory = cacheFolder.getRoot().toPath();
 
@@ -160,7 +160,7 @@ public class JibIntegrationTest {
             .setAllowInsecureRegistries(true));
 
     // Run again in offline mode, should succeed this time
-    tempRegistry.stopLocalRegistry();
+    tempRegistry.stop();
     jibContainerBuilder.containerize(
         Containerizer.to(DockerDaemonImage.named(targetImageReferenceOffline))
             .setBaseImageLayersCache(cacheDirectory)

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
@@ -52,6 +52,16 @@ public class LocalRegistry extends ExternalResource {
   /** Starts the local registry. */
   @Override
   protected void before() throws IOException, InterruptedException {
+    start();
+  }
+
+  @Override
+  protected void after() {
+    stop();
+  }
+
+  /** Starts the registry */
+  public void start() throws IOException, InterruptedException {
     // Runs the Docker registry.
     ArrayList<String> dockerTokens =
         new ArrayList<>(
@@ -96,8 +106,8 @@ public class LocalRegistry extends ExternalResource {
     waitUntilReady();
   }
 
-  @Override
-  protected void after() {
+  /** Stops the registry. */
+  public void stop() {
     try {
       logout();
       new Command("docker", "stop", containerName).run();

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
@@ -52,16 +52,16 @@ public class LocalRegistry extends ExternalResource {
   /** Starts the local registry. */
   @Override
   protected void before() throws IOException, InterruptedException {
-    startLocalRegistry();
+    start();
   }
 
   @Override
   protected void after() {
-    stopLocalRegistry();
+    stop();
   }
 
   /** Starts the registry */
-  public void startLocalRegistry() throws IOException, InterruptedException {
+  public void start() throws IOException, InterruptedException {
     // Runs the Docker registry.
     ArrayList<String> dockerTokens =
         new ArrayList<>(
@@ -107,7 +107,7 @@ public class LocalRegistry extends ExternalResource {
   }
 
   /** Stops the registry. */
-  public void stopLocalRegistry() {
+  public void stop() {
     try {
       logout();
       new Command("docker", "stop", containerName).run();

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
@@ -52,16 +52,16 @@ public class LocalRegistry extends ExternalResource {
   /** Starts the local registry. */
   @Override
   protected void before() throws IOException, InterruptedException {
-    start();
+    startLocalRegistry();
   }
 
   @Override
   protected void after() {
-    stop();
+    stopLocalRegistry();
   }
 
   /** Starts the registry */
-  public void start() throws IOException, InterruptedException {
+  public void startLocalRegistry() throws IOException, InterruptedException {
     // Runs the Docker registry.
     ArrayList<String> dockerTokens =
         new ArrayList<>(
@@ -107,7 +107,7 @@ public class LocalRegistry extends ExternalResource {
   }
 
   /** Stops the registry. */
-  public void stop() {
+  public void stopLocalRegistry() {
     try {
       logout();
       new Command("docker", "stop", containerName).run();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
@@ -145,6 +145,7 @@ public class Containerizer {
   @Nullable private Path applicationLayersCacheDirectory;
   @Nullable private EventHandlers eventHandlers;
   private boolean allowInsecureRegistries = false;
+  private boolean offline = false;
   private String toolName = DEFAULT_TOOL_NAME;
 
   /** Instantiate with {@link #to}. */
@@ -236,6 +237,18 @@ public class Containerizer {
   }
 
   /**
+   * Sets whether or not to run the build in offline mode. In offline mode, the base image is
+   * retrieved from the cache instead of pulled from a registry.
+   *
+   * @param offline if {@code true}, the build will run in offline mode
+   * @return this
+   */
+  public Containerizer setOfflineMode(boolean offline) {
+    this.offline = offline;
+    return this;
+  }
+
+  /**
    * Sets the name of the tool that is using Jib Core. The tool name is sent as part of the {@code
    * User-Agent} in registry requests and set as the {@code created_by} in the container layer
    * history. Defaults to {@code jib-core}.
@@ -281,6 +294,10 @@ public class Containerizer {
 
   boolean getAllowInsecureRegistries() {
     return allowInsecureRegistries;
+  }
+
+  boolean getOfflineMode() {
+    return offline;
   }
 
   String getToolName() {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
@@ -66,6 +66,7 @@ public class Containerizer {
     ImageConfiguration imageConfiguration =
         ImageConfiguration.builder(registryImage.getImageReference())
             .setCredentialRetrievers(registryImage.getCredentialRetrievers())
+            .setIsOnlineImage()
             .build();
 
     Function<BuildConfiguration, StepsRunner> stepsRunnerFactory =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
@@ -139,6 +139,7 @@ public class Containerizer {
   private final String description;
   private final ImageConfiguration imageConfiguration;
   private final Function<BuildConfiguration, StepsRunner> stepsRunnerFactory;
+  private final boolean mustBeOnline;
 
   private final Set<String> additionalTags = new HashSet<>();
   @Nullable private ExecutorService executorService;
@@ -147,7 +148,6 @@ public class Containerizer {
   @Nullable private EventHandlers eventHandlers;
   private boolean allowInsecureRegistries = false;
   private boolean offline = false;
-  private boolean mustBeOnline;
   private String toolName = DEFAULT_TOOL_NAME;
 
   /** Instantiate with {@link #to}. */

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
@@ -239,7 +239,8 @@ public class Containerizer {
 
   /**
    * Sets whether or not to run the build in offline mode. In offline mode, the base image is
-   * retrieved from the cache instead of pulled from a registry.
+   * retrieved from the cache instead of pulled from a registry, and the build will fail if the base
+   * image is not in the cache.
    *
    * @param offline if {@code true}, the build will run in offline mode
    * @return this
@@ -297,7 +298,7 @@ public class Containerizer {
     return allowInsecureRegistries;
   }
 
-  boolean getOfflineMode() {
+  boolean isOfflineMode() {
     return offline;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -476,10 +476,6 @@ public class JibContainerBuilder {
       Containerizer containerizer, Supplier<ExecutorService> defaultExecutorServiceFactory)
       throws IOException, CacheDirectoryCreationException, InterruptedException, RegistryException,
           ExecutionException {
-    if (containerizer.isOfflineMode() && containerizer.getImageConfiguration().isOnlineImage()) {
-      throw new IllegalStateException("Cannot build to a container registry in offline mode");
-    }
-
     boolean shutdownExecutorService = !containerizer.getExecutorService().isPresent();
     ExecutorService executorService =
         containerizer.getExecutorService().orElseGet(defaultExecutorServiceFactory);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -476,7 +476,7 @@ public class JibContainerBuilder {
       Containerizer containerizer, Supplier<ExecutorService> defaultExecutorServiceFactory)
       throws IOException, CacheDirectoryCreationException, InterruptedException, RegistryException,
           ExecutionException {
-    if (containerizer.getOfflineMode() && containerizer.getImageConfiguration().isOnlineImage()) {
+    if (containerizer.isOfflineMode() && containerizer.getImageConfiguration().isOnlineImage()) {
       throw new IllegalStateException("Cannot build to a container registry in offline mode");
     }
 
@@ -530,7 +530,7 @@ public class JibContainerBuilder {
         .setContainerConfiguration(containerConfigurationBuilder.build())
         .setLayerConfigurations(layerConfigurations)
         .setAllowInsecureRegistries(containerizer.getAllowInsecureRegistries())
-        .setOffline(containerizer.getOfflineMode())
+        .setOffline(containerizer.isOfflineMode())
         .setToolName(containerizer.getToolName())
         .setExecutorService(executorService);
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -476,6 +476,9 @@ public class JibContainerBuilder {
       Containerizer containerizer, Supplier<ExecutorService> defaultExecutorServiceFactory)
       throws IOException, CacheDirectoryCreationException, InterruptedException, RegistryException,
           ExecutionException {
+    if (containerizer.getOfflineMode() && containerizer.getImageConfiguration().isOnlineImage()) {
+      throw new IllegalStateException("Cannot build to a container registry in offline mode");
+    }
 
     boolean shutdownExecutorService = !containerizer.getExecutorService().isPresent();
     ExecutorService executorService =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -527,6 +527,7 @@ public class JibContainerBuilder {
         .setContainerConfiguration(containerConfigurationBuilder.build())
         .setLayerConfigurations(layerConfigurations)
         .setAllowInsecureRegistries(containerizer.getAllowInsecureRegistries())
+        .setOffline(containerizer.getOfflineMode())
         .setToolName(containerizer.getToolName())
         .setExecutorService(executorService);
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
@@ -82,6 +82,9 @@ class PullAndCacheBaseImageLayerStep implements AsyncStep<CachedLayer>, Callable
       Optional<CachedLayer> optionalCachedLayer = cache.retrieve(layerDigest);
       if (optionalCachedLayer.isPresent()) {
         return optionalCachedLayer.get();
+      } else if (buildConfiguration.getOffline()) {
+        throw new IOException(
+            "Cannot run Jib in offline mode; Cache is missing image layer " + layerDigest);
       }
 
       RegistryClient registryClient =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullAndCacheBaseImageLayerStep.java
@@ -82,9 +82,11 @@ class PullAndCacheBaseImageLayerStep implements AsyncStep<CachedLayer>, Callable
       Optional<CachedLayer> optionalCachedLayer = cache.retrieve(layerDigest);
       if (optionalCachedLayer.isPresent()) {
         return optionalCachedLayer.get();
-      } else if (buildConfiguration.getOffline()) {
+      } else if (buildConfiguration.isOffline()) {
         throw new IOException(
-            "Cannot run Jib in offline mode; Cache is missing image layer " + layerDigest);
+            "Cannot run Jib in offline mode; local Jib cache for base image is missing image layer "
+                + layerDigest
+                + ". You may need to rerun Jib in online mode to re-download the base image layers.");
       }
 
       RegistryClient registryClient =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.jib.builder.BuildStepType;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.builder.steps.PullBaseImageStep.BaseImageWithAuthorization;
+import com.google.cloud.tools.jib.cache.CacheCorruptedException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.configuration.credentials.Credential;
@@ -32,16 +33,18 @@ import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.http.Authorizations;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.Image;
+import com.google.cloud.tools.jib.image.ImageReference;
 import com.google.cloud.tools.jib.image.Layer;
 import com.google.cloud.tools.jib.image.LayerCountMismatchException;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.cloud.tools.jib.image.json.BadContainerConfigurationFormatException;
+import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
 import com.google.cloud.tools.jib.image.json.JsonToImageTranslator;
+import com.google.cloud.tools.jib.image.json.ManifestAndConfig;
 import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.UnknownManifestFormatException;
 import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
-import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticator;
 import com.google.cloud.tools.jib.registry.RegistryClient;
@@ -52,6 +55,7 @@ import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import javax.annotation.Nullable;
@@ -108,8 +112,8 @@ class PullBaseImageStep
   @Override
   public BaseImageWithAuthorization call()
       throws IOException, RegistryException, LayerPropertyNotFoundException,
-          LayerCountMismatchException, ExecutionException,
-          BadContainerConfigurationFormatException {
+          LayerCountMismatchException, ExecutionException, BadContainerConfigurationFormatException,
+          CacheCorruptedException {
     // Skip this step if this is a scratch image
     ImageConfiguration baseImageConfiguration = buildConfiguration.getBaseImageConfiguration();
     if (baseImageConfiguration.getImage().isScratch()) {
@@ -127,6 +131,10 @@ class PullBaseImageStep
                 "Getting base image "
                     + buildConfiguration.getBaseImageConfiguration().getImage()
                     + "..."));
+
+    if (buildConfiguration.getOffline()) {
+      return new BaseImageWithAuthorization(pullBaseImageOffline(), null);
+    }
 
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create(
@@ -229,19 +237,24 @@ class PullBaseImageStep
     switch (manifestTemplate.getSchemaVersion()) {
       case 1:
         V21ManifestTemplate v21ManifestTemplate = (V21ManifestTemplate) manifestTemplate;
+        buildConfiguration
+            .getBaseImageLayersCache()
+            .writeMetadata(
+                buildConfiguration.getBaseImageConfiguration().getImage(), v21ManifestTemplate);
         return JsonToImageTranslator.toImage(v21ManifestTemplate);
 
       case 2:
-        V22ManifestTemplate v22ManifestTemplate = (V22ManifestTemplate) manifestTemplate;
-        if (v22ManifestTemplate.getContainerConfiguration() == null
-            || v22ManifestTemplate.getContainerConfiguration().getDigest() == null) {
+        BuildableManifestTemplate buildableManifestTemplate =
+            (BuildableManifestTemplate) manifestTemplate;
+        if (buildableManifestTemplate.getContainerConfiguration() == null
+            || buildableManifestTemplate.getContainerConfiguration().getDigest() == null) {
           throw new UnknownManifestFormatException(
-              "Invalid container configuration in Docker V2.2 manifest: \n"
-                  + Blobs.writeToString(JsonTemplateMapper.toBlob(v22ManifestTemplate)));
+              "Invalid container configuration in Docker V2.2/OCI manifest: \n"
+                  + Blobs.writeToString(JsonTemplateMapper.toBlob(buildableManifestTemplate)));
         }
 
         DescriptorDigest containerConfigurationDigest =
-            v22ManifestTemplate.getContainerConfiguration().getDigest();
+            buildableManifestTemplate.getContainerConfiguration().getDigest();
 
         try (ProgressEventDispatcherContainer progressEventDispatcherContainer =
             new ProgressEventDispatcherContainer(
@@ -258,10 +271,48 @@ class PullBaseImageStep
           ContainerConfigurationTemplate containerConfigurationTemplate =
               JsonTemplateMapper.readJson(
                   containerConfigurationString, ContainerConfigurationTemplate.class);
-          return JsonToImageTranslator.toImage(v22ManifestTemplate, containerConfigurationTemplate);
+          buildConfiguration
+              .getBaseImageLayersCache()
+              .writeMetadata(
+                  buildConfiguration.getBaseImageConfiguration().getImage(),
+                  buildableManifestTemplate,
+                  containerConfigurationTemplate);
+          return JsonToImageTranslator.toImage(
+              buildableManifestTemplate, containerConfigurationTemplate);
         }
     }
 
     throw new IllegalStateException("Unknown manifest schema version");
+  }
+
+  /**
+   * Retrieves the cached base image.
+   *
+   * @return the cached image
+   * @throws IOException when an I/O exception occurs
+   * @throws CacheCorruptedException if the cache is corrupted
+   * @throws LayerPropertyNotFoundException if adding image layers fails
+   * @throws BadContainerConfigurationFormatException if the container configuration is in a bad
+   *     format
+   */
+  private Image<Layer> pullBaseImageOffline()
+      throws IOException, CacheCorruptedException, BadContainerConfigurationFormatException,
+          LayerCountMismatchException {
+    ImageReference baseImage = buildConfiguration.getBaseImageConfiguration().getImage();
+    Optional<ManifestAndConfig> metadata =
+        buildConfiguration.getBaseImageLayersCache().retrieveMetadata(baseImage);
+    if (!metadata.isPresent()) {
+      throw new IOException("Cannot run Jib in offline mode; " + baseImage + " not found in cache");
+    }
+
+    ManifestTemplate manifestTemplate = metadata.get().getManifest();
+    if (manifestTemplate instanceof V21ManifestTemplate) {
+      return JsonToImageTranslator.toImage((V21ManifestTemplate) manifestTemplate);
+    }
+
+    ContainerConfigurationTemplate configurationTemplate =
+        metadata.get().getConfig().orElseThrow(IllegalStateException::new);
+    return JsonToImageTranslator.toImage(
+        (BuildableManifestTemplate) manifestTemplate, configurationTemplate);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -132,7 +132,7 @@ class PullBaseImageStep
                     + buildConfiguration.getBaseImageConfiguration().getImage()
                     + "..."));
 
-    if (buildConfiguration.getOffline()) {
+    if (buildConfiguration.isOffline()) {
       return new BaseImageWithAuthorization(pullBaseImageOffline(), null);
     }
 
@@ -302,7 +302,8 @@ class PullBaseImageStep
     Optional<ManifestAndConfig> metadata =
         buildConfiguration.getBaseImageLayersCache().retrieveMetadata(baseImage);
     if (!metadata.isPresent()) {
-      throw new IOException("Cannot run Jib in offline mode; " + baseImage + " not found in cache");
+      throw new IOException(
+          "Cannot run Jib in offline mode; " + baseImage + " not found in local Jib cache");
     }
 
     ManifestTemplate manifestTemplate = metadata.get().getManifest();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
@@ -416,7 +416,7 @@ public class BuildConfiguration {
    *
    * @return {@code true} if the build will run in offline mode; {@code false} otherwise
    */
-  public boolean getOffline() {
+  public boolean isOffline() {
     return offline;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
@@ -57,6 +57,7 @@ public class BuildConfiguration {
     @Nullable private Path applicationLayersCacheDirectory;
     @Nullable private Path baseImageLayersCacheDirectory;
     private boolean allowInsecureRegistries = false;
+    private boolean offline = false;
     private ImmutableList<LayerConfiguration> layerConfigurations = ImmutableList.of();
     private Class<? extends BuildableManifestTemplate> targetFormat = DEFAULT_TARGET_FORMAT;
     private String toolName = DEFAULT_TOOL_NAME;
@@ -158,6 +159,17 @@ public class BuildConfiguration {
     }
 
     /**
+     * Sets whether or not to perform the build in offline mode.
+     *
+     * @param offline if {@code true}, the build will run in offline mode
+     * @return this
+     */
+    public Builder setOffline(boolean offline) {
+      this.offline = offline;
+      return this;
+    }
+
+    /**
      * Sets the layers to build.
      *
      * @param layerConfigurations the configurations for the layers
@@ -246,6 +258,7 @@ public class BuildConfiguration {
               Cache.withDirectory(Preconditions.checkNotNull(applicationLayersCacheDirectory)),
               targetFormat,
               allowInsecureRegistries,
+              offline,
               layerConfigurations,
               toolName,
               eventDispatcher,
@@ -298,6 +311,7 @@ public class BuildConfiguration {
   private final Cache applicationLayersCache;
   private Class<? extends BuildableManifestTemplate> targetFormat;
   private final boolean allowInsecureRegistries;
+  private final boolean offline;
   private final ImmutableList<LayerConfiguration> layerConfigurations;
   private final String toolName;
   private final EventDispatcher eventDispatcher;
@@ -313,6 +327,7 @@ public class BuildConfiguration {
       Cache applicationLayersCache,
       Class<? extends BuildableManifestTemplate> targetFormat,
       boolean allowInsecureRegistries,
+      boolean offline,
       ImmutableList<LayerConfiguration> layerConfigurations,
       String toolName,
       EventDispatcher eventDispatcher,
@@ -325,6 +340,7 @@ public class BuildConfiguration {
     this.applicationLayersCache = applicationLayersCache;
     this.targetFormat = targetFormat;
     this.allowInsecureRegistries = allowInsecureRegistries;
+    this.offline = offline;
     this.layerConfigurations = layerConfigurations;
     this.toolName = toolName;
     this.eventDispatcher = eventDispatcher;
@@ -393,6 +409,15 @@ public class BuildConfiguration {
    */
   public boolean getAllowInsecureRegistries() {
     return allowInsecureRegistries;
+  }
+
+  /**
+   * Gets whether or not to run the build in offline mode.
+   *
+   * @return {@code true} if the build will run in offline mode; {@code false} otherwise
+   */
+  public boolean getOffline() {
+    return offline;
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
@@ -30,6 +30,7 @@ public class ImageConfiguration {
 
     private ImageReference imageReference;
     private ImmutableList<CredentialRetriever> credentialRetrievers = ImmutableList.of();
+    private boolean isOnlineImage = false;
 
     /**
      * Sets the providers for registry credentials. The order determines the priority in which the
@@ -46,12 +47,22 @@ public class ImageConfiguration {
     }
 
     /**
+     * Indicates that the target can only be reached online.
+     *
+     * @return this
+     */
+    public Builder setIsOnlineImage() {
+      this.isOnlineImage = true;
+      return this;
+    }
+
+    /**
      * Builds the {@link ImageConfiguration}.
      *
      * @return the corresponding {@link ImageConfiguration}
      */
     public ImageConfiguration build() {
-      return new ImageConfiguration(imageReference, credentialRetrievers);
+      return new ImageConfiguration(imageReference, credentialRetrievers, isOnlineImage);
     }
 
     private Builder(ImageReference imageReference) {
@@ -71,11 +82,15 @@ public class ImageConfiguration {
 
   private final ImageReference image;
   private final ImmutableList<CredentialRetriever> credentialRetrievers;
+  private final boolean isOnlineImage;
 
   private ImageConfiguration(
-      ImageReference image, ImmutableList<CredentialRetriever> credentialRetrievers) {
+      ImageReference image,
+      ImmutableList<CredentialRetriever> credentialRetrievers,
+      boolean isOnlineImage) {
     this.image = image;
     this.credentialRetrievers = credentialRetrievers;
+    this.isOnlineImage = isOnlineImage;
   }
 
   public ImageReference getImage() {
@@ -96,5 +111,9 @@ public class ImageConfiguration {
 
   public ImmutableList<CredentialRetriever> getCredentialRetrievers() {
     return credentialRetrievers;
+  }
+
+  public boolean isOnlineImage() {
+    return isOnlineImage;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
@@ -30,7 +30,6 @@ public class ImageConfiguration {
 
     private ImageReference imageReference;
     private ImmutableList<CredentialRetriever> credentialRetrievers = ImmutableList.of();
-    private boolean isOnlineImage = false;
 
     /**
      * Sets the providers for registry credentials. The order determines the priority in which the

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
@@ -47,22 +47,12 @@ public class ImageConfiguration {
     }
 
     /**
-     * Indicates that the target can only be reached online.
-     *
-     * @return this
-     */
-    public Builder setIsOnlineImage() {
-      this.isOnlineImage = true;
-      return this;
-    }
-
-    /**
      * Builds the {@link ImageConfiguration}.
      *
      * @return the corresponding {@link ImageConfiguration}
      */
     public ImageConfiguration build() {
-      return new ImageConfiguration(imageReference, credentialRetrievers, isOnlineImage);
+      return new ImageConfiguration(imageReference, credentialRetrievers);
     }
 
     private Builder(ImageReference imageReference) {
@@ -82,15 +72,11 @@ public class ImageConfiguration {
 
   private final ImageReference image;
   private final ImmutableList<CredentialRetriever> credentialRetrievers;
-  private final boolean isOnlineImage;
 
   private ImageConfiguration(
-      ImageReference image,
-      ImmutableList<CredentialRetriever> credentialRetrievers,
-      boolean isOnlineImage) {
+      ImageReference image, ImmutableList<CredentialRetriever> credentialRetrievers) {
     this.image = image;
     this.credentialRetrievers = credentialRetrievers;
-    this.isOnlineImage = isOnlineImage;
   }
 
   public ImageReference getImage() {
@@ -111,9 +97,5 @@ public class ImageConfiguration {
 
   public ImmutableList<CredentialRetriever> getCredentialRetrievers() {
     return credentialRetrievers;
-  }
-
-  public boolean isOnlineImage() {
-    return isOnlineImage;
   }
 }

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Labels in the base image are now propagated ([#1643](https://github.com/GoogleContainerTools/jib/issues/1643))
+- Fixed an issue with using OCI base images ([#1683](https://github.com/GoogleContainerTools/jib/issues/1683))
 
 ## 1.1.2
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Labels in the base image are now propagated ([#1643](https://github.com/GoogleContainerTools/jib/issues/1643))
+- Fixed an issue with using OCI base images ([#1683](https://github.com/GoogleContainerTools/jib/issues/1683))
 
 ## 1.1.2
 


### PR DESCRIPTION
Towards #718. Also fixes #1683.

Adds a `Containerizer#setOfflineMode` to set whether or not to set offline mode. Errors out if attempting to build to a registry, or if there is missing information from the cache.