### PR TITLE
Default test runner in idea to gradle, fix checkstyle xml

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,17 @@ plugins {
   id 'net.researchgate.release' version '2.7.0' apply false
   id 'com.gradle.plugin-publish' version '0.10.1' apply false
   id 'io.freefair.maven-plugin' version '3.8.1' apply false
+
+  // apply so we can correctly configure the test runner to be gradle at the project level
+  id "org.jetbrains.gradle.plugin.idea-ext" version "0.5"
+}
+
+// run tests in intellij using gradle test runner
+idea.project.settings {
+  delegateActions {
+    delegateBuildRunToGradle = false
+    testRunner = 'GRADLE'
+  }
 }
 
 import net.ltgt.gradle.errorprone.CheckSeverity

--- a/jib-maven-plugin/config/google-checks-no-indent.xml
+++ b/jib-maven-plugin/config/google-checks-no-indent.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-    "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-    "http://checkstyle.sourceforge.net/dtds/configuration_1_3.dtd">
+    "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+    "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style


### PR DESCRIPTION
delegates test actions to the gradle runner (so that they take care of setting up the gradle plugin classpath or installing the maven plugin)

also cleans up some xml that was causing red X's in eclipse
