### PR TITLE
Resolve input files more comprehensively on jibBuildTar

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -73,8 +73,8 @@ public class BuildTarTask extends DefaultTask implements JibTask {
   }
 
   /**
-   * @return the input files to this task are all the output files for all the dependencies of the
-   *     {@code classes} task.
+   * @return a collection of all the files that jib includes in the image. Only used to calculate
+   *     UP-TO-DATE.
    */
   @InputFiles
   public FileCollection getInputFiles() {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -80,11 +80,7 @@ public class BuildTarTask extends DefaultTask implements JibTask {
   public FileCollection getInputFiles() {
     List<Path> extraDirectories =
         Preconditions.checkNotNull(jibExtension).getExtraDirectories().getPaths();
-    return extraDirectories
-        .stream()
-        .map(Path::toFile)
-        .map(directory -> GradleProjectProperties.getInputFiles(directory, getProject()))
-        .reduce(getProject().files(), getProject()::files);
+    return GradleProjectProperties.getInputFiles(getProject(), extraDirectories);
   }
 
   /**

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -267,12 +267,12 @@ class GradleProjectProperties implements ProjectProperties {
   }
 
   /**
-   * Returns the input files for a task.
+   * Returns the input files for a task. These files include the runtimeClasspath of the application
+   * and any extraDirectories defined by the user to include in the container.
    *
    * @param project the gradle project
    * @param extraDirectories the image's configured extra directories
-   * @return the input files to the task are all the output files for all the dependencies of the
-   *     {@code classes} task
+   * @return the input files
    */
   static FileCollection getInputFiles(Project project, List<Path> extraDirectories) {
     JavaPluginConvention javaPluginConvention =

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -41,7 +41,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.tools.ant.taskdefs.condition.Os;
@@ -270,25 +269,26 @@ class GradleProjectProperties implements ProjectProperties {
   /**
    * Returns the input files for a task.
    *
-   * @param extraDirectory the image's configured extra directory
    * @param project the gradle project
+   * @param extraDirectories the image's configured extra directories
    * @return the input files to the task are all the output files for all the dependencies of the
    *     {@code classes} task
    */
-  static FileCollection getInputFiles(File extraDirectory, Project project) {
-    Task classesTask = project.getTasks().getByPath("classes");
-    Set<? extends Task> classesDependencies =
-        classesTask.getTaskDependencies().getDependencies(classesTask);
-
+  static FileCollection getInputFiles(Project project, List<Path> extraDirectories) {
+    JavaPluginConvention javaPluginConvention =
+        project.getConvention().getPlugin(JavaPluginConvention.class);
+    SourceSet mainSourceSet = javaPluginConvention.getSourceSets().getByName(MAIN_SOURCE_SET_NAME);
     List<FileCollection> dependencyFileCollections = new ArrayList<>();
-    for (Task task : classesDependencies) {
-      dependencyFileCollections.add(task.getOutputs().getFiles());
-    }
-    if (Files.exists(extraDirectory.toPath())) {
-      return project.files(dependencyFileCollections, extraDirectory);
-    } else {
-      return project.files(dependencyFileCollections);
-    }
+    dependencyFileCollections.add(mainSourceSet.getRuntimeClasspath());
+
+    extraDirectories
+        .stream()
+        .filter(Files::exists)
+        .map(Path::toFile)
+        .map(project::files)
+        .forEach(dependencyFileCollections::add);
+
+    return project.files(dependencyFileCollections);
   }
 
   @Override


### PR DESCRIPTION
We haven't been including the all the input to the task correct (this only matter with jibBuildTar which has an `@Output` defined - all other jib tasks run always).

Also we had some weird code (BuildTarTask:83) that is cleaned up here.

Bug: https://github.com/GoogleContainerTools/jib/issues/1745#issuecomment-497333324