### PR TITLE
Allow setting file timestamps from plugins (#1608)

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
@@ -295,7 +295,7 @@ public class ContainerizerIntegrationTest {
     new Command("docker", "load", "--input", outputPath.toString()).run();
     assertLayerSizer(7, "testtar");
     Assert.assertEquals(
-        "Hello, world. An argument.\n", new Command("docker", "run", "--rm", "testtar").run());
+        "Hello, world. An argument.\nc", new Command("docker", "run", "--rm", "testtar").run());
   }
 
   private JibContainer buildRegistryImage(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/FixedModificationTimeProvider.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/FixedModificationTimeProvider.java
@@ -1,0 +1,35 @@
+package com.google.cloud.tools.jib.api;
+
+import java.nio.file.Path;
+import java.time.Instant;
+
+/** Modification time provider which returns fixed instant */
+public class FixedModificationTimeProvider implements ModificationTimeProvider {
+
+  /** Default file modification time (EPOCH + 1 second). */
+  public static final Instant EPOCH_PLUS_ONE_SECOND = Instant.ofEpochSecond(1);
+
+  /** Fixed modification time * */
+  private final Instant modificationTime;
+
+  /**
+   * Initializes with a fixed modification time
+   *
+   * @param modificationTime fixed modification time
+   */
+  public FixedModificationTimeProvider(Instant modificationTime) {
+    this.modificationTime = modificationTime;
+  }
+
+  /**
+   * Returns preconfigured fixed modification time
+   *
+   * @param file path to file
+   * @param pathInContainer path to file in container
+   * @return preconfigured fixed modification time
+   */
+  @Override
+  public Instant getModificationTime(Path file, AbsoluteUnixPath pathInContainer) {
+    return modificationTime;
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/KeepOriginalModificationTimeProvider.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/KeepOriginalModificationTimeProvider.java
@@ -1,0 +1,26 @@
+package com.google.cloud.tools.jib.api;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+
+/** Modification time provider which returns original file modification time */
+public class KeepOriginalModificationTimeProvider implements ModificationTimeProvider {
+
+  /**
+   * Returns the original file modification time
+   *
+   * @param file path to file
+   * @param pathInContainer path to file in container
+   * @return the original file modification time
+   */
+  @Override
+  public Instant getModificationTime(Path file, AbsoluteUnixPath pathInContainer) {
+    try {
+      return Files.getLastModifiedTime(file).toInstant();
+    } catch (IOException e) {
+      throw new IllegalStateException("Unable to define the modification time of " + file);
+    }
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/LayerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/LayerConfiguration.java
@@ -20,10 +20,10 @@ import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Instant;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nullable;
 
 /** Configures how to build a layer in the container image. Instantiate with {@link #builder}. */
 public class LayerConfiguration {
@@ -77,10 +77,7 @@ public class LayerConfiguration {
      * @return this
      */
     public Builder addEntry(Path sourceFile, AbsoluteUnixPath pathInContainer) {
-      return addEntry(
-          sourceFile,
-          pathInContainer,
-          DEFAULT_FILE_PERMISSIONS_PROVIDER.apply(sourceFile, pathInContainer));
+      return addEntry(sourceFile, pathInContainer, null, null);
     }
 
     /**
@@ -92,30 +89,7 @@ public class LayerConfiguration {
      * @param pathInContainer the path in the container file system corresponding to the {@code
      *     sourceFile}
      * @param permissions the file permissions on the container
-     * @return this
-     * @see Builder#addEntry(Path, AbsoluteUnixPath)
-     * @see FilePermissions#DEFAULT_FILE_PERMISSIONS
-     * @see FilePermissions#DEFAULT_FOLDER_PERMISSIONS
-     */
-    public Builder addEntry(
-        Path sourceFile, AbsoluteUnixPath pathInContainer, FilePermissions permissions) {
-      return addEntry(
-          sourceFile,
-          pathInContainer,
-          permissions,
-          DEFAULT_MODIFIED_TIME_PROVIDER.apply(sourceFile, pathInContainer));
-    }
-
-    /**
-     * Adds an entry to the layer with the given permissions. Only adds the single source file to
-     * the exact path in the container file system. See {@link Builder#addEntry(Path,
-     * AbsoluteUnixPath)} for more information.
-     *
-     * @param sourceFile the source file to add to the layer
-     * @param pathInContainer the path in the container file system corresponding to the {@code
-     *     sourceFile}
-     * @param permissions the file permissions on the container
-     * @param lastModifiedTime the file modification timestamp
+     * @param modificationTimeProvider modification time provider
      * @return this
      * @see Builder#addEntry(Path, AbsoluteUnixPath)
      * @see FilePermissions#DEFAULT_FILE_PERMISSIONS
@@ -124,9 +98,19 @@ public class LayerConfiguration {
     public Builder addEntry(
         Path sourceFile,
         AbsoluteUnixPath pathInContainer,
-        FilePermissions permissions,
-        Instant lastModifiedTime) {
-      return addEntry(new LayerEntry(sourceFile, pathInContainer, permissions, lastModifiedTime));
+        @Nullable FilePermissions permissions,
+        @Nullable ModificationTimeProvider modificationTimeProvider) {
+      return addEntry(
+          new LayerEntry(
+              sourceFile,
+              pathInContainer,
+              permissions == null
+                  ? DEFAULT_FILE_PERMISSIONS_PROVIDER.apply(sourceFile, pathInContainer)
+                  : permissions,
+              modificationTimeProvider == null
+                  ? DEFAULT_FILE_MODIFICATION_TIME_PROVIDER.getModificationTime(
+                      sourceFile, pathInContainer)
+                  : modificationTimeProvider.getModificationTime(sourceFile, pathInContainer)));
     }
 
     /**
@@ -146,28 +130,11 @@ public class LayerConfiguration {
      */
     public Builder addEntryRecursive(Path sourceFile, AbsoluteUnixPath pathInContainer)
         throws IOException {
-      return addEntryRecursive(sourceFile, pathInContainer, DEFAULT_FILE_PERMISSIONS_PROVIDER);
-    }
-
-    /**
-     * Adds an entry to the layer. If the source file is a directory, the directory and its contents
-     * will be added recursively.
-     *
-     * @param sourceFile the source file to add to the layer recursively
-     * @param pathInContainer the path in the container file system corresponding to the {@code
-     *     sourceFile}
-     * @param filePermissionProvider a provider that takes a source path and destination path on the
-     *     container and returns the file permissions that should be set for that path
-     * @return this
-     * @throws IOException if an exception occurred when recursively listing the directory
-     */
-    public Builder addEntryRecursive(
-        Path sourceFile,
-        AbsoluteUnixPath pathInContainer,
-        BiFunction<Path, AbsoluteUnixPath, FilePermissions> filePermissionProvider)
-        throws IOException {
       return addEntryRecursive(
-          sourceFile, pathInContainer, filePermissionProvider, DEFAULT_MODIFIED_TIME_PROVIDER);
+          sourceFile,
+          pathInContainer,
+          DEFAULT_FILE_PERMISSIONS_PROVIDER,
+          DEFAULT_FILE_MODIFICATION_TIME_PROVIDER);
     }
 
     /**
@@ -179,8 +146,7 @@ public class LayerConfiguration {
      *     sourceFile}
      * @param filePermissionProvider a provider that takes a source path and destination path on the
      *     container and returns the file permissions that should be set for that path
-     * @param lastModifiedTimeProvider a provider that takes a source path and destination path on
-     *     the container and returns the file modification time that should be set for that path
+     * @param modificationTimeProvider modification time provider
      * @return this
      * @throws IOException if an exception occurred when recursively listing the directory
      */
@@ -188,11 +154,10 @@ public class LayerConfiguration {
         Path sourceFile,
         AbsoluteUnixPath pathInContainer,
         BiFunction<Path, AbsoluteUnixPath, FilePermissions> filePermissionProvider,
-        BiFunction<Path, AbsoluteUnixPath, Instant> lastModifiedTimeProvider)
+        ModificationTimeProvider modificationTimeProvider)
         throws IOException {
       FilePermissions permissions = filePermissionProvider.apply(sourceFile, pathInContainer);
-      Instant modifiedTime = lastModifiedTimeProvider.apply(sourceFile, pathInContainer);
-      addEntry(sourceFile, pathInContainer, permissions, modifiedTime);
+      addEntry(sourceFile, pathInContainer, permissions, modificationTimeProvider);
       if (!Files.isDirectory(sourceFile)) {
         return this;
       }
@@ -202,7 +167,7 @@ public class LayerConfiguration {
               file,
               pathInContainer.resolve(file.getFileName()),
               filePermissionProvider,
-              lastModifiedTimeProvider);
+              modificationTimeProvider);
         }
       }
       return this;
@@ -226,12 +191,9 @@ public class LayerConfiguration {
                   ? FilePermissions.DEFAULT_FOLDER_PERMISSIONS
                   : FilePermissions.DEFAULT_FILE_PERMISSIONS;
 
-  /** Default file modification time (EPOCH + 1 second). */
-  public static final Instant DEFAULT_MODIFIED_TIME = Instant.ofEpochSecond(1);
-
   /** Provider that returns default file modification time (EPOCH + 1 second). */
-  public static final BiFunction<Path, AbsoluteUnixPath, Instant> DEFAULT_MODIFIED_TIME_PROVIDER =
-      (sourcePath, destinationPath) -> DEFAULT_MODIFIED_TIME;
+  private static final ModificationTimeProvider DEFAULT_FILE_MODIFICATION_TIME_PROVIDER =
+      new FixedModificationTimeProvider(FixedModificationTimeProvider.EPOCH_PLUS_ONE_SECOND);
 
   /**
    * Gets a new {@link Builder} for {@link LayerConfiguration}.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/ModificationTimeProvider.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/ModificationTimeProvider.java
@@ -1,0 +1,23 @@
+package com.google.cloud.tools.jib.api;
+
+import java.nio.file.Path;
+import java.time.Instant;
+
+/** Files modification time provider * */
+public interface ModificationTimeProvider {
+
+  /** ID of provider which keeps files original modification times */
+  String KEEP_ORIGINAL = "keep_original";
+
+  /** ID of provider which trims files modification time to (EPOCH + 1 second) */
+  String EPOCH_PLUS_SECOND = "epoch_plus_second";
+
+  /**
+   * Returns modification time for a specific file
+   *
+   * @param file path to file
+   * @param pathInContainer path to file in container
+   * @return file modification time
+   */
+  Instant getModificationTime(Path file, AbsoluteUnixPath pathInContainer);
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.jib.image;
 
-import com.google.cloud.tools.jib.api.LayerConfiguration;
+import com.google.cloud.tools.jib.api.FixedModificationTimeProvider;
 import com.google.cloud.tools.jib.api.LayerEntry;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.Blobs;
@@ -59,7 +59,7 @@ public class ReproducibleLayerBuilder {
     /**
      * Adds a {@link TarArchiveEntry} if its extraction path does not exist yet. Also adds all of
      * the parent directories on the extraction path, if the parent does not exist. Parent will have
-     * modified time to set to {@link LayerConfiguration#DEFAULT_MODIFIED_TIME}.
+     * modified time to set to {@link FixedModificationTimeProvider#EPOCH_PLUS_ONE_SECOND}.
      *
      * @param tarArchiveEntry the {@link TarArchiveEntry}
      */
@@ -73,7 +73,7 @@ public class ReproducibleLayerBuilder {
       Path namePath = Paths.get(tarArchiveEntry.getName());
       if (namePath.getParent() != namePath.getRoot()) {
         TarArchiveEntry dir = new TarArchiveEntry(DIRECTORY_FILE, namePath.getParent().toString());
-        dir.setModTime(LayerConfiguration.DEFAULT_MODIFIED_TIME.toEpochMilli());
+        dir.setModTime(FixedModificationTimeProvider.EPOCH_PLUS_ONE_SECOND.toEpochMilli());
         add(dir);
       }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/LayerConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/LayerConfigurationTest.java
@@ -35,7 +35,7 @@ public class LayerConfigurationTest {
         source,
         destination,
         LayerConfiguration.DEFAULT_FILE_PERMISSIONS_PROVIDER.apply(source, destination),
-        LayerConfiguration.DEFAULT_MODIFIED_TIME);
+        FixedModificationTimeProvider.EPOCH_PLUS_ONE_SECOND);
   }
 
   @Test
@@ -81,7 +81,7 @@ public class LayerConfigurationTest {
     BiFunction<Path, AbsoluteUnixPath, FilePermissions> permissionsProvider =
         (source, destination) ->
             destination.toString().startsWith("/app/layer/a") ? permissions1 : permissions2;
-    BiFunction<Path, AbsoluteUnixPath, Instant> timestampProvider =
+    ModificationTimeProvider timestampProvider =
         (source, destination) ->
             destination.toString().startsWith("/app/layer/a") ? timestamp1 : timestamp2;
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.cache;
 
 import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
+import com.google.cloud.tools.jib.api.FixedModificationTimeProvider;
 import com.google.cloud.tools.jib.api.LayerConfiguration;
 import com.google.cloud.tools.jib.api.LayerEntry;
 import com.google.cloud.tools.jib.blob.Blob;
@@ -99,7 +100,7 @@ public class CacheTest {
         source,
         destination,
         LayerConfiguration.DEFAULT_FILE_PERMISSIONS_PROVIDER.apply(source, destination),
-        LayerConfiguration.DEFAULT_MODIFIED_TIME);
+        FixedModificationTimeProvider.EPOCH_PLUS_ONE_SECOND);
   }
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/LayerEntriesSelectorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/LayerEntriesSelectorTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.cache;
 import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.FilePermissions;
+import com.google.cloud.tools.jib.api.FixedModificationTimeProvider;
 import com.google.cloud.tools.jib.api.LayerConfiguration;
 import com.google.cloud.tools.jib.api.LayerEntry;
 import com.google.cloud.tools.jib.cache.LayerEntriesSelector.LayerEntryTemplate;
@@ -44,7 +45,7 @@ public class LayerEntriesSelectorTest {
         source,
         destination,
         LayerConfiguration.DEFAULT_FILE_PERMISSIONS_PROVIDER.apply(source, destination),
-        LayerConfiguration.DEFAULT_MODIFIED_TIME);
+        FixedModificationTimeProvider.EPOCH_PLUS_ONE_SECOND);
   }
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -75,7 +76,7 @@ public class LayerEntriesSelectorTest {
             file3,
             AbsoluteUnixPath.get("/extraction/path"),
             FilePermissions.fromOctalString("755"),
-            LayerConfiguration.DEFAULT_MODIFIED_TIME);
+            FixedModificationTimeProvider.EPOCH_PLUS_ONE_SECOND);
     LayerEntry testLayerEntry5 =
         defaultLayerEntry(file3, AbsoluteUnixPath.get("/extraction/patha"));
     LayerEntry testLayerEntry6 =
@@ -83,7 +84,7 @@ public class LayerEntriesSelectorTest {
             file3,
             AbsoluteUnixPath.get("/extraction/patha"),
             FilePermissions.fromOctalString("755"),
-            LayerConfiguration.DEFAULT_MODIFIED_TIME);
+            FixedModificationTimeProvider.EPOCH_PLUS_ONE_SECOND);
 
     outOfOrderLayerEntries =
         ImmutableList.of(
@@ -161,13 +162,13 @@ public class LayerEntriesSelectorTest {
             layerFile,
             AbsoluteUnixPath.get("/extraction/path"),
             FilePermissions.fromOctalString("111"),
-            LayerConfiguration.DEFAULT_MODIFIED_TIME);
+            FixedModificationTimeProvider.EPOCH_PLUS_ONE_SECOND);
     LayerEntry layerEntry222 =
         new LayerEntry(
             layerFile,
             AbsoluteUnixPath.get("/extraction/path"),
             FilePermissions.fromOctalString("222"),
-            LayerConfiguration.DEFAULT_MODIFIED_TIME);
+            FixedModificationTimeProvider.EPOCH_PLUS_ONE_SECOND);
 
     // Verify that changing permissions generates a different selector
     Assert.assertNotEquals(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.image;
 
 import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.FilePermissions;
+import com.google.cloud.tools.jib.api.FixedModificationTimeProvider;
 import com.google.cloud.tools.jib.api.LayerConfiguration;
 import com.google.cloud.tools.jib.api.LayerEntry;
 import com.google.cloud.tools.jib.blob.Blob;
@@ -97,7 +98,7 @@ public class ReproducibleLayerBuilderTest {
         source,
         destination,
         LayerConfiguration.DEFAULT_FILE_PERMISSIONS_PROVIDER.apply(source, destination),
-        LayerConfiguration.DEFAULT_MODIFIED_TIME);
+        FixedModificationTimeProvider.EPOCH_PLUS_ONE_SECOND);
   }
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -334,12 +335,12 @@ public class ReproducibleLayerBuilderTest {
                         fileB,
                         AbsoluteUnixPath.get("/somewhere/fileB"),
                         FilePermissions.fromOctalString("123"),
-                        LayerConfiguration.DEFAULT_MODIFIED_TIME),
+                        Instant.ofEpochSecond(1)),
                     new LayerEntry(
                         folder,
                         AbsoluteUnixPath.get("/somewhere/folder"),
                         FilePermissions.fromOctalString("456"),
-                        LayerConfiguration.DEFAULT_MODIFIED_TIME)))
+                        Instant.ofEpochSecond(1))))
             .build();
 
     Path tarFile = temporaryFolder.newFile().toPath();

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.gradle;
 
 import com.google.cloud.tools.jib.api.ImageFormat;
