### PR TITLE
Use Docker config.json credential retrievers before inferred retrievers

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Docker credentials (`~/.docker/config.json`) are now given priority over registry-based inferred credential helpers ([#1704](https://github.com/GoogleContainerTools/jib/pulls/1704))
+
 ### Fixed
 
 ## 1.2.0

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Docker credentials (`~/.docker/config.json`) are now given priority over registry-based inferred credential helpers ([#1704](https://github.com/GoogleContainerTools/jib/pulls/1704))
+
 ### Fixed
 
 ## 1.2.0

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
@@ -137,8 +137,8 @@ public class DefaultCredentialRetrievers {
     if (inferredCredentialRetriever != null) {
       credentialRetrievers.add(inferredCredentialRetriever);
     }
-    credentialRetrievers.add(credentialRetrieverFactory.inferCredentialHelper());
     credentialRetrievers.add(credentialRetrieverFactory.dockerConfig());
+    credentialRetrievers.add(credentialRetrieverFactory.inferCredentialHelper());
     return credentialRetrievers;
   }
 }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
@@ -72,7 +72,7 @@ public class DefaultCredentialRetrieversTest {
         DefaultCredentialRetrievers.init(mockCredentialRetrieverFactory).asList();
     Assert.assertEquals(
         Arrays.asList(
-            mockInferCredentialHelperCredentialRetriever, mockDockerConfigCredentialRetriever),
+            mockDockerConfigCredentialRetriever, mockInferCredentialHelperCredentialRetriever),
         credentialRetrievers);
   }
 
@@ -89,8 +89,8 @@ public class DefaultCredentialRetrieversTest {
             mockKnownCredentialRetriever,
             mockDockerCredentialHelperCredentialRetriever,
             mockInferredCredentialRetriever,
-            mockInferCredentialHelperCredentialRetriever,
-            mockDockerConfigCredentialRetriever),
+            mockDockerConfigCredentialRetriever,
+            mockInferCredentialHelperCredentialRetriever),
         credentialRetrievers);
 
     Mockito.verify(mockCredentialRetrieverFactory).known(knownCredential, "credentialSource");
@@ -111,8 +111,8 @@ public class DefaultCredentialRetrieversTest {
     Assert.assertEquals(
         Arrays.asList(
             mockDockerCredentialHelperCredentialRetriever,
-            mockInferCredentialHelperCredentialRetriever,
-            mockDockerConfigCredentialRetriever),
+            mockDockerConfigCredentialRetriever,
+            mockInferCredentialHelperCredentialRetriever),
         credentialRetrievers);
     Mockito.verify(mockCredentialRetrieverFactory)
         .dockerCredentialHelper(fakeCredentialHelperPath.toString());


### PR DESCRIPTION
Change `DefaultCredentialsRetriever` to use the Docker `config.json`-based retriever before using inferred registry-based retrievers.

Fixes #1694 