### PR TITLE
Disconnect HttpResponse eagerly

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/Response.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/Response.java
@@ -19,12 +19,13 @@ package com.google.cloud.tools.jib.http;
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpResponse;
 import com.google.common.net.HttpHeaders;
+import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
 
 /** Holds an HTTP response. */
-public class Response {
+public class Response implements Closeable {
 
   private final HttpResponse httpResponse;
 
@@ -74,5 +75,10 @@ public class Response {
   /** @return the original request URL */
   public GenericUrl getRequestUrl() {
     return httpResponse.getRequest().getUrl();
+  }
+
+  @Override
+  public void close() throws IOException {
+    httpResponse.disconnect();
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -250,10 +250,11 @@ class RegistryEndpointCaller<T> {
       if (sendCredentials) {
         requestBuilder.setAuthorization(authorization);
       }
-      Response response =
-          connection.send(registryEndpointProvider.getHttpMethod(), requestBuilder.build());
 
-      return registryEndpointProvider.handleResponse(response);
+      try (Response response =
+          connection.send(registryEndpointProvider.getHttpMethod(), requestBuilder.build())) {
+        return registryEndpointProvider.handleResponse(response);
+      }
 
     } catch (HttpResponseException ex) {
       // First, see if the endpoint provider handles an exception as an expected response.

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/ConnectionTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/ConnectionTest.java
@@ -86,23 +86,21 @@ public class ConnectionTest {
   @Test
   public void testHttpTimeout_doNotSetByDefault() throws IOException {
     setUpMocksAndFakes(null);
-    try (Connection connection = testConnection) {
-      connection.send(HttpMethods.GET, fakeRequest);
+    try (Connection connection = testConnection;
+        Response response = connection.send(HttpMethods.GET, fakeRequest)) {
+      Mockito.verify(mockHttpRequest, Mockito.never()).setConnectTimeout(Mockito.anyInt());
+      Mockito.verify(mockHttpRequest, Mockito.never()).setReadTimeout(Mockito.anyInt());
     }
-
-    Mockito.verify(mockHttpRequest, Mockito.never()).setConnectTimeout(Mockito.anyInt());
-    Mockito.verify(mockHttpRequest, Mockito.never()).setReadTimeout(Mockito.anyInt());
   }
 
   @Test
   public void testHttpTimeout() throws IOException {
     setUpMocksAndFakes(5982);
-    try (Connection connection = testConnection) {
-      connection.send(HttpMethods.GET, fakeRequest);
+    try (Connection connection = testConnection;
+        Response response = connection.send(HttpMethods.GET, fakeRequest)) {
+      Mockito.verify(mockHttpRequest).setConnectTimeout(5982);
+      Mockito.verify(mockHttpRequest).setReadTimeout(5982);
     }
-
-    Mockito.verify(mockHttpRequest).setConnectTimeout(5982);
-    Mockito.verify(mockHttpRequest).setReadTimeout(5982);
   }
 
   private void setUpMocksAndFakes(Integer httpTimeout) throws IOException {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/ConnectionTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/ConnectionTest.java
@@ -87,7 +87,7 @@ public class ConnectionTest {
   public void testHttpTimeout_doNotSetByDefault() throws IOException {
     setUpMocksAndFakes(null);
     try (Connection connection = testConnection;
-        Response response = connection.send(HttpMethods.GET, fakeRequest)) {
+        Response ignored = connection.send(HttpMethods.GET, fakeRequest)) {
       Mockito.verify(mockHttpRequest, Mockito.never()).setConnectTimeout(Mockito.anyInt());
       Mockito.verify(mockHttpRequest, Mockito.never()).setReadTimeout(Mockito.anyInt());
     }
@@ -97,7 +97,7 @@ public class ConnectionTest {
   public void testHttpTimeout() throws IOException {
     setUpMocksAndFakes(5982);
     try (Connection connection = testConnection;
-        Response response = connection.send(HttpMethods.GET, fakeRequest)) {
+        Response ignored = connection.send(HttpMethods.GET, fakeRequest)) {
       Mockito.verify(mockHttpRequest).setConnectTimeout(5982);
       Mockito.verify(mockHttpRequest).setReadTimeout(5982);
     }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/ResponseTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/ResponseTest.java
@@ -41,8 +41,8 @@ public class ResponseTest {
 
     Mockito.when(httpResponseMock.getContent()).thenReturn(responseInputStream);
 
-    Response response = new Response(httpResponseMock);
-
-    Assert.assertArrayEquals(expectedResponse, ByteStreams.toByteArray(response.getBody()));
+    try (Response response = new Response(httpResponseMock)) {
+      Assert.assertArrayEquals(expectedResponse, ByteStreams.toByteArray(response.getBody()));
+    }
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
@@ -36,8 +36,8 @@ public class WithServerConnectionTest {
       throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException {
     try (TestWebServer server = new TestWebServer(false);
         Connection connection =
-            Connection.getConnectionFactory().apply(new URL(server.getEndpoint()))) {
-      Response response = connection.send("GET", new Request.Builder().build());
+            Connection.getConnectionFactory().apply(new URL(server.getEndpoint()));
+        Response response = connection.send("GET", new Request.Builder().build())) {
 
       Assert.assertEquals(200, response.getStatusCode());
       Assert.assertArrayEquals(
@@ -51,10 +51,9 @@ public class WithServerConnectionTest {
       throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException {
     try (TestWebServer server = new TestWebServer(false);
         Connection connection =
-            Connection.getConnectionFactory().apply(new URL(server.getEndpoint()))) {
-      connection.send("GET", new Request.Builder().build());
-      try {
-        connection.send("GET", new Request.Builder().build());
+            Connection.getConnectionFactory().apply(new URL(server.getEndpoint()));
+        Response response1 = connection.send("GET", new Request.Builder().build())) {
+      try (Response response2 = connection.send("GET", new Request.Builder().build())) {
         Assert.fail("Should fail on the second send");
       } catch (IllegalStateException ex) {
         Assert.assertEquals("Connection can send only one request", ex.getMessage());
@@ -68,8 +67,7 @@ public class WithServerConnectionTest {
     try (TestWebServer server = new TestWebServer(true);
         Connection connection =
             Connection.getConnectionFactory().apply(new URL(server.getEndpoint()))) {
-      try {
-        connection.send("GET", new Request.Builder().build());
+      try (Response response = connection.send("GET", new Request.Builder().build())) {
         Assert.fail("Should fail if cannot verify peer");
       } catch (SSLException ex) {
         Assert.assertNotNull(ex.getMessage());
@@ -82,8 +80,8 @@ public class WithServerConnectionTest {
       throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException {
     try (TestWebServer server = new TestWebServer(true);
         Connection connection =
-            Connection.getInsecureConnectionFactory().apply(new URL(server.getEndpoint()))) {
-      Response response = connection.send("GET", new Request.Builder().build());
+            Connection.getInsecureConnectionFactory().apply(new URL(server.getEndpoint()));
+        Response response = connection.send("GET", new Request.Builder().build())) {
 
       Assert.assertEquals(200, response.getStatusCode());
       Assert.assertArrayEquals(
@@ -111,8 +109,8 @@ public class WithServerConnectionTest {
       System.setProperty("http.proxyPassword", "pass_sys_prop");
 
       try (Connection connection =
-          Connection.getConnectionFactory().apply(new URL("http://does.not.matter"))) {
-        Response response = connection.send("GET", new Request.Builder().build());
+              Connection.getConnectionFactory().apply(new URL("http://does.not.matter"));
+          Response response = connection.send("GET", new Request.Builder().build())) {
         Assert.assertThat(
             server.getInputRead(),
             CoreMatchers.containsString(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerConnectionTest.java
@@ -52,8 +52,8 @@ public class WithServerConnectionTest {
     try (TestWebServer server = new TestWebServer(false);
         Connection connection =
             Connection.getConnectionFactory().apply(new URL(server.getEndpoint()));
-        Response response1 = connection.send("GET", new Request.Builder().build())) {
-      try (Response response2 = connection.send("GET", new Request.Builder().build())) {
+        Response ignored1 = connection.send("GET", new Request.Builder().build())) {
+      try (Response ignored2 = connection.send("GET", new Request.Builder().build())) {
         Assert.fail("Should fail on the second send");
       } catch (IllegalStateException ex) {
         Assert.assertEquals("Connection can send only one request", ex.getMessage());
@@ -67,7 +67,7 @@ public class WithServerConnectionTest {
     try (TestWebServer server = new TestWebServer(true);
         Connection connection =
             Connection.getConnectionFactory().apply(new URL(server.getEndpoint()))) {
-      try (Response response = connection.send("GET", new Request.Builder().build())) {
+      try (Response ignored = connection.send("GET", new Request.Builder().build())) {
         Assert.fail("Should fail if cannot verify peer");
       } catch (SSLException ex) {
         Assert.assertNotNull(ex.getMessage());


### PR DESCRIPTION
I learned from https://github.com/googleapis/google-http-java-client/issues/740 that it's good to disconnect it early when we're done.

The `HttpResponse` Javadoc says

```java
/**
 * HTTP response.
 *
 * <p>
 * Callers should call {@link #disconnect} when the HTTP response object is no longer needed.
 * However, {@link #disconnect} does not have to be called if the response stream is properly
 * closed. Example usage:
 * </p>
 *
 * <pre>
   HttpResponse response = request.execute();
   try {
     // process the HTTP response object
   } finally {
     response.disconnect();
   }
 * </pre>
```