### PR TITLE
No generics for Image<> and ImageLayers<>

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildResult.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildResult.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.jib.builder.steps;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.Image;
-import com.google.cloud.tools.jib.image.Layer;
 import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ImageToJsonTranslator;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
@@ -38,8 +37,7 @@ public class BuildResult {
    * @return a new {@link BuildResult} with the image's digest and id
    * @throws IOException if writing the digest or container configuration fails
    */
-  static BuildResult fromImage(
-      Image<Layer> image, Class<? extends BuildableManifestTemplate> targetFormat)
+  static BuildResult fromImage(Image image, Class<? extends BuildableManifestTemplate> targetFormat)
       throws IOException {
     ImageToJsonTranslator imageToJsonTranslator = new ImageToJsonTranslator(image);
     BlobDescriptor containerConfigurationBlobDescriptor =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
@@ -27,7 +27,6 @@ import com.google.cloud.tools.jib.docker.ImageTarball;
 import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.ImageReference;
-import com.google.cloud.tools.jib.image.Layer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -97,7 +96,7 @@ class LoadDockerStep implements AsyncStep<BuildResult>, Callable<BuildResult> {
     try (ProgressEventDispatcher ignored =
         progressEventDispatcherFactory.create(
             BuildStepType.LOAD_DOCKER, "loading to Docker daemon", 1)) {
-      Image<Layer> image = NonBlockingSteps.get(NonBlockingSteps.get(buildImageStep));
+      Image image = NonBlockingSteps.get(NonBlockingSteps.get(buildImageStep));
       ImageReference targetImageReference =
           buildConfiguration.getTargetImageConfiguration().getImage();
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -32,7 +32,6 @@ import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.http.Authorizations;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.Image;
-import com.google.cloud.tools.jib.image.Layer;
 import com.google.cloud.tools.jib.image.LayerCountMismatchException;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.cloud.tools.jib.image.json.BadContainerConfigurationFormatException;
@@ -65,17 +64,16 @@ class PullBaseImageStep
   /** Structure for the result returned by this step. */
   static class BaseImageWithAuthorization {
 
-    private final Image<Layer> baseImage;
+    private final Image baseImage;
     private final @Nullable Authorization baseImageAuthorization;
 
     @VisibleForTesting
-    BaseImageWithAuthorization(
-        Image<Layer> baseImage, @Nullable Authorization baseImageAuthorization) {
+    BaseImageWithAuthorization(Image baseImage, @Nullable Authorization baseImageAuthorization) {
       this.baseImage = baseImage;
       this.baseImageAuthorization = baseImageAuthorization;
     }
 
-    Image<Layer> getBaseImage() {
+    Image getBaseImage() {
       return baseImage;
     }
 
@@ -211,7 +209,7 @@ class PullBaseImageStep
    * @throws BadContainerConfigurationFormatException if the container configuration is in a bad
    *     format
    */
-  private Image<Layer> pullBaseImage(
+  private Image pullBaseImage(
       @Nullable Authorization registryAuthorization,
       ProgressEventDispatcher progressEventDispatcher)
       throws IOException, RegistryException, LayerPropertyNotFoundException,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushContainerConfigurationStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushContainerConfigurationStep.java
@@ -26,7 +26,6 @@ import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.image.Image;
-import com.google.cloud.tools.jib.image.Layer;
 import com.google.cloud.tools.jib.image.json.ImageToJsonTranslator;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -90,7 +89,7 @@ class PushContainerConfigurationStep
                 BuildStepType.PUSH_CONTAINER_CONFIGURATION, "pushing container configuration", 1);
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(buildConfiguration.getEventDispatcher(), DESCRIPTION)) {
-      Image<Layer> image = NonBlockingSteps.get(NonBlockingSteps.get(buildImageStep));
+      Image image = NonBlockingSteps.get(NonBlockingSteps.get(buildImageStep));
       Blob containerConfigurationBlob =
           new ImageToJsonTranslator(image).getContainerConfigurationBlob();
       BlobDescriptor blobDescriptor =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
@@ -26,7 +26,6 @@ import com.google.cloud.tools.jib.docker.ImageTarball;
 import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.filesystem.FileOperations;
 import com.google.cloud.tools.jib.image.Image;
-import com.google.cloud.tools.jib.image.Layer;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
@@ -97,7 +96,7 @@ public class WriteTarFileStep implements AsyncStep<BuildResult>, Callable<BuildR
     try (ProgressEventDispatcher ignored =
         progressEventDispatcherFactory.create(
             BuildStepType.WRITE_TAR_FILE, "writing to tar file", 1)) {
-      Image<Layer> image = NonBlockingSteps.get(NonBlockingSteps.get(buildImageStep));
+      Image image = NonBlockingSteps.get(NonBlockingSteps.get(buildImageStep));
 
       // Builds the image to a tarball.
       Files.createDirectories(outputPath.getParent());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/ImageTarball.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/ImageTarball.java
@@ -41,7 +41,7 @@ public class ImageTarball {
   /** File name extension for the layer content files. */
   private static final String LAYER_FILE_EXTENSION = ".tar.gz";
 
-  private final Image<Layer> image;
+  private final Image image;
 
   private final ImageReference imageReference;
 
@@ -51,7 +51,7 @@ public class ImageTarball {
    * @param image the image to convert into a tarball
    * @param imageReference image reference to set in the manifest
    */
-  public ImageTarball(Image<Layer> image, ImageReference imageReference) {
+  public ImageTarball(Image image, ImageReference imageReference) {
     this.image = image;
     this.imageReference = imageReference;
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/Image.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/Image.java
@@ -33,13 +33,13 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 /** Represents an image. */
-public class Image<T extends Layer> {
+public class Image {
 
   /** Builds the immutable {@link Image}. */
-  public static class Builder<T extends Layer> {
+  public static class Builder {
 
     private final Class<? extends ManifestTemplate> imageFormat;
-    private final ImageLayers.Builder<T> imageLayersBuilder = ImageLayers.builder();
+    private final ImageLayers.Builder imageLayersBuilder = ImageLayers.builder();
     private final ImmutableList.Builder<HistoryEntry> historyBuilder = ImmutableList.builder();
 
     // Don't use ImmutableMap.Builder because it does not allow for replacing existing keys with new
@@ -68,7 +68,7 @@ public class Image<T extends Layer> {
      * @param created the creation time
      * @return this
      */
-    public Builder<T> setCreated(Instant created) {
+    public Builder setCreated(Instant created) {
       this.created = created;
       return this;
     }
@@ -79,7 +79,7 @@ public class Image<T extends Layer> {
      * @param architecture the architecture
      * @return this
      */
-    public Builder<T> setArchitecture(String architecture) {
+    public Builder setArchitecture(String architecture) {
       this.architecture = architecture;
       return this;
     }
@@ -90,7 +90,7 @@ public class Image<T extends Layer> {
      * @param os the operating system
      * @return this
      */
-    public Builder<T> setOs(String os) {
+    public Builder setOs(String os) {
       this.os = os;
       return this;
     }
@@ -101,7 +101,7 @@ public class Image<T extends Layer> {
      * @param environment the map of environment variables
      * @return this
      */
-    public Builder<T> addEnvironment(@Nullable Map<String, String> environment) {
+    public Builder addEnvironment(@Nullable Map<String, String> environment) {
       if (environment != null) {
         this.environmentBuilder.putAll(environment);
       }
@@ -115,7 +115,7 @@ public class Image<T extends Layer> {
      * @param value the value to set it to
      * @return this
      */
-    public Builder<T> addEnvironmentVariable(String name, String value) {
+    public Builder addEnvironmentVariable(String name, String value) {
       environmentBuilder.put(name, value);
       return this;
     }
@@ -126,7 +126,7 @@ public class Image<T extends Layer> {
      * @param entrypoint the list of entrypoint tokens
      * @return this
      */
-    public Builder<T> setEntrypoint(@Nullable List<String> entrypoint) {
+    public Builder setEntrypoint(@Nullable List<String> entrypoint) {
       this.entrypoint = (entrypoint == null) ? null : ImmutableList.copyOf(entrypoint);
       return this;
     }
@@ -137,7 +137,7 @@ public class Image<T extends Layer> {
      * @param user the username/UID and optionally the groupname/GID
      * @return this
      */
-    public Builder<T> setUser(@Nullable String user) {
+    public Builder setUser(@Nullable String user) {
       this.user = user;
       return this;
     }
@@ -148,7 +148,7 @@ public class Image<T extends Layer> {
      * @param programArguments the list of arguments to append to the image entrypoint
      * @return this
      */
-    public Builder<T> setProgramArguments(@Nullable List<String> programArguments) {
+    public Builder setProgramArguments(@Nullable List<String> programArguments) {
       this.programArguments =
           (programArguments == null) ? null : ImmutableList.copyOf(programArguments);
       return this;
@@ -160,7 +160,7 @@ public class Image<T extends Layer> {
      * @param healthCheck the healthcheck configuration
      * @return this
      */
-    public Builder<T> setHealthCheck(@Nullable DockerHealthCheck healthCheck) {
+    public Builder setHealthCheck(@Nullable DockerHealthCheck healthCheck) {
       this.healthCheck = healthCheck;
       return this;
     }
@@ -171,7 +171,7 @@ public class Image<T extends Layer> {
      * @param exposedPorts the exposed ports to add
      * @return this
      */
-    public Builder<T> addExposedPorts(@Nullable Set<Port> exposedPorts) {
+    public Builder addExposedPorts(@Nullable Set<Port> exposedPorts) {
       if (exposedPorts != null) {
         exposedPortsBuilder.addAll(exposedPorts);
       }
@@ -184,7 +184,7 @@ public class Image<T extends Layer> {
      * @param volumes the directories to create volumes
      * @return this
      */
-    public Builder<T> addVolumes(@Nullable Set<AbsoluteUnixPath> volumes) {
+    public Builder addVolumes(@Nullable Set<AbsoluteUnixPath> volumes) {
       if (volumes != null) {
         volumesBuilder.addAll(ImmutableSet.copyOf(volumes));
       }
@@ -197,7 +197,7 @@ public class Image<T extends Layer> {
      * @param labels the map of labels to add
      * @return this
      */
-    public Builder<T> addLabels(@Nullable Map<String, String> labels) {
+    public Builder addLabels(@Nullable Map<String, String> labels) {
       if (labels != null) {
         labelsBuilder.putAll(labels);
       }
@@ -211,7 +211,7 @@ public class Image<T extends Layer> {
      * @param value the value of the label
      * @return this
      */
-    public Builder<T> addLabel(String name, String value) {
+    public Builder addLabel(String name, String value) {
       labelsBuilder.put(name, value);
       return this;
     }
@@ -222,7 +222,7 @@ public class Image<T extends Layer> {
      * @param workingDirectory the working directory
      * @return this
      */
-    public Builder<T> setWorkingDirectory(@Nullable String workingDirectory) {
+    public Builder setWorkingDirectory(@Nullable String workingDirectory) {
       this.workingDirectory = workingDirectory;
       return this;
     }
@@ -234,7 +234,7 @@ public class Image<T extends Layer> {
      * @return this
      * @throws LayerPropertyNotFoundException if adding the layer fails
      */
-    public Builder<T> addLayer(T layer) throws LayerPropertyNotFoundException {
+    public Builder addLayer(Layer layer) throws LayerPropertyNotFoundException {
       imageLayersBuilder.add(layer);
       return this;
     }
@@ -245,13 +245,13 @@ public class Image<T extends Layer> {
      * @param history the history object to add
      * @return this
      */
-    public Builder<T> addHistory(HistoryEntry history) {
+    public Builder addHistory(HistoryEntry history) {
       historyBuilder.add(history);
       return this;
     }
 
-    public Image<T> build() {
-      return new Image<>(
+    public Image build() {
+      return new Image(
           imageFormat,
           created,
           architecture,
@@ -270,9 +270,8 @@ public class Image<T extends Layer> {
     }
   }
 
-  public static <T extends Layer> Builder<T> builder(
-      Class<? extends ManifestTemplate> imageFormat) {
-    return new Builder<>(imageFormat);
+  public static Builder builder(Class<? extends ManifestTemplate> imageFormat) {
+    return new Builder(imageFormat);
   }
 
   /** The image format. */
@@ -288,7 +287,7 @@ public class Image<T extends Layer> {
   private final String os;
 
   /** The layers of the image, in the order in which they are applied. */
-  private final ImageLayers<T> layers;
+  private final ImageLayers layers;
 
   /** The commands used to build each layer of the image */
   private final ImmutableList<HistoryEntry> history;
@@ -325,7 +324,7 @@ public class Image<T extends Layer> {
       @Nullable Instant created,
       String architecture,
       String os,
-      ImageLayers<T> layers,
+      ImageLayers layers,
       ImmutableList<HistoryEntry> history,
       @Nullable ImmutableMap<String, String> environment,
       @Nullable ImmutableList<String> entrypoint,
@@ -415,7 +414,7 @@ public class Image<T extends Layer> {
     return user;
   }
 
-  public ImmutableList<T> getLayers() {
+  public ImmutableList<Layer> getLayers() {
     return layers.getLayers();
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageLayers.java
@@ -27,11 +27,11 @@ import java.util.Set;
 import javax.annotation.Nullable;
 
 /** Holds the layers for an image. */
-public class ImageLayers<T extends Layer> implements Iterable<T> {
+public class ImageLayers implements Iterable<Layer> {
 
-  public static class Builder<T extends Layer> {
+  public static class Builder {
 
-    private final List<T> layers = new ArrayList<>();
+    private final List<Layer> layers = new ArrayList<>();
     private final ImmutableSet.Builder<DescriptorDigest> layerDigestsBuilder =
         ImmutableSet.builder();
     private boolean removeDuplicates = false;
@@ -46,7 +46,7 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
      * @return this
      * @throws LayerPropertyNotFoundException if adding the layer fails
      */
-    public Builder<T> add(T layer) throws LayerPropertyNotFoundException {
+    public Builder add(Layer layer) throws LayerPropertyNotFoundException {
       layerDigestsBuilder.add(layer.getBlobDescriptor().getDigest());
       layers.add(layer);
       return this;
@@ -55,14 +55,12 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
     /**
      * Adds all layers in {@code layers}.
      *
-     * @param <U> child type of {@link Layer}
      * @param layers the layers to add
      * @return this
      * @throws LayerPropertyNotFoundException if adding a layer fails
      */
-    public <U extends T> Builder<T> addAll(ImageLayers<U> layers)
-        throws LayerPropertyNotFoundException {
-      for (U layer : layers) {
+    public Builder addAll(ImageLayers layers) throws LayerPropertyNotFoundException {
+      for (Layer layer : layers) {
         add(layer);
       }
       return this;
@@ -73,41 +71,41 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
      *
      * @return this
      */
-    public Builder<T> removeDuplicates() {
+    public Builder removeDuplicates() {
       removeDuplicates = true;
       return this;
     }
 
-    public ImageLayers<T> build() {
+    public ImageLayers build() {
       if (!removeDuplicates) {
-        return new ImageLayers<>(ImmutableList.copyOf(layers), layerDigestsBuilder.build());
+        return new ImageLayers(ImmutableList.copyOf(layers), layerDigestsBuilder.build());
       }
 
       // LinkedHashSet maintains the order but keeps the first occurrence. Keep last occurrence by
       // adding elements in reverse, and then reversing the result
-      Set<T> dedupedButReversed = new LinkedHashSet<T>(Lists.reverse(this.layers));
-      ImmutableList<T> deduped = ImmutableList.copyOf(dedupedButReversed).reverse();
-      return new ImageLayers<>(deduped, layerDigestsBuilder.build());
+      Set<Layer> dedupedButReversed = new LinkedHashSet<>(Lists.reverse(this.layers));
+      ImmutableList<Layer> deduped = ImmutableList.copyOf(dedupedButReversed).reverse();
+      return new ImageLayers(deduped, layerDigestsBuilder.build());
     }
   }
 
-  public static <U extends Layer> Builder<U> builder() {
-    return new Builder<>();
+  public static Builder builder() {
+    return new Builder();
   }
 
   /** The layers of the image, in the order in which they are applied. */
-  private final ImmutableList<T> layers;
+  private final ImmutableList<Layer> layers;
 
   /** Keeps track of the layers already added. */
   private final ImmutableSet<DescriptorDigest> layerDigests;
 
-  private ImageLayers(ImmutableList<T> layers, ImmutableSet<DescriptorDigest> layerDigests) {
+  private ImageLayers(ImmutableList<Layer> layers, ImmutableSet<DescriptorDigest> layerDigests) {
     this.layers = layers;
     this.layerDigests = layerDigests;
   }
 
   /** @return a read-only view of the image layers. */
-  public ImmutableList<T> getLayers() {
+  public ImmutableList<Layer> getLayers() {
     return layers;
   }
 
@@ -124,7 +122,7 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
    * @param index the index of the layer to get
    * @return the layer at the specified index
    */
-  public T get(int index) {
+  public Layer get(int index) {
     return layers.get(index);
   }
 
@@ -134,11 +132,11 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
    * @throws LayerPropertyNotFoundException if getting the layer's blob descriptor fails
    */
   @Nullable
-  public T get(DescriptorDigest digest) throws LayerPropertyNotFoundException {
+  public Layer get(DescriptorDigest digest) throws LayerPropertyNotFoundException {
     if (!has(digest)) {
       return null;
     }
-    for (T layer : layers) {
+    for (Layer layer : layers) {
       if (layer.getBlobDescriptor().getDigest().equals(digest)) {
         return layer;
       }
@@ -155,7 +153,7 @@ public class ImageLayers<T extends Layer> implements Iterable<T> {
   }
 
   @Override
-  public Iterator<T> iterator() {
+  public Iterator<Layer> iterator() {
     return getLayers().iterator();
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslator.java
@@ -129,14 +129,14 @@ public class ImageToJsonTranslator {
                 String::compareTo, keyMapper, ignored -> Collections.emptyMap()));
   }
 
-  private final Image<Layer> image;
+  private final Image image;
 
   /**
    * Instantiate with an {@link Image}.
    *
    * @param image the image to translate
    */
-  public ImageToJsonTranslator(Image<Layer> image) {
+  public ImageToJsonTranslator(Image image) {
     this.image = image;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
@@ -23,7 +23,6 @@ import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.DigestOnlyLayer;
 import com.google.cloud.tools.jib.image.Image;
-import com.google.cloud.tools.jib.image.Layer;
 import com.google.cloud.tools.jib.image.LayerCountMismatchException;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.cloud.tools.jib.image.ReferenceLayer;
@@ -71,9 +70,9 @@ public class JsonToImageTranslator {
    * @throws BadContainerConfigurationFormatException if the container configuration is in a bad
    *     format
    */
-  public static Image<Layer> toImage(V21ManifestTemplate manifestTemplate)
+  public static Image toImage(V21ManifestTemplate manifestTemplate)
       throws LayerPropertyNotFoundException, BadContainerConfigurationFormatException {
-    Image.Builder<Layer> imageBuilder = Image.builder(V21ManifestTemplate.class);
+    Image.Builder imageBuilder = Image.builder(V21ManifestTemplate.class);
 
     // V21 layers are in reverse order of V22. (The first layer is the latest one.)
     for (DescriptorDigest digest : Lists.reverse(manifestTemplate.getLayerDigests())) {
@@ -101,7 +100,7 @@ public class JsonToImageTranslator {
    * @throws BadContainerConfigurationFormatException if the container configuration is in a bad
    *     format
    */
-  public static Image<Layer> toImage(
+  public static Image toImage(
       BuildableManifestTemplate manifestTemplate,
       ContainerConfigurationTemplate containerConfigurationTemplate)
       throws LayerCountMismatchException, LayerPropertyNotFoundException,
@@ -125,7 +124,7 @@ public class JsonToImageTranslator {
           "Mismatch between image manifest and container configuration");
     }
 
-    Image.Builder<Layer> imageBuilder = Image.builder(manifestTemplate.getClass());
+    Image.Builder imageBuilder = Image.builder(manifestTemplate.getClass());
 
     for (int layerIndex = 0; layerIndex < layers.size(); layerIndex++) {
       ReferenceNoDiffIdLayer noDiffIdLayer = layers.get(layerIndex);
@@ -139,8 +138,7 @@ public class JsonToImageTranslator {
   }
 
   private static void configureBuilderWithContainerConfiguration(
-      Image.Builder<Layer> imageBuilder,
-      ContainerConfigurationTemplate containerConfigurationTemplate)
+      Image.Builder imageBuilder, ContainerConfigurationTemplate containerConfigurationTemplate)
       throws BadContainerConfigurationFormatException {
 
     containerConfigurationTemplate.getHistory().forEach(imageBuilder::addHistory);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStepTest.java
@@ -28,7 +28,6 @@ import com.google.cloud.tools.jib.configuration.LayerConfiguration;
 import com.google.cloud.tools.jib.event.EventDispatcher;
 import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.image.ImageLayers;
-import com.google.cloud.tools.jib.image.Layer;
 import com.google.cloud.tools.jib.image.LayerEntry;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.common.collect.ImmutableList;
@@ -127,8 +126,8 @@ public class BuildAndCacheApplicationLayerStepTest {
     Mockito.when(mockBuildConfiguration.getApplicationLayersCache()).thenReturn(cache);
   }
 
-  private ImageLayers<Layer> buildFakeLayersToCache() throws ExecutionException {
-    ImageLayers.Builder<Layer> applicationLayersBuilder = ImageLayers.builder();
+  private ImageLayers buildFakeLayersToCache() throws ExecutionException {
+    ImageLayers.Builder applicationLayersBuilder = ImageLayers.builder();
 
     ImmutableList<BuildAndCacheApplicationLayerStep> buildAndCacheApplicationLayerSteps =
         BuildAndCacheApplicationLayerStep.makeList(
@@ -159,7 +158,7 @@ public class BuildAndCacheApplicationLayerStepTest {
         .thenReturn(fakeLayerConfigurations);
 
     // Populates the cache.
-    ImageLayers<Layer> applicationLayers = buildFakeLayersToCache();
+    ImageLayers applicationLayers = buildFakeLayersToCache();
     Assert.assertEquals(5, applicationLayers.size());
 
     ImmutableList<LayerEntry> dependenciesLayerEntries =
@@ -221,7 +220,7 @@ public class BuildAndCacheApplicationLayerStepTest {
         .thenReturn(fakeLayerConfigurations);
 
     // Populates the cache.
-    ImageLayers<Layer> applicationLayers = buildFakeLayersToCache();
+    ImageLayers applicationLayers = buildFakeLayersToCache();
     Assert.assertEquals(3, applicationLayers.size());
 
     ImmutableList<LayerEntry> dependenciesLayerEntries =

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
@@ -27,7 +27,6 @@ import com.google.cloud.tools.jib.event.EventDispatcher;
 import com.google.cloud.tools.jib.filesystem.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.Image;
-import com.google.cloud.tools.jib.image.Layer;
 import com.google.cloud.tools.jib.image.json.HistoryEntry;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.common.collect.ImmutableList;
@@ -101,7 +100,7 @@ public class BuildImageStepTest {
             .setEmptyLayer(true)
             .build();
 
-    Image<Layer> baseImage =
+    Image baseImage =
         Image.builder(V22ManifestTemplate.class)
             .setArchitecture("wasm")
             .setOs("js")
@@ -172,7 +171,7 @@ public class BuildImageStepTest {
                 mockBuildAndCacheApplicationLayerStepDependencies,
                 mockBuildAndCacheApplicationLayerStepResources,
                 mockBuildAndCacheApplicationLayerStepClasses));
-    Image<Layer> image = buildImageStep.getFuture().get().getFuture().get();
+    Image image = buildImageStep.getFuture().get().getFuture().get();
     Assert.assertEquals(
         testDescriptorDigest, image.getLayers().asList().get(0).getBlobDescriptor().getDigest());
   }
@@ -201,7 +200,7 @@ public class BuildImageStepTest {
                 mockBuildAndCacheApplicationLayerStepDependencies,
                 mockBuildAndCacheApplicationLayerStepResources,
                 mockBuildAndCacheApplicationLayerStepClasses));
-    Image<Layer> image = buildImageStep.getFuture().get().getFuture().get();
+    Image image = buildImageStep.getFuture().get().getFuture().get();
     Assert.assertEquals("wasm", image.getArchitecture());
     Assert.assertEquals("js", image.getOs());
     Assert.assertEquals(
@@ -264,7 +263,7 @@ public class BuildImageStepTest {
                 mockBuildAndCacheApplicationLayerStepDependencies,
                 mockBuildAndCacheApplicationLayerStepResources,
                 mockBuildAndCacheApplicationLayerStepClasses));
-    Image<Layer> image = buildImageStep.getFuture().get().getFuture().get();
+    Image image = buildImageStep.getFuture().get().getFuture().get();
 
     Assert.assertEquals("/my/directory", image.getWorkingDirectory());
   }
@@ -286,7 +285,7 @@ public class BuildImageStepTest {
                 mockBuildAndCacheApplicationLayerStepDependencies,
                 mockBuildAndCacheApplicationLayerStepResources,
                 mockBuildAndCacheApplicationLayerStepClasses));
-    Image<Layer> image = buildImageStep.getFuture().get().getFuture().get();
+    Image image = buildImageStep.getFuture().get().getFuture().get();
 
     Assert.assertEquals(ImmutableList.of("baseImageEntrypoint"), image.getEntrypoint());
     Assert.assertEquals(ImmutableList.of("test"), image.getProgramArguments());
@@ -309,7 +308,7 @@ public class BuildImageStepTest {
                 mockBuildAndCacheApplicationLayerStepDependencies,
                 mockBuildAndCacheApplicationLayerStepResources,
                 mockBuildAndCacheApplicationLayerStepClasses));
-    Image<Layer> image = buildImageStep.getFuture().get().getFuture().get();
+    Image image = buildImageStep.getFuture().get().getFuture().get();
 
     Assert.assertEquals(ImmutableList.of("baseImageEntrypoint"), image.getEntrypoint());
     Assert.assertEquals(ImmutableList.of("catalina.sh", "run"), image.getProgramArguments());
@@ -332,7 +331,7 @@ public class BuildImageStepTest {
                 mockBuildAndCacheApplicationLayerStepDependencies,
                 mockBuildAndCacheApplicationLayerStepResources,
                 mockBuildAndCacheApplicationLayerStepClasses));
-    Image<Layer> image = buildImageStep.getFuture().get().getFuture().get();
+    Image image = buildImageStep.getFuture().get().getFuture().get();
 
     Assert.assertEquals(ImmutableList.of("myEntrypoint"), image.getEntrypoint());
     Assert.assertNull(image.getProgramArguments());
@@ -352,7 +351,7 @@ public class BuildImageStepTest {
                 mockBuildAndCacheApplicationLayerStepResources,
                 mockBuildAndCacheApplicationLayerStepClasses,
                 mockBuildAndCacheApplicationLayerStepExtraFiles));
-    Image<Layer> image = buildImageStep.getFuture().get().getFuture().get();
+    Image image = buildImageStep.getFuture().get().getFuture().get();
 
     // Make sure history is as expected
     HistoryEntry expectedAddedBaseLayerHistory =

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildResultTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildResultTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.image.DescriptorDigest;
 import com.google.cloud.tools.jib.image.Image;
-import com.google.cloud.tools.jib.image.Layer;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import java.io.IOException;
 import java.security.DigestException;
@@ -66,9 +65,9 @@ public class BuildResultTest {
 
   @Test
   public void testFromImage() throws IOException {
-    Image<Layer> image1 = Image.builder(V22ManifestTemplate.class).setUser("user").build();
-    Image<Layer> image2 = Image.builder(V22ManifestTemplate.class).setUser("user").build();
-    Image<Layer> image3 = Image.builder(V22ManifestTemplate.class).setUser("anotherUser").build();
+    Image image1 = Image.builder(V22ManifestTemplate.class).setUser("user").build();
+    Image image2 = Image.builder(V22ManifestTemplate.class).setUser("user").build();
+    Image image3 = Image.builder(V22ManifestTemplate.class).setUser("anotherUser").build();
     Assert.assertEquals(
         BuildResult.fromImage(image1, V22ManifestTemplate.class),
         BuildResult.fromImage(image2, V22ManifestTemplate.class));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/ImageTarballTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/ImageTarballTest.java
@@ -80,7 +80,7 @@ public class ImageTarballTest {
     Mockito.when(mockLayer2.getBlobDescriptor())
         .thenReturn(new BlobDescriptor(fileBSize, fakeDigestB));
     Mockito.when(mockLayer2.getDiffId()).thenReturn(fakeDigestB);
-    Image<Layer> testImage =
+    Image testImage =
         Image.builder(V22ManifestTemplate.class).addLayer(mockLayer1).addLayer(mockLayer2).build();
 
     ImageTarball imageToTarball = new ImageTarball(testImage, ImageReference.parse("my/image:tag"));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageLayersTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageLayersTest.java
@@ -61,7 +61,7 @@ public class ImageLayersTest {
   public void testAddLayer_success() throws LayerPropertyNotFoundException {
     List<Layer> expectedLayers = Arrays.asList(mockLayer, mockReferenceLayer, mockDigestOnlyLayer);
 
-    ImageLayers<Layer> imageLayers =
+    ImageLayers imageLayers =
         ImageLayers.builder()
             .add(mockLayer)
             .add(mockReferenceLayer)
@@ -77,7 +77,7 @@ public class ImageLayersTest {
     List<Layer> expectedLayers =
         Arrays.asList(mockLayer, mockReferenceLayer, mockDigestOnlyLayer, mockLayer2, mockLayer);
 
-    ImageLayers<Layer> imageLayers =
+    ImageLayers imageLayers =
         ImageLayers.builder()
             .add(mockLayer)
             .add(mockReferenceLayer)
@@ -95,7 +95,7 @@ public class ImageLayersTest {
     List<Layer> expectedLayers =
         Arrays.asList(mockReferenceLayer, mockDigestOnlyLayer, mockLayer2, mockLayer);
 
-    ImageLayers<Layer> imageLayers =
+    ImageLayers imageLayers =
         ImageLayers.builder()
             .removeDuplicates()
             .add(mockLayer)

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageTest.java
@@ -48,7 +48,7 @@ public class ImageTest {
 
   @Test
   public void test_smokeTest() throws LayerPropertyNotFoundException {
-    Image<Layer> image =
+    Image image =
         Image.builder(V22ManifestTemplate.class)
             .setCreated(Instant.ofEpochSecond(10000))
             .addEnvironmentVariable("crepecake", "is great")
@@ -80,7 +80,7 @@ public class ImageTest {
 
   @Test
   public void testDefaults() {
-    Image<Layer> image = Image.builder(V22ManifestTemplate.class).build();
+    Image image = Image.builder(V22ManifestTemplate.class).build();
     Assert.assertEquals("amd64", image.getArchitecture());
     Assert.assertEquals("linux", image.getOs());
     Assert.assertEquals(Collections.emptyList(), image.getLayers());
@@ -89,7 +89,7 @@ public class ImageTest {
 
   @Test
   public void testOsArch() {
-    Image<Layer> image =
+    Image image =
         Image.builder(V22ManifestTemplate.class).setArchitecture("wasm").setOs("js").build();
     Assert.assertEquals("wasm", image.getArchitecture());
     Assert.assertEquals("js", image.getOs());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslatorTest.java
@@ -55,7 +55,7 @@ public class ImageToJsonTranslatorTest {
 
   private void setUp(Class<? extends BuildableManifestTemplate> imageFormat)
       throws DigestException, LayerPropertyNotFoundException {
-    Image.Builder<Layer> testImageBuilder =
+    Image.Builder testImageBuilder =
         Image.builder(imageFormat)
             .setCreated(Instant.ofEpochSecond(20))
             .setArchitecture("wasm")

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
@@ -57,7 +57,7 @@ public class JsonToImageTranslatorTest {
     V21ManifestTemplate manifestTemplate =
         JsonTemplateMapper.readJsonFromFile(jsonFile, V21ManifestTemplate.class);
 
-    Image<Layer> image = JsonToImageTranslator.toImage(manifestTemplate);
+    Image image = JsonToImageTranslator.toImage(manifestTemplate);
 
     List<Layer> layers = image.getLayers();
     Assert.assertEquals(2, layers.size());
@@ -181,8 +181,7 @@ public class JsonToImageTranslatorTest {
     T manifestTemplate =
         JsonTemplateMapper.readJsonFromFile(manifestJsonFile, manifestTemplateClass);
 
-    Image<Layer> image =
-        JsonToImageTranslator.toImage(manifestTemplate, containerConfigurationTemplate);
+    Image image = JsonToImageTranslator.toImage(manifestTemplate, containerConfigurationTemplate);
 
     List<Layer> layers = image.getLayers();
     Assert.assertEquals(1, layers.size());


### PR DESCRIPTION
`Image<T extends Layer>` --> `Image`

`ImageLayers<T extends Layer>` --> `ImageLayers`

Does anyone remember why they were generics, like future extensibility?