### PR TITLE
Adjust TarImage API in preparation for local base image support

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- `TarImage` is constructed using `TarImage.at(...).named(...)` instead of `TarImage.named(...).saveTo(...)` ([#1918](https://github.com/GoogleContainerTools/jib/issues/1918))
+
 ### Fixed
 
 ## 0.10.1

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
@@ -322,9 +322,7 @@ public class ContainerizerIntegrationTest {
       throws IOException, InterruptedException, RegistryException, CacheDirectoryCreationException,
           ExecutionException {
     return buildImage(
-        baseImage,
-        Containerizer.to(TarImage.named(targetImage).saveTo(outputPath)),
-        additionalTags);
+        baseImage, Containerizer.to(TarImage.at(outputPath).named(targetImage)), additionalTags);
   }
 
   private JibContainer buildImage(

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
@@ -201,8 +201,8 @@ public class JibIntegrationTest {
             ManifestPullerIntegrationTest.KNOWN_MANIFEST_LIST_SHA);
     Containerizer containerizer =
         Containerizer.to(
-            TarImage.named("whatever")
-                .saveTo(cacheFolder.newFolder("goose").toPath().resolve("moose")));
+            TarImage.at(cacheFolder.newFolder("goose").toPath().resolve("moose"))
+                .named("whatever"));
 
     Jib.from(sourceImageReferenceAsManifestList).containerize(containerizer);
     // pass, no exceptions thrown

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ReproducibleImageTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ReproducibleImageTest.java
@@ -72,7 +72,7 @@ public class ReproducibleImageTest {
 
     imageTar = new File(imageLocation.getRoot(), "image.tar");
     Containerizer containerizer =
-        Containerizer.to(TarImage.named("jib-core/reproducible").saveTo(imageTar.toPath()));
+        Containerizer.to(TarImage.at(imageTar.toPath()).named("jib-core/reproducible"));
 
     Jib.fromScratch()
         .setEntrypoint("echo", "Hello World")

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
@@ -100,12 +100,18 @@ public class Containerizer {
    * @return a new {@link Containerizer}
    */
   public static Containerizer to(TarImage tarImage) {
+    if (!tarImage.getImageReference().isPresent()) {
+      throw new IllegalArgumentException(
+          "Image name must be set when building a TarImage; use TarImage#named(...) to set the name"
+              + " of the target image");
+    }
+
     ImageConfiguration imageConfiguration =
-        ImageConfiguration.builder(tarImage.getImageReference()).build();
+        ImageConfiguration.builder(tarImage.getImageReference().get()).build();
 
     Function<BuildConfiguration, StepsRunner> stepsRunnerFactory =
         buildConfiguration ->
-            StepsRunner.begin(buildConfiguration).tarBuildSteps(tarImage.getOutputFile());
+            StepsRunner.begin(buildConfiguration).tarBuildSteps(tarImage.getPath());
 
     return new Containerizer(
         DESCRIPTION_FOR_TARBALL, imageConfiguration, stepsRunnerFactory, false);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarImage.java
@@ -42,12 +42,12 @@ public class TarImage {
     return new TarImage(path);
   }
 
-  private final Path outputFile;
+  private final Path path;
   @Nullable private ImageReference imageReference;
 
   /** Instantiate with {@link #at}. */
-  private TarImage(Path outputFile) {
-    this.outputFile = outputFile;
+  private TarImage(Path path) {
+    this.path = path;
   }
 
   /**
@@ -74,13 +74,8 @@ public class TarImage {
     return named(ImageReference.parse(imageReference));
   }
 
-  /**
-   * Gets the output file to save the tarball archive to.
-   *
-   * @return the output file
-   */
   Path getPath() {
-    return outputFile;
+    return path;
   }
 
   Optional<ImageReference> getImageReference() {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarImage.java
@@ -33,7 +33,7 @@ import javax.annotation.Nullable;
 public class TarImage {
 
   /**
-   * Sets the path to the tarball archive.
+   * Constructs a {@link TarImage} with the specified path.
    *
    * @param path the path to the tarball archive
    * @return a new {@link TarImage}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarImage.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/TarImage.java
@@ -17,6 +17,8 @@
 package com.google.cloud.tools.jib.api;
 
 import java.nio.file.Path;
+import java.util.Optional;
+import javax.annotation.Nullable;
 
 /**
  * Builds to a tarball archive.
@@ -24,61 +26,52 @@ import java.nio.file.Path;
  * <p>Usage example:
  *
  * <pre>{@code
- * TarImage tarImage = TarImage.named("myimage")
- *                             .saveTo(Paths.get("image.tar"));
+ * TarImage tarImage = TarImage.at(Paths.get("image.tar"))
+ *                             .named("myimage");
  * }</pre>
  */
 public class TarImage {
 
-  /** Finishes constructing a {@link TarImage}. */
-  public static class Builder {
-
-    private final ImageReference imageReference;
-
-    private Builder(ImageReference imageReference) {
-      this.imageReference = imageReference;
-    }
-
-    /**
-     * Sets the output file to save the tarball archive to.
-     *
-     * @param outputFile the output file
-     * @return a new {@link TarImage}
-     */
-    public TarImage saveTo(Path outputFile) {
-      return new TarImage(imageReference, outputFile);
-    }
-  }
-
   /**
-   * Configures the output tarball archive with an image reference. This image reference will be the
-   * name of the image if loaded into the Docker daemon.
+   * Sets the path to the tarball archive.
    *
-   * @param imageReference the image reference
-   * @return a {@link Builder} to finish constructing a new {@link TarImage}
+   * @param path the path to the tarball archive
+   * @return a new {@link TarImage}
    */
-  public static Builder named(ImageReference imageReference) {
-    return new Builder(imageReference);
+  public static TarImage at(Path path) {
+    return new TarImage(path);
+  }
+
+  private final Path outputFile;
+  @Nullable private ImageReference imageReference;
+
+  /** Instantiate with {@link #at}. */
+  private TarImage(Path outputFile) {
+    this.outputFile = outputFile;
   }
 
   /**
-   * Configures the output tarball archive with an image reference to set as its tag.
+   * Sets the name of the image. This is the name that shows up when the tar is loaded by the Docker
+   * daemon.
    *
    * @param imageReference the image reference
-   * @return a {@link Builder} to finish constructing a new {@link TarImage}
+   * @return this
+   */
+  public TarImage named(ImageReference imageReference) {
+    this.imageReference = imageReference;
+    return this;
+  }
+
+  /**
+   * Sets the name of the image. This is the name that shows up when the tar is loaded by the Docker
+   * daemon.
+   *
+   * @param imageReference the image reference
+   * @return this
    * @throws InvalidImageReferenceException if {@code imageReference} is not a valid image reference
    */
-  public static Builder named(String imageReference) throws InvalidImageReferenceException {
+  public TarImage named(String imageReference) throws InvalidImageReferenceException {
     return named(ImageReference.parse(imageReference));
-  }
-
-  private final ImageReference imageReference;
-  private final Path outputFile;
-
-  /** Instantiate with {@link #named}. */
-  private TarImage(ImageReference imageReference, Path outputFile) {
-    this.imageReference = imageReference;
-    this.outputFile = outputFile;
   }
 
   /**
@@ -86,11 +79,11 @@ public class TarImage {
    *
    * @return the output file
    */
-  Path getOutputFile() {
+  Path getPath() {
     return outputFile;
   }
 
-  ImageReference getImageReference() {
-    return imageReference;
+  Optional<ImageReference> getImageReference() {
+    return Optional.ofNullable(imageReference);
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/ContainerizerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/ContainerizerTest.java
@@ -40,7 +40,7 @@ public class ContainerizerTest {
     DockerDaemonImage dockerDaemonImage =
         DockerDaemonImage.named(ImageReference.of(null, "repository", null));
     TarImage tarImage =
-        TarImage.named(ImageReference.of(null, "repository", null)).saveTo(Paths.get("ignored"));
+        TarImage.at(Paths.get("ignored")).named(ImageReference.of(null, "repository", null));
 
     verifyTo(Containerizer.to(registryImage));
     verifyTo(Containerizer.to(dockerDaemonImage));
@@ -119,7 +119,7 @@ public class ContainerizerTest {
   @Test
   public void testGetImageConfiguration_tarImage() throws InvalidImageReferenceException {
     Containerizer containerizer =
-        Containerizer.to(TarImage.named("tar/image").saveTo(Paths.get("output/file")));
+        Containerizer.to(TarImage.at(Paths.get("output/file")).named("tar/image"));
 
     ImageConfiguration imageConfiguration = containerizer.getImageConfiguration();
     Assert.assertEquals("tar/image", imageConfiguration.getImage().toString());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/TarImageTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/TarImageTest.java
@@ -24,9 +24,16 @@ import org.junit.Test;
 public class TarImageTest {
 
   @Test
-  public void testGetters() throws InvalidImageReferenceException {
-    TarImage tarImage = TarImage.named("tar/image").saveTo(Paths.get("output/file"));
-    Assert.assertEquals("tar/image", tarImage.getImageReference().toString());
-    Assert.assertEquals(Paths.get("output/file"), tarImage.getOutputFile());
+  public void testGetters_bothSet() throws InvalidImageReferenceException {
+    TarImage tarImage = TarImage.at(Paths.get("output/file")).named("tar/image");
+    Assert.assertEquals("tar/image", tarImage.getImageReference().get().toString());
+    Assert.assertEquals(Paths.get("output/file"), tarImage.getPath());
+  }
+
+  @Test
+  public void testGetters_nameMissing() {
+    TarImage tarImage = TarImage.at(Paths.get("output/file"));
+    Assert.assertFalse(tarImage.getImageReference().isPresent());
+    Assert.assertEquals(Paths.get("output/file"), tarImage.getPath());
   }
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -108,7 +108,7 @@ public class PluginConfigurationProcessor {
     Path tarImagePath = projectProperties.getOutputDirectory().resolve("jib-image.tar");
     ImageReference targetImageReference =
         getGeneratedTargetDockerTag(rawConfiguration, projectProperties, helpfulSuggestions);
-    TarImage targetImage = TarImage.named(targetImageReference).saveTo(tarImagePath);
+    TarImage targetImage = TarImage.at(tarImagePath).named(targetImageReference);
 
     Containerizer containerizer = Containerizer.to(targetImage);
     JibContainerBuilder jibContainerBuilder =


### PR DESCRIPTION
Fixes #1918. Changes the usage from `TarImage.named(...).saveTo(...)` to `TarImage.at(...).named(...)`. Throws an exception if the target image name is missing.