### PR TITLE
Remove useless version field from skaffold-files-v2

### DIFF
--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutput.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutput.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.jib.plugins.common;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -26,7 +25,6 @@ import java.io.OutputStream;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * Builds a JSON string containing files and directories that <a
@@ -64,8 +62,6 @@ public class SkaffoldFilesOutput {
 
   @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
   private static class SkaffoldFilesTemplate {
-
-    @Nullable private final String version = ProjectInfo.VERSION;
 
     private final List<String> build = new ArrayList<>();
 

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutputTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldFilesOutputTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class SkaffoldFilesOutputTest {
 
   private static final String TEST_JSON =
-      "{\"version\":null,\"build\":[\"buildFile1\",\"buildFile2\"],\"inputs\":[\"input1\",\"input2\"],\"ignore\":[\"ignore1\",\"ignore2\"]}";
+      "{\"build\":[\"buildFile1\",\"buildFile2\"],\"inputs\":[\"input1\",\"input2\"],\"ignore\":[\"ignore1\",\"ignore2\"]}";
 
   @Test
   public void testGetJsonString() throws IOException {
@@ -44,8 +44,7 @@ public class SkaffoldFilesOutputTest {
   public void testGetJsonString_empty() throws IOException {
     SkaffoldFilesOutput skaffoldFilesOutput = new SkaffoldFilesOutput();
     Assert.assertEquals(
-        "{\"version\":null,\"build\":[],\"inputs\":[],\"ignore\":[]}",
-        skaffoldFilesOutput.getJsonString());
+        "{\"build\":[],\"inputs\":[],\"ignore\":[]}", skaffoldFilesOutput.getJsonString());
   }
 
   @Test


### PR DESCRIPTION
Removes the `version` field from the `_skaffold-files-v2` / `_skaffoldFilesV2` output added in #1714.  This field was added in support of GoogleContainerTools/skaffold#2122 but unfortunately was proved inadequate.  We're instead introducing explicit version checks within Jib with #1813.