### PR TITLE
Increase executor shutdown timeout in tests

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -40,6 +40,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -72,6 +73,8 @@ class GradleProjectProperties implements ProjectProperties {
 
   /** Name of the `main` {@link SourceSet} to use as source files. */
   private static final String MAIN_SOURCE_SET_NAME = "main";
+
+  private static final Duration LOGGING_THREAD_SHUTDOWN_TIMEOUT = Duration.ofSeconds(1);
 
   /** @return a GradleProjectProperties from the given project and logger. */
   static GradleProjectProperties getForProject(Project project, Logger logger) {
@@ -245,7 +248,7 @@ class GradleProjectProperties implements ProjectProperties {
 
   @Override
   public void waitForLoggingThread() {
-    singleThreadedExecutor.shutDownAndAwaitTermination();
+    singleThreadedExecutor.shutDownAndAwaitTermination(LOGGING_THREAD_SHUTDOWN_TIMEOUT);
   }
 
   @Override

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -41,6 +41,7 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -71,6 +72,8 @@ public class MavenProjectProperties implements ProjectProperties {
 
   /** Used for logging during main class inference. */
   private static final String JAR_PLUGIN_NAME = "'maven-jar-plugin'";
+
+  private static final Duration LOGGING_THREAD_SHUTDOWN_TIMEOUT = Duration.ofSeconds(1);
 
   /**
    * @param project the {@link MavenProject} for the plugin.
@@ -277,7 +280,7 @@ public class MavenProjectProperties implements ProjectProperties {
 
   @Override
   public void waitForLoggingThread() {
-    singleThreadedExecutor.shutDownAndAwaitTermination();
+    singleThreadedExecutor.shutDownAndAwaitTermination(LOGGING_THREAD_SHUTDOWN_TIMEOUT);
   }
 
   @Override

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLogger.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLogger.java
@@ -44,8 +44,11 @@ class PlainConsoleLogger implements ConsoleLogger {
   @Override
   public void log(Level logLevel, String message) {
     if (messageConsumers.containsKey(logLevel)) {
-      singleThreadedExecutor.execute(() -> messageConsumers.get(logLevel).accept(message));
+      return;
     }
+    Consumer<String> messageConsumer = messageConsumers.get(logLevel);
+
+    singleThreadedExecutor.execute(() -> messageConsumer.accept(message));
   }
 
   @Override

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLogger.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLogger.java
@@ -43,7 +43,7 @@ class PlainConsoleLogger implements ConsoleLogger {
 
   @Override
   public void log(Level logLevel, String message) {
-    if (messageConsumers.containsKey(logLevel)) {
+    if (!messageConsumers.containsKey(logLevel)) {
       return;
     }
     Consumer<String> messageConsumer = messageConsumers.get(logLevel);

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLogger.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLogger.java
@@ -43,12 +43,9 @@ class PlainConsoleLogger implements ConsoleLogger {
 
   @Override
   public void log(Level logLevel, String message) {
-    if (!messageConsumers.containsKey(logLevel)) {
-      return;
+    if (messageConsumers.containsKey(logLevel)) {
+      singleThreadedExecutor.execute(() -> messageConsumers.get(logLevel).accept(message));
     }
-    Consumer<String> messageConsumer = messageConsumers.get(logLevel);
-
-    singleThreadedExecutor.execute(() -> messageConsumer.accept(message));
   }
 
   @Override

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/SingleThreadedExecutor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/SingleThreadedExecutor.java
@@ -29,20 +29,16 @@ import java.util.concurrent.TimeUnit;
  */
 public class SingleThreadedExecutor {
 
-  private static final Duration EXECUTOR_SHUTDOWN_WAIT = Duration.ofSeconds(1);
-
   private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
   /** Shuts down the {@link #executorService} and waits for it to terminate. */
-  public void shutDownAndAwaitTermination() {
+  public void shutDownAndAwaitTermination(Duration timeout) {
     executorService.shutdown();
 
     try {
-      if (!executorService.awaitTermination(
-          EXECUTOR_SHUTDOWN_WAIT.getSeconds(), TimeUnit.SECONDS)) {
+      if (!executorService.awaitTermination(timeout.getSeconds(), TimeUnit.SECONDS)) {
         executorService.shutdownNow();
-        if (!executorService.awaitTermination(
-            EXECUTOR_SHUTDOWN_WAIT.getSeconds(), TimeUnit.SECONDS)) {
+        if (!executorService.awaitTermination(timeout.getSeconds(), TimeUnit.SECONDS)) {
           System.err.println("Could not shut down SingleThreadedExecutor");
         }
       }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/SingleThreadedExecutor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/SingleThreadedExecutor.java
@@ -31,7 +31,12 @@ public class SingleThreadedExecutor {
 
   private final ExecutorService executorService = Executors.newSingleThreadExecutor();
 
-  /** Shuts down the {@link #executorService} and waits for it to terminate. */
+  /**
+   * Shuts down the {@link #executorService} and waits for it to terminate.
+   *
+   * @param timeout timeout to wait. The method may call {@link ExecutorService#awaitTermination}
+   *     times with the given timeout, so the overall wait time can go up to 2 times the timeout
+   */
   public void shutDownAndAwaitTermination(Duration timeout) {
     executorService.shutdown();
 

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooterTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooterTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.plugins.common.logging;
 
 import com.google.cloud.tools.jib.api.LogEvent.Level;
 import com.google.common.collect.ImmutableMap;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -30,6 +31,8 @@ import org.junit.Test;
 
 /** Tests for {@link AnsiLoggerWithFooter}. */
 public class AnsiLoggerWithFooterTest {
+
+  private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(3);
 
   private final SingleThreadedExecutor singleThreadedExecutor = new SingleThreadedExecutor();
 
@@ -89,7 +92,7 @@ public class AnsiLoggerWithFooterTest {
     testAnsiLoggerWithFooter.log(Level.WARN, "warn");
     testAnsiLoggerWithFooter.log(Level.ERROR, "error");
 
-    singleThreadedExecutor.shutDownAndAwaitTermination();
+    singleThreadedExecutor.shutDownAndAwaitTermination(SHUTDOWN_TIMEOUT);
 
     Assert.assertEquals(
         Arrays.asList("lifecycle", "progress", "info", "debug", "warn", "error"), messages);
@@ -113,7 +116,7 @@ public class AnsiLoggerWithFooterTest {
     testAnsiLoggerWithFooter.log(Level.WARN, "warn");
     testAnsiLoggerWithFooter.log(Level.ERROR, "error");
 
-    singleThreadedExecutor.shutDownAndAwaitTermination();
+    singleThreadedExecutor.shutDownAndAwaitTermination(SHUTDOWN_TIMEOUT);
 
     Assert.assertEquals(Collections.singletonList("lifecycle"), messages);
     Assert.assertEquals(Collections.singletonList(Level.LIFECYCLE), levels);
@@ -125,7 +128,7 @@ public class AnsiLoggerWithFooterTest {
     testAnsiLoggerWithFooter.log(Level.INFO, "message");
     testAnsiLoggerWithFooter.log(Level.INFO, "another message");
 
-    singleThreadedExecutor.shutDownAndAwaitTermination();
+    singleThreadedExecutor.shutDownAndAwaitTermination(SHUTDOWN_TIMEOUT);
 
     Assert.assertEquals(
         Arrays.asList(
@@ -156,7 +159,7 @@ public class AnsiLoggerWithFooterTest {
     testAnsiLoggerWithFooter.setFooter(Arrays.asList("two line", "footer"));
     testAnsiLoggerWithFooter.log(Level.WARN, "another message");
 
-    singleThreadedExecutor.shutDownAndAwaitTermination();
+    singleThreadedExecutor.shutDownAndAwaitTermination(SHUTDOWN_TIMEOUT);
 
     Assert.assertEquals(
         Arrays.asList(

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLoggerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLoggerTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.plugins.common.logging;
 
 import com.google.cloud.tools.jib.api.LogEvent.Level;
 import com.google.common.collect.ImmutableMap;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -29,6 +30,8 @@ import org.junit.Test;
 
 /** Tests for {@link PlainConsoleLogger}. */
 public class PlainConsoleLoggerTest {
+
+  private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(3);
 
   private final SingleThreadedExecutor singleThreadedExecutor = new SingleThreadedExecutor();
 
@@ -60,7 +63,7 @@ public class PlainConsoleLoggerTest {
     testPlainConsoleLogger.log(Level.WARN, "warn");
     testPlainConsoleLogger.log(Level.ERROR, "error");
 
-    singleThreadedExecutor.shutDownAndAwaitTermination();
+    singleThreadedExecutor.shutDownAndAwaitTermination(SHUTDOWN_TIMEOUT);
 
     Assert.assertEquals(
         Arrays.asList(
@@ -84,7 +87,7 @@ public class PlainConsoleLoggerTest {
     testPlainConsoleLogger.log(Level.WARN, "warn");
     testPlainConsoleLogger.log(Level.ERROR, "error");
 
-    singleThreadedExecutor.shutDownAndAwaitTermination();
+    singleThreadedExecutor.shutDownAndAwaitTermination(SHUTDOWN_TIMEOUT);
 
     Assert.assertEquals(Collections.singletonList(Level.WARN), levels);
     Assert.assertEquals(Collections.singletonList("warn"), messages);

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/SingleThreadedExecutorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/SingleThreadedExecutorTest.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.plugins.common.logging;
 
 import com.google.cloud.tools.jib.MultithreadedExecutor;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.locks.Lock;
@@ -27,6 +28,8 @@ import org.junit.Test;
 
 /** Tests for {@link SingleThreadedExecutor}. */
 public class SingleThreadedExecutorTest {
+
+  private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(3);
 
   @SuppressWarnings("ThreadPriorityCheck") // use of Thread.yield()
   @Test
@@ -50,6 +53,6 @@ public class SingleThreadedExecutorTest {
               }));
     }
 
-    singleThreadedExecutor.shutDownAndAwaitTermination();
+    singleThreadedExecutor.shutDownAndAwaitTermination(SHUTDOWN_TIMEOUT);
   }
 }


### PR DESCRIPTION
Fixes #1839. Unlike #1846, `SingleThreadedExecutor` is not code only for testing, so I'm retaining the same 1-sec timeout in prod.