### PR TITLE
Better error message for registries not supporting OCI manifest push

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ManifestPusher.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ManifestPusher.java
@@ -115,7 +115,9 @@ class ManifestPusher implements RegistryEndpointProvider<DescriptorDigest> {
     ErrorCodes errorCode = ErrorResponseUtil.getErrorCode(httpResponseException);
     if (errorCode == ErrorCodes.MANIFEST_INVALID || errorCode == ErrorCodes.TAG_INVALID) {
       throw new RegistryErrorExceptionBuilder(getActionDescription(), httpResponseException)
-          .addReason("Registry may not support Image Manifest Version 2, Schema 2")
+          .addReason(
+              "Registry may not support pushing OCI Manifest or "
+                  + "Docker Image Manifest Version 2, Schema 2")
           .build();
     }
     // rethrow: unhandled error response code.

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java
@@ -163,7 +163,8 @@ public class ManifestPusherTest {
         new HttpResponseException.Builder(
                 HttpStatus.SC_BAD_REQUEST, "Bad Request", new HttpHeaders())
             .setContent(
-                "{\"errors\":[{\"code\":\"TAG_INVALID\",\"message\":\"manifest tag did not match URI\"}]}")
+                "{\"errors\":[{\"code\":\"TAG_INVALID\","
+                    + "\"message\":\"manifest tag did not match URI\"}]}")
             .build();
     try {
       testManifestPusher.handleHttpResponseException(exception);
@@ -173,7 +174,8 @@ public class ManifestPusherTest {
       Assert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
-              "Registry may not support Image Manifest Version 2, Schema 2"));
+              "Registry may not support pushing OCI Manifest or "
+                  + "Docker Image Manifest Version 2, Schema 2"));
     }
   }
 
@@ -185,7 +187,8 @@ public class ManifestPusherTest {
         new HttpResponseException.Builder(
                 HttpStatus.SC_BAD_REQUEST, "Bad Request", new HttpHeaders())
             .setContent(
-                "{\"errors\":[{\"code\":\"MANIFEST_INVALID\",\"message\":\"manifest invalid\",\"detail\":{}}]}")
+                "{\"errors\":[{\"code\":\"MANIFEST_INVALID\","
+                    + "\"message\":\"manifest invalid\",\"detail\":{}}]}")
             .build();
     try {
       testManifestPusher.handleHttpResponseException(exception);
@@ -195,7 +198,8 @@ public class ManifestPusherTest {
       Assert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
-              "Registry may not support Image Manifest Version 2, Schema 2"));
+              "Registry may not support pushing OCI Manifest or "
+                  + "Docker Image Manifest Version 2, Schema 2"));
     }
   }
 
@@ -206,8 +210,9 @@ public class ManifestPusherTest {
         new HttpResponseException.Builder(
                 HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE, "UNSUPPORTED MEDIA TYPE", new HttpHeaders())
             .setContent(
-                "{\"errors\":[{\"code\":\"MANIFEST_INVALID\",\"detail\":"
-                    + "{\"message\":\"manifest schema version not supported\"},\"message\":\"manifest invalid\"}]}")
+                "{\"errors\":[{\"code\":\"MANIFEST_INVALID\","
+                    + "\"detail\":{\"message\":\"manifest schema version not supported\"},"
+                    + "\"message\":\"manifest invalid\"}]}")
             .build();
     try {
       testManifestPusher.handleHttpResponseException(exception);
@@ -217,7 +222,8 @@ public class ManifestPusherTest {
       Assert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
-              "Registry may not support Image Manifest Version 2, Schema 2"));
+              "Registry may not support pushing OCI Manifest or "
+                  + "Docker Image Manifest Version 2, Schema 2"));
     }
   }
 


### PR DESCRIPTION
Fixes #1646.

I don't feel it's worth adding extra code to actually distinguish OCI vs Docker V2.2.