### PR TITLE
Add internal Skaffold-init task/goal

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -41,6 +41,7 @@ public class JibPlugin implements Plugin<Project> {
   @VisibleForTesting static final String BUILD_DOCKER_TASK_NAME = "jibDockerBuild";
   @VisibleForTesting static final String FILES_TASK_NAME = "_jibSkaffoldFiles";
   @VisibleForTesting static final String FILES_TASK_V2_NAME = "_jibSkaffoldFilesV2";
+  @VisibleForTesting static final String INIT_TASK_NAME = "_jibSkaffoldInit";
   @VisibleForTesting static final String EXPLODED_WAR_TASK_NAME = "jibExplodedWar";
 
   /**
@@ -120,6 +121,7 @@ public class JibPlugin implements Plugin<Project> {
             .setJibExtension(jibExtension);
     project.getTasks().create(FILES_TASK_NAME, FilesTask.class).setJibExtension(jibExtension);
     project.getTasks().create(FILES_TASK_V2_NAME, FilesTaskV2.class).setJibExtension(jibExtension);
+    project.getTasks().create(INIT_TASK_NAME, SkaffoldInitTask.class).setJibExtension(jibExtension);
 
     project.afterEvaluate(
         projectAfterEvaluation -> {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTask.java
@@ -44,7 +44,7 @@ public class SkaffoldInitTask extends DefaultTask {
     if (!getProject().equals(getProject().getRootProject())) {
       skaffoldInitOutput.setProject(getProject().getName());
     }
-    System.out.println("\nBEGIN JIB");
+    System.out.println("\nBEGIN JIB JSON");
     System.out.println(skaffoldInitOutput.getJsonString());
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTask.java
@@ -21,10 +21,14 @@ import javax.annotation.Nullable;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
 
+/**
+ * Prints out to.image configuration and project name, used for Jib project detection in Skaffold.
+ *
+ * <p>Expected use: {@code ./gradlew _jibSkaffoldInit -q}
+ */
 public class SkaffoldInitTask extends DefaultTask {
 
-  @Nullable
-  private JibExtension jibExtension;
+  @Nullable private JibExtension jibExtension;
 
   public SkaffoldInitTask setJibExtension(JibExtension jibExtension) {
     this.jibExtension = jibExtension;

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTask.java
@@ -16,7 +16,9 @@
 
 package com.google.cloud.tools.jib.gradle;
 
+import com.google.cloud.tools.jib.plugins.common.SkaffoldInitOutput;
 import com.google.common.base.Preconditions;
+import java.io.IOException;
 import javax.annotation.Nullable;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.TaskAction;
@@ -36,10 +38,13 @@ public class SkaffoldInitTask extends DefaultTask {
   }
 
   @TaskAction
-  public void listModulesAndTargets() {
-    String target = Preconditions.checkNotNull(jibExtension).getTo().getImage();
+  public void listModulesAndTargets() throws IOException {
+    SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput();
+    skaffoldInitOutput.setImage(Preconditions.checkNotNull(jibExtension).getTo().getImage());
+    if (!getProject().equals(getProject().getRootProject())) {
+      skaffoldInitOutput.setProject(getProject().getName());
+    }
     System.out.println("\nBEGIN JIB");
-    System.out.println(target == null ? "?" : target);
-    System.out.println(getProject().getName());
+    System.out.println(skaffoldInitOutput.getJsonString());
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTask.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.gradle;
+
+import com.google.common.base.Preconditions;
+import javax.annotation.Nullable;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.TaskAction;
+
+public class SkaffoldInitTask extends DefaultTask {
+
+  @Nullable
+  private JibExtension jibExtension;
+
+  public SkaffoldInitTask setJibExtension(JibExtension jibExtension) {
+    this.jibExtension = jibExtension;
+    return this;
+  }
+
+  @TaskAction
+  public void listModulesAndTargets() {
+    String target = Preconditions.checkNotNull(jibExtension).getTo().getImage();
+    System.out.println("\nBEGIN JIB");
+    System.out.println(target == null ? "?" : target);
+    System.out.println(getProject().getName());
+  }
+}

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTaskTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTaskTest.java
@@ -38,12 +38,13 @@ public class SkaffoldInitTaskTest {
   @ClassRule public static final TestProject multiTestProject = new TestProject("multi-service");
 
   /**
-   * Verifies that the files task succeeded and returns the list of paths it prints out.
+   * Verifies that the files task succeeded and returns the list of JSON strings printed by the
+   * task.
    *
    * @param project the project to run the task on
-   * @return the JSON string printed by the task
+   * @return the JSON strings printed by the task
    */
-  private static List<String> verifyTaskSuccess(TestProject project) {
+  private static List<String> getJsons(TestProject project) {
     BuildResult buildResult =
         project.build(JibPlugin.INIT_TASK_NAME, "-q", "-D_TARGET_IMAGE=testimage");
     BuildTask jibTask = buildResult.task(":" + JibPlugin.INIT_TASK_NAME);
@@ -65,7 +66,7 @@ public class SkaffoldInitTaskTest {
 
   @Test
   public void testFilesTask_singleProject() throws IOException {
-    List<String> outputs = verifyTaskSuccess(simpleTestProject);
+    List<String> outputs = getJsons(simpleTestProject);
     Assert.assertEquals(1, outputs.size());
 
     SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(0));
@@ -75,7 +76,7 @@ public class SkaffoldInitTaskTest {
 
   @Test
   public void testFilesTask_multiProject() throws IOException {
-    List<String> outputs = verifyTaskSuccess(multiTestProject);
+    List<String> outputs = getJsons(multiTestProject);
     Assert.assertEquals(3, outputs.size());
 
     SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(0));

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTaskTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTaskTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.gradle;
+
+import com.google.cloud.tools.jib.plugins.common.SkaffoldInitOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.BuildTask;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/** Tests for {@link SkaffoldInitTask}. */
+public class SkaffoldInitTaskTest {
+
+  @ClassRule public static final TestProject simpleTestProject = new TestProject("simple");
+
+  @ClassRule public static final TestProject multiTestProject = new TestProject("multi-service");
+
+  /**
+   * Verifies that the files task succeeded and returns the list of paths it prints out.
+   *
+   * @param project the project to run the task on
+   * @return the JSON string printed by the task
+   */
+  private static List<String> verifyTaskSuccess(TestProject project) {
+    BuildResult buildResult =
+        project.build(JibPlugin.INIT_TASK_NAME, "-q", "-D_TARGET_IMAGE=testimage");
+    BuildTask jibTask = buildResult.task(":" + JibPlugin.INIT_TASK_NAME);
+    Assert.assertNotNull(jibTask);
+    Assert.assertEquals(TaskOutcome.SUCCESS, jibTask.getOutcome());
+    String output = buildResult.getOutput().trim();
+    Assert.assertThat(output, CoreMatchers.startsWith("BEGIN JIB JSON"));
+
+    Pattern pattern = Pattern.compile("BEGIN JIB JSON\r?\n(\\{.*})");
+    Matcher matcher = pattern.matcher(output);
+    List<String> jsons = new ArrayList<>();
+    while (matcher.find()) {
+      jsons.add(matcher.group(1));
+    }
+
+    // Return task output with header removed
+    return jsons;
+  }
+
+  @Test
+  public void testFilesTask_singleProject() throws IOException {
+    List<String> outputs = verifyTaskSuccess(simpleTestProject);
+    Assert.assertEquals(1, outputs.size());
+
+    SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(0));
+    Assert.assertEquals("testimage", skaffoldInitOutput.getImage());
+    Assert.assertNull(skaffoldInitOutput.getProject());
+  }
+
+  @Test
+  public void testFilesTask_multiProject() throws IOException {
+    List<String> outputs = verifyTaskSuccess(multiTestProject);
+    Assert.assertEquals(3, outputs.size());
+
+    SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(0));
+    Assert.assertEquals("testimage", skaffoldInitOutput.getImage());
+    Assert.assertNull(skaffoldInitOutput.getProject());
+
+    skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(1));
+    Assert.assertEquals("testimage", skaffoldInitOutput.getImage());
+    Assert.assertEquals("complex-service", skaffoldInitOutput.getProject());
+
+    skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(2));
+    Assert.assertEquals("testimage", skaffoldInitOutput.getImage());
+    Assert.assertEquals("simple-service", skaffoldInitOutput.getProject());
+  }
+}

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -259,7 +259,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
     return Preconditions.checkNotNull(session);
   }
 
-  MavenProject getProject() {
+  protected MavenProject getProject() {
     return Preconditions.checkNotNull(project);
   }
 
@@ -302,7 +302,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
    * @return the configured target image reference
    */
   @Nullable
-  String getTargetImage() {
+  protected String getTargetImage() {
     String propertyAlternate = getProperty(PropertyNames.TO_IMAGE_ALTERNATE);
     if (propertyAlternate != null) {
       return propertyAlternate;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/SkaffoldInitMojo.java
@@ -20,6 +20,11 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
+/**
+ * Prints out to.image configuration and project name, used for Jib project detection in Skaffold.
+ *
+ * <p>Expected use: {@code ./mvnw jib:_skaffold-init -q}
+ */
 @Mojo(name = SkaffoldInitMojo.GOAL_NAME, requiresDependencyCollection = ResolutionScope.NONE)
 public class SkaffoldInitMojo extends JibPluginConfiguration {
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/SkaffoldInitMojo.java
@@ -16,6 +16,9 @@
 
 package com.google.cloud.tools.jib.maven;
 
+import com.google.cloud.tools.jib.plugins.common.SkaffoldInitOutput;
+import java.io.IOException;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
@@ -30,10 +33,18 @@ public class SkaffoldInitMojo extends JibPluginConfiguration {
   static final String GOAL_NAME = "_skaffold-init";
 
   @Override
-  public void execute() {
-    String target = getTargetImage();
+  public void execute() throws MojoExecutionException {
+    SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput();
+    skaffoldInitOutput.setImage(getTargetImage());
+    if (!getProject().getName().equals(getProject().getParent().getName())) {
+      skaffoldInitOutput.setProject(getProject().getName());
+    }
+
     System.out.println("\nBEGIN JIB");
-    System.out.println(target == null ? "?" : target);
-    System.out.println(getProject().getName());
+    try {
+      System.out.println(skaffoldInitOutput.getJsonString());
+    } catch (IOException ex) {
+      throw new MojoExecutionException(ex.getMessage());
+    }
   }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/SkaffoldInitMojo.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+@Mojo(name = SkaffoldInitMojo.GOAL_NAME, requiresDependencyCollection = ResolutionScope.NONE)
+public class SkaffoldInitMojo extends JibPluginConfiguration {
+
+  @VisibleForTesting static final String GOAL_NAME = "_skaffold-init";
+
+  @Override
+  public void execute() {
+    String target = getTargetImage();
+    System.out.println("\nBEGIN JIB");
+    System.out.println(target == null ? "?" : target);
+    System.out.println(getProject().getName());
+  }
+}

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/SkaffoldInitMojo.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.maven;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
@@ -28,7 +27,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 @Mojo(name = SkaffoldInitMojo.GOAL_NAME, requiresDependencyCollection = ResolutionScope.NONE)
 public class SkaffoldInitMojo extends JibPluginConfiguration {
 
-  @VisibleForTesting static final String GOAL_NAME = "_skaffold-init";
+  static final String GOAL_NAME = "_skaffold-init";
 
   @Override
   public void execute() {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.maven.skaffold;
 
 import com.google.cloud.tools.jib.maven.JibPluginConfiguration;
 import com.google.cloud.tools.jib.plugins.common.SkaffoldInitOutput;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -31,7 +32,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 @Mojo(name = SkaffoldInitMojo.GOAL_NAME, requiresDependencyCollection = ResolutionScope.NONE)
 public class SkaffoldInitMojo extends JibPluginConfiguration {
 
-  static final String GOAL_NAME = "_skaffold-init";
+  @VisibleForTesting static final String GOAL_NAME = "_skaffold-init";
 
   @Override
   public void execute() throws MojoExecutionException {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
@@ -14,8 +14,9 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.maven;
+package com.google.cloud.tools.jib.maven.skaffold;
 
+import com.google.cloud.tools.jib.maven.JibPluginConfiguration;
 import com.google.cloud.tools.jib.plugins.common.SkaffoldInitOutput;
 import java.io.IOException;
 import org.apache.maven.plugin.MojoExecutionException;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
@@ -41,7 +41,7 @@ public class SkaffoldInitMojo extends JibPluginConfiguration {
       skaffoldInitOutput.setProject(getProject().getName());
     }
 
-    System.out.println("\nBEGIN JIB");
+    System.out.println("\nBEGIN JIB JSON");
     try {
       System.out.println(skaffoldInitOutput.getJsonString());
     } catch (IOException ex) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
@@ -37,7 +37,7 @@ public class SkaffoldInitMojo extends JibPluginConfiguration {
   public void execute() throws MojoExecutionException {
     SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput();
     skaffoldInitOutput.setImage(getTargetImage());
-    if (!getProject().getName().equals(getProject().getParent().getName())) {
+    if (getProject().getParent() != null) {
       skaffoldInitOutput.setProject(getProject().getName());
     }
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
@@ -46,7 +46,7 @@ public class SkaffoldInitMojo extends JibPluginConfiguration {
     try {
       System.out.println(skaffoldInitOutput.getJsonString());
     } catch (IOException ex) {
-      throw new MojoExecutionException(ex.getMessage());
+      throw new MojoExecutionException(ex.getMessage(), ex);
     }
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojoTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojoTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven.skaffold;
+
+import com.google.cloud.tools.jib.maven.TestPlugin;
+import com.google.cloud.tools.jib.maven.TestProject;
+import com.google.cloud.tools.jib.plugins.common.SkaffoldFilesOutput;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/** Tests for {@link SkaffoldInitMojo}. */
+public class SkaffoldInitMojoTest {
+
+  @ClassRule
+  public static final TestPlugin testPlugin = new TestPlugin();
+
+  @ClassRule
+  public static final TestProject simpleTestProject = new TestProject(testPlugin, "simple");
+
+  @ClassRule
+  public static final TestProject multiTestProject = new TestProject(testPlugin, "multi");
+
+  private static void verifyFiles(Path projectRoot)
+      throws VerificationException, IOException {
+
+    Verifier verifier = new Verifier(projectRoot.toString());
+    verifier.setAutoclean(false);
+    verifier.addCliOption("-q");
+    verifier.executeGoal("jib:" + FilesMojoV2.GOAL_NAME);
+
+    verifier.verifyErrorFreeLog();
+    Path logFile = Paths.get(verifier.getBasedir()).resolve(verifier.getLogFileName());
+    List<String> log = Files.readAllLines(logFile, StandardCharsets.UTF_8);
+
+    int begin = log.indexOf("BEGIN JIB JSON");
+    Assert.assertTrue(begin > -1);
+    SkaffoldFilesOutput output = new SkaffoldFilesOutput(log.get(begin + 1));
+    Assert.assertEquals(0, output.getIgnore().size());
+  }
+
+  @Test
+  public void testFilesMojo_singleModule() throws IOException {
+    Path projectRoot = simpleTestProject.getProjectRoot();
+
+
+  }
+
+  @Test
+  public void testFilesMojo_multiModule() throws IOException {
+    Path projectRoot = multiTestProject.getProjectRoot();
+
+
+  }
+}

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/SkaffoldInitOutput.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/SkaffoldInitOutput.java
@@ -17,9 +17,11 @@
 package com.google.cloud.tools.jib.plugins.common;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -38,25 +40,33 @@ import javax.annotation.Nullable;
  * }
  * }</pre>
  */
+@JsonInclude(Include.NON_NULL)
+@JsonAutoDetect(
+    fieldVisibility = Visibility.ANY,
+    setterVisibility = Visibility.NONE,
+    getterVisibility = Visibility.NONE)
 public class SkaffoldInitOutput {
 
-  @JsonInclude(Include.NON_NULL)
-  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-  private static class SkaffoldInitTemplate {
+  @Nullable private String image;
 
-    @Nullable private String image;
+  @Nullable private String project;
 
-    @Nullable private String project;
+  public SkaffoldInitOutput() {}
+
+  @VisibleForTesting
+  public SkaffoldInitOutput(String json) throws IOException {
+    SkaffoldInitOutput skaffoldInitOutput =
+        new ObjectMapper().readValue(json, SkaffoldInitOutput.class);
+    this.image = skaffoldInitOutput.image;
+    this.project = skaffoldInitOutput.project;
   }
 
-  private final SkaffoldInitTemplate skaffoldInitTemplate = new SkaffoldInitTemplate();
-
   public void setImage(@Nullable String image) {
-    skaffoldInitTemplate.image = image;
+    this.image = image;
   }
 
   public void setProject(@Nullable String project) {
-    skaffoldInitTemplate.project = project;
+    this.project = project;
   }
 
   /**
@@ -67,8 +77,20 @@ public class SkaffoldInitOutput {
    */
   public String getJsonString() throws IOException {
     try (OutputStream outputStream = new ByteArrayOutputStream()) {
-      new ObjectMapper().writeValue(outputStream, skaffoldInitTemplate);
+      new ObjectMapper().writeValue(outputStream, this);
       return outputStream.toString();
     }
+  }
+
+  @VisibleForTesting
+  @Nullable
+  public String getImage() {
+    return image;
+  }
+
+  @VisibleForTesting
+  @Nullable
+  public String getProject() {
+    return project;
   }
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/SkaffoldInitOutput.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/SkaffoldInitOutput.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.plugins.common;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import javax.annotation.Nullable;
+
+/**
+ * Builds a JSON string containing the configured target image and sub-project name, to be consumed
+ * by <a href="https://github.com/GoogleContainerTools/skaffold">Skaffold</a>.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * {
+ *   "image":"gcr.io/project/test",
+ *   "project":"project-name"
+ * }
+ * }</pre>
+ */
+public class SkaffoldInitOutput {
+
+  @JsonInclude(Include.NON_NULL)
+  @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+  private static class SkaffoldInitTemplate {
+
+    @Nullable private String image;
+
+    @Nullable private String project;
+  }
+
+  private final SkaffoldInitTemplate skaffoldInitTemplate = new SkaffoldInitTemplate();
+
+  public void setImage(@Nullable String image) {
+    skaffoldInitTemplate.image = image;
+  }
+
+  public void setProject(@Nullable String project) {
+    skaffoldInitTemplate.project = project;
+  }
+
+  /**
+   * Gets the added files in JSON format.
+   *
+   * @return the files in a JSON string
+   * @throws IOException if writing out the JSON fails
+   */
+  public String getJsonString() throws IOException {
+    try (OutputStream outputStream = new ByteArrayOutputStream()) {
+      new ObjectMapper().writeValue(outputStream, skaffoldInitTemplate);
+      return outputStream.toString();
+    }
+  }
+}


### PR DESCRIPTION
Adds task/goal for skaffold-init usage that prints the `to.image` configuration and project name to be consumed by skaffold.

e.g.

```
BEGIN JIB
{"image":"gcr.io/image/name","project":"project-name"}
```