### PR TITLE
Fix root progress construction

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcher.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/ProgressEventDispatcher.java
@@ -147,7 +147,7 @@ public class ProgressEventDispatcher implements Closeable {
   private long decrementRemainingAllocationUnits(long units) {
     Preconditions.checkState(!closed);
 
-    if (remainingAllocationUnits > units) {
+    if (remainingAllocationUnits >= units) {
       remainingAllocationUnits -= units;
       return units;
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -103,7 +103,7 @@ public class StepsRunner {
   private final List<Runnable> stepsToRun = new ArrayList<>();
 
   @Nullable private String rootProgressDescription;
-  private Deque<ProgressEventDispatcher.Factory> childProgressDispatcherFactories =
+  private final Deque<ProgressEventDispatcher.Factory> childProgressDispatcherFactories =
       new ArrayDeque<>();
 
   private StepsRunner(


### PR DESCRIPTION
Fixes #1796.

I missed that the root progress tree should be created in the main thread. (`newChildProducer()` should not be called in child threads.)