### PR TITLE
Allow parsing of scratch as an image string

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageReference.java
@@ -92,6 +92,10 @@ public class ImageReference {
    * @throws InvalidImageReferenceException if {@code reference} is formatted incorrectly
    */
   public static ImageReference parse(String reference) throws InvalidImageReferenceException {
+    if (reference.equals("scratch")) {
+      return ImageReference.scratch();
+    }
+
     Matcher matcher = REFERENCE_PATTERN.matcher(reference);
 
     if (!matcher.find() || matcher.groupCount() < 4) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildConfiguration.java
@@ -244,7 +244,9 @@ public class BuildConfiguration {
 
       switch (missingFields.size()) {
         case 0: // No errors
-          if (Preconditions.checkNotNull(baseImageConfiguration).getImage().usesDefaultTag()) {
+          Preconditions.checkNotNull(baseImageConfiguration);
+          if (baseImageConfiguration.getImage().usesDefaultTag()
+              && !baseImageConfiguration.getImage().isScratch()) {
             eventHandlers.dispatch(
                 LogEvent.warn(
                     "Base image '"

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/ImageReferenceTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/ImageReferenceTest.java
@@ -181,7 +181,8 @@ public class ImageReferenceTest {
   }
 
   @Test
-  public void testIsScratch() {
+  public void testIsScratch() throws InvalidImageReferenceException {
+    Assert.assertTrue(ImageReference.parse("scratch").isScratch());
     Assert.assertTrue(ImageReference.scratch().isScratch());
     Assert.assertFalse(ImageReference.of("", "scratch", "").isScratch());
     Assert.assertFalse(ImageReference.of(null, "scratch", null).isScratch());


### PR DESCRIPTION
fixes #1794 

This automatically allows gradle/maven users to supply a from.image = "scratch".