### PR TITLE
Move ImageFormat to api package

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageFormat.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageFormat.java
@@ -14,28 +14,14 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.image;
+package com.google.cloud.tools.jib.api;
 
-import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
-import com.google.cloud.tools.jib.image.json.OCIManifestTemplate;
-import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
-
-/** Enumeration of {@link BuildableManifestTemplate}s that indicates the format of the image. */
+/** Indicates the format of the image. */
 public enum ImageFormat {
 
   /** @see <a href="https://docs.docker.com/registry/spec/manifest-v2-2/">Docker V2.2</a> */
-  Docker(V22ManifestTemplate.class),
+  Docker,
 
   /** @see <a href="https://github.com/opencontainers/image-spec/blob/master/manifest.md">OCI</a> */
-  OCI(OCIManifestTemplate.class);
-
-  private final Class<? extends BuildableManifestTemplate> manifestTemplateClass;
-
-  ImageFormat(Class<? extends BuildableManifestTemplate> manifestTemplateClass) {
-    this.manifestTemplateClass = manifestTemplateClass;
-  }
-
-  public Class<? extends BuildableManifestTemplate> getManifestTemplateClass() {
-    return manifestTemplateClass;
-  }
+  OCI
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -26,8 +26,6 @@ import com.google.cloud.tools.jib.configuration.LayerConfiguration;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.image.LayerEntry;
-import com.google.cloud.tools.jib.image.json.OCIManifestTemplate;
-import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -390,8 +388,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setFormat(ImageFormat imageFormat) {
-    buildConfigurationBuilder.setTargetFormat(
-        imageFormat == ImageFormat.Docker ? V22ManifestTemplate.class : OCIManifestTemplate.class);
+    buildConfigurationBuilder.setTargetFormat(imageFormat);
     return this;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -25,8 +25,9 @@ import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.configuration.LayerConfiguration;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.event.events.LogEvent;
-import com.google.cloud.tools.jib.image.ImageFormat;
 import com.google.cloud.tools.jib.image.LayerEntry;
+import com.google.cloud.tools.jib.image.json.OCIManifestTemplate;
+import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.net.UnknownHostException;
@@ -389,7 +390,8 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setFormat(ImageFormat imageFormat) {
-    buildConfigurationBuilder.setTargetFormat(imageFormat.getManifestTemplateClass());
+    buildConfigurationBuilder.setTargetFormat(
+        imageFormat == ImageFormat.Docker ? V22ManifestTemplate.class : OCIManifestTemplate.class);
     return this;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
@@ -16,10 +16,12 @@
 
 package com.google.cloud.tools.jib.configuration;
 
+import com.google.cloud.tools.jib.api.ImageFormat;
 import com.google.cloud.tools.jib.cache.Cache;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.event.events.LogEvent;
 import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
+import com.google.cloud.tools.jib.image.json.OCIManifestTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.common.annotations.VisibleForTesting;
@@ -139,8 +141,11 @@ public class BuildConfiguration {
      * @param targetFormat the target format
      * @return this
      */
-    public Builder setTargetFormat(Class<? extends BuildableManifestTemplate> targetFormat) {
-      this.targetFormat = targetFormat;
+    public Builder setTargetFormat(ImageFormat targetFormat) {
+      this.targetFormat =
+          targetFormat == ImageFormat.Docker
+              ? V22ManifestTemplate.class
+              : OCIManifestTemplate.class;
       return this;
     }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
@@ -26,7 +26,8 @@ import com.google.cloud.tools.jib.configuration.credentials.Credential;
 import com.google.cloud.tools.jib.configuration.credentials.CredentialRetriever;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.event.JibEvent;
-import com.google.cloud.tools.jib.image.ImageFormat;
+import com.google.cloud.tools.jib.image.json.OCIManifestTemplate;
+import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.cloud.tools.jib.registry.credentials.CredentialRetrievalException;
 import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
@@ -193,8 +194,7 @@ public class JibContainerBuilderTest {
 
     Assert.assertEquals("jib-core", buildConfiguration.getToolName());
 
-    Assert.assertSame(
-        ImageFormat.Docker.getManifestTemplateClass(), buildConfiguration.getTargetFormat());
+    Assert.assertSame(V22ManifestTemplate.class, buildConfiguration.getTargetFormat());
 
     Assert.assertEquals("jib-core", buildConfiguration.getToolName());
 
@@ -208,8 +208,7 @@ public class JibContainerBuilderTest {
                     .withAdditionalTag("tag2")
                     .setToolName("toolName"),
                 MoreExecutors.newDirectExecutorService());
-    Assert.assertSame(
-        ImageFormat.OCI.getManifestTemplateClass(), buildConfiguration.getTargetFormat());
+    Assert.assertSame(OCIManifestTemplate.class, buildConfiguration.getTargetFormat());
     Assert.assertEquals(
         ImmutableSet.of("latest", "tag1", "tag2"), buildConfiguration.getAllTargetImageTags());
     Assert.assertEquals("toolName", buildConfiguration.getToolName());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildConfigurationTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.configuration;
 
 import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.api.ImageFormat;
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.Port;
 import com.google.cloud.tools.jib.configuration.credentials.Credential;
@@ -100,7 +101,7 @@ public class BuildConfigurationTest {
             .setContainerConfiguration(containerConfiguration)
             .setApplicationLayersCacheDirectory(expectedApplicationLayersCacheDirectory)
             .setBaseImageLayersCacheDirectory(expectedBaseImageLayersCacheDirectory)
-            .setTargetFormat(OCIManifestTemplate.class)
+            .setTargetFormat(ImageFormat.OCI)
             .setAllowInsecureRegistries(true)
             .setLayerConfigurations(expectedLayerConfigurations)
             .setToolName(expectedCreatedBy)

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.jib.gradle;
 
-import com.google.cloud.tools.jib.image.ImageFormat;
+import com.google.cloud.tools.jib.api.ImageFormat;
 import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.common.base.Preconditions;

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -18,7 +18,7 @@ package com.google.cloud.tools.jib.gradle;
 
 import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.FilePermissions;
-import com.google.cloud.tools.jib.image.ImageFormat;
+import com.google.cloud.tools.jib.api.ImageFormat;
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
 import com.google.cloud.tools.jib.plugins.common.RawConfiguration;
 import java.nio.file.Path;

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.jib.gradle;
 
-import com.google.cloud.tools.jib.image.ImageFormat;
+import com.google.cloud.tools.jib.api.ImageFormat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -18,9 +18,9 @@ package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
+import com.google.cloud.tools.jib.api.ImageFormat;
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
-import com.google.cloud.tools.jib.image.ImageFormat;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
 import com.google.cloud.tools.jib.plugins.common.IncompatibleBaseImageJavaVersionException;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
@@ -18,7 +18,7 @@ package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.FilePermissions;
-import com.google.cloud.tools.jib.image.ImageFormat;
+import com.google.cloud.tools.jib.api.ImageFormat;
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
 import com.google.cloud.tools.jib.plugins.common.RawConfiguration;
 import java.nio.file.Path;

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
@@ -18,7 +18,7 @@ package com.google.cloud.tools.jib.plugins.common;
 
 import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.FilePermissions;
-import com.google.cloud.tools.jib.image.ImageFormat;
+import com.google.cloud.tools.jib.api.ImageFormat;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
Towards #1428. Moves `ImageFormat` to api package and removes references to underlying classes.