### PR TITLE
Fix BuildImageMojoIntegrationTest

### DIFF
--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -546,24 +546,30 @@ public class BuildImageMojoIntegrationTest {
 
   @Test
   public void testExecute_jibRequireVersion_ok() throws VerificationException, IOException {
-    String targetImage = "simpleimage:maven" + System.nanoTime();
+    String targetImage = "localhost:6000/simpleimage:maven" + System.nanoTime();
 
-    Instant before = Instant.now();
     Verifier verifier = new Verifier(simpleTestProject.getProjectRoot().toString());
-    // this plugin should match 1.0
-    verifier.setSystemProperty("jib.requiredVersion", "1.0");
     verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
+    // properties required to push to :6000 for plain pom.xml
+    verifier.setSystemProperty("jib.to.auth.username", "testuser2");
+    verifier.setSystemProperty("jib.to.auth.password", "testpassword2");
+    verifier.setSystemProperty("sendCredentialsOverHttp", "true");
+    verifier.setSystemProperty("jib.allowInsecureRegistries", "true");
+    // this test plugin should match 1.0
+    verifier.setSystemProperty("jib.requiredVersion", "1.0");
     verifier.executeGoals(Arrays.asList("package", "jib:build"));
     verifier.verifyErrorFreeLog();
   }
 
   @Test
   public void testExecute_jibRequireVersion_fail() throws IOException {
-    String targetImage = "simpleimage:maven" + System.nanoTime();
+    String targetImage = "localhost:6000/simpleimage:maven" + System.nanoTime();
     try {
       Verifier verifier = new Verifier(simpleTestProject.getProjectRoot().toString());
-      verifier.setSystemProperty("jib.requiredVersion", "[,1.0]");
+      // other properties aren't required as this should fail due to jib.requiredVersion
       verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
+      // this plugin should be > 1.0 and so jib:build should fail
+      verifier.setSystemProperty("jib.requiredVersion", "[,1.0]");
       verifier.executeGoals(Arrays.asList("package", "jib:build"));
       Assert.fail();
     } catch (VerificationException ex) {


### PR DESCRIPTION
The `BuildImageMojoIntegrationTest` tests were failing as they were trying to push to Docker Hub.  I'm still not sure why it worked for me locally.

This PR fixes the `testExecute_jibRequireVersion_ok` and `testExecute_jibRequireVersion_fail` tests to push to the local docker registry on port 6000.  `_ok` is expected to succeed and so this test must explicitly set the Jib properties required to build to a local registry.  It's a bit confusing as some of these properties are set in the `pom-complex.xml` or `pom-complex-properties.xml` files.  But we're just trying to keep this test be simple.