### PR TITLE
Add test for proxy user/password properties

### DIFF
--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
@@ -117,6 +117,8 @@ public class TestWebServer implements Closeable {
     return null;
   }
 
+  // For use to ignore (i.e., accept and do nothing) a return value from ExecutionService.submit().
+  // Without "consuming" the return value this way, Error Prone will complain to use it.
   private void ignoreReturn(Future<Void> future) {
     // do nothing; to make Error Prone happy
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
@@ -105,11 +105,10 @@ public class TestWebServer implements Closeable {
   private Void serveResponses() throws IOException {
     threadStarted.release();
     try (Socket socket = serverSocket.accept()) {
+      InputStream in = socket.getInputStream();
+      BufferedReader reader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
 
       for (String response : responses) {
-        InputStream in = socket.getInputStream();
-        BufferedReader reader =
-            new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
         for (String line = reader.readLine();
             line != null && !line.isEmpty(); // An empty line marks the end of an HTTP request.
             line = reader.readLine()) {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
@@ -22,7 +22,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
+import java.util.Arrays;
 import javax.net.ssl.SSLException;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -87,6 +89,38 @@ public class WithServerConnectionTest {
       Assert.assertArrayEquals(
           "Hello World!".getBytes(StandardCharsets.UTF_8),
           ByteStreams.toByteArray(response.getBody()));
+    }
+  }
+
+  @Test
+  public void testProxyCredentialProperties()
+      throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException {
+    String proxyResponse =
+        "HTTP/1.1 407 Proxy Authentication Required\n"
+            + "Proxy-Authenticate: BASIC realm=\"some-realm\"\n"
+            + "Cache-Control: no-cache\n"
+            + "Pragma: no-cache\n"
+            + "Content-Length: 0\n\n";
+    String targetServerResponse = "HTTP/1.1 200 OK\nContent-Length:12\n\nHello World!";
+
+    try (TestWebServer server =
+        new TestWebServer(false, Arrays.asList(proxyResponse, targetServerResponse))) {
+      System.setProperty("http.proxyHost", "localhost");
+      System.setProperty("http.proxyPort", String.valueOf(server.getLocalPort()));
+      System.setProperty("http.proxyUser", "user_sys_prop");
+      System.setProperty("http.proxyPassword", "pass_sys_prop");
+
+      try (Connection connection =
+          Connection.getConnectionFactory().apply(new URL("http://does.not.matter"))) {
+        Response response = connection.send("GET", new Request.Builder().build());
+        Assert.assertThat(
+            server.getInputRead(),
+            CoreMatchers.containsString(
+                "Proxy-Authorization: Basic dXNlcl9zeXNfcHJvcDpwYXNzX3N5c19wcm9w"));
+        Assert.assertArrayEquals(
+            "Hello World!".getBytes(StandardCharsets.UTF_8),
+            ByteStreams.toByteArray(response.getBody()));
+      }
     }
   }
 }


### PR DESCRIPTION
- Enhance `TestWebServer` to return a given (and only given) set of responses in order.
- Emulate a proxy server response to test HTTP proxy user/password properties.

Towards #1434 (which is blocked on a new 1.30.2 release.)

Adding the test early to unblock #1808.