### PR TITLE
Update JavaContainerBuilder for multiple dep layers

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -6,8 +6,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
-- `JibContainerBuilder#addDependencies` is now split into three methods: `addDependencies`, `addSnapshotDependencies`, `addProjectDependneices` ([#1773](https://github.com/GoogleContainerTools/jib/pull/1773))
 
+- `JibContainerBuilder#addDependencies` is now split into three methods: `addDependencies`, `addSnapshotDependencies`, `addProjectDependencies` ([#1773](https://github.com/GoogleContainerTools/jib/pull/1773))
 
 ### Fixed
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
+- `JibContainerBuilder#addDependencies` is now split into three methods: `addDependencies`, `addSnapshotDependencies`, `addProjectDependneices` ([#1773](https://github.com/GoogleContainerTools/jib/pull/1773))
+
 
 ### Fixed
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JavaContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JavaContainerBuilder.java
@@ -273,7 +273,12 @@ public class JavaContainerBuilder {
   }
 
   /**
-   * Convenience alternative to {@link #addDependencies(List)}.
+   * Adds dependency JARs to the image. Duplicate JAR filenames across all dependencies are renamed
+   * with the filesize in order to avoid collisions.
+   *
+   * @param dependencyFiles the list of dependency JARs to add to the image
+   * @return this
+   * @throws IOException if adding the layer fails
    */
   public JavaContainerBuilder addDependencies(Path... dependencyFiles) throws IOException {
     return addDependencies(Arrays.asList(dependencyFiles));
@@ -295,19 +300,24 @@ public class JavaContainerBuilder {
       }
     }
     addedSnapshotDependencies.addAll(dependencyFiles);
-    classpathOrder.add(LayerType.DEPENDENCIES); // this is a single classpath entry will all deps
+    classpathOrder.add(LayerType.DEPENDENCIES); // this is a single classpath entry with all deps
     return this;
   }
 
   /**
-   * Convenience alternative to {@link #addSnapshotDependencies(List)}.
+   * Adds snapshot dependency JARs to the image. Duplicate JAR filenames across all dependencies are
+   * renamed with the filesize in order to avoid collisions.
+   *
+   * @param dependencyFiles the list of dependency JARs to add to the image
+   * @return this
+   * @throws IOException if adding the layer fails
    */
   public JavaContainerBuilder addSnapshotDependencies(Path... dependencyFiles) throws IOException {
     return addSnapshotDependencies(Arrays.asList(dependencyFiles));
   }
 
   /**
-   * Adds project dependency JARs to the image. Project dependency generally are jars produced from
+   * Adds project dependency JARs to the image. Generally, project dependency are jars produced from
    * source in this project as part of other modules/sub-projects. Duplicate JAR filenames across
    * all dependencies are renamed with the filesize in order to avoid collisions.
    *
@@ -323,12 +333,18 @@ public class JavaContainerBuilder {
       }
     }
     addedProjectDependencies.addAll(dependencyFiles);
-    classpathOrder.add(LayerType.DEPENDENCIES); // this is a single classpath entry will all deps
+    classpathOrder.add(LayerType.DEPENDENCIES); // this is a single classpath entry with all deps
     return this;
   }
 
   /**
-   * Convenience alternative to {@link #addProjectDependencies(List)}.
+   * Adds project dependency JARs to the image. Generally, project dependency are jars produced from
+   * source in this project as part of other modules/sub-projects. Duplicate JAR filenames across
+   * all dependencies are renamed with the filesize in order to avoid collisions.
+   *
+   * @param dependencyFiles the list of dependency JARs to add to the image
+   * @return this
+   * @throws IOException if adding the layer fails
    */
   public JavaContainerBuilder addProjectDependencies(Path... dependencyFiles) throws IOException {
     return addProjectDependencies(Arrays.asList(dependencyFiles));

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JavaContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JavaContainerBuilder.java
@@ -550,11 +550,10 @@ public class JavaContainerBuilder {
     for (LayerType layerType : layerMap.keySet()) {
       for (Path file : Preconditions.checkNotNull(layerMap.get(layerType))) {
         // handle duplicates by appending filesize to the end of the file
-        String jarName =
-            duplicates.contains(file.getFileName().toString())
-                ? file.getFileName().toString().replaceFirst("\\.jar$", "-" + Files.size(file))
-                    + ".jar"
-                : file.getFileName().toString();
+        String jarName = file.getFileName().toString();
+        if (duplicates.contains(jarName)) {
+          jarName = jarName.replaceFirst("\\.jar$", "-" + Files.size(file)) + ".jar";
+        }
         // Add dependencies to layer configuration
         addFileToLayer(
             layerBuilders,

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JavaContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JavaContainerBuilderTest.java
@@ -69,7 +69,7 @@ public class JavaContainerBuilderTest {
                 getResource("core/application/dependencies/dependency-1.0.0.jar"),
                 getResource("core/application/dependencies/more/dependency-1.0.0.jar"))
             .addSnapshotDependencies(
-              getResource("core/application/snapshot-dependencies/dependency-1.0.0-SNAPSHOT.jar"))
+                getResource("core/application/snapshot-dependencies/dependency-1.0.0-SNAPSHOT.jar"))
             .addProjectDependencies(
                 getResource("core/application/dependencies/libraryA.jar"),
                 getResource("core/application/dependencies/libraryB.jar"))
@@ -119,7 +119,8 @@ public class JavaContainerBuilderTest {
             AbsoluteUnixPath.get("/hello/different-libs/libraryA.jar"),
             AbsoluteUnixPath.get("/hello/different-libs/libraryB.jar"));
     Assert.assertEquals(
-        expectedProjectDependencies, getExtractionPaths(buildConfiguration, "project dependencies"));
+        expectedProjectDependencies,
+        getExtractionPaths(buildConfiguration, "project dependencies"));
 
     // Check resources
     List<AbsoluteUnixPath> expectedResources =

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JavaContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JavaContainerBuilderTest.java
@@ -67,10 +67,12 @@ public class JavaContainerBuilderTest {
             .addClasses(getResource("core/application/classes"))
             .addDependencies(
                 getResource("core/application/dependencies/dependency-1.0.0.jar"),
-                getResource("core/application/dependencies/more/dependency-1.0.0.jar"),
+                getResource("core/application/dependencies/more/dependency-1.0.0.jar"))
+            .addSnapshotDependencies(
+              getResource("core/application/snapshot-dependencies/dependency-1.0.0-SNAPSHOT.jar"))
+            .addProjectDependencies(
                 getResource("core/application/dependencies/libraryA.jar"),
-                getResource("core/application/dependencies/libraryB.jar"),
-                getResource("core/application/snapshot-dependencies/dependency-1.0.0-SNAPSHOT.jar"))
+                getResource("core/application/dependencies/libraryB.jar"))
             .addToClasspath(getResource("core/fileA"), getResource("core/fileB"))
             .setClassesDestination(RelativeUnixPath.get("different-classes"))
             .setResourcesDestination(RelativeUnixPath.get("different-resources"))
@@ -100,9 +102,7 @@ public class JavaContainerBuilderTest {
     List<AbsoluteUnixPath> expectedDependencies =
         ImmutableList.of(
             AbsoluteUnixPath.get("/hello/different-libs/dependency-1.0.0-770.jar"),
-            AbsoluteUnixPath.get("/hello/different-libs/dependency-1.0.0-200.jar"),
-            AbsoluteUnixPath.get("/hello/different-libs/libraryA.jar"),
-            AbsoluteUnixPath.get("/hello/different-libs/libraryB.jar"));
+            AbsoluteUnixPath.get("/hello/different-libs/dependency-1.0.0-200.jar"));
     Assert.assertEquals(
         expectedDependencies, getExtractionPaths(buildConfiguration, "dependencies"));
 
@@ -113,6 +113,13 @@ public class JavaContainerBuilderTest {
     Assert.assertEquals(
         expectedSnapshotDependencies,
         getExtractionPaths(buildConfiguration, "snapshot dependencies"));
+
+    List<AbsoluteUnixPath> expectedProjectDependencies =
+        ImmutableList.of(
+            AbsoluteUnixPath.get("/hello/different-libs/libraryA.jar"),
+            AbsoluteUnixPath.get("/hello/different-libs/libraryB.jar"));
+    Assert.assertEquals(
+        expectedProjectDependencies, getExtractionPaths(buildConfiguration, "project dependencies"));
 
     // Check resources
     List<AbsoluteUnixPath> expectedResources =
@@ -145,7 +152,7 @@ public class JavaContainerBuilderTest {
         JavaContainerBuilder.fromDistroless()
             .addDependencies(getResource("core/application/dependencies/libraryA.jar"))
             .addDependencies(getResource("core/application/dependencies/libraryB.jar"))
-            .addDependencies(
+            .addSnapshotDependencies(
                 getResource("core/application/snapshot-dependencies/dependency-1.0.0-SNAPSHOT.jar"))
             .addClasses(getResource("core/application/classes/"))
             .addClasses(getResource("core/class-finder-tests/extension"))

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -196,6 +196,15 @@ public class MavenProjectProperties implements ProjectProperties {
               project
                   .getArtifacts()
                   .stream()
+                  .filter(artifact -> !artifact.isSnapshot())
+                  .map(Artifact::getFile)
+                  .map(File::toPath)
+                  .collect(Collectors.toList()))
+          .addSnapshotDependencies(
+              project
+                  .getArtifacts()
+                  .stream()
+                  .filter(Artifact::isSnapshot)
                   .map(Artifact::getFile)
                   .map(File::toPath)
                   .collect(Collectors.toList()))

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelper.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelper.java
@@ -100,8 +100,6 @@ public class JavaContainerBuilderHelper {
               .filterRoot()
               .filter(path -> !path.getFileName().toString().contains("SNAPSHOT"))
               .walk());
-    }
-    if (Files.exists(webInfLib)) {
       javaContainerBuilder.addSnapshotDependencies(
           new DirectoryWalker(webInfLib)
               .filterRoot()

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelper.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelper.java
@@ -95,7 +95,18 @@ public class JavaContainerBuilderHelper {
       javaContainerBuilder.addClasses(webInfClasses, isClassFile);
     }
     if (Files.exists(webInfLib)) {
-      javaContainerBuilder.addDependencies(new DirectoryWalker(webInfLib).filterRoot().walk());
+      javaContainerBuilder.addDependencies(
+          new DirectoryWalker(webInfLib)
+              .filterRoot()
+              .filter(path -> !path.getFileName().toString().contains("SNAPSHOT"))
+              .walk());
+    }
+    if (Files.exists(webInfLib)) {
+      javaContainerBuilder.addSnapshotDependencies(
+          new DirectoryWalker(webInfLib)
+              .filterRoot()
+              .filter(path -> path.getFileName().toString().contains("SNAPSHOT"))
+              .walk());
     }
     return javaContainerBuilder.toContainerBuilder();
   }


### PR DESCRIPTION
This is part of #1724

This just redoes the previous behavior with a new API.

It does NOT cover: 
- "changing" dependencies marked in gradle
- "project/module" dependencies