### PR TITLE
Rename DockerLoadManifestEntryTemplate

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/ImageTarball.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/ImageTarball.java
@@ -17,7 +17,7 @@
 package com.google.cloud.tools.jib.docker;
 
 import com.google.cloud.tools.jib.api.ImageReference;
-import com.google.cloud.tools.jib.docker.json.DockerLoadManifestEntryTemplate;
+import com.google.cloud.tools.jib.docker.json.DockerManifestEntryTemplate;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.Layer;
 import com.google.cloud.tools.jib.image.json.ImageToJsonTranslator;
@@ -57,7 +57,7 @@ public class ImageTarball {
 
   public void writeTo(OutputStream out) throws IOException {
     TarStreamBuilder tarStreamBuilder = new TarStreamBuilder();
-    DockerLoadManifestEntryTemplate manifestTemplate = new DockerLoadManifestEntryTemplate();
+    DockerManifestEntryTemplate manifestTemplate = new DockerManifestEntryTemplate();
 
     // Adds all the layers to the tarball and manifest.
     for (Layer layer : image.getLayers()) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplate.java
@@ -45,11 +45,15 @@ import java.util.List;
  * @see <a href="https://github.com/moby/moby/blob/master/image/tarexport/load.go">Docker load
  *     source</a>
  */
-public class DockerLoadManifestEntryTemplate implements JsonTemplate {
+public class DockerManifestEntryTemplate implements JsonTemplate {
 
-  private final String config = "config.json";
+  private String config = "config.json";
   private List<String> repoTags = Collections.singletonList(null);
   private final List<String> layers = new ArrayList<>();
+
+  public void setConfig(String config) {
+    this.config = config;
+  }
 
   public void setRepoTags(String repoTags) {
     this.repoTags = Collections.singletonList(repoTags);
@@ -57,5 +61,13 @@ public class DockerLoadManifestEntryTemplate implements JsonTemplate {
 
   public void addLayerFile(String layer) {
     layers.add(layer);
+  }
+
+  public String getConfig() {
+    return config;
+  }
+
+  public List<String> getLayerFiles() {
+    return layers;
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/ImageTarballTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/ImageTarballTest.java
@@ -21,7 +21,7 @@ import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.blob.Blobs;
-import com.google.cloud.tools.jib.docker.json.DockerLoadManifestEntryTemplate;
+import com.google.cloud.tools.jib.docker.json.DockerManifestEntryTemplate;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.Layer;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
@@ -120,7 +120,7 @@ public class ImageTarballTest {
       String manifestJson =
           CharStreams.toString(
               new InputStreamReader(tarArchiveInputStream, StandardCharsets.UTF_8));
-      JsonTemplateMapper.readListOfJson(manifestJson, DockerLoadManifestEntryTemplate.class);
+      JsonTemplateMapper.readListOfJson(manifestJson, DockerManifestEntryTemplate.class);
     }
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/json/DockerManifestTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/json/DockerManifestTemplateTest.java
@@ -16,8 +16,10 @@
 
 package com.google.cloud.tools.jib.docker.json;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -30,8 +32,8 @@ import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
-/** Tests for {@link DockerLoadManifestEntryTemplate}. */
-public class DockerLoadManifestTemplateTest {
+/** Tests for {@link DockerManifestEntryTemplate}. */
+public class DockerManifestTemplateTest {
 
   @Test
   public void testToJson() throws URISyntaxException, IOException {
@@ -39,14 +41,28 @@ public class DockerLoadManifestTemplateTest {
     Path jsonFile = Paths.get(Resources.getResource("core/json/loadmanifest.json").toURI());
     String expectedJson = new String(Files.readAllBytes(jsonFile), StandardCharsets.UTF_8);
 
-    DockerLoadManifestEntryTemplate template = new DockerLoadManifestEntryTemplate();
+    DockerManifestEntryTemplate template = new DockerManifestEntryTemplate();
     template.setRepoTags(
         ImageReference.of("testregistry", "testrepo", "testtag").toStringWithTag());
     template.addLayerFile("layer1.tar.gz");
     template.addLayerFile("layer2.tar.gz");
     template.addLayerFile("layer3.tar.gz");
 
-    List<DockerLoadManifestEntryTemplate> loadManifest = Collections.singletonList(template);
+    List<DockerManifestEntryTemplate> loadManifest = Collections.singletonList(template);
     Assert.assertEquals(expectedJson, JsonTemplateMapper.toUtf8String(loadManifest));
+  }
+
+  @Test
+  public void testFromJson() throws URISyntaxException, IOException {
+    // Loads the expected JSON string.
+    Path jsonFile = Paths.get(Resources.getResource("core/json/loadmanifest.json").toURI());
+    String sourceJson = new String(Files.readAllBytes(jsonFile), StandardCharsets.UTF_8);
+    DockerManifestEntryTemplate template =
+        new ObjectMapper().readValue(sourceJson, DockerManifestEntryTemplate[].class)[0];
+
+    Assert.assertEquals(
+        ImmutableList.of("layer1.tar.gz", "layer2.tar.gz", "layer3.tar.gz"),
+        template.getLayerFiles());
+    Assert.assertEquals("config.json", template.getConfig());
   }
 }


### PR DESCRIPTION
Small PR towards #1468.

`DockerLoadManifestEntryTemplate` was originally used for `docker load` exclusively, but it will also need to be used for parsing `docker save` output in #1468. This PR renames the class, adds some getters, and adds a test.