### PR TITLE
Force downgrading to org.apache.httpcomponents:httpclient:4.5.6 prevent URI normalization

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed an issue interacting with certain registries due to changes to URL handling in the underlying Apache HttpClient library. ([#1924](https://github.com/GoogleContainerTools/jib/issues/1924))
+
 ## 0.10.1
 
 ### Added

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -43,6 +43,11 @@ dependencies {
   // for best compatibility.
   implementation 'com.google.http-client:google-http-client:1.31.0'
   implementation 'com.google.http-client:google-http-client-apache-v2:1.31.0'
+  // TODO: remove once https://github.com/googleapis/google-http-java-client/issues/795 is fixed and released.
+  // Forcing to downgrade this to 4.5.6 fixes https://github.com/GoogleContainerTools/jib/issues/1914
+  implementation('org.apache.httpcomponents:httpclient:4.5.6') {
+    force = true
+  }
   implementation 'com.google.auth:google-auth-library-oauth2-http:0.16.2'
   implementation 'com.google.guava:guava:28.0-jre'
 

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -41,7 +41,7 @@ dependencies {
   // For Google libraries, check <http-client-bom.version>, <google.auth.version>, <guava.version>,
   // ... in https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-clients/pom.xml
   // for best compatibility.
-  /
+  //
   // TODO: remove once https://github.com/googleapis/google-http-java-client/issues/795 is fixed and released.
   // Forcing to downgrade this to 4.5.6 fixes https://github.com/GoogleContainerTools/jib/issues/1914
   // However, #795 and upgrading httpclient alone may not fix #1914. We may need to explicitly disable URI

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -41,16 +41,21 @@ dependencies {
   // For Google libraries, check <http-client-bom.version>, <google.auth.version>, <guava.version>,
   // ... in https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-clients/pom.xml
   // for best compatibility.
-  implementation 'com.google.http-client:google-http-client:1.31.0'
-  implementation 'com.google.http-client:google-http-client-apache-v2:1.31.0'
+  /
   // TODO: remove once https://github.com/googleapis/google-http-java-client/issues/795 is fixed and released.
   // Forcing to downgrade this to 4.5.6 fixes https://github.com/GoogleContainerTools/jib/issues/1914
   // However, #795 and upgrading httpclient alone may not fix #1914. We may need to explicitly disable URI
   // normalization as discussed in #795.
-  implementation('org.apache.httpcomponents:httpclient:4.5.6') {
-    force = true
+  implementation('com.google.http-client:google-http-client:1.31.0') {
+    exclude group: "org.apache.httpcomponents", module: "httpclient"
   }
-  implementation 'com.google.auth:google-auth-library-oauth2-http:0.16.2'
+  implementation('com.google.http-client:google-http-client-apache-v2:1.31.0') {
+    exclude group: "org.apache.httpcomponents", module: "httpclient"
+  }
+  implementation('com.google.auth:google-auth-library-oauth2-http:0.16.2') {
+    exclude group: "org.apache.httpcomponents", module: "httpclient"
+  }
+  implementation 'org.apache.httpcomponents:httpclient:4.5.6'
   implementation 'com.google.guava:guava:28.0-jre'
 
   implementation 'org.apache.commons:commons-compress:1.18'

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -45,6 +45,8 @@ dependencies {
   implementation 'com.google.http-client:google-http-client-apache-v2:1.31.0'
   // TODO: remove once https://github.com/googleapis/google-http-java-client/issues/795 is fixed and released.
   // Forcing to downgrade this to 4.5.6 fixes https://github.com/GoogleContainerTools/jib/issues/1914
+  // However, #795 and upgrading httpclient alone may not fix #1914. We may need to explicitly disable URI
+  // normalization as discussed in #795.
   implementation('org.apache.httpcomponents:httpclient:4.5.6') {
     force = true
   }

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed an issue interacting with certain registries due to changes to URL handling in the underlying Apache HttpClient library. ([#1924](https://github.com/GoogleContainerTools/jib/issues/1924))
+
 ## 1.5.0
 
 ### Added

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -61,12 +61,16 @@ configurations {
 
 dependencies {
   // These are copied over from jib-core and are necessary for the jib-core sourcesets.
-  compile 'com.google.http-client:google-http-client:1.31.0'
-  compile 'com.google.http-client:google-http-client-apache-v2:1.31.0'
-  compile('org.apache.httpcomponents:httpclient:4.5.6') {
-    force = true
+  compile('com.google.http-client:google-http-client:1.31.0') {
+    exclude group: "org.apache.httpcomponents", module: "httpclient"
   }
-  compile 'com.google.auth:google-auth-library-oauth2-http:0.16.2'
+  compile('com.google.http-client:google-http-client-apache-v2:1.31.0') {
+    exclude group: "org.apache.httpcomponents", module: "httpclient"
+  }
+  compile('com.google.auth:google-auth-library-oauth2-http:0.16.2') {
+    exclude group: "org.apache.httpcomponents", module: "httpclient"
+  }
+  compile 'org.apache.httpcomponents:httpclient:4.5.6'
   compile 'com.google.guava:guava:28.0-jre'
 
   compile 'org.apache.commons:commons-compress:1.18'

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -63,6 +63,9 @@ dependencies {
   // These are copied over from jib-core and are necessary for the jib-core sourcesets.
   compile 'com.google.http-client:google-http-client:1.31.0'
   compile 'com.google.http-client:google-http-client-apache-v2:1.31.0'
+  compile('org.apache.httpcomponents:httpclient:4.5.6') {
+    force = true
+  }
   compile 'com.google.auth:google-auth-library-oauth2-http:0.16.2'
   compile 'com.google.guava:guava:28.0-jre'
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed an issue interacting with certain registries due to changes to URL handling in the underlying Apache HttpClient library. ([#1924](https://github.com/GoogleContainerTools/jib/issues/1924))
+
 ## 1.5.0
 
 ### Added

--- a/jib-maven-plugin/pom.xml
+++ b/jib-maven-plugin/pom.xml
@@ -63,6 +63,12 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.6</version>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.auth</groupId>
       <artifactId>google-auth-library-oauth2-http</artifactId>
       <version>0.16.2</version>

--- a/jib-plugins-common/build.gradle
+++ b/jib-plugins-common/build.gradle
@@ -31,6 +31,9 @@ dependencies {
   // Make sure these are consistent with jib-maven-plugin.
   compile 'com.google.http-client:google-http-client:1.31.0'
   compile 'com.google.http-client:google-http-client-apache-v2:1.31.0'
+  compile('org.apache.httpcomponents:httpclient:4.5.6') {
+    force = true
+  }
   compile 'com.google.auth:google-auth-library-oauth2-http:0.16.2'
   compile 'com.google.guava:guava:28.0-jre'
 

--- a/jib-plugins-common/build.gradle
+++ b/jib-plugins-common/build.gradle
@@ -29,12 +29,16 @@ sourceSets {
 
 dependencies {
   // Make sure these are consistent with jib-maven-plugin.
-  compile 'com.google.http-client:google-http-client:1.31.0'
-  compile 'com.google.http-client:google-http-client-apache-v2:1.31.0'
-  compile('org.apache.httpcomponents:httpclient:4.5.6') {
-    force = true
+  compile('com.google.http-client:google-http-client:1.31.0') {
+    exclude group: "org.apache.httpcomponents", module: "httpclient"
   }
-  compile 'com.google.auth:google-auth-library-oauth2-http:0.16.2'
+  compile('com.google.http-client:google-http-client-apache-v2:1.31.0') {
+    exclude group: "org.apache.httpcomponents", module: "httpclient"
+  }
+  compile('com.google.auth:google-auth-library-oauth2-http:0.16.2') {
+    exclude group: "org.apache.httpcomponents", module: "httpclient"
+  }
+  compile 'org.apache.httpcomponents:httpclient:4.5.6'
   compile 'com.google.guava:guava:28.0-jre'
 
   compile 'org.apache.commons:commons-compress:1.18'


### PR DESCRIPTION
They tracked that `org.apache.httpcomponents:httpclient:4.5.7` introduced a breaking change by as part of URI normalization. There have been other reports of breakage due to the change too. Details are in https://github.com/googleapis/google-http-java-client/issues/795.

I think it is safe to force this version (https://github.com/googleapis/google-http-java-client/issues/795#issuecomment-523530986). I verified this fixes #1914 (for Maven) and full integration tests pass.

Fixes #1914.