### PR TITLE
Use `jib.containerize` property to only containerize specific module/project

### DIFF
--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -76,7 +76,10 @@ public class BuildDockerMojo extends JibPluginConfiguration {
       return;
     } else if (!isContainerizable()) {
       getLog()
-          .info("Skipping containerization of this module (" + PropertyNames.CONTAINERIZE + ")");
+          .info(
+              "Skipping containerization of this module (not specified in "
+                  + PropertyNames.CONTAINERIZE
+                  + ")");
       return;
     }
     if ("pom".equals(getProject().getPackaging())) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -74,6 +74,10 @@ public class BuildDockerMojo extends JibPluginConfiguration {
     if (isSkipped()) {
       getLog().info("Skipping containerization because jib-maven-plugin: skip = true");
       return;
+    } else if (!isContainerizable()) {
+      getLog()
+          .info("Skipping containerization of this module (" + PropertyNames.CONTAINERIZE + ")");
+      return;
     }
     if ("pom".equals(getProject().getPackaging())) {
       getLog().info("Skipping containerization because packaging is 'pom'...");

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -32,6 +32,7 @@ import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryExceptio
 import com.google.cloud.tools.jib.plugins.common.JibBuildRunner;
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
+import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.cloud.tools.jib.plugins.common.RawConfiguration;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
@@ -58,6 +59,10 @@ public class BuildImageMojo extends JibPluginConfiguration {
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (isSkipped()) {
       getLog().info("Skipping containerization because jib-maven-plugin: skip = true");
+      return;
+    } else if (!isContainerizable()) {
+      getLog()
+          .info("Skipping containerization of this module (" + PropertyNames.CONTAINERIZE + ")");
       return;
     }
     if ("pom".equals(getProject().getPackaging())) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -62,7 +62,10 @@ public class BuildImageMojo extends JibPluginConfiguration {
       return;
     } else if (!isContainerizable()) {
       getLog()
-          .info("Skipping containerization of this module (" + PropertyNames.CONTAINERIZE + ")");
+          .info(
+              "Skipping containerization of this module (not specified in "
+                  + PropertyNames.CONTAINERIZE
+                  + ")");
       return;
     }
     if ("pom".equals(getProject().getPackaging())) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -60,7 +60,10 @@ public class BuildTarMojo extends JibPluginConfiguration {
       return;
     } else if (!isContainerizable()) {
       getLog()
-          .info("Skipping containerization of this module (" + PropertyNames.CONTAINERIZE + ")");
+          .info(
+              "Skipping containerization of this module (not specified in "
+                  + PropertyNames.CONTAINERIZE
+                  + ")");
       return;
     }
     if ("pom".equals(getProject().getPackaging())) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -30,6 +30,7 @@ import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryExceptio
 import com.google.cloud.tools.jib.plugins.common.JibBuildRunner;
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
+import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.cloud.tools.jib.plugins.common.RawConfiguration;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
@@ -56,6 +57,10 @@ public class BuildTarMojo extends JibPluginConfiguration {
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (isSkipped()) {
       getLog().info("Skipping containerization because jib-maven-plugin: skip = true");
+      return;
+    } else if (!isContainerizable()) {
+      getLog()
+          .info("Skipping containerization of this module (" + PropertyNames.CONTAINERIZE + ")");
       return;
     }
     if ("pom".equals(getProject().getPackaging())) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -628,7 +628,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   }
 
   /**
-   * Return false if the `jib.comntainerized` property is specified and does not match this
+   * Return false if the `jib.containerize` property is specified and does not match this
    * module/project. Used by the Skaffold-Jib binding.
    *
    * @return true if this module should be containerized

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -626,6 +626,29 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
     return skip;
   }
 
+  /**
+   * Return false if the `jib.comntainerized` property is specified and does not match this
+   * module/project. Used by the Skaffold-Jib binding.
+   *
+   * @return true if this module should be containerized
+   */
+  boolean isContainerizable() {
+    String moduleSpecification = getProperty(PropertyNames.CONTAINERIZE);
+    if (project == null || Strings.isNullOrEmpty(moduleSpecification)) {
+      return true;
+    }
+    // modules can be specified in one of three ways:
+    // 1) a `groupId:artifactId`
+    // 2) an `:artifactId`
+    // 3) relative path within the repository
+    if (moduleSpecification.equals(project.getGroupId() + ":" + project.getArtifactId())
+        || moduleSpecification.equals(":" + project.getArtifactId())) {
+      return true;
+    }
+    Path projectBase = project.getBasedir().toPath();
+    return projectBase.endsWith(moduleSpecification);
+  }
+
   SettingsDecrypter getSettingsDecrypter() {
     return settingsDecrypter;
   }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
@@ -160,8 +160,8 @@ public class BuildDockerMojoIntegrationTest {
   }
 
   @Test
-  public void testExecute_jibContainerize() throws VerificationException, IOException {
-    SkippedGoalVerifier.verifyJibContainerize(emptyTestProject, BuildDockerMojo.GOAL_NAME, ":foo");
+  public void testExecute_jibContainerizeSkips() throws VerificationException, IOException {
+    SkippedGoalVerifier.verifyJibContainerizeSkips(emptyTestProject, BuildDockerMojo.GOAL_NAME);
   }
 
   @Test

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
@@ -155,8 +155,13 @@ public class BuildDockerMojoIntegrationTest {
   }
 
   @Test
-  public void testExecute_skipJibGoal() throws VerificationException, IOException {
-    SkippedGoalVerifier.verifyGoalIsSkipped(emptyTestProject, BuildDockerMojo.GOAL_NAME);
+  public void testExecute_jibSkip() throws VerificationException, IOException {
+    SkippedGoalVerifier.verifyJibSkip(emptyTestProject, BuildDockerMojo.GOAL_NAME);
+  }
+
+  @Test
+  public void testExecute_jibContainerize() throws VerificationException, IOException {
+    SkippedGoalVerifier.verifyJibContainerize(emptyTestProject, BuildDockerMojo.GOAL_NAME, ":foo");
   }
 
   @Test

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -535,8 +535,14 @@ public class BuildImageMojoIntegrationTest {
   }
 
   @Test
-  public void testExecute_skipJibGoal() throws VerificationException, IOException {
-    SkippedGoalVerifier.verifyGoalIsSkipped(skippedTestProject, BuildImageMojo.GOAL_NAME);
+  public void testExecute_jibSkip() throws VerificationException, IOException {
+    SkippedGoalVerifier.verifyJibSkip(skippedTestProject, BuildImageMojo.GOAL_NAME);
+  }
+
+  @Test
+  public void testExecute_jibContainerize() throws VerificationException, IOException {
+    SkippedGoalVerifier.verifyJibContainerize(
+        skippedTestProject, BuildDockerMojo.GOAL_NAME, ":foo");
   }
 
   @Test

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -540,9 +540,8 @@ public class BuildImageMojoIntegrationTest {
   }
 
   @Test
-  public void testExecute_jibContainerize() throws VerificationException, IOException {
-    SkippedGoalVerifier.verifyJibContainerize(
-        skippedTestProject, BuildDockerMojo.GOAL_NAME, ":foo");
+  public void testExecute_jibContainerizeSkips() throws VerificationException, IOException {
+    SkippedGoalVerifier.verifyJibContainerizeSkips(simpleTestProject, BuildDockerMojo.GOAL_NAME);
   }
 
   @Test

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
@@ -80,7 +80,13 @@ public class BuildTarMojoIntegrationTest {
   }
 
   @Test
-  public void testExecute_skipJibGoal() throws VerificationException, IOException {
-    SkippedGoalVerifier.verifyGoalIsSkipped(skippedTestProject, BuildTarMojo.GOAL_NAME);
+  public void testExecute_jibSkip() throws VerificationException, IOException {
+    SkippedGoalVerifier.verifyJibSkip(skippedTestProject, BuildTarMojo.GOAL_NAME);
+  }
+
+  @Test
+  public void testExecute_jibContainerize() throws VerificationException, IOException {
+    SkippedGoalVerifier.verifyJibContainerize(
+        skippedTestProject, BuildDockerMojo.GOAL_NAME, ":foo");
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
@@ -85,8 +85,7 @@ public class BuildTarMojoIntegrationTest {
   }
 
   @Test
-  public void testExecute_jibContainerize() throws VerificationException, IOException {
-    SkippedGoalVerifier.verifyJibContainerize(
-        skippedTestProject, BuildDockerMojo.GOAL_NAME, ":foo");
+  public void testExecute_jibContainerizeSkips() throws VerificationException, IOException {
+    SkippedGoalVerifier.verifyJibContainerizeSkips(simpleTestProject, BuildDockerMojo.GOAL_NAME);
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.maven.JibPluginConfiguration.PermissionConfigu
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.io.File;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
@@ -319,5 +320,58 @@ public class JibPluginConfigurationTest {
               + "'jib.extraDirectories.permissions'",
           ex.getMessage());
     }
+  }
+
+  @Test
+  public void testIsContainerizable_noProperty() {
+    Properties projectProperties = project.getProperties();
+
+    projectProperties.remove("jib.containerize");
+    Assert.assertTrue(testPluginConfiguration.isContainerizable());
+
+    projectProperties.setProperty("jib.containerize", "");
+    Assert.assertTrue(testPluginConfiguration.isContainerizable());
+  }
+
+  @Test
+  public void testIsContainerizable_artifactId() {
+    project.setGroupId("group");
+    project.setArtifactId("artifact");
+    project.setFile(new File("/repository/project/pom.xml")); // sets baseDir
+
+    Properties projectProperties = project.getProperties();
+    projectProperties.setProperty("jib.containerize", ":artifact");
+    Assert.assertTrue(testPluginConfiguration.isContainerizable());
+
+    projectProperties.setProperty("jib.containerize", ":artifact2");
+    Assert.assertFalse(testPluginConfiguration.isContainerizable());
+  }
+
+  @Test
+  public void testIsContainerizable_groupAndArtifactId() {
+    project.setGroupId("group");
+    project.setArtifactId("artifact");
+    project.setFile(new File("/repository/project/pom.xml")); // sets baseDir
+
+    Properties projectProperties = project.getProperties();
+    projectProperties.setProperty("jib.containerize", "group:artifact");
+    Assert.assertTrue(testPluginConfiguration.isContainerizable());
+
+    projectProperties.setProperty("jib.containerize", "group:artifact2");
+    Assert.assertFalse(testPluginConfiguration.isContainerizable());
+  }
+
+  @Test
+  public void testIsContainerizable_directory() {
+    project.setGroupId("group");
+    project.setArtifactId("artifact");
+    project.setFile(new File("/repository/project/pom.xml")); // sets baseDir
+
+    Properties projectProperties = project.getProperties();
+    projectProperties.setProperty("jib.containerize", "project");
+    Assert.assertTrue(testPluginConfiguration.isContainerizable());
+
+    projectProperties.setProperty("jib.containerize", "project2");
+    Assert.assertFalse(testPluginConfiguration.isContainerizable());
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SkippedGoalVerifier.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SkippedGoalVerifier.java
@@ -26,11 +26,11 @@ import org.apache.maven.it.Verifier;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 
-/** A simple verifier utility to test goal skipping accross all our jib goals. */
+/** A simple verifier utility to test goal skipping across all our jib goals. */
 class SkippedGoalVerifier {
 
-  /** Verifies that a Jib goal is skipped. */
-  static void verifyGoalIsSkipped(TestProject testProject, String goal)
+  /** Verifies that a Jib goal is skipped with {@code jib.skip=true}. */
+  static void verifyJibSkip(TestProject testProject, String goal)
       throws VerificationException, IOException {
     Verifier verifier = new Verifier(testProject.getProjectRoot().toString());
     verifier.setAutoclean(false);
@@ -43,6 +43,24 @@ class SkippedGoalVerifier {
         new String(Files.readAllBytes(logFile), StandardCharsets.UTF_8),
         CoreMatchers.containsString(
             "[INFO] Skipping containerization because jib-maven-plugin: skip = true\n"
+                + "[INFO] ------------------------------------------------------------------------\n"
+                + "[INFO] BUILD SUCCESS"));
+  }
+
+  /** Verifies that a Jib goal is skipped with {@code jib.comntainerize=group:artifact}. */
+  static void verifyJibContainerize(TestProject testProject, String goal, String spec)
+      throws VerificationException, IOException {
+    Verifier verifier = new Verifier(testProject.getProjectRoot().toString());
+    verifier.setAutoclean(false);
+    verifier.setSystemProperty("jib.containerize", spec);
+
+    verifier.executeGoal("jib:" + goal);
+
+    Path logFile = Paths.get(verifier.getBasedir(), verifier.getLogFileName());
+    Assert.assertThat(
+        new String(Files.readAllBytes(logFile), StandardCharsets.UTF_8),
+        CoreMatchers.containsString(
+            "[INFO] Skipping containerization of this module (jib.containerize)\n"
                 + "[INFO] ------------------------------------------------------------------------\n"
                 + "[INFO] BUILD SUCCESS"));
   }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SkippedGoalVerifier.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SkippedGoalVerifier.java
@@ -47,12 +47,13 @@ class SkippedGoalVerifier {
                 + "[INFO] BUILD SUCCESS"));
   }
 
-  /** Verifies that a Jib goal is skipped with {@code jib.comntainerize=group:artifact}. */
-  static void verifyJibContainerize(TestProject testProject, String goal, String spec)
+  /** Verifies that a Jib goal is skipped with {@code jib.containerize=noGroup:noArtifact}. */
+  static void verifyJibContainerizeSkips(TestProject testProject, String goal)
       throws VerificationException, IOException {
     Verifier verifier = new Verifier(testProject.getProjectRoot().toString());
     verifier.setAutoclean(false);
-    verifier.setSystemProperty("jib.containerize", spec);
+    // noGroup:noArtifact should never match
+    verifier.setSystemProperty("jib.containerize", "noGroup:noArtifact");
 
     verifier.executeGoal("jib:" + goal);
 
@@ -60,7 +61,7 @@ class SkippedGoalVerifier {
     Assert.assertThat(
         new String(Files.readAllBytes(logFile), StandardCharsets.UTF_8),
         CoreMatchers.containsString(
-            "[INFO] Skipping containerization of this module (jib.containerize)\n"
+            "[INFO] Skipping containerization of this module (not specified in jib.containerize)\n"
                 + "[INFO] ------------------------------------------------------------------------\n"
                 + "[INFO] BUILD SUCCESS"));
   }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
@@ -58,6 +58,7 @@ public class PropertyNames {
   public static final String DOCKER_CLIENT_ENVIRONMENT = "jib.dockerClient.environment";
   public static final String SKIP = "jib.skip";
   public static final String CONSOLE = "jib.console";
+  public static final String CONTAINERIZE = "jib.containerize";
 
   private PropertyNames() {}
 }


### PR DESCRIPTION
Add new property `jib.containerize` to cause `jib-maven-plugin` to skip building image for all projects except for the specified module/project.  The module/project can be specified in one of three ways:

  - by the relative path to the module (`path/to/module`)
  - by the module's artifact ID (`:artifactId`)
  - by the module's group and artifact IDs (`groupId:artifactId`)

This is intended for use by Skaffold for multi-module projects.