### PR TITLE
Remove unused code / renaming methods

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -79,7 +79,7 @@ public class StepsRunner {
    */
   public static StepsRunner begin(BuildConfiguration buildConfiguration) {
     ExecutorService executorService =
-        JibSystemProperties.isSerializedExecutionEnabled()
+        JibSystemProperties.serializedExecution()
             ? MoreExecutors.newDirectExecutorService()
             : buildConfiguration.getExecutorService();
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
@@ -18,17 +18,16 @@ package com.google.cloud.tools.jib.global;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.collect.Range;
 
 /** Names of system properties defined/used by Jib. */
 public class JibSystemProperties {
 
+  @VisibleForTesting
+  public static final String SEND_CREDENTIALS_OVER_HTTP = "sendCredentialsOverHttp";
+
   @VisibleForTesting public static final String HTTP_TIMEOUT = "jib.httpTimeout";
 
   @VisibleForTesting static final String CROSS_REPOSITORY_BLOB_MOUNTS = "jib.blobMounts";
-
-  @VisibleForTesting
-  public static final String SEND_CREDENTIALS_OVER_HTTP = "sendCredentialsOverHttp";
 
   private static final String SERIALIZE = "jibSerialize";
 
@@ -66,7 +65,7 @@ public class JibSystemProperties {
    *
    * @return {@code true} if Jib's execution should be serialized, {@code false} if not
    */
-  public static boolean isSerializedExecutionEnabled() {
+  public static boolean serializedExecution() {
     return Boolean.getBoolean(SERIALIZE);
   }
 
@@ -77,7 +76,7 @@ public class JibSystemProperties {
    * @return {@code true} if authentication information is allowed to be sent over insecure
    *     connections, {@code false} if not
    */
-  public static boolean isSendCredentialsOverHttpEnabled() {
+  public static boolean sendCredentialsOverHttp() {
     return Boolean.getBoolean(SEND_CREDENTIALS_OVER_HTTP);
   }
 
@@ -89,48 +88,6 @@ public class JibSystemProperties {
    */
   public static boolean isUserAgentEnabled() {
     return Strings.isNullOrEmpty(System.getProperty(DISABLE_USER_AGENT));
-  }
-
-  /**
-   * Checks the {@code jib.httpTimeout} system property for invalid (non-integer or negative)
-   * values.
-   *
-   * @throws NumberFormatException if invalid values
-   */
-  public static void checkHttpTimeoutProperty() throws NumberFormatException {
-    checkNumericSystemProperty(HTTP_TIMEOUT, Range.atLeast(0));
-  }
-
-  /**
-   * Checks if {@code http.proxyPort} and {@code https.proxyPort} system properties are in the
-   * [0..65535] range when set.
-   *
-   * @throws NumberFormatException if invalid values
-   */
-  public static void checkProxyPortProperty() throws NumberFormatException {
-    checkNumericSystemProperty("http.proxyPort", Range.closed(0, 65535));
-    checkNumericSystemProperty("https.proxyPort", Range.closed(0, 65535));
-  }
-
-  private static void checkNumericSystemProperty(String property, Range<Integer> validRange) {
-    String value = System.getProperty(property);
-    if (value == null) {
-      return;
-    }
-
-    int parsed;
-    try {
-      parsed = Integer.parseInt(value);
-    } catch (NumberFormatException ex) {
-      throw new NumberFormatException(property + " must be an integer: " + value);
-    }
-    if (validRange.hasLowerBound() && validRange.lowerEndpoint() > parsed) {
-      throw new NumberFormatException(
-          property + " cannot be less than " + validRange.lowerEndpoint() + ": " + value);
-    } else if (validRange.hasUpperBound() && validRange.upperEndpoint() < parsed) {
-      throw new NumberFormatException(
-          property + " cannot be greater than " + validRange.upperEndpoint() + ": " + value);
-    }
   }
 
   private JibSystemProperties() {}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -232,8 +232,7 @@ class RegistryEndpointCaller<T> {
   private T call(URL url, Function<URL, Connection> connectionFactory)
       throws IOException, RegistryException {
     // Only sends authorization if using HTTPS or explicitly forcing over HTTP.
-    boolean sendCredentials =
-        isHttpsProtocol(url) || JibSystemProperties.isSendCredentialsOverHttpEnabled();
+    boolean sendCredentials = isHttpsProtocol(url) || JibSystemProperties.sendCredentialsOverHttp();
 
     try (Connection connection = connectionFactory.apply(url)) {
       Request.Builder requestBuilder =

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/global/JibSystemPropertiesTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/global/JibSystemPropertiesTest.java
@@ -16,142 +16,16 @@
 
 package com.google.cloud.tools.jib.global;
 
-import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 /** Tests for {@link JibSystemProperties}. */
 public class JibSystemPropertiesTest {
 
-  @Nullable private String httpProxyPortSaved;
-  @Nullable private String httpsProxyPortSaved;
-
-  @Before
-  public void setUp() {
-    httpProxyPortSaved = System.getProperty("http.proxyPort");
-    httpsProxyPortSaved = System.getProperty("https.proxyPort");
-  }
-
   @After
   public void tearDown() {
-    System.clearProperty(JibSystemProperties.HTTP_TIMEOUT);
-    System.clearProperty("http.proxyPort");
-    System.clearProperty("https.proxyPort");
-    if (httpProxyPortSaved != null) {
-      System.setProperty("http.proxyPort", httpProxyPortSaved);
-    }
-    if (httpsProxyPortSaved != null) {
-      System.setProperty("https.proxyPort", httpsProxyPortSaved);
-    }
     System.clearProperty(JibSystemProperties.CROSS_REPOSITORY_BLOB_MOUNTS);
-  }
-
-  @Test
-  public void testCheckHttpTimeoutProperty_ok() throws NumberFormatException {
-    Assert.assertNull(System.getProperty(JibSystemProperties.HTTP_TIMEOUT));
-    JibSystemProperties.checkHttpTimeoutProperty();
-  }
-
-  @Test
-  public void testCheckHttpTimeoutProperty_stringValue() {
-    System.setProperty(JibSystemProperties.HTTP_TIMEOUT, "random string");
-    try {
-      JibSystemProperties.checkHttpTimeoutProperty();
-      Assert.fail();
-    } catch (NumberFormatException ex) {
-      Assert.assertEquals("jib.httpTimeout must be an integer: random string", ex.getMessage());
-    }
-  }
-
-  @Test
-  public void testCheckHttpProxyPortProperty_undefined() throws NumberFormatException {
-    System.clearProperty("http.proxyPort");
-    System.clearProperty("https.proxyPort");
-    JibSystemProperties.checkProxyPortProperty();
-  }
-
-  @Test
-  public void testCheckHttpProxyPortProperty() throws NumberFormatException {
-    System.setProperty("http.proxyPort", "0");
-    System.setProperty("https.proxyPort", "0");
-    JibSystemProperties.checkProxyPortProperty();
-
-    System.setProperty("http.proxyPort", "1");
-    System.setProperty("https.proxyPort", "1");
-    JibSystemProperties.checkProxyPortProperty();
-
-    System.setProperty("http.proxyPort", "65535");
-    System.setProperty("https.proxyPort", "65535");
-    JibSystemProperties.checkProxyPortProperty();
-
-    System.setProperty("http.proxyPort", "65534");
-    System.setProperty("https.proxyPort", "65534");
-    JibSystemProperties.checkProxyPortProperty();
-  }
-
-  @Test
-  public void testCheckHttpProxyPortProperty_negativeValue() {
-    System.setProperty("http.proxyPort", "-1");
-    System.clearProperty("https.proxyPort");
-    try {
-      JibSystemProperties.checkProxyPortProperty();
-      Assert.fail();
-    } catch (NumberFormatException ex) {
-      Assert.assertEquals("http.proxyPort cannot be less than 0: -1", ex.getMessage());
-    }
-
-    System.clearProperty("http.proxyPort");
-    System.setProperty("https.proxyPort", "-1");
-    try {
-      JibSystemProperties.checkProxyPortProperty();
-      Assert.fail();
-    } catch (NumberFormatException ex) {
-      Assert.assertEquals("https.proxyPort cannot be less than 0: -1", ex.getMessage());
-    }
-  }
-
-  @Test
-  public void testCheckHttpProxyPortProperty_over65535() {
-    System.setProperty("http.proxyPort", "65536");
-    System.clearProperty("https.proxyPort");
-    try {
-      JibSystemProperties.checkProxyPortProperty();
-      Assert.fail();
-    } catch (NumberFormatException ex) {
-      Assert.assertEquals("http.proxyPort cannot be greater than 65535: 65536", ex.getMessage());
-    }
-
-    System.clearProperty("http.proxyPort");
-    System.setProperty("https.proxyPort", "65536");
-    try {
-      JibSystemProperties.checkProxyPortProperty();
-      Assert.fail();
-    } catch (NumberFormatException ex) {
-      Assert.assertEquals("https.proxyPort cannot be greater than 65535: 65536", ex.getMessage());
-    }
-  }
-
-  @Test
-  public void testCheckHttpProxyPortProperty_stringValue() {
-    System.setProperty("http.proxyPort", "some string");
-    System.clearProperty("https.proxyPort");
-    try {
-      JibSystemProperties.checkProxyPortProperty();
-      Assert.fail();
-    } catch (NumberFormatException ex) {
-      Assert.assertEquals("http.proxyPort must be an integer: some string", ex.getMessage());
-    }
-
-    System.clearProperty("http.proxyPort");
-    System.setProperty("https.proxyPort", "some string");
-    try {
-      JibSystemProperties.checkProxyPortProperty();
-      Assert.fail();
-    } catch (NumberFormatException ex) {
-      Assert.assertEquals("https.proxyPort must be an integer: some string", ex.getMessage());
-    }
   }
 
   @Test


### PR DESCRIPTION
The code to validate some system properties are unused. It doesn't hurt to check them somewhere, but I think it doesn't provide much value.