### PR TITLE
Introduce support for enforcing minimum Jib plugin versions

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/CheckJibVersionTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/CheckJibVersionTask.java
@@ -27,7 +27,7 @@ import org.gradle.api.tasks.TaskAction;
  * jib.requiredVersion} property) will error in such a way that it indicates the jib version is out
  * of date. This goal can be removed once there are no users of Jib prior to 1.4.0.
  *
- * <p>Expected use: {@code ./gradlew _skaffoldEnsureJibUpToDate -Djib.requiredVersion='[1.4,2)'
+ * <p>Expected use: {@code ./gradlew _skaffoldFailIfJibOutOfDate -Djib.requiredVersion='[1.4,2)'
  * jibDockerBuild --image=xxx}
  */
 public class CheckJibVersionTask extends DefaultTask {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/CheckJibVersionTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/CheckJibVersionTask.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.jib.gradle;
+
+import com.google.common.base.Strings;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.GradleException;
+import org.gradle.api.tasks.TaskAction;
+
+/**
+ * This internal Skaffold-related goal checks that the Jib plugin version is within some specified
+ * range. It is only required so that older versions of Jib (prior to the introduction of the {@code
+ * jib.requiredVersion} property) will error in such a way that it indicates the jib version is out
+ * of date. This goal can be removed once there are no users of Jib prior to 1.4.0.
+ *
+ * <p>Expected use: {@code ./gradlew _skaffoldEnsureJibUpToDate -Djib.requiredVersion='[1.4,2)'
+ * jibDockerBuild --image=xxx}
+ */
+public class CheckJibVersionTask extends DefaultTask {
+
+  @TaskAction
+  public void checkVersion() {
+    if (Strings.isNullOrEmpty(System.getProperty(JibPlugin.REQUIRED_VERSION_PROPERTY_NAME))) {
+      throw new GradleException(
+          JibPlugin.CHECK_REQUIRED_VERSION_TASK_NAME
+              + " requires "
+              + JibPlugin.REQUIRED_VERSION_PROPERTY_NAME
+              + " to be set");
+    }
+    // no-op as Jib version compatibility is actually checked in JibPlugin
+  }
+}

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -151,7 +151,7 @@ public class JibPlugin implements Plugin<Project> {
     project.getTasks().create(FILES_TASK_V2_NAME, FilesTaskV2.class).setJibExtension(jibExtension);
     project.getTasks().create(INIT_TASK_NAME, SkaffoldInitTask.class).setJibExtension(jibExtension);
 
-    // A no-op check to catch older versions of Jib.  This can be removed when we are certain people
+    // A check to catch older versions of Jib.  This can be removed once we are certain people
     // are using Jib 1.3.1 or later.
     project.getTasks().create(CHECK_REQUIRED_VERSION_TASK_NAME, CheckJibVersionTask.class);
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -47,7 +47,7 @@ public class JibPlugin implements Plugin<Project> {
 
   @VisibleForTesting static final String EXPLODED_WAR_TASK_NAME = "jibExplodedWar";
 
-  static final String CHECK_REQUIRED_VERSION_TASK_NAME = "_skaffoldEnsureJibUpToDate";
+  static final String CHECK_REQUIRED_VERSION_TASK_NAME = "_skaffoldFailIfJibOutOfDate";
 
   static final String REQUIRED_VERSION_PROPERTY_NAME = "jib.requiredVersion";
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -59,7 +59,7 @@ public class JibPluginTest {
 
   @After
   public void tearDown() {
-    System.clearProperty("jib.requiredVersion");
+    System.clearProperty(JibPlugin.REQUIRED_VERSION_PROPERTY_NAME);
   }
 
   @Test
@@ -111,10 +111,17 @@ public class JibPluginTest {
   }
 
   @Test
+  public void testCheckJibVersionNames() {
+    // These identifiers will be baked into Skaffold and should not be changed
+    Assert.assertEquals(JibPlugin.REQUIRED_VERSION_PROPERTY_NAME, "jib.requiredVersion");
+    Assert.assertEquals(JibPlugin.CHECK_REQUIRED_VERSION_TASK_NAME, "_skaffoldEnsureJibUpToDate");
+  }
+
+  @Test
   public void testCheckJibVersionInvoked() {
     Project rootProject =
         ProjectBuilder.builder().withProjectDir(testProjectRoot.getRoot()).withName("root").build();
-    System.setProperty("jib.requiredVersion", "10000.0"); // not here yet
+    System.setProperty(JibPlugin.REQUIRED_VERSION_PROPERTY_NAME, "10000.0"); // not here yet
     try {
       rootProject.getPluginManager().apply("com.google.cloud.tools.jib");
       Assert.fail("should have failed");

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.stream.Collectors;
+import org.gradle.api.GradleException;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
@@ -34,6 +35,7 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.UnexpectedBuildFailure;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Rule;
@@ -54,6 +56,11 @@ public class JibPluginTest {
   }
 
   @Rule public final TemporaryFolder testProjectRoot = new TemporaryFolder();
+
+  @After
+  public void tearDown() {
+    System.clearProperty("jib.requiredVersion");
+  }
 
   @Test
   public void testCheckGradleVersion_pass() throws IOException {
@@ -100,6 +107,22 @@ public class JibPluginTest {
                       + " or higher. You can upgrade by running 'gradle wrapper --gradle-version="
                       + JibPlugin.GRADLE_MIN_VERSION.getVersion()
                       + "'."));
+    }
+  }
+
+  @Test
+  public void testCheckJibVersionInvoked() {
+    Project rootProject =
+        ProjectBuilder.builder().withProjectDir(testProjectRoot.getRoot()).withName("root").build();
+    System.setProperty("jib.requiredVersion", "10000.0"); // not here yet
+    try {
+      rootProject.getPluginManager().apply("com.google.cloud.tools.jib");
+      Assert.fail("should have failed");
+    } catch (GradleException ex) {
+      // Gradle tests aren't run from a jar and so don't have an identifiable plugin version
+      Assert.assertEquals(
+          "Failed to apply plugin [id 'com.google.cloud.tools.jib']", ex.getMessage());
+      Assert.assertEquals("Could not determine Jib plugin version", ex.getCause().getMessage());
     }
   }
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -114,7 +114,7 @@ public class JibPluginTest {
   public void testCheckJibVersionNames() {
     // These identifiers will be baked into Skaffold and should not be changed
     Assert.assertEquals(JibPlugin.REQUIRED_VERSION_PROPERTY_NAME, "jib.requiredVersion");
-    Assert.assertEquals(JibPlugin.CHECK_REQUIRED_VERSION_TASK_NAME, "_skaffoldEnsureJibUpToDate");
+    Assert.assertEquals(JibPlugin.CHECK_REQUIRED_VERSION_TASK_NAME, "_skaffoldFailIfJibOutOfDate");
   }
 
   @Test

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -69,6 +69,7 @@ public class BuildDockerMojo extends JibPluginConfiguration {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
+    checkJibVersion();
     if (isSkipped()) {
       getLog().info("Skipping containerization because jib-maven-plugin: skip = true");
       return;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -55,6 +55,7 @@ public class BuildImageMojo extends JibPluginConfiguration {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
+    checkJibVersion();
     if (isSkipped()) {
       getLog().info("Skipping containerization because jib-maven-plugin: skip = true");
       return;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -53,6 +53,7 @@ public class BuildTarMojo extends JibPluginConfiguration {
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
+    checkJibVersion();
     if (isSkipped()) {
       getLog().info("Skipping containerization because jib-maven-plugin: skip = true");
       return;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -36,6 +36,8 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -229,6 +231,8 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   @Parameter(defaultValue = "${project}", readonly = true)
   private MavenProject project;
 
+  @Component protected PluginDescriptor descriptor;
+
   @Parameter private FromConfiguration from = new FromConfiguration();
 
   @Parameter private ToConfiguration to = new ToConfiguration();
@@ -259,6 +263,11 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
 
   protected MavenProject getProject() {
     return Preconditions.checkNotNull(project);
+  }
+
+  protected void checkJibVersion() throws MojoExecutionException {
+    Preconditions.checkNotNull(descriptor);
+    MojoCommon.checkJibVersion(descriptor);
   }
 
   /**

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/CheckJibVersionMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/CheckJibVersionMojo.java
@@ -31,7 +31,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  * jib.requiredVersion} property) will error in such a way that it indicates the jib version is out
  * of date. This goal can be removed once there are no users of Jib prior to 1.4.0.
  *
- * <p>Expected use: {@code mvn jib:_skaffold-ensure-jib-up-to-date -Djib.requiredVersion='[1.4,2)'
+ * <p>Expected use: {@code mvn jib:_skaffold-fail-if-jib-out-of-date -Djib.requiredVersion='[1.4,2)'
  * jib:build -Dimage=xxx}
  */
 @Mojo(
@@ -41,7 +41,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
     defaultPhase = LifecyclePhase.INITIALIZE)
 public class CheckJibVersionMojo extends SkaffoldBindingMojo {
 
-  @VisibleForTesting static final String GOAL_NAME = "_skaffold-ensure-jib-up-to-date";
+  @VisibleForTesting static final String GOAL_NAME = "_skaffold-fail-if-jib-out-of-date";
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/CheckJibVersionMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/CheckJibVersionMojo.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.jib.maven.skaffold;
+
+import com.google.cloud.tools.jib.maven.MojoCommon;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
+
+/**
+ * This internal Skaffold-related goal checks that the Jib plugin version is within some specified
+ * range. It is only required so that older versions of Jib (prior to the introduction of the {@code
+ * jib.requiredVersion} property) will error in such a way that it indicates the jib version is out
+ * of date. This goal can be removed once there are no users of Jib prior to 1.4.0.
+ *
+ * <p>Expected use: {@code mvn jib:_skaffold-ensure-jib-up-to-date -Djib.requiredVersion='[1.4,2)'
+ * jib:build -Dimage=xxx}
+ */
+@Mojo(
+    name = CheckJibVersionMojo.GOAL_NAME,
+    requiresProject = false,
+    requiresDependencyCollection = ResolutionScope.NONE,
+    defaultPhase = LifecyclePhase.INITIALIZE)
+public class CheckJibVersionMojo extends SkaffoldBindingMojo {
+
+  @VisibleForTesting static final String GOAL_NAME = "_skaffold-ensure-jib-up-to-date";
+
+  @Override
+  public void execute() throws MojoExecutionException, MojoFailureException {
+    if (Strings.isNullOrEmpty(System.getProperty(MojoCommon.REQUIRED_VERSION_PROPERTY_NAME))) {
+      throw new MojoExecutionException(
+          GOAL_NAME + " requires " + MojoCommon.REQUIRED_VERSION_PROPERTY_NAME + " to be set");
+    }
+    checkJibVersion();
+  }
+}

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojo.java
@@ -35,7 +35,6 @@ import javax.annotation.Nullable;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.FileSet;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -62,7 +61,7 @@ import org.eclipse.aether.graph.DependencyFilter;
 @Mojo(
     name = FilesMojo.GOAL_NAME,
     requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
-public class FilesMojo extends AbstractMojo {
+public class FilesMojo extends SkaffoldBindingMojo {
 
   @VisibleForTesting static final String GOAL_NAME = "_skaffold-files";
 
@@ -94,6 +93,7 @@ public class FilesMojo extends AbstractMojo {
     Preconditions.checkNotNull(projects);
     Preconditions.checkNotNull(session);
     Preconditions.checkNotNull(projectDependenciesResolver);
+    checkJibVersion();
 
     // print out pom configuration files
     System.out.println(project.getFile());

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2.java
@@ -36,7 +36,6 @@ import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.FileSet;
 import org.apache.maven.model.Plugin;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -64,7 +63,7 @@ import org.eclipse.aether.graph.DependencyFilter;
     name = FilesMojoV2.GOAL_NAME,
     requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
     aggregator = true)
-public class FilesMojoV2 extends AbstractMojo {
+public class FilesMojoV2 extends SkaffoldBindingMojo {
 
   @VisibleForTesting static final String GOAL_NAME = "_skaffold-files-v2";
 
@@ -86,6 +85,7 @@ public class FilesMojoV2 extends AbstractMojo {
     Preconditions.checkNotNull(projects);
     Preconditions.checkNotNull(session);
     Preconditions.checkNotNull(projectDependenciesResolver);
+    checkJibVersion();
 
     for (MavenProject project : projects) {
       // Add pom configuration files

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/PackageGoalsMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/PackageGoalsMojo.java
@@ -23,7 +23,6 @@ import javax.annotation.Nullable;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.lifecycle.LifecycleExecutor;
 import org.apache.maven.lifecycle.MavenExecutionPlan;
-import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -44,7 +43,7 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
     name = PackageGoalsMojo.GOAL_NAME,
     requiresDirectInvocation = true,
     requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME)
-public class PackageGoalsMojo extends AbstractMojo {
+public class PackageGoalsMojo extends SkaffoldBindingMojo {
 
   @VisibleForTesting static final String GOAL_NAME = "_skaffold-package-goals";
 
@@ -58,6 +57,7 @@ public class PackageGoalsMojo extends AbstractMojo {
   public void execute() throws MojoExecutionException, MojoFailureException {
     Preconditions.checkNotNull(lifecycleExecutor);
     Preconditions.checkNotNull(session);
+    checkJibVersion();
 
     MavenExecutionPlan mavenExecutionPlan;
     try {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldBindingMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldBindingMojo.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.jib.maven.skaffold;
+
+import com.google.cloud.tools.jib.maven.MojoCommon;
+import com.google.common.base.Preconditions;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugins.annotations.Component;
+
+/** Base class for Skaffold-related goals. */
+abstract class SkaffoldBindingMojo extends AbstractMojo {
+  @Component protected PluginDescriptor descriptor;
+
+  protected void checkJibVersion() throws MojoExecutionException {
+    Preconditions.checkNotNull(descriptor);
+    MojoCommon.checkJibVersion(descriptor);
+  }
+}

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
@@ -36,6 +36,7 @@ public class SkaffoldInitMojo extends JibPluginConfiguration {
 
   @Override
   public void execute() throws MojoExecutionException {
+    checkJibVersion();
     SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput();
     skaffoldInitOutput.setImage(getTargetImage());
     if (getProject().getParent() != null) {

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
@@ -224,4 +224,30 @@ public class BuildDockerMojoIntegrationTest {
                   + "clean jib:build\" instead of \"mvn clean package jib:build\"?)"));
     }
   }
+
+  @Test
+  public void testExecute_jibRequireVersion_ok() throws VerificationException, IOException {
+    String targetImage = "simpleimage:maven" + System.nanoTime();
+
+    Instant before = Instant.now();
+    Verifier verifier = new Verifier(simpleTestProject.getProjectRoot().toString());
+    // this plugin should match 1.0
+    verifier.setSystemProperty("jib.requiredVersion", "1.0");
+    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
+    verifier.executeGoals(Arrays.asList("package", "jib:dockerBuild"));
+    verifier.verifyErrorFreeLog();
+  }
+
+  @Test
+  public void testExecute_jibRequireVersion_fail() throws VerificationException, IOException {
+    String targetImage = "simpleimage:maven" + System.nanoTime();
+
+    Instant before = Instant.now();
+    Verifier verifier = new Verifier(simpleTestProject.getProjectRoot().toString());
+    verifier.setSystemProperty("jib.requiredVersion", "[,1.0]");
+    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
+    verifier.executeGoals(Arrays.asList("package", "jib:dockerBuild"));
+    verifier.verifyTextInLog("BUILD FAILURE");
+    verifier.verifyTextInLog("but is required to be");
+  }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -545,6 +545,32 @@ public class BuildImageMojoIntegrationTest {
   }
 
   @Test
+  public void testExecute_jibRequireVersion_ok() throws VerificationException, IOException {
+    String targetImage = "simpleimage:maven" + System.nanoTime();
+
+    Instant before = Instant.now();
+    Verifier verifier = new Verifier(simpleTestProject.getProjectRoot().toString());
+    // this plugin should match 1.0
+    verifier.setSystemProperty("jib.requiredVersion", "1.0");
+    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
+    verifier.executeGoals(Arrays.asList("package", "jib:build"));
+    verifier.verifyErrorFreeLog();
+  }
+
+  @Test
+  public void testExecute_jibRequireVersion_fail() throws VerificationException, IOException {
+    String targetImage = "simpleimage:maven" + System.nanoTime();
+
+    Instant before = Instant.now();
+    Verifier verifier = new Verifier(simpleTestProject.getProjectRoot().toString());
+    verifier.setSystemProperty("jib.requiredVersion", "[,1.0]");
+    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
+    verifier.executeGoals(Arrays.asList("package", "jib:build"));
+    verifier.verifyTextInLog("BUILD FAILURE");
+    verifier.verifyTextInLog("but is required to be");
+  }
+
+  @Test
   public void testExecute_jettyServlet25()
       throws VerificationException, IOException, InterruptedException {
     buildAndRunWar("jetty-servlet25:maven", "pom.xml");

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.Command;
 import java.io.IOException;
 import java.security.DigestException;
 import java.time.Instant;
+import java.util.Arrays;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.junit.Assert;
@@ -87,5 +88,31 @@ public class BuildTarMojoIntegrationTest {
   @Test
   public void testExecute_jibContainerizeSkips() throws VerificationException, IOException {
     SkippedGoalVerifier.verifyJibContainerizeSkips(simpleTestProject, BuildDockerMojo.GOAL_NAME);
+  }
+
+  @Test
+  public void testExecute_jibRequireVersion_ok() throws VerificationException, IOException {
+    String targetImage = "simpleimage:maven" + System.nanoTime();
+
+    Instant before = Instant.now();
+    Verifier verifier = new Verifier(simpleTestProject.getProjectRoot().toString());
+    // this plugin should match 1.0
+    verifier.setSystemProperty("jib.requiredVersion", "1.0");
+    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
+    verifier.executeGoals(Arrays.asList("package", "jib:buildTar"));
+    verifier.verifyErrorFreeLog();
+  }
+
+  @Test
+  public void testExecute_jibRequireVersion_fail() throws VerificationException, IOException {
+    String targetImage = "simpleimage:maven" + System.nanoTime();
+
+    Instant before = Instant.now();
+    Verifier verifier = new Verifier(simpleTestProject.getProjectRoot().toString());
+    verifier.setSystemProperty("jib.requiredVersion", "[,1.0]");
+    verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
+    verifier.executeGoals(Arrays.asList("package", "jib:buildTar"));
+    verifier.verifyTextInLog("BUILD FAILURE");
+    verifier.verifyTextInLog("but is required to be");
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/CheckJibVersionMojoTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/CheckJibVersionMojoTest.java
@@ -35,7 +35,7 @@ public class CheckJibVersionMojoTest {
 
   @Test
   public void testIdentifiers() {
-    // these identifiers will be baked into Skaffold and should not be changed
+    // These identifiers will be baked into Skaffold and should not be changed
     Assert.assertEquals("_skaffold-ensure-jib-up-to-date", CheckJibVersionMojo.GOAL_NAME);
     Assert.assertEquals("jib.requiredVersion", MojoCommon.REQUIRED_VERSION_PROPERTY_NAME);
   }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/CheckJibVersionMojoTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/CheckJibVersionMojoTest.java
@@ -36,7 +36,7 @@ public class CheckJibVersionMojoTest {
   @Test
   public void testIdentifiers() {
     // These identifiers will be baked into Skaffold and should not be changed
-    Assert.assertEquals("_skaffold-ensure-jib-up-to-date", CheckJibVersionMojo.GOAL_NAME);
+    Assert.assertEquals("_skaffold-fail-if-jib-out-of-date", CheckJibVersionMojo.GOAL_NAME);
     Assert.assertEquals("jib.requiredVersion", MojoCommon.REQUIRED_VERSION_PROPERTY_NAME);
   }
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/CheckJibVersionMojoTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/CheckJibVersionMojoTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.jib.maven.skaffold;
+
+import com.google.cloud.tools.jib.maven.MojoCommon;
+import com.google.cloud.tools.jib.maven.TestPlugin;
+import com.google.cloud.tools.jib.maven.TestProject;
+import java.io.IOException;
+import org.apache.maven.it.VerificationException;
+import org.apache.maven.it.Verifier;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+/** Tests for {@link CheckJibVersionMojo}. */
+public class CheckJibVersionMojoTest {
+  @ClassRule public static final TestPlugin testPlugin = new TestPlugin();
+
+  @ClassRule
+  public static final TestProject simpleTestProject = new TestProject(testPlugin, "simple");
+
+  @Test
+  public void testIdentifiers() {
+    // these identifiers will be baked into Skaffold and should not be changed
+    Assert.assertEquals("_skaffold-ensure-jib-up-to-date", CheckJibVersionMojo.GOAL_NAME);
+    Assert.assertEquals("jib.requiredVersion", MojoCommon.REQUIRED_VERSION_PROPERTY_NAME);
+  }
+
+  @Test
+  public void testFailOnMissingProperty() throws VerificationException, IOException {
+    Verifier verifier = new Verifier(simpleTestProject.getProjectRoot().toString());
+    try {
+      verifier.executeGoal("jib:" + CheckJibVersionMojo.GOAL_NAME);
+      Assert.fail("build should have failed");
+    } catch (VerificationException ex) {
+      verifier.verifyTextInLog("requires jib.requiredVersion to be set");
+    }
+  }
+
+  @Test
+  public void testFailOnOutOfDate() throws VerificationException, IOException {
+    Verifier verifier = new Verifier(simpleTestProject.getProjectRoot().toString());
+    verifier.setSystemProperty(MojoCommon.REQUIRED_VERSION_PROPERTY_NAME, "[,1.0)");
+    try {
+      verifier.executeGoal("jib:" + CheckJibVersionMojo.GOAL_NAME);
+      Assert.fail("build should have failed");
+    } catch (VerificationException ex) {
+      verifier.verifyTextInLog("but is required to be [,1.0)");
+    }
+  }
+
+  @Test
+  public void testSuccess() throws VerificationException, IOException {
+    Verifier verifier = new Verifier(simpleTestProject.getProjectRoot().toString());
+    verifier.setSystemProperty(MojoCommon.REQUIRED_VERSION_PROPERTY_NAME, "[1.0,)");
+    verifier.executeGoal("jib:" + CheckJibVersionMojo.GOAL_NAME);
+    verifier.verifyErrorFreeLog();
+  }
+}

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/VersionChecker.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/VersionChecker.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.jib.plugins.common;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+
+/**
+ * A simple version-range checker, intended to check whether a Jib plugin version falls in some
+ * range. A version range can be in one of two forms:
+ *
+ * <ol>
+ *   <li>A <em>bounded range</em> such as {@code [1.0,3.5)}, where square brackets indicate an open
+ *       boundary (includes the value) and parentheses indicates a closed boundary (excludes the
+ *       actual value). Either of the lower or upper bounds can be dropped (but not both!), such as
+ *       to indicate an exclusive upper- or lower-bound. For example, {@code [,4)} indicates up to
+ *       but not including version 4.0.
+ *   <li>a single version such a {@code 1.0} which acts as an open lower bound and akin to {@code
+ *       [1.0,)}
+ * </ol>
+ *
+ * To support custom version representations, the actual version object type ({@code <V>}) is
+ * pluggable. It must implement {@link Comparable}.
+ *
+ * <p>This class exists as Gradle has no version-range-type class and Maven's {@code
+ * org.apache.maven.artifact.versioning.VersionRange} treats a single version as an exact bound.
+ * Note that Gradle's {@code org.gradle.util.GradleVersion} class does not support
+ * major-version-only versions.
+ */
+public class VersionChecker<V extends Comparable<? super V>> {
+  /** The expected version representation. */
+  private static final String VERSION_PATTERN = "\\d+(\\.\\d+(\\.\\d+)?)?";
+
+  // Helper functions to avoid the cognitive burden of {@link Comparable#compareTo()}
+
+  /** Return {@code true} if {@code a} is less than {@code b}. */
+  @VisibleForTesting
+  static <T extends Comparable<? super T>> boolean LT(T a, T b) {
+    return a.compareTo(b) < 0;
+  }
+
+  /** Return {@code true} if {@code a} is less than or equal to {@code b}. */
+  @VisibleForTesting
+  static <T extends Comparable<? super T>> boolean LE(T a, T b) {
+    return a.compareTo(b) <= 0;
+  }
+
+  /** Return {@code true} if {@code a} is greater than {@code b}. */
+  @VisibleForTesting
+  static <T extends Comparable<? super T>> boolean GT(T a, T b) {
+    return a.compareTo(b) > 0;
+  }
+
+  /** Return {@code true} if {@code a} is greater than or equal to {@code b}. */
+  @VisibleForTesting
+  static <T extends Comparable<? super T>> boolean GE(T a, T b) {
+    return a.compareTo(b) >= 0;
+  }
+
+  /** Responsible for converting a string representation to a comparable version representation. */
+  private Function<String, V> converter;
+
+  public VersionChecker(Function<String, V> converter) {
+    this.converter = converter;
+  }
+
+  /**
+   * Return {@code true} if {@code actualVersion} is contained within the version range represented
+   * by {@code acceptableVersionRange}.
+   *
+   * @param acceptableVersionRange the encoded version range
+   * @param actualVersion the version to be compared
+   * @return true if the version is acceptable
+   * @throws IllegalArgumentException if the version could not be parsed
+   */
+  @VisibleForTesting
+  public boolean compatibleVersion(String acceptableVersionRange, String actualVersion) {
+    V pluginVersion = parseVersion(actualVersion);
+
+    // Treat a single version "1.4" as a lower bound (equivalent to "[1.4,)")
+    if (acceptableVersionRange.matches(VERSION_PATTERN)) {
+      return GE(pluginVersion, parseVersion(acceptableVersionRange));
+    }
+
+    // Otherwise ensure it is a version range with bounds
+    Preconditions.checkArgument(
+        acceptableVersionRange.matches(
+            "[\\[(](" + VERSION_PATTERN + ")?,(" + VERSION_PATTERN + ")?[\\])]"),
+        "invalid version range");
+    BiPredicate<V, V> bottomComparator =
+        acceptableVersionRange.startsWith("[") ? VersionChecker::GE : VersionChecker::GT;
+    BiPredicate<V, V> topComparator =
+        acceptableVersionRange.endsWith("]") ? VersionChecker::LE : VersionChecker::LT;
+    // extract the two version specs
+    String[] range =
+        acceptableVersionRange.substring(1, acceptableVersionRange.length() - 1).split(",", -1);
+    Preconditions.checkArgument(range.length == 2, "version range must have upper and lower bound");
+    Preconditions.checkArgument(
+        range[0].length() != 0 || range[1].length() != 0,
+        "upper and lower bounds cannot both be empty");
+
+    if (!range[0].isEmpty() && !bottomComparator.test(pluginVersion, parseVersion(range[0]))) {
+      return false;
+    }
+    if (!range[1].isEmpty() && !topComparator.test(pluginVersion, parseVersion(range[1]))) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * @return the parsed version
+   * @throws IllegalArgumentException if an exception occurred
+   */
+  private V parseVersion(String versionString) {
+    // catch other exceptions and turn into an IllegalArgumentException
+    try {
+      return converter.apply(versionString);
+    } catch (IllegalArgumentException ex) {
+      throw ex; // rethrow
+    } catch (Throwable ex) {
+      // Gradle's GradleVersion throws all sorts of unchecked exceptions
+      throw new IllegalArgumentException("unable to parse '" + versionString + "'", ex);
+    }
+  }
+}

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/VersionChecker.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/VersionChecker.java
@@ -49,10 +49,11 @@ import java.util.regex.Pattern;
 public class VersionChecker<V extends Comparable<? super V>> {
   /** Regular expression to match a single version. */
   private static final String VERSION_REGEX = "\\d+(\\.\\d+(\\.\\d+)?)?";
-  
+
   /** Regular expression to match an interval version range. */
-  private static final String INTERVAL_REGEX = "[\\[(](?<left>" + VERSION_REGEX + ")?,(?<right>" + VERSION_REGEX + ")?[])]";
-  
+  private static final String INTERVAL_REGEX =
+      "[\\[(](?<left>" + VERSION_REGEX + ")?,(?<right>" + VERSION_REGEX + ")?[])]";
+
   private static final Pattern INTERVAL_PATTERN = Pattern.compile(INTERVAL_REGEX);
 
   // Helper functions to avoid the cognitive burden of {@link Comparable#compareTo()}

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/VersionCheckerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/VersionCheckerTest.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2019 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.cloud.tools.jib.plugins.common;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/** Tests for {@link VersionChecker}. */
+public class VersionCheckerTest {
+  private static class TestVersion implements Comparable<TestVersion> {
+    private int[] components;
+
+    TestVersion(String version) {
+      String[] parts = version.split("\\.", -1);
+      components = new int[parts.length];
+      for (int i = 0; i < parts.length; i++) {
+        components[i] = Integer.parseInt(parts[i]);
+      }
+    }
+
+    @Override
+    public int compareTo(TestVersion other) {
+      for (int i = 0; i < Math.max(components.length, other.components.length); i++) {
+        int a = i < components.length ? components[i] : 0;
+        int b = i < other.components.length ? other.components[i] : 0;
+        if (a < b) {
+          return -1;
+        } else if (a > b) {
+          return 1;
+        }
+      }
+      return 0;
+    }
+  }
+
+  private VersionChecker<TestVersion> checker;
+
+  @Before
+  public void setUp() {
+    Assert.assertTrue(new TestVersion("1.0").compareTo(new TestVersion("1.1.1")) < 0);
+    Assert.assertTrue(new TestVersion("1.1.1").compareTo(new TestVersion("1.0")) > 0);
+    Assert.assertTrue(new TestVersion("1.1").compareTo(new TestVersion("1.1.0.0")) == 0);
+    checker = new VersionChecker<>(TestVersion::new);
+  }
+
+  @Test
+  public void testComparators_LT() {
+    Assert.assertTrue(VersionChecker.LT(0, 1));
+    Assert.assertFalse(VersionChecker.LT(1, 1));
+    Assert.assertFalse(VersionChecker.LT(2, 1));
+  }
+
+  @Test
+  public void testComparators_LE() {
+    Assert.assertTrue(VersionChecker.LE(0, 1));
+    Assert.assertTrue(VersionChecker.LE(1, 1));
+    Assert.assertFalse(VersionChecker.LE(2, 1));
+  }
+
+  @Test
+  public void testComparators_GE() {
+    Assert.assertFalse(VersionChecker.GE(0, 1));
+    Assert.assertTrue(VersionChecker.GE(1, 1));
+    Assert.assertTrue(VersionChecker.GE(2, 1));
+  }
+
+  @Test
+  public void testComparators_GT() {
+    Assert.assertFalse(VersionChecker.GT(0, 1));
+    Assert.assertFalse(VersionChecker.GT(1, 1));
+    Assert.assertTrue(VersionChecker.GT(2, 1));
+  }
+
+  @Test
+  public void testRange_lowOpen() {
+    Assert.assertFalse(checker.compatibleVersion("[2.3,4.3]", "1.0"));
+    Assert.assertFalse(checker.compatibleVersion("[2.3,4.3)", "1.0"));
+    Assert.assertFalse(checker.compatibleVersion("[2.3,)", "1.0"));
+    Assert.assertFalse(checker.compatibleVersion("[2.3,]", "1.0"));
+  }
+
+  @Test
+  public void testRange_lowOpen_exact() {
+    Assert.assertTrue(checker.compatibleVersion("[2.3,4.3]", "2.3"));
+    Assert.assertTrue(checker.compatibleVersion("[2.3,4.3)", "2.3"));
+    Assert.assertTrue(checker.compatibleVersion("[2.3,)", "2.3"));
+    Assert.assertTrue(checker.compatibleVersion("[2.3,]", "2.3"));
+  }
+
+  @Test
+  public void testRange_lowClosed() {
+    Assert.assertFalse(checker.compatibleVersion("(2.3,4.3]", "1.0"));
+    Assert.assertFalse(checker.compatibleVersion("(2.3,4.3)", "1.0"));
+    Assert.assertFalse(checker.compatibleVersion("(2.3,)", "1.0"));
+    Assert.assertFalse(checker.compatibleVersion("(2.3,]", "1.0"));
+  }
+
+  @Test
+  public void testRange_lowClosed_exact() {
+    Assert.assertFalse(checker.compatibleVersion("(2.3,4.3]", "2.3"));
+    Assert.assertFalse(checker.compatibleVersion("(2.3,4.3)", "2.3"));
+    Assert.assertFalse(checker.compatibleVersion("(2.3,)", "2.3"));
+    Assert.assertFalse(checker.compatibleVersion("(2.3,]", "2.3"));
+  }
+
+  @Test
+  public void testRange_highOpen() {
+    Assert.assertFalse(checker.compatibleVersion("[2.3,4.3]", "5.0"));
+    Assert.assertFalse(checker.compatibleVersion("(2.3,4.3]", "5.0"));
+    Assert.assertFalse(checker.compatibleVersion("[,4.3]", "5.0"));
+    Assert.assertFalse(checker.compatibleVersion("(,4.3]", "5.0"));
+  }
+
+  @Test
+  public void testRange_highOpen_exact() {
+    Assert.assertTrue(checker.compatibleVersion("[2.3,4.3]", "4.3"));
+    Assert.assertTrue(checker.compatibleVersion("(2.3,4.3]", "4.3"));
+    Assert.assertTrue(checker.compatibleVersion("[,4.3]", "4.3"));
+    Assert.assertTrue(checker.compatibleVersion("(,4.3]", "4.3"));
+  }
+
+  @Test
+  public void testRange_between() {
+    Assert.assertTrue(checker.compatibleVersion("[2.3,4.3]", "2.4"));
+    Assert.assertTrue(checker.compatibleVersion("(2.3,4.3]", "4.2"));
+    Assert.assertTrue(checker.compatibleVersion("[2.3,4.3)", "2.4"));
+    Assert.assertTrue(checker.compatibleVersion("(2.3,4.3)", "4.2"));
+  }
+
+  @Test
+  public void testRange_highClosed() {
+    Assert.assertFalse(checker.compatibleVersion("[2.3,4.3)", "5.0"));
+    Assert.assertFalse(checker.compatibleVersion("(2.3,4.3)", "5.0"));
+    Assert.assertFalse(checker.compatibleVersion("[,4.3)", "5.0"));
+    Assert.assertFalse(checker.compatibleVersion("(,4.3)", "5.0"));
+  }
+
+  @Test
+  public void testRange_highClosed_exact() {
+    Assert.assertFalse(checker.compatibleVersion("[2.3,4.3)", "4.3"));
+    Assert.assertFalse(checker.compatibleVersion("(2.3,4.3)", "4.3"));
+    Assert.assertFalse(checker.compatibleVersion("[,4.3)", "4.3"));
+    Assert.assertFalse(checker.compatibleVersion("(,4.3)", "4.3"));
+  }
+
+  @Test
+  public void testMinimumBound_low() {
+    Assert.assertFalse(checker.compatibleVersion("2.3", "1.0"));
+    Assert.assertFalse(checker.compatibleVersion("2.3", "2.2"));
+  }
+
+  @Test
+  public void testMinimumBound_exact() {
+    Assert.assertTrue(checker.compatibleVersion("2.3", "2.3"));
+  }
+
+  @Test
+  public void testMinimumBound_high() {
+    Assert.assertTrue(checker.compatibleVersion("2.3", "2.4"));
+    Assert.assertTrue(checker.compatibleVersion("2.3", "4.0"));
+  }
+
+  // @SuppressWarnings({"TryFailThrowable", "AssertionFailureIgnored"})
+  @Test
+  public void testRange_invalid() {
+    for (String rangeSpec :
+        new String[] {"[]", "[,]", "(,]", "[,)", "(,)", "[1,2,3]", "[1]", "foo", "{,2.3)", ""}) {
+      try {
+        checker.compatibleVersion(rangeSpec, "1.3");
+        Assert.fail("should have thrown an exception for " + rangeSpec);
+      } catch (IllegalArgumentException ex) {
+        // as expected
+      }
+    }
+  }
+}

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/VersionCheckerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/VersionCheckerTest.java
@@ -87,7 +87,7 @@ public class VersionCheckerTest {
   }
 
   @Test
-  public void testRange_lowOpen() {
+  public void testRange_leftClosed() {
     Assert.assertFalse(checker.compatibleVersion("[2.3,4.3]", "1.0"));
     Assert.assertFalse(checker.compatibleVersion("[2.3,4.3)", "1.0"));
     Assert.assertFalse(checker.compatibleVersion("[2.3,)", "1.0"));
@@ -95,7 +95,7 @@ public class VersionCheckerTest {
   }
 
   @Test
-  public void testRange_lowOpen_exact() {
+  public void testRange_leftClosed_exact() {
     Assert.assertTrue(checker.compatibleVersion("[2.3,4.3]", "2.3"));
     Assert.assertTrue(checker.compatibleVersion("[2.3,4.3)", "2.3"));
     Assert.assertTrue(checker.compatibleVersion("[2.3,)", "2.3"));
@@ -103,7 +103,7 @@ public class VersionCheckerTest {
   }
 
   @Test
-  public void testRange_lowClosed() {
+  public void testRange_leftOpen() {
     Assert.assertFalse(checker.compatibleVersion("(2.3,4.3]", "1.0"));
     Assert.assertFalse(checker.compatibleVersion("(2.3,4.3)", "1.0"));
     Assert.assertFalse(checker.compatibleVersion("(2.3,)", "1.0"));
@@ -111,7 +111,7 @@ public class VersionCheckerTest {
   }
 
   @Test
-  public void testRange_lowClosed_exact() {
+  public void testRange_leftOpen_exact() {
     Assert.assertFalse(checker.compatibleVersion("(2.3,4.3]", "2.3"));
     Assert.assertFalse(checker.compatibleVersion("(2.3,4.3)", "2.3"));
     Assert.assertFalse(checker.compatibleVersion("(2.3,)", "2.3"));
@@ -119,7 +119,7 @@ public class VersionCheckerTest {
   }
 
   @Test
-  public void testRange_highOpen() {
+  public void testRange_rightClosed() {
     Assert.assertFalse(checker.compatibleVersion("[2.3,4.3]", "5.0"));
     Assert.assertFalse(checker.compatibleVersion("(2.3,4.3]", "5.0"));
     Assert.assertFalse(checker.compatibleVersion("[,4.3]", "5.0"));
@@ -127,7 +127,7 @@ public class VersionCheckerTest {
   }
 
   @Test
-  public void testRange_highOpen_exact() {
+  public void testRange_rightClosed_exact() {
     Assert.assertTrue(checker.compatibleVersion("[2.3,4.3]", "4.3"));
     Assert.assertTrue(checker.compatibleVersion("(2.3,4.3]", "4.3"));
     Assert.assertTrue(checker.compatibleVersion("[,4.3]", "4.3"));
@@ -143,7 +143,7 @@ public class VersionCheckerTest {
   }
 
   @Test
-  public void testRange_highClosed() {
+  public void testRange_rightOpen() {
     Assert.assertFalse(checker.compatibleVersion("[2.3,4.3)", "5.0"));
     Assert.assertFalse(checker.compatibleVersion("(2.3,4.3)", "5.0"));
     Assert.assertFalse(checker.compatibleVersion("[,4.3)", "5.0"));
@@ -151,7 +151,7 @@ public class VersionCheckerTest {
   }
 
   @Test
-  public void testRange_highClosed_exact() {
+  public void testRange_rightOpen_exact() {
     Assert.assertFalse(checker.compatibleVersion("[2.3,4.3)", "4.3"));
     Assert.assertFalse(checker.compatibleVersion("(2.3,4.3)", "4.3"));
     Assert.assertFalse(checker.compatibleVersion("[,4.3)", "4.3"));


### PR DESCRIPTION
Jib provides some internal goals and properties to support Skaffold’s Jib binding for Maven and Gradle. Some of the improvements to this binding cannot be made backwards compatible, and may require the user to update their version of Jib.  We need some way to detect and enforce these version requirements.

This PR:
  1. Adds support to Jib's goals and tasks to define an expected or required version range as specified through a new property `jib.requiredVersion`.  This property can take two forms: a minimum version number (e.g., `1.4.0`) or a Maven-like version-range (`[1.4,2.0)`).
  2. Changes the Gradle `JibPlugin#apply()` to perform a version check if `jib.requiredVersion` is set.
  3. Changes the various Maven goals to perform a version check if `jib.requiredVersion` is set.
  4. Adds a new Maven goal `_skaffold-ensure-jib-up-to-date` and corresponding Gradle task `_skaffoldEnsureJibUpToDate` that fail if `jib.requiredVersion` is not set.  These goals will be called by Skaffold to fail and thus prompt users to update to a newer version of Jib.  Ideallyt these goals could be removed once we're confident there are no users of older Jib or Skaffold.
