### PR TITLE
Leverage Nullaway checks using Optional for async step results

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.registry.RegistryAuthenticator;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
 
@@ -34,26 +35,25 @@ import javax.annotation.Nullable;
  * @see <a
  *     href="https://docs.docker.com/registry/spec/auth/token/">https://docs.docker.com/registry/spec/auth/token/</a>
  */
-class AuthenticatePushStep implements Callable<Authorization> {
+class AuthenticatePushStep implements Callable<Optional<Authorization>> {
 
   private static final String DESCRIPTION = "Authenticating push to %s";
 
   private final BuildConfiguration buildConfiguration;
   private final ProgressEventDispatcher.Factory progressEventDispatcherFactory;
-  private final Credential registryCredential;
+  @Nullable private final Credential registryCredential;
 
   AuthenticatePushStep(
       BuildConfiguration buildConfiguration,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
-      Credential registryCredential) {
+      @Nullable Credential registryCredential) {
     this.buildConfiguration = buildConfiguration;
     this.progressEventDispatcherFactory = progressEventDispatcherFactory;
     this.registryCredential = registryCredential;
   }
 
   @Override
-  @Nullable
-  public Authorization call() throws IOException, RegistryException {
+  public Optional<Authorization> call() throws IOException, RegistryException {
     String registry = buildConfiguration.getTargetImageConfiguration().getImageRegistry();
     try (ProgressEventDispatcher ignored =
             progressEventDispatcherFactory.create("authenticating push to " + registry, 1);
@@ -66,15 +66,16 @@ class AuthenticatePushStep implements Callable<Authorization> {
               .newRegistryClient()
               .getRegistryAuthenticator();
       if (registryAuthenticator != null) {
-        return registryAuthenticator.authenticatePush(registryCredential);
+        return Optional.ofNullable(registryAuthenticator.authenticatePush(registryCredential));
       }
     } catch (InsecureRegistryException ex) {
       // Cannot skip certificate validation or use HTTP; fall through.
     }
 
     return (registryCredential == null || registryCredential.isOAuth2RefreshToken())
-        ? null
-        : Authorization.fromBasicCredentials(
-            registryCredential.getUsername(), registryCredential.getPassword());
+        ? Optional.empty()
+        : Optional.ofNullable(
+            Authorization.fromBasicCredentials(
+                registryCredential.getUsername(), registryCredential.getPassword()));
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
@@ -66,7 +66,7 @@ class AuthenticatePushStep implements Callable<Optional<Authorization>> {
               .newRegistryClient()
               .getRegistryAuthenticator();
       if (registryAuthenticator != null) {
-        return Optional.ofNullable(registryAuthenticator.authenticatePush(registryCredential));
+        return Optional.of(registryAuthenticator.authenticatePush(registryCredential));
       }
     } catch (InsecureRegistryException ex) {
       // Cannot skip certificate validation or use HTTP; fall through.
@@ -74,7 +74,7 @@ class AuthenticatePushStep implements Callable<Optional<Authorization>> {
 
     return (registryCredential == null || registryCredential.isOAuth2RefreshToken())
         ? Optional.empty()
-        : Optional.ofNullable(
+        : Optional.of(
             Authorization.fromBasicCredentials(
                 registryCredential.getUsername(), registryCredential.getPassword()));
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -136,7 +136,8 @@ class PullBaseImageStep implements Callable<ImageAndAuthorization> {
         Credential registryCredential =
             RetrieveRegistryCredentialsStep.forBaseImage(
                     buildConfiguration, progressEventDispatcher.newChildProducer())
-                .call();
+                .call()
+                .orElse(null);
 
         Authorization registryAuthorization =
             registryCredential == null || registryCredential.isOAuth2RefreshToken()

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -28,6 +28,7 @@ import com.google.cloud.tools.jib.http.Authorization;
 import com.google.cloud.tools.jib.registry.RegistryClient;
 import java.io.IOException;
 import java.util.concurrent.Callable;
+import javax.annotation.Nullable;
 
 /** Pushes a BLOB to the target registry. */
 class PushBlobStep implements Callable<BlobDescriptor> {
@@ -37,14 +38,14 @@ class PushBlobStep implements Callable<BlobDescriptor> {
   private final BuildConfiguration buildConfiguration;
   private final ProgressEventDispatcher.Factory progressEventDipatcherFactory;
 
-  private final Authorization authorization;
+  @Nullable private final Authorization authorization;
   private final BlobDescriptor blobDescriptor;
   private final Blob blob;
 
   PushBlobStep(
       BuildConfiguration buildConfiguration,
       ProgressEventDispatcher.Factory progressEventDipatcherFactory,
-      Authorization authorization,
+      @Nullable Authorization authorization,
       BlobDescriptor blobDescriptor,
       Blob blob) {
     this.buildConfiguration = buildConfiguration;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushContainerConfigurationStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushContainerConfigurationStep.java
@@ -29,6 +29,7 @@ import com.google.cloud.tools.jib.image.json.ImageToJsonTranslator;
 import com.google.cloud.tools.jib.json.JsonTemplate;
 import java.io.IOException;
 import java.util.concurrent.Callable;
+import javax.annotation.Nullable;
 
 /** Pushes the container configuration. */
 class PushContainerConfigurationStep implements Callable<BlobDescriptor> {
@@ -38,13 +39,13 @@ class PushContainerConfigurationStep implements Callable<BlobDescriptor> {
   private final BuildConfiguration buildConfiguration;
   private final ProgressEventDispatcher.Factory progressEventDispatcherFactory;
 
-  private final Authorization pushAuthorization;
+  @Nullable private final Authorization pushAuthorization;
   private final Image builtImage;
 
   PushContainerConfigurationStep(
       BuildConfiguration buildConfiguration,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
-      Authorization authenticatePushStep,
+      @Nullable Authorization authenticatePushStep,
       Image builtImage) {
     this.buildConfiguration = buildConfiguration;
     this.progressEventDispatcherFactory = progressEventDispatcherFactory;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import javax.annotation.Nullable;
 
 /** Pushes the final image. Outputs the pushed image digest. */
 class PushImageStep implements Callable<BuildResult> {
@@ -46,7 +47,7 @@ class PushImageStep implements Callable<BuildResult> {
   private final BuildConfiguration buildConfiguration;
   private final ProgressEventDispatcher.Factory progressEventDispatcherFactory;
 
-  private final Authorization pushAuthorization;
+  @Nullable private final Authorization pushAuthorization;
   private final BlobDescriptor containerConfigurationDigestAndSize;
   private final Image builtImage;
 
@@ -57,7 +58,7 @@ class PushImageStep implements Callable<BuildResult> {
       ListeningExecutorService listeningExecutorService,
       BuildConfiguration buildConfiguration,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
-      Authorization pushAuthorization,
+      @Nullable Authorization pushAuthorization,
       BlobDescriptor containerConfigurationDigestAndSize,
       Image builtImage) {
     this.listeningExecutorService = listeningExecutorService;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import javax.annotation.Nullable;
 
 class PushLayerStep implements Callable<BlobDescriptor> {
 
@@ -38,13 +39,13 @@ class PushLayerStep implements Callable<BlobDescriptor> {
   private final BuildConfiguration buildConfiguration;
   private final ProgressEventDispatcher.Factory progressEventDispatcherFactory;
 
-  private final Authorization pushAuthorization;
+  @Nullable private final Authorization pushAuthorization;
   private final Future<CachedLayerAndName> cachedLayerAndName;
 
   static ImmutableList<PushLayerStep> makeList(
       BuildConfiguration buildConfiguration,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
-      Authorization pushAuthorization,
+      @Nullable Authorization pushAuthorization,
       List<Future<CachedLayerAndName>> cachedLayers) {
     try (TimerEventDispatcher ignored =
             new TimerEventDispatcher(buildConfiguration.getEventHandlers(), DESCRIPTION);
@@ -68,7 +69,7 @@ class PushLayerStep implements Callable<BlobDescriptor> {
   PushLayerStep(
       BuildConfiguration buildConfiguration,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
-      Authorization pushAuthorization,
+      @Nullable Authorization pushAuthorization,
       Future<CachedLayerAndName> cachedLayerAndName) {
     this.buildConfiguration = buildConfiguration;
     this.progressEventDispatcherFactory = progressEventDispatcherFactory;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -34,6 +34,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -62,8 +63,8 @@ public class StepsRunner {
     private Future<List<Future<CachedLayerAndName>>> baseImageLayers = failedFuture();
     @Nullable private List<Future<CachedLayerAndName>> applicationLayers;
     private Future<Image> builtImage = failedFuture();
-    private Future<Credential> targetRegistryCredentials = failedFuture();
-    private Future<Authorization> pushAuthorization = failedFuture();
+    private Future<Optional<Credential>> targetRegistryCredentials = failedFuture();
+    private Future<Optional<Authorization>> pushAuthorization = failedFuture();
     private Future<List<Future<BlobDescriptor>>> baseImageLayerPushResults = failedFuture();
     private Future<List<Future<BlobDescriptor>>> applicationLayerPushResults = failedFuture();
     private Future<BlobDescriptor> containerConfigurationPushResult = failedFuture();
@@ -129,7 +130,7 @@ public class StepsRunner {
                 new AuthenticatePushStep(
                         buildConfiguration,
                         childProgressDispatcherFactory,
-                        results.targetRegistryCredentials.get())
+                        results.targetRegistryCredentials.get().orElse(null))
                     .call());
   }
 
@@ -167,7 +168,7 @@ public class StepsRunner {
                     PushLayerStep.makeList(
                         buildConfiguration,
                         childProgressDispatcherFactory,
-                        results.pushAuthorization.get(),
+                        results.pushAuthorization.get().orElse(null),
                         results.baseImageLayers.get())));
   }
 
@@ -207,7 +208,7 @@ public class StepsRunner {
                 new PushContainerConfigurationStep(
                         buildConfiguration,
                         childProgressDispatcherFactory,
-                        results.pushAuthorization.get(),
+                        results.pushAuthorization.get().orElse(null),
                         results.builtImage.get())
                     .call());
   }
@@ -223,7 +224,7 @@ public class StepsRunner {
                     PushLayerStep.makeList(
                         buildConfiguration,
                         childProgressDispatcherFactory,
-                        results.pushAuthorization.get(),
+                        results.pushAuthorization.get().orElse(null),
                         Verify.verifyNotNull(results.applicationLayers))));
   }
 
@@ -241,7 +242,7 @@ public class StepsRunner {
                       executorService,
                       buildConfiguration,
                       childProgressDispatcherFactory,
-                      results.pushAuthorization.get(),
+                      results.pushAuthorization.get().orElse(null),
                       results.containerConfigurationPushResult.get(),
                       results.builtImage.get())
                   .call();

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
@@ -58,13 +58,13 @@ public class RetrieveRegistryCredentialsStepTest {
                 () -> Optional.of(Credential.from("ignored", "ignored"))));
 
     Assert.assertEquals(
-        Credential.from("baseusername", "basepassword"),
+        Optional.of(Credential.from("baseusername", "basepassword")),
         RetrieveRegistryCredentialsStep.forBaseImage(
                 buildConfiguration,
                 ProgressEventDispatcher.newRoot(mockEventHandlers, "ignored", 1).newChildProducer())
             .call());
     Assert.assertEquals(
-        Credential.from("targetusername", "targetpassword"),
+        Optional.of(Credential.from("targetusername", "targetpassword")),
         RetrieveRegistryCredentialsStep.forTargetImage(
                 buildConfiguration,
                 ProgressEventDispatcher.newRoot(mockEventHandlers, "ignored", 1).newChildProducer())
@@ -76,22 +76,24 @@ public class RetrieveRegistryCredentialsStepTest {
     BuildConfiguration buildConfiguration =
         makeFakeBuildConfiguration(
             Arrays.asList(Optional::empty, Optional::empty), Collections.emptyList());
-    Assert.assertNull(
+    Assert.assertFalse(
         RetrieveRegistryCredentialsStep.forBaseImage(
                 buildConfiguration,
                 ProgressEventDispatcher.newRoot(mockEventHandlers, "ignored", 1).newChildProducer())
-            .call());
+            .call()
+            .isPresent());
 
     Mockito.verify(mockEventHandlers, Mockito.atLeastOnce())
         .dispatch(Mockito.any(ProgressEvent.class));
     Mockito.verify(mockEventHandlers)
         .dispatch(LogEvent.info("No credentials could be retrieved for registry baseregistry"));
 
-    Assert.assertNull(
+    Assert.assertFalse(
         RetrieveRegistryCredentialsStep.forTargetImage(
                 buildConfiguration,
                 ProgressEventDispatcher.newRoot(mockEventHandlers, "ignored", 1).newChildProducer())
-            .call());
+            .call()
+            .isPresent());
 
     Mockito.verify(mockEventHandlers)
         .dispatch(LogEvent.info("No credentials could be retrieved for registry baseregistry"));


### PR DESCRIPTION
Getting a result from a `Future` invalidates Nullaway that has been extremely useful, as we can no longer enforce if `Future.get()` may return null or not. `Optional` works wonders here.

I see two steps among all may return null:

1. `RetrieveRegistryCredentialsStep` returning a `Credential`
2. `AuthenticatePushStep` returning an `Authorization`

We can leverage Nullaway checks using `Optional`.