### PR TITLE
Use tri-state enum for blob existence in target repository

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStep.java
@@ -74,7 +74,7 @@ class ObtainBaseImageLayerStep implements Callable<PreparedLayer> {
     BlobExistenceChecker blobExistenceChecker =
         digest ->
             targetRegistryClient.checkBlob(digest).isPresent()
-                ? StateInTarget.EXISTS
+                ? StateInTarget.EXISTING
                 : StateInTarget.MISSING;
 
     return makeList(
@@ -139,7 +139,7 @@ class ObtainBaseImageLayerStep implements Callable<PreparedLayer> {
                 buildConfiguration.getEventHandlers(), String.format(DESCRIPTION, layerDigest))) {
 
       StateInTarget stateInTarget = blobExistenceChecker.check(layerDigest);
-      if (stateInTarget == StateInTarget.EXISTS) {
+      if (stateInTarget == StateInTarget.EXISTING) {
         return new PreparedLayer.Builder(layer).setStateInTarget(stateInTarget).build();
       }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStep.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
+import com.google.cloud.tools.jib.builder.steps.PreparedLayer.StateInTarget;
 import com.google.cloud.tools.jib.builder.steps.PullBaseImageStep.ImageAndAuthorization;
 import com.google.cloud.tools.jib.cache.Cache;
 import com.google.cloud.tools.jib.cache.CacheCorruptedException;
@@ -45,16 +46,16 @@ class ObtainBaseImageLayerStep implements Callable<PreparedLayer> {
   @FunctionalInterface
   private interface BlobExistenceChecker {
 
-    Optional<Boolean> exists(DescriptorDigest digest) throws IOException, RegistryException;
+    StateInTarget check(DescriptorDigest digest) throws IOException, RegistryException;
   }
 
   static ImmutableList<ObtainBaseImageLayerStep> makeListForForcedDownload(
       BuildConfiguration buildConfiguration,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
       ImageAndAuthorization baseImageAndAuth) {
-    BlobExistenceChecker noOpBlobChecker = ignored -> Optional.empty();
+    BlobExistenceChecker noOpChecker = ignored -> StateInTarget.UNKNOWN;
     return makeList(
-        buildConfiguration, progressEventDispatcherFactory, baseImageAndAuth, noOpBlobChecker);
+        buildConfiguration, progressEventDispatcherFactory, baseImageAndAuth, noOpChecker);
   }
 
   static ImmutableList<ObtainBaseImageLayerStep> makeListForSelectiveDownload(
@@ -71,7 +72,10 @@ class ObtainBaseImageLayerStep implements Callable<PreparedLayer> {
             .newRegistryClient();
     // TODO: also check if cross-repo blob mount is possible.
     BlobExistenceChecker blobExistenceChecker =
-        digest -> Optional.of(targetRegistryClient.checkBlob(digest).isPresent());
+        digest ->
+            targetRegistryClient.checkBlob(digest).isPresent()
+                ? StateInTarget.EXISTS
+                : StateInTarget.MISSING;
 
     return makeList(
         buildConfiguration, progressEventDispatcherFactory, baseImageAndAuth, blobExistenceChecker);
@@ -134,9 +138,9 @@ class ObtainBaseImageLayerStep implements Callable<PreparedLayer> {
             new TimerEventDispatcher(
                 buildConfiguration.getEventHandlers(), String.format(DESCRIPTION, layerDigest))) {
 
-      Optional<Boolean> layerExists = blobExistenceChecker.exists(layerDigest);
-      if (layerExists.orElse(false)) {
-        return new PreparedLayer.Builder(layer).setStateInTarget(layerExists).build();
+      StateInTarget stateInTarget = blobExistenceChecker.check(layerDigest);
+      if (stateInTarget == StateInTarget.EXISTS) {
+        return new PreparedLayer.Builder(layer).setStateInTarget(stateInTarget).build();
       }
 
       Cache cache = buildConfiguration.getBaseImageLayersCache();
@@ -145,7 +149,7 @@ class ObtainBaseImageLayerStep implements Callable<PreparedLayer> {
       Optional<CachedLayer> optionalCachedLayer = cache.retrieve(layerDigest);
       if (optionalCachedLayer.isPresent()) {
         CachedLayer cachedLayer = optionalCachedLayer.get();
-        return new PreparedLayer.Builder(cachedLayer).setStateInTarget(layerExists).build();
+        return new PreparedLayer.Builder(cachedLayer).setStateInTarget(stateInTarget).build();
       } else if (buildConfiguration.isOffline()) {
         throw new IOException(
             "Cannot run Jib in offline mode; local Jib cache for base image is missing image layer "
@@ -170,7 +174,7 @@ class ObtainBaseImageLayerStep implements Callable<PreparedLayer> {
                     layerDigest,
                     progressEventDispatcherWrapper::setProgressTarget,
                     progressEventDispatcherWrapper::dispatchProgress));
-        return new PreparedLayer.Builder(cachedLayer).setStateInTarget(layerExists).build();
+        return new PreparedLayer.Builder(cachedLayer).setStateInTarget(stateInTarget).build();
       }
     }
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PreparedLayer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PreparedLayer.java
@@ -30,7 +30,7 @@ class PreparedLayer implements Layer {
 
   enum StateInTarget {
     UNKNOWN,
-    EXISTS,
+    EXISTING,
     MISSING
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PreparedLayer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PreparedLayer.java
@@ -20,7 +20,6 @@ import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.image.Layer;
-import java.util.Optional;
 
 /**
  * Layer prepared from {@link BuildAndCacheApplicationLayerStep} and {@link
@@ -29,11 +28,17 @@ import java.util.Optional;
  */
 class PreparedLayer implements Layer {
 
+  enum StateInTarget {
+    UNKNOWN,
+    EXISTS,
+    MISSING
+  }
+
   static class Builder {
 
     private Layer layer;
     private String name = "unnamed layer";
-    private Optional<Boolean> stateInTarget = Optional.empty();
+    private StateInTarget stateInTarget = StateInTarget.UNKNOWN;
 
     Builder(Layer layer) {
       this.layer = layer;
@@ -44,8 +49,8 @@ class PreparedLayer implements Layer {
       return this;
     }
 
-    /** Sets whether the layer exists in a target destination. Empty (absence) means unknown. */
-    Builder setStateInTarget(Optional<Boolean> stateInTarget) {
+    /** Sets whether the layer exists in a target destination. */
+    Builder setStateInTarget(StateInTarget stateInTarget) {
       this.stateInTarget = stateInTarget;
       return this;
     }
@@ -57,9 +62,9 @@ class PreparedLayer implements Layer {
 
   private final Layer layer;
   private final String name;
-  private final Optional<Boolean> stateInTarget;
+  private final StateInTarget stateInTarget;
 
-  private PreparedLayer(Layer layer, String name, Optional<Boolean> stateInTarget) {
+  private PreparedLayer(Layer layer, String name, StateInTarget stateInTarget) {
     this.layer = layer;
     this.name = name;
     this.stateInTarget = stateInTarget;
@@ -69,7 +74,7 @@ class PreparedLayer implements Layer {
     return name;
   }
 
-  Optional<Boolean> existsInTarget() {
+  StateInTarget existsInTarget() {
     return stateInTarget;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PreparedLayer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PreparedLayer.java
@@ -74,7 +74,7 @@ class PreparedLayer implements Layer {
     return name;
   }
 
-  StateInTarget stateInTarget() {
+  StateInTarget getStateInTarget() {
     return stateInTarget;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PreparedLayer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PreparedLayer.java
@@ -74,7 +74,7 @@ class PreparedLayer implements Layer {
     return name;
   }
 
-  StateInTarget existsInTarget() {
+  StateInTarget stateInTarget() {
     return stateInTarget;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
@@ -81,7 +81,7 @@ class PushLayerStep implements Callable<BlobDescriptor> {
       throws IOException, RegistryException, ExecutionException, InterruptedException {
     PreparedLayer layer = preparedLayer.get();
 
-    if (layer.existsInTarget() == StateInTarget.EXISTS) {
+    if (layer.existsInTarget() == StateInTarget.EXISTING) {
       return layer.getBlobDescriptor(); // skip pushing if known to exist in registry
     }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
@@ -81,11 +81,11 @@ class PushLayerStep implements Callable<BlobDescriptor> {
       throws IOException, RegistryException, ExecutionException, InterruptedException {
     PreparedLayer layer = preparedLayer.get();
 
-    if (layer.stateInTarget() == StateInTarget.EXISTING) {
+    if (layer.getStateInTarget() == StateInTarget.EXISTING) {
       return layer.getBlobDescriptor(); // skip pushing if known to exist in registry
     }
 
-    boolean forcePush = layer.stateInTarget() == StateInTarget.MISSING;
+    boolean forcePush = layer.getStateInTarget() == StateInTarget.MISSING;
     return new PushBlobStep(
             buildConfiguration,
             progressEventDispatcherFactory,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
@@ -81,11 +81,11 @@ class PushLayerStep implements Callable<BlobDescriptor> {
       throws IOException, RegistryException, ExecutionException, InterruptedException {
     PreparedLayer layer = preparedLayer.get();
 
-    if (layer.existsInTarget() == StateInTarget.EXISTING) {
+    if (layer.stateInTarget() == StateInTarget.EXISTING) {
       return layer.getBlobDescriptor(); // skip pushing if known to exist in registry
     }
 
-    boolean forcePush = layer.existsInTarget() == StateInTarget.MISSING;
+    boolean forcePush = layer.stateInTarget() == StateInTarget.MISSING;
     return new PushBlobStep(
             buildConfiguration,
             progressEventDispatcherFactory,

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStepTest.java
@@ -139,7 +139,7 @@ public class ObtainBaseImageLayerStepTest {
     PreparedLayer preparedExistingLayer = pullers.get(0).call();
     PreparedLayer preparedFreshLayer = pullers.get(1).call();
 
-    // Unknown if layers exist in target registry.
+    // existence unknown
     Assert.assertEquals(StateInTarget.UNKNOWN, preparedExistingLayer.getStateInTarget());
     Assert.assertEquals(StateInTarget.UNKNOWN, preparedFreshLayer.getStateInTarget());
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStepTest.java
@@ -114,8 +114,8 @@ public class ObtainBaseImageLayerStepTest {
     PreparedLayer preparedExistingLayer = pullers.get(0).call();
     PreparedLayer preparedFreshLayer = pullers.get(1).call();
 
-    Assert.assertEquals(StateInTarget.EXISTING, preparedExistingLayer.stateInTarget());
-    Assert.assertEquals(StateInTarget.MISSING, preparedFreshLayer.stateInTarget());
+    Assert.assertEquals(StateInTarget.EXISTING, preparedExistingLayer.getStateInTarget());
+    Assert.assertEquals(StateInTarget.MISSING, preparedFreshLayer.getStateInTarget());
 
     // Should have queried all blobs.
     Mockito.verify(registryClient).checkBlob(existingLayerDigest);
@@ -140,8 +140,8 @@ public class ObtainBaseImageLayerStepTest {
     PreparedLayer preparedFreshLayer = pullers.get(1).call();
 
     // Unknown if layers exist in target registry.
-    Assert.assertEquals(StateInTarget.UNKNOWN, preparedExistingLayer.stateInTarget());
-    Assert.assertEquals(StateInTarget.UNKNOWN, preparedFreshLayer.stateInTarget());
+    Assert.assertEquals(StateInTarget.UNKNOWN, preparedExistingLayer.getStateInTarget());
+    Assert.assertEquals(StateInTarget.UNKNOWN, preparedFreshLayer.getStateInTarget());
 
     // No blob checking should happen.
     Mockito.verify(registryClient, Mockito.never()).checkBlob(existingLayerDigest);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStepTest.java
@@ -114,7 +114,7 @@ public class ObtainBaseImageLayerStepTest {
     PreparedLayer preparedExistingLayer = pullers.get(0).call();
     PreparedLayer preparedFreshLayer = pullers.get(1).call();
 
-    Assert.assertEquals(StateInTarget.EXISTS, preparedExistingLayer.existsInTarget());
+    Assert.assertEquals(StateInTarget.EXISTING, preparedExistingLayer.existsInTarget());
     Assert.assertEquals(StateInTarget.MISSING, preparedFreshLayer.existsInTarget());
 
     // Should have queried all blobs.

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStepTest.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
+import com.google.cloud.tools.jib.builder.steps.PreparedLayer.StateInTarget;
 import com.google.cloud.tools.jib.builder.steps.PullBaseImageStep.ImageAndAuthorization;
 import com.google.cloud.tools.jib.cache.CacheCorruptedException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
@@ -113,8 +114,8 @@ public class ObtainBaseImageLayerStepTest {
     PreparedLayer preparedExistingLayer = pullers.get(0).call();
     PreparedLayer preparedFreshLayer = pullers.get(1).call();
 
-    Assert.assertTrue(preparedExistingLayer.existsInTarget().get());
-    Assert.assertFalse(preparedFreshLayer.existsInTarget().get());
+    Assert.assertEquals(StateInTarget.EXISTS, preparedExistingLayer.existsInTarget());
+    Assert.assertEquals(StateInTarget.MISSING, preparedFreshLayer.existsInTarget());
 
     // Should have queried all blobs.
     Mockito.verify(registryClient).checkBlob(existingLayerDigest);
@@ -139,8 +140,8 @@ public class ObtainBaseImageLayerStepTest {
     PreparedLayer preparedFreshLayer = pullers.get(1).call();
 
     // Unknown if layers exist in target registry.
-    Assert.assertEquals(Optional.empty(), preparedExistingLayer.existsInTarget());
-    Assert.assertEquals(Optional.empty(), preparedFreshLayer.existsInTarget());
+    Assert.assertEquals(StateInTarget.UNKNOWN, preparedExistingLayer.existsInTarget());
+    Assert.assertEquals(StateInTarget.UNKNOWN, preparedFreshLayer.existsInTarget());
 
     // No blob checking should happen.
     Mockito.verify(registryClient, Mockito.never()).checkBlob(existingLayerDigest);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStepTest.java
@@ -114,8 +114,8 @@ public class ObtainBaseImageLayerStepTest {
     PreparedLayer preparedExistingLayer = pullers.get(0).call();
     PreparedLayer preparedFreshLayer = pullers.get(1).call();
 
-    Assert.assertEquals(StateInTarget.EXISTING, preparedExistingLayer.existsInTarget());
-    Assert.assertEquals(StateInTarget.MISSING, preparedFreshLayer.existsInTarget());
+    Assert.assertEquals(StateInTarget.EXISTING, preparedExistingLayer.stateInTarget());
+    Assert.assertEquals(StateInTarget.MISSING, preparedFreshLayer.stateInTarget());
 
     // Should have queried all blobs.
     Mockito.verify(registryClient).checkBlob(existingLayerDigest);
@@ -140,8 +140,8 @@ public class ObtainBaseImageLayerStepTest {
     PreparedLayer preparedFreshLayer = pullers.get(1).call();
 
     // Unknown if layers exist in target registry.
-    Assert.assertEquals(StateInTarget.UNKNOWN, preparedExistingLayer.existsInTarget());
-    Assert.assertEquals(StateInTarget.UNKNOWN, preparedFreshLayer.existsInTarget());
+    Assert.assertEquals(StateInTarget.UNKNOWN, preparedExistingLayer.stateInTarget());
+    Assert.assertEquals(StateInTarget.UNKNOWN, preparedFreshLayer.stateInTarget());
 
     // No blob checking should happen.
     Mockito.verify(registryClient, Mockito.never()).checkBlob(existingLayerDigest);


### PR DESCRIPTION
Fixes #1867. Turns out this is not complicated at all.