### PR TITLE
Update changelogs and version strings for 1.3.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,12 +134,12 @@ To use a local build of the `jib-gradle-plugin`:
                 mavenCentral()
             }
             dependencies {
-                classpath 'com.google.cloud.tools:jib-gradle-plugin:1.2.1-SNAPSHOT'
+                classpath 'com.google.cloud.tools:jib-gradle-plugin:1.3.1-SNAPSHOT'
             }
         }
 
         plugins {
-            // id 'com.google.cloud.tools.jib' version '1.2.0'
+            // id 'com.google.cloud.tools.jib' version '1.3.0'
         }
 
         // Applies the java plugin after Jib to make sure it works in this order.

--- a/examples/dropwizard/pom.xml
+++ b/examples/dropwizard/pom.xml
@@ -26,7 +26,7 @@
         <dropwizard-template-config.version>1.5.0</dropwizard-template-config.version>
 
         <jib.container.appRoot>/app</jib.container.appRoot>
-        <jib-maven-plugin.version>1.2.0</jib-maven-plugin.version>
+        <jib-maven-plugin.version>1.3.0</jib-maven-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/helloworld/build.gradle
+++ b/examples/helloworld/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'com.google.cloud.tools.jib' version '1.2.0'
+  id 'com.google.cloud.tools.jib' version '1.3.0'
 }
 
 sourceCompatibility = 1.8

--- a/examples/helloworld/pom.xml
+++ b/examples/helloworld/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jib-maven-plugin.version>1.2.0</jib-maven-plugin.version>
+    <jib-maven-plugin.version>1.3.0</jib-maven-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
   </properties>
 

--- a/examples/java-agent/build.gradle
+++ b/examples/java-agent/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'com.google.cloud.tools.jib' version '1.2.0'
+  id 'com.google.cloud.tools.jib' version '1.3.0'
   id 'de.undercouch.download' version '3.4.0'
   id "com.gorylenko.gradle-git-properties" version "1.5.2"
 }

--- a/examples/java-agent/pom.xml
+++ b/examples/java-agent/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jib-maven-plugin.version>1.2.0</jib-maven-plugin.version>
+    <jib-maven-plugin.version>1.3.0</jib-maven-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <download-maven-plugin.version>1.4.1</download-maven-plugin.version>
     <git-commit-id-plugin.version>2.2.5</git-commit-id-plugin.version>

--- a/examples/ktor/build.gradle.kts
+++ b/examples/ktor/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     application
     kotlin("jvm") version "1.3.10"
-    id("com.google.cloud.tools.jib") version "1.2.0"
+    id("com.google.cloud.tools.jib") version "1.3.0"
 }
 
 group = "example"

--- a/examples/micronaut/build.gradle
+++ b/examples/micronaut/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'groovy'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
     id 'net.ltgt.apt-idea' version '0.18'
-    id 'com.google.cloud.tools.jib' version '1.2.0'
+    id 'com.google.cloud.tools.jib' version '1.3.0'
 }
 
 version '0.1'

--- a/examples/multi-module/build.gradle
+++ b/examples/multi-module/build.gradle
@@ -8,7 +8,7 @@ buildscript {
   dependencies {
     classpath 'org.springframework.boot:spring-boot-gradle-plugin:2.0.3.RELEASE'
     classpath 'io.spring.gradle:dependency-management-plugin:1.0.6.RELEASE'
-    classpath 'gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:1.2.0'
+    classpath 'gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:1.3.0'
   }
 }
 

--- a/examples/multi-module/pom.xml
+++ b/examples/multi-module/pom.xml
@@ -40,7 +40,7 @@
         <plugin>
           <groupId>com.google.cloud.tools</groupId>
           <artifactId>jib-maven-plugin</artifactId>
-          <version>1.2.0</version>
+          <version>1.3.0</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'idea'
     id 'org.springframework.boot' version '2.0.4.RELEASE'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
-    id 'com.google.cloud.tools.jib' version '1.2.0'
+    id 'com.google.cloud.tools.jib' version '1.3.0'
 }
 
 repositories {

--- a/examples/spring-boot/pom.xml
+++ b/examples/spring-boot/pom.xml
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>1.2.0</version>
+                <version>1.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/examples/vertx/build.gradle
+++ b/examples/vertx/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'io.vertx.vertx-plugin' version '0.1.0'
-    id 'com.google.cloud.tools.jib' version '1.2.0'
+    id 'com.google.cloud.tools.jib' version '1.3.0'
 }
 
 repositories {

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+### Changed
+
+### Fixed
+
+## 0.10.0
+
+### Added
+
 - `Containerizer#addEventHandler` for adding event handlers
 
 ### Changed
@@ -13,8 +21,6 @@ All notable changes to this project will be documented in this file.
 - Event handlers are now added directly to the `Containerizer` rather than adding them to an `EventHandlers` object first
 - Removed multiple classes to simplify the event system (`JibEventType`, `BuildStepType`, `EventDispatcher`, `DefaultEventDispatcher`, `LayerCountEvent`)
 - MainClassFinder now uses a static method instead of requiring instantiation
-
-### Fixed
 
 ## 0.9.2
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+### Fixed
+
+## 1.3.0
+
+### Changed
+
 - Docker credentials (`~/.docker/config.json`) are now given priority over registry-based inferred credential helpers ([#1704](https://github.com/GoogleContainerTools/jib/pulls/1704))
 
 ### Fixed

--- a/jib-gradle-plugin/README.md
+++ b/jib-gradle-plugin/README.md
@@ -42,7 +42,7 @@ In your Gradle Java project, add the plugin to your `build.gradle`:
 
 ```groovy
 plugins {
-  id 'com.google.cloud.tools.jib' version '1.2.0'
+  id 'com.google.cloud.tools.jib' version '1.3.0'
 }
 ```
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+### Fixed
+
+## 1.3.0
+
+### Changed
+
 - Docker credentials (`~/.docker/config.json`) are now given priority over registry-based inferred credential helpers ([#1704](https://github.com/GoogleContainerTools/jib/pulls/1704))
 
 ### Fixed

--- a/jib-maven-plugin/README.md
+++ b/jib-maven-plugin/README.md
@@ -37,7 +37,7 @@ For information about the project, see the [Jib project README](../README.md).
 You can containerize your application easily with one command:
 
 ```shell
-mvn compile com.google.cloud.tools:jib-maven-plugin:1.2.0:build -Dimage=<MY IMAGE>
+mvn compile com.google.cloud.tools:jib-maven-plugin:1.3.0:build -Dimage=<MY IMAGE>
 ```
 
 This builds and pushes a container image for your application to a container registry. *If you encounter authentication issues, see [Authentication Methods](#authentication-methods).*
@@ -45,7 +45,7 @@ This builds and pushes a container image for your application to a container reg
 To build to a Docker daemon, use:
 
 ```shell
-mvn compile com.google.cloud.tools:jib-maven-plugin:1.2.0:dockerBuild
+mvn compile com.google.cloud.tools:jib-maven-plugin:1.3.0:dockerBuild
 ```
 
 If you would like to set up Jib as part of your Maven build, follow the guide below.
@@ -63,7 +63,7 @@ In your Maven Java project, add the plugin to your `pom.xml`:
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
-        <version>1.2.0</version>
+        <version>1.3.0</version>
         <configuration>
           <to>
             <image>myimage</image>


### PR DESCRIPTION
Merge after release is done.

Note: jib-core 0.10.0 version changes are in https://github.com/GoogleContainerTools/jib/pull/1766