### PR TITLE
Stay on Ubuntu Trusty on Travis for oraclejdk8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,10 @@ git:
 language: java
 matrix:
   include:
-    - name: OpenJDK 8
-      jdk: openjdk8
+     # using `openjdk8` leads to javadoc errors.
+    - name: Oracle DK 8 on Trusty
+      jdk: oraclejdk8
+      dist: trusty # oraclejdk8 is absent in Xenial, so go back to trusty
     - name: OpenJDK 11
       jdk: openjdk11
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,8 @@ git:
 language: java
 matrix:
   include:
-    - name: Oracle JDK 8
-      # using `openjdk8` leads to javadoc errors
-      jdk: oraclejdk8
+    - name: OpenJDK 8
+      jdk: openjdk8
     - name: OpenJDK 11
       jdk: openjdk11
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ git:
 language: java
 matrix:
   include:
-     # using `openjdk8` leads to javadoc errors.
-    - name: Oracle DK 8 on Trusty
+    - name: Oracle JDK 8 on Trusty
+      # using `openjdk8` leads to javadoc errors
       jdk: oraclejdk8
-      dist: trusty # oraclejdk8 is absent in Xenial, so go back to trusty
+      dist: trusty # oraclejdk8 absent in Xenial
     - name: OpenJDK 11
       jdk: openjdk11
 env:


### PR DESCRIPTION
We are hitting build failures as Travis cannot install Oracle JDK 8. It is not available on Xenial, so one way to resolve this is to stay on Trusty. Switching to openjdk8 is another option, but it will hit the Javadoc-related bug. There does exist a workaround (modifying our Javadoc to have fully qualified class names for nested classes) for the Javadoc bug, but I don't really like that.