### PR TITLE
Add `upstreamClient` property to jib which tools using jib to build and push images can use.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Range;
 /** Names of system properties defined/used by Jib. */
 public class JibSystemProperties {
 
-  public static final String _JIB_UPSTREAM_CLIENT = "jib.upstreamClient";
+  public static final String UPSTREAM_CLIENT = "_JIB_UPSTREAM_CLIENT";
 
   @VisibleForTesting public static final String HTTP_TIMEOUT = "jib.httpTimeout";
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
@@ -23,6 +23,8 @@ import com.google.common.collect.Range;
 /** Names of system properties defined/used by Jib. */
 public class JibSystemProperties {
 
+  public static final String UPSTREAM_CLIENT = "jib.upstreamClient";
+
   @VisibleForTesting public static final String HTTP_TIMEOUT = "jib.httpTimeout";
 
   @VisibleForTesting static final String CROSS_REPOSITORY_BLOB_MOUNTS = "jib.blobMounts";
@@ -35,7 +37,6 @@ public class JibSystemProperties {
   private static final String SERIALIZE = "jibSerialize";
 
   private static final String DISABLE_USER_AGENT = "_JIB_DISABLE_USER_AGENT";
-  public static final String UPSTREAM_CLIENT = "jib.upstreamClient";
 
   /**
    * Gets the HTTP connection/read timeouts for registry interactions in milliseconds. This is

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
@@ -35,6 +35,7 @@ public class JibSystemProperties {
   private static final String SERIALIZE = "jibSerialize";
 
   private static final String DISABLE_USER_AGENT = "_JIB_DISABLE_USER_AGENT";
+  public static final String UPSTREAM_CLIENT = "jib.upstreamClient";
 
   /**
    * Gets the HTTP connection/read timeouts for registry interactions in milliseconds. This is

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
@@ -23,7 +23,7 @@ import com.google.common.collect.Range;
 /** Names of system properties defined/used by Jib. */
 public class JibSystemProperties {
 
-  public static final String UPSTREAM_CLIENT = "jib.upstreamClient";
+  public static final String _JIB_UPSTREAM_CLIENT = "jib.upstreamClient";
 
   @VisibleForTesting public static final String HTTP_TIMEOUT = "jib.httpTimeout";
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -130,10 +130,10 @@ public class RegistryClient {
       if (userAgentSuffix != null) {
         userAgentBuilder.append(" ").append(userAgentSuffix);
       }
-      if (!Strings.isNullOrEmpty(System.getProperty(JibSystemProperties.UPSTREAM_CLIENT))) {
+      if (!Strings.isNullOrEmpty(System.getProperty(JibSystemProperties._JIB_UPSTREAM_CLIENT))) {
         userAgentBuilder
             .append(" ")
-            .append(System.getProperty(JibSystemProperties.UPSTREAM_CLIENT));
+            .append(System.getProperty(JibSystemProperties._JIB_UPSTREAM_CLIENT));
       }
       return userAgentBuilder.toString();
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -130,10 +130,10 @@ public class RegistryClient {
       if (userAgentSuffix != null) {
         userAgentBuilder.append(" ").append(userAgentSuffix);
       }
-      if (!Strings.isNullOrEmpty(System.getProperty(JibSystemProperties._JIB_UPSTREAM_CLIENT))) {
+      if (!Strings.isNullOrEmpty(System.getProperty(JibSystemProperties.UPSTREAM_CLIENT))) {
         userAgentBuilder
             .append(" ")
-            .append(System.getProperty(JibSystemProperties._JIB_UPSTREAM_CLIENT));
+            .append(System.getProperty(JibSystemProperties.UPSTREAM_CLIENT));
       }
       return userAgentBuilder.toString();
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -129,6 +129,11 @@ public class RegistryClient {
       if (userAgentSuffix != null) {
         userAgentBuilder.append(" ").append(userAgentSuffix);
       }
+      if (System.getProperty(JibSystemProperties.UPSTREAM_CLIENT) != null) {
+        userAgentBuilder
+            .append(" ")
+            .append(System.getProperty(JibSystemProperties.UPSTREAM_CLIENT));
+      }
       return userAgentBuilder.toString();
     }
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -34,6 +34,7 @@ import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
 import java.io.IOException;
@@ -129,7 +130,7 @@ public class RegistryClient {
       if (userAgentSuffix != null) {
         userAgentBuilder.append(" ").append(userAgentSuffix);
       }
-      if (System.getProperty(JibSystemProperties.UPSTREAM_CLIENT) != null) {
+      if (!Strings.isNullOrEmpty(System.getProperty(JibSystemProperties.UPSTREAM_CLIENT))) {
         userAgentBuilder
             .append(" ")
             .append(System.getProperty(JibSystemProperties.UPSTREAM_CLIENT));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
@@ -21,7 +21,9 @@ import com.google.cloud.tools.jib.global.JibSystemProperties;
 import com.google.cloud.tools.jib.http.Authorization;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
@@ -42,6 +44,8 @@ public class RegistryClientTest {
     testRegistryClientFactory =
         RegistryClient.factory(eventHandlers, "some.server.url", "some image name");
   }
+
+  @Rule public final RestoreSystemProperties systemPropertyRestorer = new RestoreSystemProperties();
 
   @Test
   public void testGetUserAgent_null() {
@@ -84,7 +88,6 @@ public class RegistryClientTest {
             .newRegistryClient();
     Assert.assertTrue(registryClient.getUserAgent().startsWith("jib "));
     Assert.assertTrue(registryClient.getUserAgent().endsWith(" skaffold-0.34.0"));
-    System.clearProperty(JibSystemProperties.UPSTREAM_CLIENT);
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
@@ -79,7 +79,7 @@ public class RegistryClientTest {
 
   @Test
   public void testGetUserAgentWithUpstreamClient() {
-    System.setProperty(JibSystemProperties._JIB_UPSTREAM_CLIENT, "skaffold/0.34.0");
+    System.setProperty(JibSystemProperties.UPSTREAM_CLIENT, "skaffold/0.34.0");
 
     RegistryClient registryClient =
         testRegistryClientFactory

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.registry;
 
 import com.google.cloud.tools.jib.event.EventHandlers;
+import com.google.cloud.tools.jib.global.JibSystemProperties;
 import com.google.cloud.tools.jib.http.Authorization;
 import org.junit.Assert;
 import org.junit.Before;
@@ -70,6 +71,20 @@ public class RegistryClientTest {
 
     Assert.assertTrue(registryClient.getUserAgent().startsWith("jib "));
     Assert.assertTrue(registryClient.getUserAgent().endsWith(" some user agent suffix"));
+  }
+
+  @Test
+  public void testGetUserAgentWithUpstreamClient() {
+    System.setProperty(JibSystemProperties.UPSTREAM_CLIENT, "skaffold-0.34.0");
+
+    RegistryClient registryClient =
+        testRegistryClientFactory
+            .setAllowInsecureRegistries(true)
+            .setUserAgentSuffix("foo")
+            .newRegistryClient();
+    Assert.assertTrue(registryClient.getUserAgent().startsWith("jib "));
+    Assert.assertTrue(registryClient.getUserAgent().endsWith(" skaffold-0.34.0"));
+    System.clearProperty(JibSystemProperties.UPSTREAM_CLIENT);
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
@@ -79,7 +79,7 @@ public class RegistryClientTest {
 
   @Test
   public void testGetUserAgentWithUpstreamClient() {
-    System.setProperty(JibSystemProperties.UPSTREAM_CLIENT, "skaffold-0.34.0");
+    System.setProperty(JibSystemProperties._JIB_UPSTREAM_CLIENT, "skaffold/0.34.0");
 
     RegistryClient registryClient =
         testRegistryClientFactory
@@ -87,7 +87,7 @@ public class RegistryClientTest {
             .setUserAgentSuffix("foo")
             .newRegistryClient();
     Assert.assertTrue(registryClient.getUserAgent().startsWith("jib "));
-    Assert.assertTrue(registryClient.getUserAgent().endsWith(" skaffold-0.34.0"));
+    Assert.assertTrue(registryClient.getUserAgent().endsWith(" skaffold/0.34.0"));
   }
 
   @Test


### PR DESCRIPTION
skaffold uses `jib` to build and push java images. In order to track,  skaffold-jib adoption we want to add `UpstreamClient(skaffold-version)` to images pushed to GCR by skaffold via jib.
See https://github.com/GoogleContainerTools/skaffold/pull/2723 for kaniko implementation.


If upstreamClient is present, it will added to the user-agent when pushing to registry

<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->
