### PR TITLE
Adjust MainClassFinder api

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Multiple classes have been moved to the `com.google.cloud.tools.jib.api` package
 - Removed `EventDispatcher` and `DefaultEventDispatcher`; events are now dispatched directly from `EventHandlers`
+- MainClassFinder now uses a static method instead of requiring instantiation
 
 ### Fixed
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JavaContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JavaContainerBuilder.java
@@ -20,7 +20,6 @@ import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.cloud.tools.jib.configuration.LayerConfiguration;
 import com.google.cloud.tools.jib.filesystem.DirectoryWalker;
 import com.google.cloud.tools.jib.frontend.JavaEntrypointConstructor;
-import com.google.cloud.tools.jib.frontend.MainClassFinder;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/MainClassFinder.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.jib.api;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -27,7 +26,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import javax.annotation.Nullable;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
@@ -94,7 +92,7 @@ public class MainClassFinder {
      * @return the type of the result
      */
     public Type getType() {
-      return Preconditions.checkNotNull(type);
+      return type;
     }
 
     /**
@@ -137,29 +135,39 @@ public class MainClassFinder {
     }
   }
 
-  private final ImmutableList<Path> files;
-  private final EventHandlers eventHandlers;
-
   /**
-   * Finds a class with {@code psvm} (see class javadoc) in {@code files}.
+   * Tries to find classes with {@code psvm} (see class javadoc) in {@code files}.
    *
-   * @param files the files to check
-   * @param eventHandlers used for dispatching log events.
-   */
-  public MainClassFinder(List<Path> files, EventHandlers eventHandlers) {
-    this.files = ImmutableList.copyOf(files);
-    this.eventHandlers = eventHandlers;
-  }
-
-  /**
-   * Tries to find classes with {@code psvm} (see class javadoc) in {@link #files}.
-   *
+   * @param files the files to search
+   * @param eventHandlers the {@link EventHandlers} used for handling log messages
    * @return the {@link Result} of the main class finding attempt
    */
-  public Result find() {
+  public static Result find(List<Path> files, EventHandlers eventHandlers) {
     List<String> mainClasses = new ArrayList<>();
     for (Path file : files) {
-      findMainClass(file).ifPresent(mainClasses::add);
+      // Makes sure classFile is valid.
+      if (!Files.exists(file)
+          || !Files.isRegularFile(file)
+          || !file.toString().endsWith(".class")) {
+        continue;
+      }
+
+      MainClassVisitor mainClassVisitor = new MainClassVisitor();
+      try (InputStream classFileInputStream = Files.newInputStream(file)) {
+        ClassReader reader = new ClassReader(classFileInputStream);
+        reader.accept(mainClassVisitor, 0);
+        if (mainClassVisitor.visitedMainClass) {
+          mainClasses.add(reader.getClassName().replace('/', '.'));
+        }
+
+      } catch (ArrayIndexOutOfBoundsException ignored) {
+        // Not a valid class file (thrown by ClassReader if it reads an invalid format)
+        eventHandlers.dispatch(LogEvent.warn("Invalid class file found: " + file));
+
+      } catch (IOException ignored) {
+        // Could not read class file.
+        eventHandlers.dispatch(LogEvent.warn("Could not read file: " + file));
+      }
     }
 
     if (mainClasses.size() == 1) {
@@ -172,39 +180,5 @@ public class MainClassFinder {
     }
     // More than one main class found.
     return Result.multipleMainClasses(mainClasses);
-  }
-
-  /**
-   * Checks the {@code file} for being a {@code .class} file with {@code public static void
-   * main(String[] args)}.
-   *
-   * @param file the file
-   * @return name of the class containing a main method, or {@link Optional#empty} if {@code
-   *     classFile} is not a class
-   */
-  private Optional<String> findMainClass(Path file) {
-    // Makes sure classFile is valid.
-    if (!Files.exists(file) || !Files.isRegularFile(file) || !file.toString().endsWith(".class")) {
-      return Optional.empty();
-    }
-
-    MainClassVisitor mainClassVisitor = new MainClassVisitor();
-    try (InputStream classFileInputStream = Files.newInputStream(file)) {
-      ClassReader reader = new ClassReader(classFileInputStream);
-      reader.accept(mainClassVisitor, 0);
-      if (mainClassVisitor.visitedMainClass) {
-        return Optional.of(reader.getClassName().replace('/', '.'));
-      }
-
-    } catch (ArrayIndexOutOfBoundsException ignored) {
-      // Not a valid class file (thrown by ClassReader if it reads an invalid format)
-      eventHandlers.dispatch(LogEvent.warn("Invalid class file found: " + file));
-
-    } catch (IOException ignored) {
-      // Could not read class file.
-      eventHandlers.dispatch(LogEvent.warn("Could not read file: " + file));
-    }
-
-    return Optional.empty();
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/MainClassFinder.java
@@ -146,9 +146,19 @@ public class MainClassFinder {
     List<String> mainClasses = new ArrayList<>();
     for (Path file : files) {
       // Makes sure classFile is valid.
-      if (!Files.exists(file)
-          || !Files.isRegularFile(file)
-          || !file.toString().endsWith(".class")) {
+      if (!Files.exists(file)) {
+        eventHandlers.dispatch(
+            LogEvent.debug("MainClassFinder: " + file + " does not exist; ignoring"));
+        continue;
+      }
+      if (!Files.isRegularFile(file)) {
+        eventHandlers.dispatch(
+            LogEvent.debug("MainClassFinder: " + file + " is not a regular file; skipping"));
+        continue;
+      }
+      if (!file.toString().endsWith(".class")) {
+        eventHandlers.dispatch(
+            LogEvent.debug("MainClassFinder: " + file + " is not a class file; skipping"));
         continue;
       }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/MainClassFinder.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.frontend;
+package com.google.cloud.tools.jib.api;
 
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.event.events.LogEvent;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/MainClassFinderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/MainClassFinderTest.java
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/** Tests for {@link com.google.cloud.tools.jib.api.MainClassFinder}. */
+/** Tests for {@link MainClassFinder}. */
 @RunWith(MockitoJUnitRunner.class)
 public class MainClassFinderTest {
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/MainClassFinderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/MainClassFinderTest.java
@@ -41,7 +41,7 @@ public class MainClassFinderTest {
   public void testFindMainClass_simple() throws URISyntaxException, IOException {
     Path rootDirectory = Paths.get(Resources.getResource("core/class-finder-tests/simple").toURI());
     MainClassFinder.Result mainClassFinderResult =
-        new MainClassFinder(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers).find();
+        MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers);
     Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("HelloWorld"));
@@ -52,7 +52,7 @@ public class MainClassFinderTest {
     Path rootDirectory =
         Paths.get(Resources.getResource("core/class-finder-tests/subdirectories").toURI());
     MainClassFinder.Result mainClassFinderResult =
-        new MainClassFinder(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers).find();
+        MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers);
     Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(),
@@ -64,7 +64,7 @@ public class MainClassFinderTest {
     Path rootDirectory =
         Paths.get(Resources.getResource("core/class-finder-tests/no-main").toURI());
     MainClassFinder.Result mainClassFinderResult =
-        new MainClassFinder(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers).find();
+        MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers);
     Assert.assertEquals(Type.MAIN_CLASS_NOT_FOUND, mainClassFinderResult.getType());
   }
 
@@ -73,7 +73,7 @@ public class MainClassFinderTest {
     Path rootDirectory =
         Paths.get(Resources.getResource("core/class-finder-tests/multiple").toURI());
     MainClassFinder.Result mainClassFinderResult =
-        new MainClassFinder(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers).find();
+        MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers);
     Assert.assertEquals(
         MainClassFinder.Result.Type.MULTIPLE_MAIN_CLASSES, mainClassFinderResult.getType());
     Assert.assertEquals(2, mainClassFinderResult.getFoundMainClasses().size());
@@ -87,7 +87,7 @@ public class MainClassFinderTest {
     Path rootDirectory =
         Paths.get(Resources.getResource("core/class-finder-tests/extension").toURI());
     MainClassFinder.Result mainClassFinderResult =
-        new MainClassFinder(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers).find();
+        MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers);
     Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("main.MainClass"));
@@ -98,7 +98,7 @@ public class MainClassFinderTest {
     Path rootDirectory =
         Paths.get(Resources.getResource("core/class-finder-tests/imported-methods").toURI());
     MainClassFinder.Result mainClassFinderResult =
-        new MainClassFinder(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers).find();
+        MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers);
     Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("main.MainClass"));
@@ -109,7 +109,7 @@ public class MainClassFinderTest {
     Path rootDirectory =
         Paths.get(Resources.getResource("core/class-finder-tests/external-classes").toURI());
     MainClassFinder.Result mainClassFinderResult =
-        new MainClassFinder(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers).find();
+        MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers);
     Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("main.MainClass"));
@@ -120,7 +120,7 @@ public class MainClassFinderTest {
     Path rootDirectory =
         Paths.get(Resources.getResource("core/class-finder-tests/inner-classes").toURI());
     MainClassFinder.Result mainClassFinderResult =
-        new MainClassFinder(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers).find();
+        MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers);
     Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(),
@@ -132,7 +132,7 @@ public class MainClassFinderTest {
     Path rootDirectory =
         Paths.get(Resources.getResource("core/class-finder-tests/varargs").toURI());
     MainClassFinder.Result mainClassFinderResult =
-        new MainClassFinder(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers).find();
+        MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), mockEventHandlers);
     Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("HelloWorld"));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/MainClassFinderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/MainClassFinderTest.java
@@ -14,11 +14,11 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.frontend;
+package com.google.cloud.tools.jib.api;
 
+import com.google.cloud.tools.jib.api.MainClassFinder.Result.Type;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.filesystem.DirectoryWalker;
-import com.google.cloud.tools.jib.frontend.MainClassFinder.Result.Type;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -31,7 +31,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-/** Tests for {@link MainClassFinder}. */
+/** Tests for {@link com.google.cloud.tools.jib.api.MainClassFinder}. */
 @RunWith(MockitoJUnitRunner.class)
 public class MainClassFinderTest {
 

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/MainClassResolver.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/MainClassResolver.java
@@ -116,8 +116,8 @@ public class MainClassResolver {
                     + "; attempting to infer main class."));
 
     MainClassFinder.Result mainClassFinderResult =
-        new MainClassFinder(projectProperties.getClassFiles(), projectProperties.getEventHandlers())
-            .find();
+        MainClassFinder.find(
+            projectProperties.getClassFiles(), projectProperties.getEventHandlers());
 
     switch (mainClassFinderResult.getType()) {
       case MAIN_CLASS_FOUND:

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/MainClassResolver.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/MainClassResolver.java
@@ -16,8 +16,8 @@
 
 package com.google.cloud.tools.jib.plugins.common;
 
+import com.google.cloud.tools.jib.api.MainClassFinder;
 import com.google.cloud.tools.jib.event.events.LogEvent;
-import com.google.cloud.tools.jib.frontend.MainClassFinder;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;


### PR DESCRIPTION
Towards #1428. Made `MainClassFinder` use a static method instead of requiring instantiation, and moves the class to the `api` package (this is a useful class for building the entrypoint for a Java container).