### PR TITLE
No need to pass appRoot when instantiate ProjectProperties

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.gradle;
 
-import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
@@ -105,11 +104,8 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
 
     try {
       RawConfiguration gradleRawConfiguration = new GradleRawConfiguration(jibExtension);
-      AbsoluteUnixPath appRoot =
-          PluginConfigurationProcessor.getAppRootChecked(
-              gradleRawConfiguration, TaskCommon.isWarProject(getProject()));
       GradleProjectProperties projectProperties =
-          GradleProjectProperties.getForProject(getProject(), getLogger(), appRoot);
+          GradleProjectProperties.getForProject(getProject(), getLogger());
 
       GradleHelpfulSuggestionsBuilder gradleHelpfulSuggestionsBuilder =
           new GradleHelpfulSuggestionsBuilder(HELPFUL_SUGGESTIONS_PREFIX, jibExtension);

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.gradle;
 
-import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
@@ -82,11 +81,8 @@ public class BuildImageTask extends DefaultTask implements JibTask {
 
     try {
       RawConfiguration gradleRawConfiguration = new GradleRawConfiguration(jibExtension);
-      AbsoluteUnixPath appRoot =
-          PluginConfigurationProcessor.getAppRootChecked(
-              gradleRawConfiguration, TaskCommon.isWarProject(getProject()));
       GradleProjectProperties projectProperties =
-          GradleProjectProperties.getForProject(getProject(), getLogger(), appRoot);
+          GradleProjectProperties.getForProject(getProject(), getLogger());
 
       if (Strings.isNullOrEmpty(jibExtension.getTo().getImage())) {
         throw new GradleException(

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.gradle;
 
-import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
@@ -109,11 +108,8 @@ public class BuildTarTask extends DefaultTask implements JibTask {
 
     try {
       RawConfiguration gradleRawConfiguration = new GradleRawConfiguration(jibExtension);
-      AbsoluteUnixPath appRoot =
-          PluginConfigurationProcessor.getAppRootChecked(
-              gradleRawConfiguration, TaskCommon.isWarProject(getProject()));
       GradleProjectProperties projectProperties =
-          GradleProjectProperties.getForProject(getProject(), getLogger(), appRoot);
+          GradleProjectProperties.getForProject(getProject(), getLogger());
       GradleHelpfulSuggestionsBuilder gradleHelpfulSuggestionsBuilder =
           new GradleHelpfulSuggestionsBuilder(HELPFUL_SUGGESTIONS_PREFIX, jibExtension);
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -71,9 +71,8 @@ class GradleProjectProperties implements ProjectProperties {
   private static final String MAIN_SOURCE_SET_NAME = "main";
 
   /** @return a GradleProjectProperties from the given project and logger. */
-  static GradleProjectProperties getForProject(
-      Project project, Logger logger, AbsoluteUnixPath appRoot) {
-    return new GradleProjectProperties(project, logger, appRoot);
+  static GradleProjectProperties getForProject(Project project, Logger logger) {
+    return new GradleProjectProperties(project, logger);
   }
 
   static Path getExplodedWarDirectory(Project project) {
@@ -143,19 +142,18 @@ class GradleProjectProperties implements ProjectProperties {
   private final SingleThreadedExecutor singleThreadedExecutor = new SingleThreadedExecutor();
   private final EventHandlers eventHandlers;
   private final Logger logger;
-  private final AbsoluteUnixPath appRoot;
 
   @VisibleForTesting
-  GradleProjectProperties(Project project, Logger logger, AbsoluteUnixPath appRoot) {
+  GradleProjectProperties(Project project, Logger logger) {
     this.project = project;
     this.logger = logger;
-    this.appRoot = appRoot;
 
     eventHandlers = makeEventHandlers(project, logger, singleThreadedExecutor);
   }
 
   @Override
-  public JibContainerBuilder createContainerBuilder(RegistryImage baseImage) {
+  public JibContainerBuilder createContainerBuilder(
+      RegistryImage baseImage, AbsoluteUnixPath appRoot) {
     try {
       if (isWarProject()) {
         logger.info("WAR project identified, creating WAR image: " + project.getDisplayName());
@@ -266,7 +264,7 @@ class GradleProjectProperties implements ProjectProperties {
 
   @Override
   public boolean isWarProject() {
-    return TaskCommon.isWarProject(project);
+    return TaskCommon.getWarTask(project) != null;
   }
 
   /**

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -36,10 +36,6 @@ import org.slf4j.LoggerFactory;
 /** Collection of common methods to share between Gradle tasks. */
 class TaskCommon {
 
-  static boolean isWarProject(Project project) {
-    return getWarTask(project) != null;
-  }
-
   @Nullable
   static War getWarTask(Project project) {
     WarPluginConvention warPluginConvention =

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -221,8 +221,7 @@ public class GradleProjectPropertiesTest {
         getResource("gradle/webapp").resolve("jib-exploded-war/WEB-INF/classes/empty_dir");
     Files.createDirectories(emptyDirectory);
 
-    gradleProjectProperties =
-        new GradleProjectProperties(mockProject, mockLogger, AbsoluteUnixPath.get("/app"));
+    gradleProjectProperties = new GradleProjectProperties(mockProject, mockLogger);
   }
 
   @Test
@@ -361,7 +360,8 @@ public class GradleProjectPropertiesTest {
     Path nonexistentFile = Paths.get("/nonexistent/file");
     Mockito.when(mockMainSourceSetOutput.getClassesDirs())
         .thenReturn(new TestFileCollection(ImmutableSet.of(nonexistentFile)));
-    gradleProjectProperties.createContainerBuilder(RegistryImage.named("base"));
+    gradleProjectProperties.createContainerBuilder(
+        RegistryImage.named("base"), AbsoluteUnixPath.get("/anything"));
     Mockito.verify(mockLogger).warn("No classes files were found - did you compile your project?");
   }
 
@@ -551,8 +551,8 @@ public class GradleProjectPropertiesTest {
   private BuildConfiguration setupBuildConfiguration(String appRoot)
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException {
     JibContainerBuilder jibContainerBuilder =
-        new GradleProjectProperties(mockProject, mockLogger, AbsoluteUnixPath.get(appRoot))
-            .createContainerBuilder(RegistryImage.named("base"));
+        new GradleProjectProperties(mockProject, mockLogger)
+            .createContainerBuilder(RegistryImage.named("base"), AbsoluteUnixPath.get(appRoot));
     return JibContainerBuilderTestHelper.toBuildConfiguration(
         jibContainerBuilder,
         Containerizer.to(RegistryImage.named("to"))

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.maven;
 
-import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
@@ -97,11 +96,8 @@ public class BuildDockerMojo extends JibPluginConfiguration {
 
     try {
       RawConfiguration mavenRawConfiguration = new MavenRawConfiguration(this);
-      AbsoluteUnixPath appRoot =
-          PluginConfigurationProcessor.getAppRootChecked(
-              mavenRawConfiguration, MojoCommon.isWarProject(getProject()));
       MavenProjectProperties projectProperties =
-          MavenProjectProperties.getForProject(getProject(), getSession(), getLog(), appRoot);
+          MavenProjectProperties.getForProject(getProject(), getSession(), getLog());
 
       MavenHelpfulSuggestionsBuilder mavenHelpfulSuggestionsBuilder =
           new MavenHelpfulSuggestionsBuilder(HELPFUL_SUGGESTIONS_PREFIX, this);

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.maven;
 
-import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.ImageFormat;
 import com.google.cloud.tools.jib.api.ImageReference;
@@ -95,11 +94,8 @@ public class BuildImageMojo extends JibPluginConfiguration {
 
     try {
       RawConfiguration mavenRawConfiguration = new MavenRawConfiguration(this);
-      AbsoluteUnixPath appRoot =
-          PluginConfigurationProcessor.getAppRootChecked(
-              mavenRawConfiguration, MojoCommon.isWarProject(getProject()));
       MavenProjectProperties projectProperties =
-          MavenProjectProperties.getForProject(getProject(), getSession(), getLog(), appRoot);
+          MavenProjectProperties.getForProject(getProject(), getSession(), getLog());
 
       PluginConfigurationProcessor pluginConfigurationProcessor =
           PluginConfigurationProcessor.processCommonConfigurationForRegistryImage(

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.maven;
 
-import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
@@ -71,11 +70,8 @@ public class BuildTarMojo extends JibPluginConfiguration {
 
     try {
       RawConfiguration mavenRawConfiguration = new MavenRawConfiguration(this);
-      AbsoluteUnixPath appRoot =
-          PluginConfigurationProcessor.getAppRootChecked(
-              mavenRawConfiguration, MojoCommon.isWarProject(getProject()));
       MavenProjectProperties projectProperties =
-          MavenProjectProperties.getForProject(getProject(), getSession(), getLog(), appRoot);
+          MavenProjectProperties.getForProject(getProject(), getSession(), getLog());
 
       MavenHelpfulSuggestionsBuilder mavenHelpfulSuggestionsBuilder =
           new MavenHelpfulSuggestionsBuilder(HELPFUL_SUGGESTIONS_PREFIX, this);

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -70,12 +70,10 @@ public class MavenProjectProperties implements ProjectProperties {
    * @param project the {@link MavenProject} for the plugin.
    * @param session the {@link MavenSession} for the plugin.
    * @param log the Maven {@link Log} to log messages during Jib execution
-   * @param appRoot root directory in the image where the app will be placed
    * @return a MavenProjectProperties from the given project and logger.
    */
-  static MavenProjectProperties getForProject(
-      MavenProject project, MavenSession session, Log log, AbsoluteUnixPath appRoot) {
-    return new MavenProjectProperties(project, session, log, appRoot);
+  static MavenProjectProperties getForProject(MavenProject project, MavenSession session, Log log) {
+    return new MavenProjectProperties(project, session, log);
   }
 
   /**
@@ -189,19 +187,17 @@ public class MavenProjectProperties implements ProjectProperties {
   private final MavenSession session;
   private final SingleThreadedExecutor singleThreadedExecutor = new SingleThreadedExecutor();
   private final EventHandlers eventHandlers;
-  private final AbsoluteUnixPath appRoot;
 
   @VisibleForTesting
-  MavenProjectProperties(
-      MavenProject project, MavenSession session, Log log, AbsoluteUnixPath appRoot) {
+  MavenProjectProperties(MavenProject project, MavenSession session, Log log) {
     this.project = project;
-    this.appRoot = appRoot;
     this.session = session;
     eventHandlers = makeEventHandlers(session, log, singleThreadedExecutor);
   }
 
   @Override
-  public JibContainerBuilder createContainerBuilder(RegistryImage baseImage) throws IOException {
+  public JibContainerBuilder createContainerBuilder(
+      RegistryImage baseImage, AbsoluteUnixPath appRoot) throws IOException {
     try {
       if (isWarProject()) {
         Path explodedWarPath =
@@ -296,9 +292,16 @@ public class MavenProjectProperties implements ProjectProperties {
     return JAR_PLUGIN_NAME;
   }
 
+  /**
+   * Gets whether or not the given project is a war project. This is the case for projects with
+   * packaging {@code war} and {@code gwt-app}.
+   *
+   * @return {@code true} if the project is a war project, {@code false} if not
+   */
   @Override
   public boolean isWarProject() {
-    return MojoCommon.isWarProject(project);
+    String packaging = project.getPackaging();
+    return "war".equals(packaging) || "gwt-app".equals(packaging);
   }
 
   @Override

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
@@ -32,18 +32,6 @@ import org.apache.maven.project.MavenProject;
 class MojoCommon {
 
   /**
-   * Gets whether or not the given project is a war project. This is the case for projects with
-   * packaging {@code war} and {@code gwt-app}.
-   *
-   * @param project the Maven project
-   * @return {@code true} if the project is a war project, {@code false} if not
-   */
-  static boolean isWarProject(MavenProject project) {
-    String packaging = project.getPackaging();
-    return "war".equals(packaging) || "gwt-app".equals(packaging);
-  }
-
-  /**
    * Gets the list of extra directory paths from a {@link JibPluginConfiguration}. Returns {@code
    * (project dir)/src/main/jib} by default if not configured.
    *

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -176,8 +176,7 @@ public class MavenProjectPropertiesTest {
   public void setup() throws IOException, URISyntaxException {
     Mockito.when(mockMavenSession.getRequest()).thenReturn(mockMavenRequest);
     mavenProjectProperties =
-        new MavenProjectProperties(
-            mockMavenProject, mockMavenSession, mockLog, AbsoluteUnixPath.get("/app"));
+        new MavenProjectProperties(mockMavenProject, mockMavenSession, mockLog);
     jarPluginConfiguration = new Xpp3Dom("");
     archive = new Xpp3Dom("archive");
     manifest = new Xpp3Dom("manifest");
@@ -363,7 +362,7 @@ public class MavenProjectPropertiesTest {
   public void testCreateContainerBuilder_correctFiles()
       throws URISyntaxException, IOException, InvalidImageReferenceException,
           CacheDirectoryCreationException {
-    BuildConfiguration configuration = setupBuildConfiguration(AbsoluteUnixPath.get("/app"));
+    BuildConfiguration configuration = setupBuildConfiguration("/app");
     ContainerBuilderLayers layers = new ContainerBuilderLayers(configuration);
 
     Path dependenciesPath = getResource("maven/application/dependencies");
@@ -403,7 +402,7 @@ public class MavenProjectPropertiesTest {
   @Test
   public void testCreateContainerBuilder_nonDefaultAppRoot()
       throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
-    BuildConfiguration configuration = setupBuildConfiguration(AbsoluteUnixPath.get("/my/app"));
+    BuildConfiguration configuration = setupBuildConfiguration("/my/app");
     assertNonDefaultAppRoot(configuration);
   }
 
@@ -416,7 +415,7 @@ public class MavenProjectPropertiesTest {
     Mockito.when(mockBuild.getDirectory()).thenReturn(outputPath.toString());
     Mockito.when(mockBuild.getFinalName()).thenReturn("final-name");
 
-    BuildConfiguration configuration = setupBuildConfiguration(AbsoluteUnixPath.get("/my/app"));
+    BuildConfiguration configuration = setupBuildConfiguration("/my/app");
     ContainerBuilderLayers layers = new ContainerBuilderLayers(configuration);
     assertSourcePathsUnordered(
         ImmutableList.of(outputPath.resolve("final-name/WEB-INF/lib/dependency-1.0.0.jar")),
@@ -479,7 +478,7 @@ public class MavenProjectPropertiesTest {
       throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
     // Test when the default packaging is set
     Mockito.when(mockMavenProject.getPackaging()).thenReturn("jar");
-    BuildConfiguration configuration = setupBuildConfiguration(AbsoluteUnixPath.get("/my/app"));
+    BuildConfiguration configuration = setupBuildConfiguration("/my/app");
     assertNonDefaultAppRoot(configuration);
   }
 
@@ -492,7 +491,7 @@ public class MavenProjectPropertiesTest {
         .thenReturn(temporaryFolder.getRoot().toPath().toString());
     Mockito.when(mockBuild.getFinalName()).thenReturn("final-name");
 
-    setupBuildConfiguration(AbsoluteUnixPath.get("/my/app")); // should pass
+    setupBuildConfiguration("/my/app"); // should pass
   }
 
   @Test
@@ -504,7 +503,7 @@ public class MavenProjectPropertiesTest {
         .thenReturn(temporaryFolder.getRoot().toPath().toString());
     Mockito.when(mockBuild.getFinalName()).thenReturn("final-name");
 
-    setupBuildConfiguration(AbsoluteUnixPath.get("/my/app")); // should pass
+    setupBuildConfiguration("/my/app"); // should pass
   }
 
   @Test
@@ -516,38 +515,38 @@ public class MavenProjectPropertiesTest {
         .thenReturn(temporaryFolder.getRoot().toPath().toString());
     Mockito.when(mockBuild.getFinalName()).thenReturn("final-name");
 
-    setupBuildConfiguration(AbsoluteUnixPath.get("/my/app")); // should pass
+    setupBuildConfiguration("/my/app"); // should pass
   }
 
   @Test
   public void testIsWarProject_WarPackagingIsWar() {
     Mockito.when(mockMavenProject.getPackaging()).thenReturn("war");
-    Assert.assertTrue(MojoCommon.isWarProject(mockMavenProject));
+    Assert.assertTrue(mavenProjectProperties.isWarProject());
   }
 
   @Test
   public void testIsWarProject_GwtAppPackagingIsWar() {
     Mockito.when(mockMavenProject.getPackaging()).thenReturn("gwt-app");
-    Assert.assertTrue(MojoCommon.isWarProject(mockMavenProject));
+    Assert.assertTrue(mavenProjectProperties.isWarProject());
   }
 
   @Test
   public void testIsWarProject_JarPackagingIsNotWar() {
     Mockito.when(mockMavenProject.getPackaging()).thenReturn("jar");
-    Assert.assertFalse(MojoCommon.isWarProject(mockMavenProject));
+    Assert.assertFalse(mavenProjectProperties.isWarProject());
   }
 
   @Test
   public void testIsWarProject_GwtLibPackagingIsNotWar() {
     Mockito.when(mockMavenProject.getPackaging()).thenReturn("gwt-lib");
-    Assert.assertFalse(MojoCommon.isWarProject(mockMavenProject));
+    Assert.assertFalse(mavenProjectProperties.isWarProject());
   }
 
-  private BuildConfiguration setupBuildConfiguration(AbsoluteUnixPath appRoot)
+  private BuildConfiguration setupBuildConfiguration(String appRoot)
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException {
     JibContainerBuilder JibContainerBuilder =
-        new MavenProjectProperties(mockMavenProject, mockMavenSession, mockLog, appRoot)
-            .createContainerBuilder(RegistryImage.named("base"));
+        new MavenProjectProperties(mockMavenProject, mockMavenSession, mockLog)
+            .createContainerBuilder(RegistryImage.named("base"), AbsoluteUnixPath.get(appRoot));
     return JibContainerBuilderTestHelper.toBuildConfiguration(
         JibContainerBuilder,
         Containerizer.to(RegistryImage.named("to"))

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -183,7 +183,8 @@ public class PluginConfigurationProcessor {
 
     JibContainerBuilder jibContainerBuilder =
         projectProperties
-            .createContainerBuilder(baseImage)
+            .createContainerBuilder(
+                baseImage, getAppRootChecked(rawConfiguration, projectProperties))
             .setEntrypoint(computeEntrypoint(rawConfiguration, projectProperties))
             .setProgramArguments(rawConfiguration.getProgramArguments().orElse(null))
             .setEnvironment(rawConfiguration.getEnvironment())
@@ -242,8 +243,7 @@ public class PluginConfigurationProcessor {
   static List<String> computeEntrypoint(
       RawConfiguration rawConfiguration, ProjectProperties projectProperties)
       throws MainClassInferenceException, InvalidAppRootException, IOException {
-    AbsoluteUnixPath appRoot =
-        getAppRootChecked(rawConfiguration, projectProperties.isWarProject());
+    AbsoluteUnixPath appRoot = getAppRootChecked(rawConfiguration, projectProperties);
 
     Optional<List<String>> rawEntrypoint = rawConfiguration.getEntrypoint();
     List<String> rawExtraClasspath = rawConfiguration.getExtraClasspath();
@@ -358,17 +358,18 @@ public class PluginConfigurationProcessor {
    * JavaContainerBuilder#DEFAULT_APP_ROOT} for other projects.
    *
    * @param rawConfiguration raw configuration data
-   * @param isWarProject whether or not the project is a WAR project
+   * @param projectProperties the project properties
    * @return the app root value
    * @throws InvalidAppRootException if {@code appRoot} value is not an absolute Unix path
    */
   @VisibleForTesting
-  public static AbsoluteUnixPath getAppRootChecked(
-      RawConfiguration rawConfiguration, boolean isWarProject) throws InvalidAppRootException {
+  static AbsoluteUnixPath getAppRootChecked(
+      RawConfiguration rawConfiguration, ProjectProperties projectProperties)
+      throws InvalidAppRootException {
     String appRoot = rawConfiguration.getAppRoot();
     if (appRoot.isEmpty()) {
       appRoot =
-          isWarProject
+          projectProperties.isWarProject()
               ? JavaContainerBuilder.DEFAULT_WEB_APP_ROOT
               : JavaContainerBuilder.DEFAULT_APP_ROOT;
     }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.plugins.common;
 
+import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.RegistryImage;
 import com.google.cloud.tools.jib.event.EventHandlers;
@@ -50,10 +51,12 @@ public interface ProjectProperties {
    * Starts the containerization process.
    *
    * @param baseImage the base image
+   * @param appRoot root directory in the image where the app will be placed
    * @return a {@link JibContainerBuilder} with classes, resources, and dependencies added to it
    * @throws IOException if there is a problem walking the project files
    */
-  JibContainerBuilder createContainerBuilder(RegistryImage baseImage) throws IOException;
+  JibContainerBuilder createContainerBuilder(RegistryImage baseImage, AbsoluteUnixPath appRoot)
+      throws IOException;
 
   List<Path> getClassFiles() throws IOException;
 

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -434,7 +434,6 @@ public class PluginConfigurationProcessorTest {
   @Test
   public void testGetAppRootChecked() throws InvalidAppRootException {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("/some/root");
-    Mockito.when(projectProperties.isWarProject()).thenReturn(false);
 
     Assert.assertEquals(
         AbsoluteUnixPath.get("/some/root"),
@@ -444,7 +443,6 @@ public class PluginConfigurationProcessorTest {
   @Test
   public void testGetAppRootChecked_errorOnNonAbsolutePath() {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("relative/path");
-    Mockito.when(projectProperties.isWarProject()).thenReturn(false);
 
     try {
       PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties);
@@ -457,7 +455,6 @@ public class PluginConfigurationProcessorTest {
   @Test
   public void testGetAppRootChecked_errorOnWindowsPath() {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("\\windows\\path");
-    Mockito.when(projectProperties.isWarProject()).thenReturn(false);
 
     try {
       PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties);
@@ -470,7 +467,6 @@ public class PluginConfigurationProcessorTest {
   @Test
   public void testGetAppRootChecked_errorOnWindowsPathWithDriveLetter() {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("C:\\windows\\path");
-    Mockito.when(projectProperties.isWarProject()).thenReturn(false);
 
     try {
       PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties);

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -101,7 +101,9 @@ public class PluginConfigurationProcessorTest {
     Mockito.when(projectProperties.getEventHandlers())
         .thenReturn(EventHandlers.builder().add(LogEvent.class, logger).build());
     Mockito.when(projectProperties.getDefaultCacheDirectory()).thenReturn(Paths.get("cache"));
-    Mockito.when(projectProperties.createContainerBuilder(Mockito.any()))
+    Mockito.when(
+            projectProperties.createContainerBuilder(
+                Mockito.any(RegistryImage.class), Mockito.any(AbsoluteUnixPath.class)))
         .thenReturn(Jib.from("base"));
     Mockito.when(projectProperties.isOffline()).thenReturn(false);
 
@@ -432,18 +434,20 @@ public class PluginConfigurationProcessorTest {
   @Test
   public void testGetAppRootChecked() throws InvalidAppRootException {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("/some/root");
+    Mockito.when(projectProperties.isWarProject()).thenReturn(false);
 
     Assert.assertEquals(
         AbsoluteUnixPath.get("/some/root"),
-        PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, false));
+        PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties));
   }
 
   @Test
   public void testGetAppRootChecked_errorOnNonAbsolutePath() {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("relative/path");
+    Mockito.when(projectProperties.isWarProject()).thenReturn(false);
 
     try {
-      PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, false);
+      PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties);
       Assert.fail();
     } catch (InvalidAppRootException ex) {
       Assert.assertEquals("relative/path", ex.getMessage());
@@ -453,9 +457,10 @@ public class PluginConfigurationProcessorTest {
   @Test
   public void testGetAppRootChecked_errorOnWindowsPath() {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("\\windows\\path");
+    Mockito.when(projectProperties.isWarProject()).thenReturn(false);
 
     try {
-      PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, false);
+      PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties);
       Assert.fail();
     } catch (InvalidAppRootException ex) {
       Assert.assertEquals("\\windows\\path", ex.getMessage());
@@ -465,9 +470,10 @@ public class PluginConfigurationProcessorTest {
   @Test
   public void testGetAppRootChecked_errorOnWindowsPathWithDriveLetter() {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("C:\\windows\\path");
+    Mockito.when(projectProperties.isWarProject()).thenReturn(false);
 
     try {
-      PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, false);
+      PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties);
       Assert.fail();
     } catch (InvalidAppRootException ex) {
       Assert.assertEquals("C:\\windows\\path", ex.getMessage());
@@ -477,19 +483,21 @@ public class PluginConfigurationProcessorTest {
   @Test
   public void testGetAppRootChecked_defaultNonWarProject() throws InvalidAppRootException {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("");
+    Mockito.when(projectProperties.isWarProject()).thenReturn(false);
 
     Assert.assertEquals(
         AbsoluteUnixPath.get("/app"),
-        PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, false));
+        PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties));
   }
 
   @Test
   public void testGetAppRootChecked_defaultWarProject() throws InvalidAppRootException {
     Mockito.when(rawConfiguration.getAppRoot()).thenReturn("");
+    Mockito.when(projectProperties.isWarProject()).thenReturn(true);
 
     Assert.assertEquals(
         AbsoluteUnixPath.get("/jetty/webapps/ROOT"),
-        PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, true));
+        PluginConfigurationProcessor.getAppRootChecked(rawConfiguration, projectProperties));
   }
 
   @Test


### PR DESCRIPTION
It has been a real pain that we have to pass `appRoot` to instantiate a `ProjectProperties` instance. This was a chicken-and-egg situation: you need to know a certain project property to process and compute a correct `appRoot` value, but in order for `PluginConfigurationProcessor (PCP)` to process it correctly, it needs an instance of `ProjectProperties`.

So, to circumvent this annoyance, we had to do these unpleasant things:
- Exposed `PCP.getAppRootChecked()` as `public`, which is inconsistent with other `getXXXChecked()` families that are exclusively used by `PCP`.
- Had a different method signature for `PCP.getAppRootChecked()` from other `getXXXChecked()` families.
- Needed `TaskCommon.isWarProject()` and `MojoCommon.isWarProject()`.
- Had to call `getAppRootChecked()` at the beginning of MOJOs to compute `appRoot` before proper config computation is carried out by `PCP`.

But now it seems like we don't have to pass `appRoot` to instantiate `ProjectProperties`.