### PR TITLE
Add version to skaffold-files-v2 output

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ProjectInfo.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ProjectInfo.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.jib;
 
+import javax.annotation.Nullable;
+
 /** Constants relating to the Jib project. */
 public class ProjectInfo {
 
@@ -25,7 +27,8 @@ public class ProjectInfo {
   /** Link to file an issue against the GitHub repository. */
   public static final String GITHUB_NEW_ISSUE_URL = GITHUB_URL + "/issues/new";
 
-  /** The project version. */
+  /** The project version. May be {@code null} if the version cannot be determined. */
+  @Nullable
   public static final String VERSION = ProjectInfo.class.getPackage().getImplementationVersion();
 
   private ProjectInfo() {}

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutput.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutput.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.plugins.common;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -25,6 +26,7 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Builds a JSON string containing files and directories that <a
@@ -62,6 +64,8 @@ public class SkaffoldFilesOutput {
 
   @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   private static class SkaffoldFilesTemplate {
+
+    @Nullable private final String version = ProjectInfo.VERSION;
 
     private final List<String> build = new ArrayList<>();
 

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutputTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutputTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class SkaffoldFilesOutputTest {
 
   private static final String TEST_JSON =
-      "{\"build\":[\"buildFile1\",\"buildFile2\"],\"inputs\":[\"input1\",\"input2\"],\"ignore\":[\"ignore1\",\"ignore2\"]}";
+      "{\"version\":null,\"build\":[\"buildFile1\",\"buildFile2\"],\"inputs\":[\"input1\",\"input2\"],\"ignore\":[\"ignore1\",\"ignore2\"]}";
 
   @Test
   public void testGetJsonString() throws IOException {
@@ -44,7 +44,8 @@ public class SkaffoldFilesOutputTest {
   public void testGetJsonString_empty() throws IOException {
     SkaffoldFilesOutput skaffoldFilesOutput = new SkaffoldFilesOutput();
     Assert.assertEquals(
-        "{\"build\":[],\"inputs\":[],\"ignore\":[]}", skaffoldFilesOutput.getJsonString());
+        "{\"version\":null,\"build\":[],\"inputs\":[],\"ignore\":[]}",
+        skaffoldFilesOutput.getJsonString());
   }
 
   @Test


### PR DESCRIPTION
Add a `version` field to the JSON object output by the `skaffold-files-v2` goal so as to allow the format to evolve.  We populate this field with the Jib plugin version.

Note that the `ProjectInfo.VERSION` field is `@Nullable`, since it will be `null` when run from tests.