+import com.google.cloud.tools.jib.api.ModificationTimeProvider;
 import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.common.base.Preconditions;
@@ -47,6 +48,7 @@ public class ContainerParameters {
   private String appRoot = "";
   @Nullable private String user;
   @Nullable private String workingDirectory;
+  private String filesModificationTimeProvider = ModificationTimeProvider.EPOCH_PLUS_SECOND;
 
   @Input
   @Optional
@@ -246,5 +248,18 @@ public class ContainerParameters {
 
   public void setWorkingDirectory(String workingDirectory) {
     this.workingDirectory = workingDirectory;
+  }
+
+  @Input
+  @Optional
+  public String getFilesModificationTimeProvider() {
+    if (System.getProperty(PropertyNames.CONTAINER_FILES_MODIFICATION_TIME) != null) {
+      return System.getProperty(PropertyNames.CONTAINER_FILES_MODIFICATION_TIME);
+    }
+    return filesModificationTimeProvider;
+  }
+
+  public void setFilesModificationTimeProvider(String filesModificationTimeProvider) {
+    this.filesModificationTimeProvider = filesModificationTimeProvider;
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoriesParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoriesParameters.java
@@ -38,6 +38,7 @@ public class ExtraDirectoriesParameters {
 
   private List<Path> paths;
   private Map<String, String> permissions = Collections.emptyMap();
+  private Map<String, String> modificationTimes = Collections.emptyMap();
 
   @Inject
   public ExtraDirectoriesParameters(Project project, JibExtension jibExtension) {
@@ -107,5 +108,25 @@ public class ExtraDirectoriesParameters {
 
   public void setPermissions(Map<String, String> permissions) {
     this.permissions = permissions;
+  }
+
+  /**
+   * Gets the modification times for files in the extra layer on the container. Maps from absolute
+   * path on the container to a modification time provider type (e.g. {@code "/path/on/container" ->
+   * "keep_original"}).
+   *
+   * @return the permissions map from path on container to file permissions
+   */
+  @Input
+  public Map<String, String> getModificationTimes() {
+    String property = System.getProperty(PropertyNames.EXTRA_DIRECTORIES_MODIFICATION_TIMES);
+    if (property != null) {
+      return ConfigurationPropertyValidator.parseMapProperty(property);
+    }
+    return modificationTimes;
+  }
+
+  public void setModificationTimes(Map<String, String> modificationTimes) {
+    this.modificationTimes = modificationTimes;
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.api.Containerizer;
 import com.google.cloud.tools.jib.api.JavaContainerBuilder;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.api.ModificationTimeProvider;
 import com.google.cloud.tools.jib.api.RegistryImage;
 import com.google.cloud.tools.jib.event.events.ProgressEvent;
 import com.google.cloud.tools.jib.event.events.TimerEvent;
@@ -128,9 +129,14 @@ class GradleProjectProperties implements ProjectProperties {
 
   @Override
   public JibContainerBuilder createContainerBuilder(
-      RegistryImage baseImage, AbsoluteUnixPath appRoot, ContainerizingMode containerizingMode) {
+      RegistryImage baseImage,
+      AbsoluteUnixPath appRoot,
+      ContainerizingMode containerizingMode,
+      ModificationTimeProvider modificationTimeProvider) {
     JavaContainerBuilder javaContainerBuilder =
-        JavaContainerBuilder.from(baseImage).setAppRoot(appRoot);
+        JavaContainerBuilder.from(baseImage)
+            .setAppRoot(appRoot)
+            .setModificationTimeProvider(modificationTimeProvider);
 
     try {
       if (isWarProject()) {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -151,6 +151,11 @@ class GradleRawConfiguration implements RawConfiguration {
   }
 
   @Override
+  public String getFilesModificationTime() {
+    return jibExtension.getContainer().getFilesModificationTimeProvider();
+  }
+
+  @Override
   public List<Path> getExtraDirectories() {
     return jibExtension.getExtraDirectories().getPaths();
   }
@@ -158,6 +163,12 @@ class GradleRawConfiguration implements RawConfiguration {
   @Override
   public Map<AbsoluteUnixPath, FilePermissions> getExtraDirectoryPermissions() {
     return TaskCommon.convertPermissionsMap(jibExtension.getExtraDirectories().getPermissions());
+  }
+
+  @Override
+  public Map<AbsoluteUnixPath, String> getExtraDirectoryModificationTimes() {
+    return TaskCommon.convertModificationTimesMap(
+        jibExtension.getExtraDirectories().getModificationTimes());
   }
 
   @Override

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -101,5 +101,22 @@ class TaskCommon {
     return permissionsMap;
   }
 
+  /**
+   * Validates and converts a {@code String->String}
+   * file-path-to-file-modification-time-provider-type map to an equivalent {@code
+   * AbsoluteUnixPath->String} map.
+   *
+   * @param stringMap the map to convert (example entry: {@code "/path/on/container" -> "755"})
+   * @return the converted map
+   */
+  static Map<AbsoluteUnixPath, String> convertModificationTimesMap(Map<String, String> stringMap) {
+    Map<AbsoluteUnixPath, String> modificationTimesMap = new HashMap<>();
+    for (Map.Entry<String, String> entry : stringMap.entrySet()) {
+      AbsoluteUnixPath key = AbsoluteUnixPath.get(entry.getKey());
+      modificationTimesMap.put(key, entry.getValue());
+    }
+    return modificationTimesMap;
+  }
+
   private TaskCommon() {}
 }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.Containerizer;
 import com.google.cloud.tools.jib.api.FilePermissions;
+import com.google.cloud.tools.jib.api.FixedModificationTimeProvider;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.JavaContainerBuilder;
 import com.google.cloud.tools.jib.api.JavaContainerBuilder.LayerType;
@@ -366,7 +367,8 @@ public class GradleProjectPropertiesTest {
     gradleProjectProperties.createContainerBuilder(
         RegistryImage.named("base"),
         AbsoluteUnixPath.get("/anything"),
-        DEFAULT_CONTAINERIZING_MODE);
+        DEFAULT_CONTAINERIZING_MODE,
+        new FixedModificationTimeProvider(FixedModificationTimeProvider.EPOCH_PLUS_ONE_SECOND));
     Mockito.verify(mockLogger).warn("No classes files were found - did you compile your project?");
   }
 
@@ -560,7 +562,9 @@ public class GradleProjectPropertiesTest {
             .createContainerBuilder(
                 RegistryImage.named("base"),
                 AbsoluteUnixPath.get(appRoot),
-                DEFAULT_CONTAINERIZING_MODE);
+                DEFAULT_CONTAINERIZING_MODE,
+                new FixedModificationTimeProvider(
+                    FixedModificationTimeProvider.EPOCH_PLUS_ONE_SECOND));
     return JibContainerBuilderTestHelper.toBuildConfiguration(
         jibContainerBuilder,
         Containerizer.to(RegistryImage.named("to"))

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -59,6 +59,7 @@ public class JibExtensionTest {
     System.clearProperty("jib.extraDirectory.permissions");
     System.clearProperty("jib.extraDirectories.paths");
     System.clearProperty("jib.extraDirectories.permissions");
+    System.clearProperty("jib.extraDirectories.modificationTimes");
   }
 
   @Before
@@ -191,6 +192,8 @@ public class JibExtensionTest {
         extraDirectories -> {
           extraDirectories.setPaths("test/path");
           extraDirectories.setPermissions(ImmutableMap.of("file1", "123", "file2", "456"));
+          extraDirectories.setModificationTimes(
+              ImmutableMap.of("file1", "epoch_plus_second", "file2", "keep_original"));
         });
     Assert.assertFalse(testJibExtension.extraDirectoryConfigured);
     Assert.assertTrue(testJibExtension.extraDirectoriesConfigured);
@@ -201,6 +204,9 @@ public class JibExtensionTest {
     Assert.assertEquals(
         ImmutableMap.of("file1", "123", "file2", "456"),
         testJibExtension.getExtraDirectories().getPermissions());
+    Assert.assertEquals(
+        ImmutableMap.of("file1", "epoch_plus_second", "file2", "keep_original"),
+        testJibExtension.getExtraDirectories().getModificationTimes());
   }
 
   @Test
@@ -304,6 +310,11 @@ public class JibExtensionTest {
     Assert.assertEquals(
         ImmutableMap.of("/foo/bar", "707", "/baz", "456"),
         testJibExtension.getExtraDirectories().getPermissions());
+    System.setProperty(
+        "jib.extraDirectories.modificationTimes", "/foo/bar=epoch_plus_second,/baz=keep_original");
+    Assert.assertEquals(
+        ImmutableMap.of("/foo/bar", "epoch_plus_second", "/baz", "keep_original"),
+        testJibExtension.getExtraDirectories().getModificationTimes());
   }
 
   @Test

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.api.Containerizer;
 import com.google.cloud.tools.jib.api.JavaContainerBuilder;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.api.ModificationTimeProvider;
 import com.google.cloud.tools.jib.api.RegistryImage;
 import com.google.cloud.tools.jib.event.events.ProgressEvent;
 import com.google.cloud.tools.jib.event.events.TimerEvent;
@@ -178,10 +179,15 @@ public class MavenProjectProperties implements ProjectProperties {
 
   @Override
   public JibContainerBuilder createContainerBuilder(
-      RegistryImage baseImage, AbsoluteUnixPath appRoot, ContainerizingMode containerizingMode)
+      RegistryImage baseImage,
+      AbsoluteUnixPath appRoot,
+      ContainerizingMode containerizingMode,
+      ModificationTimeProvider modificationTimeProvider)
       throws IOException {
     JavaContainerBuilder javaContainerBuilder =
-        JavaContainerBuilder.from(baseImage).setAppRoot(appRoot);
+        JavaContainerBuilder.from(baseImage)
+            .setAppRoot(appRoot)
+            .setModificationTimeProvider(modificationTimeProvider);
 
     try {
       if (isWarProject()) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
@@ -156,6 +156,11 @@ class MavenRawConfiguration implements RawConfiguration {
   }
 
   @Override
+  public String getFilesModificationTime() {
+    return jibPluginConfiguration.getFilesModificationTime();
+  }
+
+  @Override
   public List<Path> getExtraDirectories() {
     return MojoCommon.getExtraDirectories(jibPluginConfiguration);
   }
@@ -163,6 +168,12 @@ class MavenRawConfiguration implements RawConfiguration {
   @Override
   public Map<AbsoluteUnixPath, FilePermissions> getExtraDirectoryPermissions() {
     return MojoCommon.convertPermissionsList(jibPluginConfiguration.getExtraDirectoryPermissions());
+  }
+
+  @Override
+  public Map<AbsoluteUnixPath, String> getExtraDirectoryModificationTimes() {
+    return MojoCommon.convertModificationTimesList(
+        jibPluginConfiguration.getExtraDirectoryModificationTimes());
   }
 
   @Override

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.FilePermissions;
+import com.google.cloud.tools.jib.maven.JibPluginConfiguration.ModificationTimeConfiguration;
 import com.google.cloud.tools.jib.maven.JibPluginConfiguration.PermissionConfiguration;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -70,6 +71,28 @@ class MojoCommon {
       permissionsMap.put(key, value);
     }
     return permissionsMap;
+  }
+
+  /**
+   * Validates and converts a list of {@link ModificationTimeConfiguration} to an equivalent {@code
+   * AbsoluteUnixPath->String} map.
+   *
+   * @param modificationTimesList the list to convert
+   * @return the resulting map
+   */
+  @VisibleForTesting
+  static Map<AbsoluteUnixPath, String> convertModificationTimesList(
+      List<ModificationTimeConfiguration> modificationTimesList) {
+    Map<AbsoluteUnixPath, String> providersMap = new HashMap<>();
+    for (ModificationTimeConfiguration modificationTime : modificationTimesList) {
+      if (!modificationTime.getFile().isPresent() || !modificationTime.getValue().isPresent()) {
+        throw new IllegalArgumentException(
+            "Incomplete <modificationTime> configuration; requires <file> and <value> fields to be set");
+      }
+      AbsoluteUnixPath key = AbsoluteUnixPath.get(modificationTime.getFile().get());
+      providersMap.put(key, modificationTime.getValue().get());
+    }
+    return providersMap;
   }
 
   private MojoCommon() {}

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
@@ -103,7 +103,7 @@ public class BuildDockerMojoIntegrationTest {
 
     Instant before = Instant.now();
     Assert.assertEquals(
-        "Hello, world. An argument.\nrw-r--r--\nrw-r--r--\nfoo\ncat\n",
+        "Hello, world. An argument.\n1970-01-01T00:00:01Z\nrw-r--r--\nrw-r--r--\nfoo\ncat\n1970-01-01T00:00:01Z\n1970-01-01T00:00:01Z\n",
         buildToDockerDaemonAndRun(simpleTestProject.getProjectRoot(), targetImage));
     Instant buildTime =
         Instant.parse(
@@ -149,7 +149,7 @@ public class BuildDockerMojoIntegrationTest {
   public void testExecute_defaultTarget()
       throws VerificationException, IOException, InterruptedException, DigestException {
     Assert.assertEquals(
-        "Hello, world. An argument.\n",
+        "Hello, world. An argument.\n1970-01-01T00:00:01Z\n",
         buildToDockerDaemonAndRun(
             defaultTargetTestProject.getProjectRoot(),
             "default-target-name:default-target-version"));
@@ -191,7 +191,8 @@ public class BuildDockerMojoIntegrationTest {
     buildToDockerDaemon(
         simpleTestProject.getProjectRoot(), "image reference ignored", "pom-no-to-image.xml");
     Assert.assertEquals(
-        "Hello, world. \n", new Command("docker", "run", "--rm", "my-artifact-id:1").run());
+        "Hello, world. \n1970-01-01T00:00:01Z\n",
+        new Command("docker", "run", "--rm", "my-artifact-id:1").run());
   }
 
   @Test

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
@@ -70,7 +70,7 @@ public class BuildTarMojoIntegrationTest {
                 .toString())
         .run();
     Assert.assertEquals(
-        "Hello, world. An argument.\nrw-r--r--\nrw-r--r--\nfoo\ncat\n",
+        "Hello, world. An argument.\n1970-01-01T00:00:01Z\nrw-r--r--\nrw-r--r--\nfoo\ncat\n1970-01-01T00:00:01Z\n1970-01-01T00:00:01Z\n",
         new Command("docker", "run", "--rm", targetImage).run());
 
     Instant buildTime =

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
@@ -120,6 +120,8 @@ public class JibPluginConfigurationTest {
     Assert.assertEquals("myUser", testPluginConfiguration.getUser());
     sessionProperties.put("jib.container.workingDirectory", "working directory");
     Assert.assertEquals("working directory", testPluginConfiguration.getWorkingDirectory());
+    sessionProperties.put("jib.container.filesModificationTime", "keep_original");
+    Assert.assertEquals("keep_original", testPluginConfiguration.getFilesModificationTime());
     sessionProperties.put("jib.container.extraClasspath", "/foo,/bar");
     Assert.assertEquals(
         ImmutableList.of("/foo", "/bar"), testPluginConfiguration.getExtraClasspath());
@@ -136,6 +138,15 @@ public class JibPluginConfigurationTest {
     Assert.assertEquals("123", permissions.get(0).getMode().get());
     Assert.assertEquals("/another/file", permissions.get(1).getFile().get());
     Assert.assertEquals("456", permissions.get(1).getMode().get());
+    sessionProperties.put(
+        "jib.extraDirectories.modificationTimes",
+        "/test/file1=epoch_plus_second,/another/file=keep_original");
+    List<JibPluginConfiguration.ModificationTimeConfiguration> modificationTimes =
+        testPluginConfiguration.getExtraDirectoryModificationTimes();
+    Assert.assertEquals("/test/file1", modificationTimes.get(0).getFile().get());
+    Assert.assertEquals("epoch_plus_second", modificationTimes.get(0).getValue().get());
+    Assert.assertEquals("/another/file", modificationTimes.get(1).getFile().get());
+    Assert.assertEquals("keep_original", modificationTimes.get(1).getValue().get());
   }
 
   @Test
@@ -187,6 +198,8 @@ public class JibPluginConfigurationTest {
     Assert.assertEquals("myUser", testPluginConfiguration.getUser());
     project.getProperties().setProperty("jib.container.workingDirectory", "working directory");
     Assert.assertEquals("working directory", testPluginConfiguration.getWorkingDirectory());
+    project.getProperties().setProperty("jib.container.filesModificationTime", "keep_original");
+    Assert.assertEquals("keep_original", testPluginConfiguration.getFilesModificationTime());
     project.getProperties().setProperty("jib.container.extraClasspath", "/foo,/bar");
     Assert.assertEquals(
         ImmutableList.of("/foo", "/bar"), testPluginConfiguration.getExtraClasspath());
@@ -205,6 +218,17 @@ public class JibPluginConfigurationTest {
     Assert.assertEquals("123", permissions.get(0).getMode().get());
     Assert.assertEquals("/another/file", permissions.get(1).getFile().get());
     Assert.assertEquals("456", permissions.get(1).getMode().get());
+    project
+        .getProperties()
+        .setProperty(
+            "jib.extraDirectories.modificationTimes",
+            "/test/file1=epoch_plus_second,/another/file=keep_original");
+    List<JibPluginConfiguration.ModificationTimeConfiguration> modificationTimes =
+        testPluginConfiguration.getExtraDirectoryModificationTimes();
+    Assert.assertEquals("/test/file1", modificationTimes.get(0).getFile().get());
+    Assert.assertEquals("epoch_plus_second", modificationTimes.get(0).getValue().get());
+    Assert.assertEquals("/another/file", modificationTimes.get(1).getFile().get());
+    Assert.assertEquals("keep_original", modificationTimes.get(1).getValue().get());
   }
 
   @Test

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.maven;
 import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.Containerizer;
+import com.google.cloud.tools.jib.api.FixedModificationTimeProvider;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.JavaContainerBuilder.LayerType;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
@@ -613,7 +614,11 @@ public class MavenProjectPropertiesTest {
     JibContainerBuilder JibContainerBuilder =
         new MavenProjectProperties(mockMavenProject, mockMavenSession, mockLog)
             .createContainerBuilder(
-                RegistryImage.named("base"), AbsoluteUnixPath.get(appRoot), containerizingMode);
+                RegistryImage.named("base"),
+                AbsoluteUnixPath.get(appRoot),
+                containerizingMode,
+                new FixedModificationTimeProvider(
+                    FixedModificationTimeProvider.EPOCH_PLUS_ONE_SECOND));
     return JibContainerBuilderTestHelper.toBuildConfiguration(
         JibContainerBuilder,
         Containerizer.to(RegistryImage.named("to"))

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenRawConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenRawConfigurationTest.java
@@ -75,6 +75,7 @@ public class MavenRawConfigurationTest {
         .thenReturn(new HashSet<>(Arrays.asList("additional", "tags")));
     Mockito.when(jibPluginConfiguration.getUseCurrentTimestamp()).thenReturn(true);
     Mockito.when(jibPluginConfiguration.getUser()).thenReturn("admin:wheel");
+    Mockito.when(jibPluginConfiguration.getFilesModificationTime()).thenReturn("keep_original");
 
     MavenRawConfiguration rawConfiguration = new MavenRawConfiguration(jibPluginConfiguration);
 
@@ -102,6 +103,7 @@ public class MavenRawConfigurationTest {
         new HashSet<>(Arrays.asList("additional", "tags")), rawConfiguration.getToTags());
     Assert.assertTrue(rawConfiguration.getUseCurrentTimestamp());
     Assert.assertEquals("admin:wheel", rawConfiguration.getUser().get());
+    Assert.assertEquals("keep_original", rawConfiguration.getFilesModificationTime());
 
     Mockito.verifyNoMoreInteractions(eventHandlers);
   }

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex-files-modification-time-custom.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex-files-modification-time-custom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.test</groupId>
+  <artifactId>hello-world</artifactId>
+  <version>1</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.test</groupId>
+      <artifactId>dependency</artifactId>
+      <version>1.0.0</version>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/libs/dependency-1.0.0.jar</systemPath>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>${jib-maven-plugin.version}</version>
+        <configuration>
+          <from>
+            <image>localhost:5000/distroless/java</image>
+            <auth>
+              <username>testuser</username>
+              <password>testpassword</password>
+            </auth>
+          </from>
+          <to>
+            <image>${_TARGET_IMAGE}</image>
+            <auth>
+              <username>${_TARGET_USERNAME}</username>
+              <password>${_TARGET_PASSWORD}</password>
+            </auth>
+          </to>
+          <container>
+            <useCurrentTimestamp>true</useCurrentTimestamp>
+            <filesModificationTime>2019-06-17T16:30:00Z</filesModificationTime>
+            <args>
+              <arg>An argument.</arg>
+            </args>
+            <mainClass>com.test.HelloWorld</mainClass>
+            <extraClasspath><path>/other</path></extraClasspath>
+            <format>Docker</format>
+          </container>
+          <allowInsecureRegistries>true</allowInsecureRegistries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex-files-modification-time-keep-original.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex-files-modification-time-keep-original.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.test</groupId>
+  <artifactId>hello-world</artifactId>
+  <version>1</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.test</groupId>
+      <artifactId>dependency</artifactId>
+      <version>1.0.0</version>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/libs/dependency-1.0.0.jar</systemPath>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>${jib-maven-plugin.version}</version>
+        <configuration>
+          <from>
+            <image>localhost:5000/distroless/java</image>
+            <auth>
+              <username>testuser</username>
+              <password>testpassword</password>
+            </auth>
+          </from>
+          <to>
+            <image>${_TARGET_IMAGE}</image>
+            <auth>
+              <username>${_TARGET_USERNAME}</username>
+              <password>${_TARGET_PASSWORD}</password>
+            </auth>
+          </to>
+          <container>
+            <useCurrentTimestamp>true</useCurrentTimestamp>
+            <filesModificationTime>keep_original</filesModificationTime>
+            <args>
+              <arg>An argument.</arg>
+            </args>
+            <mainClass>com.test.HelloWorld</mainClass>
+            <extraClasspath><path>/other</path></extraClasspath>
+            <format>Docker</format>
+          </container>
+          <allowInsecureRegistries>true</allowInsecureRegistries>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-extra-dirs-modification-times.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-extra-dirs-modification-times.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.test</groupId>
+  <artifactId>my-artifact-id</artifactId>
+  <version>1</version>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <jib-maven-plugin.version>@@PluginVersion@@</jib-maven-plugin.version>
+    <jib.to.image>${_TARGET_IMAGE}</jib.to.image>
+    <jib.container.args>An argument.</jib.container.args>
+    <jib.container.ports>1000/tcp,2000-2003/udp</jib.container.ports>
+    <jib.container.labels>key1=value1,key2=value2</jib.container.labels>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.test</groupId>
+      <artifactId>dependency</artifactId>
+      <version>1.0.0</version>
+      <scope>system</scope>
+      <systemPath>${project.basedir}/libs/dependency-1.0.0.jar</systemPath>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>com.google.cloud.tools</groupId>
+        <artifactId>jib-maven-plugin</artifactId>
+        <version>${jib-maven-plugin.version}</version>
+        <configuration>
+          <extraDirectories>
+            <paths>
+              <path>${project.basedir}/src/main/jib-custom</path>
+              <path>${project.basedir}/src/main/jib-custom-2</path>
+            </paths>
+            <modificationTimes>
+              <modificationTime>
+                <file>/baz</file>
+                <value>keep_original</value>
+              </modificationTime>
+              <modificationTime>
+                <file>/foo</file>
+                <value>epoch_plus_second</value>
+              </modificationTime>
+              <modificationTime>
+                <file>/bar/cat</file>
+                <value>2019-06-14T14:15:00Z</value>
+              </modificationTime>
+            </modificationTimes>
+          </extraDirectories>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/src/main/java/com/test/HelloWorld.java
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/src/main/java/com/test/HelloWorld.java
@@ -42,6 +42,7 @@ public class HelloWorld {
                 HelloWorld.class.getResourceAsStream("/world"), StandardCharsets.UTF_8))) {
       String world = reader.readLine();
       System.out.println(greeting + ", " + world + ". " + (args.length > 0 ? args[0] : ""));
+      System.out.println(Files.getLastModifiedTime(Paths.get(classLoader.getResource("world").toURI())).toString());
 
       // Prints the contents of the extra files.
       if (Files.exists(Paths.get("/foo"))) {
@@ -53,11 +54,14 @@ public class HelloWorld {
             new String(Files.readAllBytes(Paths.get("/foo")), StandardCharsets.UTF_8));
         System.out.println(
             new String(Files.readAllBytes(Paths.get("/bar/cat")), StandardCharsets.UTF_8));
+        System.out.println(Files.getLastModifiedTime(Paths.get("/foo")).toString());
+        System.out.println(Files.getLastModifiedTime(Paths.get("/bar/cat")).toString());
       }
       // Prints the contents of the files in the second extra directory.
       if (Files.exists(Paths.get("/baz"))) {
         System.out.println(
             new String(Files.readAllBytes(Paths.get("/baz")), StandardCharsets.UTF_8));
+        System.out.println(Files.getLastModifiedTime(Paths.get("/baz")).toString());
       }
 
       // Prints jvm flags

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.api.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.Containerizer;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.api.ModificationTimeProvider;
 import com.google.cloud.tools.jib.api.RegistryImage;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -61,11 +62,15 @@ public interface ProjectProperties {
    * @param baseImage the base image
    * @param appRoot root directory in the image where the app will be placed
    * @param containerizingMode mode to containerize the app
+   * @param modificationTimeProvider image files modification time prvoider
    * @return a {@link JibContainerBuilder} with classes, resources, and dependencies added to it
    * @throws IOException if there is a problem walking the project files
    */
   JibContainerBuilder createContainerBuilder(
-      RegistryImage baseImage, AbsoluteUnixPath appRoot, ContainerizingMode containerizingMode)
+      RegistryImage baseImage,
+      AbsoluteUnixPath appRoot,
+      ContainerizingMode containerizingMode,
+      ModificationTimeProvider modificationTimeProvider)
       throws IOException;
 
   List<Path> getClassFiles() throws IOException;

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
@@ -43,6 +43,8 @@ public class PropertyNames {
   public static final String CONTAINER_VOLUMES = "jib.container.volumes";
   public static final String CONTAINER_PORTS = "jib.container.ports";
   public static final String CONTAINER_USE_CURRENT_TIMESTAMP = "jib.container.useCurrentTimestamp";
+  public static final String CONTAINER_FILES_MODIFICATION_TIME =
+      "jib.container.filesModificationTime";
   public static final String USE_ONLY_PROJECT_CACHE = "jib.useOnlyProjectCache";
   public static final String BASE_IMAGE_CACHE = "jib.baseImageCache";
   public static final String APPLICATION_CACHE = "jib.applicationCache";
@@ -54,6 +56,8 @@ public class PropertyNames {
   public static final String EXTRA_DIRECTORY_PERMISSIONS = "jib.extraDirectory.permissions";
 
   public static final String EXTRA_DIRECTORIES_PERMISSIONS = "jib.extraDirectories.permissions";
+  public static final String EXTRA_DIRECTORIES_MODIFICATION_TIMES =
+      "jib.extraDirectories.modificationTimes";
   public static final String DOCKER_CLIENT_EXECUTABLE = "jib.dockerClient.executable";
   public static final String DOCKER_CLIENT_ENVIRONMENT = "jib.dockerClient.environment";
   public static final String CONTAINERIZING_MODE = "jib.containerizingMode";

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
@@ -76,9 +76,13 @@ public interface RawConfiguration {
 
   Optional<String> getProperty(String propertyName);
 
+  String getFilesModificationTime();
+
   List<Path> getExtraDirectories();
 
   Map<AbsoluteUnixPath, FilePermissions> getExtraDirectoryPermissions();
+
+  Map<AbsoluteUnixPath, String> getExtraDirectoryModificationTimes();
 
   String getContainerizingMode();
 }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelperTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelperTest.java
@@ -84,7 +84,7 @@ public class JavaContainerBuilderHelperTest {
     Path extraFilesDirectory = Paths.get(Resources.getResource("core/layer").toURI());
     LayerConfiguration layerConfiguration =
         JavaContainerBuilderHelper.extraDirectoryLayerConfiguration(
-            extraFilesDirectory, Collections.emptyMap());
+            extraFilesDirectory, Collections.emptyMap(), Collections.emptyMap());
     assertSourcePathsUnordered(
         Arrays.asList(
             extraFilesDirectory.resolve("a"),


### PR DESCRIPTION
Addressed ticket GoogleContainerTools#1608. Implemented possibility to set modification times for container files and extra dir files.
The modification time value can be:

- epoch_plus_second - current behavior, modification time will be trimmed to epoch + 1 second
- keep_original - original modification time will be kept
- date in ISO 8601 format, e.g 2019-06-18T12:00:00Z

Unfortunately I was not able to run all integration tests successfully because of verification errors in BuildImageMojoIntegrationTest.