### PR TITLE
Fix lock file failures

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
@@ -73,10 +73,16 @@ public class LockFile implements Closeable {
 
     } finally {
       try {
-        Preconditions.checkNotNull(lockMap.get(lockFile)).unlock();
         Files.delete(lockFile);
 
-      } catch (IllegalMonitorStateException | IOException ignored) {
+      } catch (IOException ignored) {
+
+      } finally {
+        try {
+          Preconditions.checkNotNull(lockMap.get(lockFile)).unlock();
+
+        } catch (IllegalMonitorStateException ignored) {
+        }
       }
     }
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import java.io.Closeable;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.channels.FileLock;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,10 +35,12 @@ public class LockFile implements Closeable {
 
   private final Path lockFile;
   private final FileLock fileLock;
+  private final OutputStream outputStream;
 
-  private LockFile(Path lockFile, FileLock fileLock) {
+  private LockFile(Path lockFile, FileLock fileLock, OutputStream outputStream) {
     this.lockFile = lockFile;
     this.fileLock = fileLock;
+    this.outputStream = outputStream;
   }
 
   /**
@@ -58,8 +61,17 @@ public class LockFile implements Closeable {
     }
 
     Files.createDirectories(lockFile.getParent());
-    FileLock fileLock = new FileOutputStream(lockFile.toFile()).getChannel().lock();
-    return new LockFile(lockFile, fileLock);
+    FileOutputStream outputStream = new FileOutputStream(lockFile.toFile());
+    FileLock fileLock = null;
+    try {
+      fileLock = outputStream.getChannel().lock();
+      return new LockFile(lockFile, fileLock, outputStream);
+
+    } finally {
+      if (fileLock == null) {
+        outputStream.close();
+      }
+    }
   }
 
   /** Releases the lock file. */
@@ -67,23 +79,13 @@ public class LockFile implements Closeable {
   public void close() {
     try {
       fileLock.release();
+      outputStream.close();
 
     } catch (IOException ex) {
       throw new IllegalStateException("Unable to release lock", ex);
 
     } finally {
-      try {
-        Files.delete(lockFile);
-
-      } catch (IOException ignored) {
-
-      } finally {
-        try {
-          Preconditions.checkNotNull(lockMap.get(lockFile)).unlock();
-
-        } catch (IllegalMonitorStateException ignored) {
-        }
-      }
+      Preconditions.checkNotNull(lockMap.get(lockFile)).unlock();
     }
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
@@ -52,11 +52,7 @@ public class LockFileTest {
     // Run the runnable once in this thread + once in the main thread
     Thread thread = new Thread(procedure);
     thread.start();
-
-    while (!Files.exists(temporaryFolder.getRoot().toPath().resolve("testLock"))) {
-      // wait until lock file exists so we can delete it
-    }
-    Files.delete(temporaryFolder.getRoot().toPath().resolve("testLock"));
+    procedure.run();
     thread.join();
 
     // Assert no overlap while lock was in place

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
@@ -41,7 +41,7 @@ public class LockFileTest {
             Assert.assertTrue(Files.exists(temporaryFolder.getRoot().toPath().resolve("testLock")));
 
             int valueBeforeSleep = atomicInt.intValue();
-            Thread.sleep(100);
+            Thread.sleep(500);
             atomicInt.set(valueBeforeSleep + 1);
 
           } catch (InterruptedException | IOException ex) {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
@@ -30,7 +30,7 @@ public class LockFileTest {
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
-  public void testLockAndRelease() throws InterruptedException, IOException {
+  public void testLockAndRelease() throws InterruptedException {
     AtomicInteger atomicInt = new AtomicInteger(0);
 
     // Runnable that would produce a race condition without a lock file
@@ -41,7 +41,7 @@ public class LockFileTest {
             Assert.assertTrue(Files.exists(temporaryFolder.getRoot().toPath().resolve("testLock")));
 
             int valueBeforeSleep = atomicInt.intValue();
-            Thread.sleep(500);
+            Thread.sleep(100);
             atomicInt.set(valueBeforeSleep + 1);
 
           } catch (InterruptedException | IOException ex) {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/LockFileTest.java
@@ -40,6 +40,11 @@ public class LockFileTest {
               LockFile.lock(temporaryFolder.getRoot().toPath().resolve("testLock"))) {
             Assert.assertTrue(Files.exists(temporaryFolder.getRoot().toPath().resolve("testLock")));
 
+            // Try deleting file
+            Files.delete(temporaryFolder.getRoot().toPath().resolve("testLock"));
+            Assert.assertFalse(
+                Files.exists(temporaryFolder.getRoot().toPath().resolve("testLock")));
+
             int valueBeforeSleep = atomicInt.intValue();
             Thread.sleep(500);
             atomicInt.set(valueBeforeSleep + 1);


### PR DESCRIPTION
Fixes #1695.

- No longer deletes lock file. This was causing a race condition where one thread could release a lock, another thread could acquire a lock, and then the first thread would delete the lock file, which caused the test to fail.
- Saves a reference to the original lock file output stream to prevent it from being garbage collected/closed/releasing the file lock acquired from it.