### PR TITLE
Leverage NullAway checks with Optional for registry client framework

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverIntegrationTest.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.http.Authorization;
 import java.io.IOException;
+import java.util.Optional;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -31,9 +32,10 @@ public class AuthenticationMethodRetrieverIntegrationTest {
     RegistryClient registryClient =
         RegistryClient.factory(EventHandlers.NONE, "registry.hub.docker.com", "library/busybox")
             .newRegistryClient();
-    RegistryAuthenticator registryAuthenticator = registryClient.getRegistryAuthenticator();
-    Assert.assertNotNull(registryAuthenticator);
-    Authorization authorization = registryAuthenticator.authenticatePull(null);
+    Optional<RegistryAuthenticator> registryAuthenticator =
+        registryClient.getRegistryAuthenticator();
+    Assert.assertTrue(registryAuthenticator.isPresent());
+    Authorization authorization = registryAuthenticator.get().authenticatePull(null);
 
     RegistryClient authorizedRegistryClient =
         RegistryClient.factory(EventHandlers.NONE, "registry.hub.docker.com", "library/busybox")

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
@@ -47,7 +47,7 @@ public class BlobCheckerIntegrationTest {
         registryClient.pullManifest("latest", V22ManifestTemplate.class);
     DescriptorDigest blobDigest = manifestTemplate.getLayers().get(0).getDigest();
 
-    Assert.assertEquals(blobDigest, registryClient.checkBlob(blobDigest).getDigest());
+    Assert.assertEquals(blobDigest, registryClient.checkBlob(blobDigest).get().getDigest());
   }
 
   @Test
@@ -60,6 +60,6 @@ public class BlobCheckerIntegrationTest {
         DescriptorDigest.fromHash(
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
-    Assert.assertNull(registryClient.checkBlob(fakeBlobDigest));
+    Assert.assertFalse(registryClient.checkBlob(fakeBlobDigest).isPresent());
   }
 }

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -73,7 +73,7 @@ public class ManifestPullerIntegrationTest {
     RegistryClient.Factory factory =
         RegistryClient.factory(EventHandlers.NONE, "registry-1.docker.io", "library/openjdk");
     Authorization authorization =
-        factory.newRegistryClient().getRegistryAuthenticator().authenticatePull(null);
+        factory.newRegistryClient().getRegistryAuthenticator().get().authenticatePull(null);
     RegistryClient registryClient = factory.setAuthorization(authorization).newRegistryClient();
 
     // Ensure 11-jre-slim is a manifest list

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorIntegrationTest.java
@@ -22,6 +22,7 @@ import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.http.Authorization;
 import java.io.IOException;
+import java.util.Optional;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,15 +33,15 @@ public class RegistryAuthenticatorIntegrationTest {
   public void testAuthenticate()
       throws IOException, RegistryException, InvalidImageReferenceException {
     ImageReference dockerHubImageReference = ImageReference.parse("library/busybox");
-    RegistryAuthenticator registryAuthenticator =
+    Optional<RegistryAuthenticator> registryAuthenticator =
         RegistryClient.factory(
                 EventHandlers.NONE,
                 dockerHubImageReference.getRegistry(),
                 dockerHubImageReference.getRepository())
             .newRegistryClient()
             .getRegistryAuthenticator();
-    Assert.assertNotNull(registryAuthenticator);
-    Authorization authorization = registryAuthenticator.authenticatePull(null);
+    Assert.assertTrue(registryAuthenticator.isPresent());
+    Authorization authorization = registryAuthenticator.get().authenticatePull(null);
 
     // Checks that some token was received.
     Assert.assertTrue(0 < authorization.getToken().length());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
@@ -60,13 +60,13 @@ class AuthenticatePushStep implements Callable<Optional<Authorization>> {
         TimerEventDispatcher ignored2 =
             new TimerEventDispatcher(
                 buildConfiguration.getEventHandlers(), String.format(DESCRIPTION, registry))) {
-      RegistryAuthenticator registryAuthenticator =
+      Optional<RegistryAuthenticator> registryAuthenticator =
           buildConfiguration
               .newTargetImageRegistryClientFactory()
               .newRegistryClient()
               .getRegistryAuthenticator();
-      if (registryAuthenticator != null) {
-        return Optional.of(registryAuthenticator.authenticatePush(registryCredential));
+      if (registryAuthenticator.isPresent()) {
+        return Optional.of(registryAuthenticator.get().authenticatePush(registryCredential));
       }
     } catch (InsecureRegistryException ex) {
       // Cannot skip certificate validation or use HTTP; fall through.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -155,14 +155,14 @@ class PullBaseImageStep implements Callable<ImageAndAuthorization> {
           // The registry requires us to authenticate using the Docker Token Authentication.
           // See https://docs.docker.com/registry/spec/auth/token
           try {
-            RegistryAuthenticator registryAuthenticator =
+            Optional<RegistryAuthenticator> registryAuthenticator =
                 buildConfiguration
                     .newBaseImageRegistryClientFactory()
                     .newRegistryClient()
                     .getRegistryAuthenticator();
-            if (registryAuthenticator != null) {
+            if (registryAuthenticator.isPresent()) {
               Authorization pullAuthorization =
-                  registryAuthenticator.authenticatePull(registryCredential);
+                  registryAuthenticator.get().authenticatePull(registryCredential);
 
               return new ImageAndAuthorization(
                   pullBaseImage(pullAuthorization, progressEventDispatcher), pullAuthorization);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -72,7 +72,7 @@ class PushBlobStep implements Callable<BlobDescriptor> {
               .newRegistryClient();
 
       // check if the BLOB is available
-      if (registryClient.checkBlob(blobDescriptor.getDigest()) != null) {
+      if (registryClient.checkBlob(blobDescriptor.getDigest()).isPresent()) {
         buildConfiguration
             .getEventHandlers()
             .dispatch(LogEvent.info("BLOB : " + blobDescriptor + " already exists on registry"));

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetriever.java
@@ -57,7 +57,7 @@ class AuthenticationMethodRetriever
    * The request did not error, meaning that the registry does not require authentication.
    *
    * @param response ignored
-   * @return the authenticator
+   * @return {@link Optional#empty()}
    */
   @Override
   public Optional<RegistryAuthenticator> handleResponse(Response response) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetriever.java
@@ -26,10 +26,12 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import javax.annotation.Nullable;
 
 /** Retrieves the {@code WWW-Authenticate} header from the registry API. */
-class AuthenticationMethodRetriever implements RegistryEndpointProvider<RegistryAuthenticator> {
+class AuthenticationMethodRetriever
+    implements RegistryEndpointProvider<Optional<RegistryAuthenticator>> {
 
   private final RegistryEndpointRequestProperties registryEndpointRequestProperties;
   private final String userAgent;
@@ -55,12 +57,11 @@ class AuthenticationMethodRetriever implements RegistryEndpointProvider<Registry
    * The request did not error, meaning that the registry does not require authentication.
    *
    * @param response ignored
-   * @return {@code null}
+   * @return the authenticator
    */
   @Override
-  @Nullable
-  public RegistryAuthenticator handleResponse(Response response) {
-    return null;
+  public Optional<RegistryAuthenticator> handleResponse(Response response) {
+    return Optional.empty();
   }
 
   @Override
@@ -79,8 +80,7 @@ class AuthenticationMethodRetriever implements RegistryEndpointProvider<Registry
   }
 
   @Override
-  @Nullable
-  public RegistryAuthenticator handleHttpResponseException(
+  public Optional<RegistryAuthenticator> handleHttpResponseException(
       HttpResponseException httpResponseException)
       throws HttpResponseException, RegistryErrorException {
     // Only valid for status code of '401 Unauthorized'.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
@@ -40,6 +40,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
@@ -64,8 +65,7 @@ public class RegistryAuthenticator {
    * @see <a
    *     href="https://docs.docker.com/registry/spec/auth/token/#how-to-authenticate">https://docs.docker.com/registry/spec/auth/token/#how-to-authenticate</a>
    */
-  @Nullable
-  static RegistryAuthenticator fromAuthenticationMethod(
+  static Optional<RegistryAuthenticator> fromAuthenticationMethod(
       String authenticationMethod,
       RegistryEndpointRequestProperties registryEndpointRequestProperties,
       String userAgent)
@@ -73,7 +73,7 @@ public class RegistryAuthenticator {
     // If the authentication method starts with 'basic ' (case insensitive), no registry
     // authentication is needed.
     if (authenticationMethod.matches("^(?i)(basic) .*")) {
-      return null;
+      return Optional.empty();
     }
 
     // Checks that the authentication method starts with 'bearer ' (case insensitive).
@@ -104,7 +104,8 @@ public class RegistryAuthenticator {
             ? serviceMatcher.group(1)
             : registryEndpointRequestProperties.getServerUrl();
 
-    return new RegistryAuthenticator(realm, service, registryEndpointRequestProperties, userAgent);
+    return Optional.of(
+        new RegistryAuthenticator(realm, service, registryEndpointRequestProperties, userAgent));
   }
 
   private static RegistryAuthenticationFailedException newRegistryAuthenticationFailedException(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -34,13 +34,12 @@ import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -263,12 +262,12 @@ public class RegistryClient {
 
   /**
    * @return the {@link RegistryAuthenticator} to authenticate pulls/pushes with the registry, or
-   *     {@code null} if no token authentication is necessary
+   *     {@link Optional#empty()} if no token authentication is necessary
    * @throws IOException if communicating with the endpoint fails
    * @throws RegistryException if communicating with the endpoint fails
    */
-  @Nullable
-  public RegistryAuthenticator getRegistryAuthenticator() throws IOException, RegistryException {
+  public Optional<RegistryAuthenticator> getRegistryAuthenticator()
+      throws IOException, RegistryException {
     // Gets the WWW-Authenticate header (eg. 'WWW-Authenticate: Bearer
     // realm="https://gcr.io/v2/token",service="gcr.io"')
     return callRegistryEndpoint(
@@ -291,11 +290,7 @@ public class RegistryClient {
       String imageTag, Class<T> manifestTemplateClass) throws IOException, RegistryException {
     ManifestPuller<T> manifestPuller =
         new ManifestPuller<>(registryEndpointRequestProperties, imageTag, manifestTemplateClass);
-    T manifestTemplate = callRegistryEndpoint(manifestPuller);
-    if (manifestTemplate == null) {
-      throw new IllegalStateException("ManifestPuller#handleResponse does not return null");
-    }
-    return manifestTemplate;
+    return callRegistryEndpoint(manifestPuller);
   }
 
   public ManifestTemplate pullManifest(String imageTag) throws IOException, RegistryException {
@@ -313,21 +308,19 @@ public class RegistryClient {
    */
   public DescriptorDigest pushManifest(BuildableManifestTemplate manifestTemplate, String imageTag)
       throws IOException, RegistryException {
-    return Verify.verifyNotNull(
-        callRegistryEndpoint(
-            new ManifestPusher(
-                registryEndpointRequestProperties, manifestTemplate, imageTag, eventHandlers)));
+    return callRegistryEndpoint(
+        new ManifestPusher(
+            registryEndpointRequestProperties, manifestTemplate, imageTag, eventHandlers));
   }
 
   /**
    * @param blobDigest the blob digest to check for
-   * @return the BLOB's {@link BlobDescriptor} if the BLOB exists on the registry, or {@code null}
-   *     if it doesn't
+   * @return the BLOB's {@link BlobDescriptor} if the BLOB exists on the registry, or {@link
+   *     Optional#empty()} if it doesn't
    * @throws IOException if communicating with the endpoint fails
    * @throws RegistryException if communicating with the endpoint fails
    */
-  @Nullable
-  public BlobDescriptor checkBlob(DescriptorDigest blobDigest)
+  public Optional<BlobDescriptor> checkBlob(DescriptorDigest blobDigest)
       throws IOException, RegistryException {
     BlobChecker blobChecker = new BlobChecker(registryEndpointRequestProperties, blobDigest);
     return callRegistryEndpoint(blobChecker);
@@ -401,8 +394,8 @@ public class RegistryClient {
 
         // POST /v2/<name>/blobs/uploads/?mount={blob.digest}&from={sourceRepository}
         // POST /v2/<name>/blobs/uploads/
-        URL patchLocation = callRegistryEndpoint(blobPusher.initializer());
-        if (patchLocation == null) {
+        Optional<URL> patchLocation = callRegistryEndpoint(blobPusher.initializer());
+        if (!patchLocation.isPresent()) {
           // The BLOB exists already.
           return true;
         }
@@ -411,8 +404,7 @@ public class RegistryClient {
 
         // PATCH <Location> with BLOB
         URL putLocation =
-            callRegistryEndpoint(blobPusher.writer(patchLocation, writtenByteCountListener));
-        Preconditions.checkNotNull(putLocation);
+            callRegistryEndpoint(blobPusher.writer(patchLocation.get(), writtenByteCountListener));
 
         timerEventDispatcher2.lap("pushBlob PUT " + blobDigest);
 
@@ -465,7 +457,6 @@ public class RegistryClient {
    * @throws IOException if communicating with the endpoint fails
    * @throws RegistryException if communicating with the endpoint fails
    */
-  @Nullable
   private <T> T callRegistryEndpoint(RegistryEndpointProvider<T> registryEndpointProvider)
       throws IOException, RegistryException {
     return new RegistryEndpointCaller<>(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -159,12 +159,10 @@ class RegistryEndpointCaller<T> {
    * @throws IOException for most I/O exceptions when making the request
    * @throws RegistryException for known exceptions when interacting with the registry
    */
-  @Nullable
   T call() throws IOException, RegistryException {
     return callWithAllowInsecureRegistryHandling(initialRequestUrl);
   }
 
-  @Nullable
   private T callWithAllowInsecureRegistryHandling(URL url) throws IOException, RegistryException {
     if (!isHttpsProtocol(url) && !allowInsecureRegistries) {
       throw new InsecureRegistryException(url);
@@ -186,7 +184,6 @@ class RegistryEndpointCaller<T> {
     }
   }
 
-  @Nullable
   private T handleUnverifiableServerException(URL url) throws IOException, RegistryException {
     if (!allowInsecureRegistries) {
       throw new InsecureRegistryException(url);
@@ -203,7 +200,6 @@ class RegistryEndpointCaller<T> {
     }
   }
 
-  @Nullable
   private T fallBackToHttp(URL url) throws IOException, RegistryException {
     GenericUrl httpUrl = new GenericUrl(url);
     httpUrl.setScheme("http");
@@ -229,11 +225,10 @@ class RegistryEndpointCaller<T> {
    * Calls the registry endpoint with a certain {@link URL}.
    *
    * @param url the endpoint URL to call
-   * @return an object representing the response, or {@code null}
+   * @return an object representing the response
    * @throws IOException for most I/O exceptions when making the request
    * @throws RegistryException for known exceptions when interacting with the registry
    */
-  @Nullable
   private T call(URL url, Function<URL, Connection> connectionFactory)
       throws IOException, RegistryException {
     // Only sends authorization if using HTTPS or explicitly forcing over HTTP.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointProvider.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointProvider.java
@@ -50,7 +50,6 @@ interface RegistryEndpointProvider<T> {
   List<String> getAccept();
 
   /** Handles the response specific to the registry action. */
-  @Nullable
   T handleResponse(Response response) throws IOException, RegistryException;
 
   /**
@@ -61,7 +60,6 @@ interface RegistryEndpointProvider<T> {
    *     could not be handled
    * @throws RegistryErrorException if there is an error with a remote registry
    */
-  @Nullable
   default T handleHttpResponseException(HttpResponseException httpResponseException)
       throws HttpResponseException, RegistryErrorException {
     throw httpResponseException;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverTest.java
@@ -56,8 +56,8 @@ public class AuthenticationMethodRetrieverTest {
 
   @Test
   public void testHandleResponse() {
-    Assert.assertNull(
-        testAuthenticationMethodRetriever.handleResponse(Mockito.mock(Response.class)));
+    Assert.assertFalse(
+        testAuthenticationMethodRetriever.handleResponse(Mockito.mock(Response.class)).isPresent());
   }
 
   @Test
@@ -146,7 +146,9 @@ public class AuthenticationMethodRetrieverTest {
     Mockito.when(mockHeaders.getAuthenticate()).thenReturn(authenticationMethod);
 
     RegistryAuthenticator registryAuthenticator =
-        testAuthenticationMethodRetriever.handleHttpResponseException(mockHttpResponseException);
+        testAuthenticationMethodRetriever
+            .handleHttpResponseException(mockHttpResponseException)
+            .get();
 
     Assert.assertEquals(
         new URL("https://somerealm?service=someservice&scope=repository:someImageName:someScope"),

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobCheckerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobCheckerTest.java
@@ -62,7 +62,7 @@ public class BlobCheckerTest {
     Mockito.when(mockResponse.getContentLength()).thenReturn(0L);
     BlobDescriptor expectedBlobDescriptor = new BlobDescriptor(0, fakeDigest);
 
-    BlobDescriptor blobDescriptor = testBlobChecker.handleResponse(mockResponse);
+    BlobDescriptor blobDescriptor = testBlobChecker.handleResponse(mockResponse).get();
 
     Assert.assertEquals(expectedBlobDescriptor, blobDescriptor);
   }
@@ -93,10 +93,8 @@ public class BlobCheckerTest {
     Mockito.when(mockHttpResponseException.getContent())
         .thenReturn(JsonTemplateMapper.toUtf8String(emptyErrorResponseTemplate));
 
-    BlobDescriptor blobDescriptor =
-        testBlobChecker.handleHttpResponseException(mockHttpResponseException);
-
-    Assert.assertNull(blobDescriptor);
+    Assert.assertFalse(
+        testBlobChecker.handleHttpResponseException(mockHttpResponseException).isPresent());
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobPusherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobPusherTest.java
@@ -80,7 +80,7 @@ public class BlobPusherTest {
   @Test
   public void testInitializer_handleResponse_created() throws IOException, RegistryException {
     Mockito.when(mockResponse.getStatusCode()).thenReturn(201); // Created
-    Assert.assertNull(testBlobPusher.initializer().handleResponse(mockResponse));
+    Assert.assertFalse(testBlobPusher.initializer().handleResponse(mockResponse).isPresent());
   }
 
   @Test
@@ -92,7 +92,7 @@ public class BlobPusherTest {
     Mockito.when(mockResponse.getRequestUrl()).thenReturn(requestUrl);
     Assert.assertEquals(
         new URL("https://someurl/location"),
-        testBlobPusher.initializer().handleResponse(mockResponse));
+        testBlobPusher.initializer().handleResponse(mockResponse).get());
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
@@ -41,9 +41,10 @@ public class RegistryAuthenticatorTest {
   public void setUp() throws RegistryAuthenticationFailedException {
     registryAuthenticator =
         RegistryAuthenticator.fromAuthenticationMethod(
-            "Bearer realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
-            registryEndpointRequestProperties,
-            "user-agent");
+                "Bearer realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
+                registryEndpointRequestProperties,
+                "user-agent")
+            .get();
   }
 
   @Test
@@ -51,9 +52,10 @@ public class RegistryAuthenticatorTest {
       throws MalformedURLException, RegistryAuthenticationFailedException {
     RegistryAuthenticator registryAuthenticator =
         RegistryAuthenticator.fromAuthenticationMethod(
-            "Bearer realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
-            registryEndpointRequestProperties,
-            "user-agent");
+                "Bearer realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
+                registryEndpointRequestProperties,
+                "user-agent")
+            .get();
     Assert.assertEquals(
         new URL("https://somerealm?service=someservice&scope=repository:someimage:scope"),
         registryAuthenticator.getAuthenticationUrl(
@@ -61,9 +63,10 @@ public class RegistryAuthenticatorTest {
 
     registryAuthenticator =
         RegistryAuthenticator.fromAuthenticationMethod(
-            "bEaReR realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
-            registryEndpointRequestProperties,
-            "user-agent");
+                "bEaReR realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
+                registryEndpointRequestProperties,
+                "user-agent")
+            .get();
     Assert.assertEquals(
         new URL("https://somerealm?service=someservice&scope=repository:someimage:scope"),
         registryAuthenticator.getAuthenticationUrl(
@@ -124,23 +127,26 @@ public class RegistryAuthenticatorTest {
 
   @Test
   public void testFromAuthenticationMethod_basic() throws RegistryAuthenticationFailedException {
-    Assert.assertNull(
+    Assert.assertFalse(
         RegistryAuthenticator.fromAuthenticationMethod(
-            "Basic realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
-            registryEndpointRequestProperties,
-            "user-agent"));
+                "Basic realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
+                registryEndpointRequestProperties,
+                "user-agent")
+            .isPresent());
 
-    Assert.assertNull(
+    Assert.assertFalse(
         RegistryAuthenticator.fromAuthenticationMethod(
-            "BASIC realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
-            registryEndpointRequestProperties,
-            "user-agent"));
+                "BASIC realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
+                registryEndpointRequestProperties,
+                "user-agent")
+            .isPresent());
 
-    Assert.assertNull(
+    Assert.assertFalse(
         RegistryAuthenticator.fromAuthenticationMethod(
-            "bASIC realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
-            registryEndpointRequestProperties,
-            "user-agent"));
+                "bASIC realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
+                registryEndpointRequestProperties,
+                "user-agent")
+            .isPresent());
   }
 
   @Test
@@ -178,7 +184,10 @@ public class RegistryAuthenticatorTest {
       throws MalformedURLException, RegistryAuthenticationFailedException {
     RegistryAuthenticator registryAuthenticator =
         RegistryAuthenticator.fromAuthenticationMethod(
-            "Bearer realm=\"https://somerealm\"", registryEndpointRequestProperties, "user-agent");
+                "Bearer realm=\"https://somerealm\"",
+                registryEndpointRequestProperties,
+                "user-agent")
+            .get();
 
     Assert.assertEquals(
         new URL("https://somerealm?service=someserver&scope=repository:someimage:scope"),
@@ -193,9 +202,10 @@ public class RegistryAuthenticatorTest {
       try {
         RegistryAuthenticator authenticator =
             RegistryAuthenticator.fromAuthenticationMethod(
-                "Bearer realm=\"" + server.getEndpoint() + "\"",
-                registryEndpointRequestProperties,
-                "Competent-Agent");
+                    "Bearer realm=\"" + server.getEndpoint() + "\"",
+                    registryEndpointRequestProperties,
+                    "Competent-Agent")
+                .get();
         authenticator.authenticatePush(null);
       } catch (RegistryAuthenticationFailedException ex) {
         // Doesn't matter if auth fails. We only examine what we sent.


### PR DESCRIPTION
Currently, the registry client framework has `callRegistryEndpoint()`, `call???()`, `handleResponse()`, etc. always return `@Nullable` generic results. Not only did this lead to code like below to manually suppress null warnings, but this also renders the NullAway checks largely useless.

```java
    T manifestTemplate = callRegistryEndpoint(manifestPuller);
    if (manifestTemplate == null) {
      throw new IllegalStateException("ManifestPuller#handleResponse does not return null");
    }
``` 
```java
    return Verify.verifyNotNull(callRegistryEndpoint(...));
```
```java
        URL putLocation = callRegistryEndpoint(...);
        Preconditions.checkNotNull(putLocation);
```

`Optional` comes to the rescue, as in #1804.