### PR TITLE
Add save to DockerClient

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
@@ -159,6 +159,38 @@ public class DockerClient {
   }
 
   /**
+   * Saves an image tarball from the Docker daemon.
+   *
+   * @see <a
+   *     href="https://docs.docker.com/engine/reference/commandline/save/">https://docs.docker.com/engine/reference/commandline/save</a>
+   * @param imageReference the image to save
+   * @param outputPath the destination path to save the output tarball
+   * @return stdout from {@code docker}
+   * @throws InterruptedException if the 'docker save' process is interrupted
+   * @throws IOException if saving the blob from 'docker save' fails
+   */
+  public String save(ImageReference imageReference, Path outputPath)
+      throws InterruptedException, IOException {
+    // Runs 'docker load'.
+    Process dockerProcess = docker("save", imageReference.toString(), "-o", outputPath.toString());
+
+    try (InputStreamReader stdout =
+        new InputStreamReader(dockerProcess.getInputStream(), StandardCharsets.UTF_8)) {
+      String output = CharStreams.toString(stdout);
+
+      if (dockerProcess.waitFor() != 0) {
+        try (InputStreamReader stderr =
+            new InputStreamReader(dockerProcess.getErrorStream(), StandardCharsets.UTF_8)) {
+          throw new IOException(
+              "'docker save' command failed with output: " + CharStreams.toString(stderr));
+        }
+      }
+
+      return output;
+    }
+  }
+
+  /**
    * Tags the image referenced by {@code originalImageReference} with a new image reference {@code
    * newImageReference}.
    *

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
@@ -173,16 +173,11 @@ public class DockerClient {
     // Runs 'docker save'.
     Process dockerProcess = docker("save", imageReference.toString(), "-o", outputPath.toString());
 
-    try (InputStreamReader stdout =
-        new InputStreamReader(dockerProcess.getInputStream(), StandardCharsets.UTF_8)) {
-      String output = CharStreams.toString(stdout);
-
-      if (dockerProcess.waitFor() != 0) {
-        try (InputStreamReader stderr =
-            new InputStreamReader(dockerProcess.getErrorStream(), StandardCharsets.UTF_8)) {
-          throw new IOException(
-              "'docker save' command failed with output: " + CharStreams.toString(stderr));
-        }
+    if (dockerProcess.waitFor() != 0) {
+      try (InputStreamReader stderr =
+          new InputStreamReader(dockerProcess.getErrorStream(), StandardCharsets.UTF_8)) {
+        throw new IOException(
+            "'docker save' command failed with output: " + CharStreams.toString(stderr));
       }
     }
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
@@ -165,13 +165,12 @@ public class DockerClient {
    *     href="https://docs.docker.com/engine/reference/commandline/save/">https://docs.docker.com/engine/reference/commandline/save</a>
    * @param imageReference the image to save
    * @param outputPath the destination path to save the output tarball
-   * @return stdout from {@code docker}
    * @throws InterruptedException if the 'docker save' process is interrupted
-   * @throws IOException if saving the blob from 'docker save' fails
+   * @throws IOException if creating the tarball fails
    */
-  public String save(ImageReference imageReference, Path outputPath)
+  public void save(ImageReference imageReference, Path outputPath)
       throws InterruptedException, IOException {
-    // Runs 'docker load'.
+    // Runs 'docker save'.
     Process dockerProcess = docker("save", imageReference.toString(), "-o", outputPath.toString());
 
     try (InputStreamReader stdout =
@@ -185,8 +184,6 @@ public class DockerClient {
               "'docker save' command failed with output: " + CharStreams.toString(stderr));
         }
       }
-
-      return output;
     }
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
@@ -187,6 +187,28 @@ public class DockerClientTest {
   }
 
   @Test
+  public void testSave_fail() throws InterruptedException {
+    DockerClient testDockerClient =
+        new DockerClient(
+            subcommand -> {
+              Assert.assertEquals(Arrays.asList("save", "testimage", "-o", "out.tar"), subcommand);
+              return mockProcessBuilder;
+            });
+    Mockito.when(mockProcess.waitFor()).thenReturn(1);
+
+    Mockito.when(mockProcess.getErrorStream())
+        .thenReturn(new ByteArrayInputStream("error".getBytes(StandardCharsets.UTF_8)));
+
+    try {
+      testDockerClient.save(ImageReference.of(null, "testimage", null), Paths.get("out.tar"));
+      Assert.fail("docker save should have failed");
+
+    } catch (IOException ex) {
+      Assert.assertEquals("'docker save' command failed with output: error", ex.getMessage());
+    }
+  }
+
+  @Test
   public void testTag() throws InterruptedException, IOException, InvalidImageReferenceException {
     DockerClient testDockerClient =
         new DockerClient(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
@@ -183,10 +183,6 @@ public class DockerClientTest {
             });
     Mockito.when(mockProcess.waitFor()).thenReturn(0);
 
-    // Simulates stdout.
-    Mockito.when(mockProcess.getInputStream())
-        .thenReturn(new ByteArrayInputStream("output".getBytes(StandardCharsets.UTF_8)));
-
     testDockerClient.save(ImageReference.of(null, "testimage", null), Paths.get("out.tar"));
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
@@ -174,6 +174,25 @@ public class DockerClientTest {
   }
 
   @Test
+  public void testSave() throws InterruptedException, IOException {
+    DockerClient testDockerClient =
+        new DockerClient(
+            subcommand -> {
+              Assert.assertEquals(Arrays.asList("save", "testimage", "-o", "out.tar"), subcommand);
+              return mockProcessBuilder;
+            });
+    Mockito.when(mockProcess.waitFor()).thenReturn(0);
+
+    // Simulates stdout.
+    Mockito.when(mockProcess.getInputStream())
+        .thenReturn(new ByteArrayInputStream("output".getBytes(StandardCharsets.UTF_8)));
+
+    String output =
+        testDockerClient.save(ImageReference.of(null, "testimage", null), Paths.get("out.tar"));
+    Assert.assertEquals("output", output);
+  }
+
+  @Test
   public void testTag() throws InterruptedException, IOException, InvalidImageReferenceException {
     DockerClient testDockerClient =
         new DockerClient(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
@@ -187,9 +187,7 @@ public class DockerClientTest {
     Mockito.when(mockProcess.getInputStream())
         .thenReturn(new ByteArrayInputStream("output".getBytes(StandardCharsets.UTF_8)));
 
-    String output =
-        testDockerClient.save(ImageReference.of(null, "testimage", null), Paths.get("out.tar"));
-    Assert.assertEquals("output", output);
+    testDockerClient.save(ImageReference.of(null, "testimage", null), Paths.get("out.tar"));
   }
 
   @Test


### PR DESCRIPTION
Towards #1468. Adds a `DockerClient` method to `docker save` a specified image to the specified path.