### PR TITLE
Reorder priority for retrieving auth from Docker config (~/.docker/config.json)

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -11,7 +11,8 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `TarImage` is constructed using `TarImage.at(...).named(...)` instead of `TarImage.named(...).saveTo(...)` ([#1918](https://github.com/GoogleContainerTools/jib/issues/1918))
-- For retrieving credentials from Docker config (`~/.docker/config.json`), `credHelpers` now takes precedence over `credsStore`, followed by `auths`. Moreover, the legacy `credsStore` no longer requires defining empty registry entries in `auths` to be used. This means that if `credsStore` is defined, `auths` will be completely ignored. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
+- For retrieving credentials from Docker config (`~/.docker/config.json`), `credHelpers` now takes precedence over `credsStore`, followed by `auths`. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
+- The legacy `credsStore` no longer requires defining empty registry entries in `auths` to be used. This now means that if `credsStore` is defined, `auths` will be completely ignored. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
 
 ### Fixed
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - `TarImage` is constructed using `TarImage.at(...).named(...)` instead of `TarImage.named(...).saveTo(...)` ([#1918](https://github.com/GoogleContainerTools/jib/issues/1918))
+- For retrieving credentials from Docker config (`~/.docker/config.json`), `credHelpers` now takes precedence over `credsStore`, followed by `auths`. Moreover, the legacy `credsStore` no longer requires defining empty registry entries in `auths` to be used. This means that if `credsStore` is defined, `auths` will be completely ignored. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
 
 ### Fixed
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
@@ -32,12 +32,12 @@ import javax.annotation.Nullable;
  * {
  *   "auths": {
  *     "registry": {
- *       "auth": "username:password in base64"
+ *       "auth": "username:password string in base64"
  *     },
  *     "anotherregistry": {},
  *     ...
  *   },
- *   "credsStore": "credential helper name",
+ *   "credsStore": "legacy credential helper config acting as a \"default\" helper",
  *   "credHelpers": {
  *     "registry": "credential helper name",
  *     "anotherregistry": "another credential helper name",
@@ -46,17 +46,15 @@ import javax.annotation.Nullable;
  * }
  * }</pre>
  *
- * If an {@code auth} is defined for a registry, that is a valid {@code Basic} authorization to use
- * for that registry.
- *
- * <p>If {@code credsStore} is defined, is a credential helper that stores authorizations for all
- * registries listed under {@code auths}.
- *
  * <p>Each entry in {@code credHelpers} is a mapping from a registry to a credential helper that
- * stores the authorization for that registry.
+ * stores the authorization for that registry. This takes precedence over {@code credsStore} if
+ * there exists a match.
  *
- * @see <a
- *     href="https://www.projectatomic.io/blog/2016/03/docker-credentials-store/">https://www.projectatomic.io/blog/2016/03/docker-credentials-store/</a>
+ * <p>{@code credsStore} is a legacy config that acts to provide a "default" credential helper if
+ * there is no match in {@code credHelpers}.
+ *
+ * <p>If an {@code auth} is defined for a registry, that is a valid {@code Basic} authorization to
+ * use for that registry.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class DockerConfigTemplate implements JsonTemplate {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigTest.java
@@ -111,7 +111,7 @@ public class DockerConfigTest {
         new DockerConfig(JsonTemplateMapper.readJsonFromFile(json, DockerConfigTemplate.class));
 
     Assert.assertEquals(
-        Paths.get("docker-credential-credHelper for https://with.protocol.in.helpers"),
+        Paths.get("docker-credential-credHelper for https__with.protocol.in.helpers"),
         dockerConfig.getCredentialHelperFor("with.protocol.in.helpers").getCredentialHelper());
   }
 
@@ -137,7 +137,7 @@ public class DockerConfigTest {
 
     Assert.assertEquals(
         Paths.get(
-            "docker-credential-credHelper for https://with.protocol.and.suffix.in.helpers/suffix"),
+            "docker-credential-credHelper for https__with.protocol.and.suffix.in.helpers/suffix"),
         dockerConfig
             .getCredentialHelperFor("with.protocol.and.suffix.in.helpers")
             .getCredentialHelper());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigTest.java
@@ -52,21 +52,14 @@ public class DockerConfigTest {
     Assert.assertNull(dockerConfig.getAuthFor("just registry"));
 
     Assert.assertEquals(
-        Paths.get("docker-credential-some credential store"),
+        Paths.get("docker-credential-some credential helper"),
         dockerConfig.getCredentialHelperFor("some registry").getCredentialHelper());
-    Assert.assertEquals(
-        Paths.get("docker-credential-some credential store"),
-        dockerConfig.getCredentialHelperFor("some other registry").getCredentialHelper());
-    Assert.assertEquals(
-        Paths.get("docker-credential-some credential store"),
-        dockerConfig.getCredentialHelperFor("just registry").getCredentialHelper());
-    Assert.assertEquals(
-        Paths.get("docker-credential-some credential store"),
-        dockerConfig.getCredentialHelperFor("with.protocol").getCredentialHelper());
     Assert.assertEquals(
         Paths.get("docker-credential-another credential helper"),
         dockerConfig.getCredentialHelperFor("another registry").getCredentialHelper());
-    Assert.assertNull(dockerConfig.getCredentialHelperFor("unknonwn registry"));
+    Assert.assertEquals(
+        Paths.get("docker-credential-some credential store"),
+        dockerConfig.getCredentialHelperFor("unknown registry").getCredentialHelper());
   }
 
   @Test
@@ -98,15 +91,16 @@ public class DockerConfigTest {
   }
 
   @Test
-  public void testGetCredentialHelperFor() throws URISyntaxException, IOException {
+  public void testGetCredentialHelperFor_exactMatchInCredHelpers()
+      throws URISyntaxException, IOException {
     Path json = Paths.get(Resources.getResource("core/json/dockerconfig.json").toURI());
 
     DockerConfig dockerConfig =
         new DockerConfig(JsonTemplateMapper.readJsonFromFile(json, DockerConfigTemplate.class));
 
     Assert.assertEquals(
-        Paths.get("docker-credential-some credential store"),
-        dockerConfig.getCredentialHelperFor("just registry").getCredentialHelper());
+        Paths.get("docker-credential-credHelper for just.registry.in.helpers"),
+        dockerConfig.getCredentialHelperFor("just.registry.in.helpers").getCredentialHelper());
   }
 
   @Test
@@ -117,8 +111,8 @@ public class DockerConfigTest {
         new DockerConfig(JsonTemplateMapper.readJsonFromFile(json, DockerConfigTemplate.class));
 
     Assert.assertEquals(
-        Paths.get("docker-credential-some credential store"),
-        dockerConfig.getCredentialHelperFor("with.protocol").getCredentialHelper());
+        Paths.get("docker-credential-credHelper for https://with.protocol.in.helpers"),
+        dockerConfig.getCredentialHelperFor("with.protocol.in.helpers").getCredentialHelper());
   }
 
   @Test
@@ -129,8 +123,8 @@ public class DockerConfigTest {
         new DockerConfig(JsonTemplateMapper.readJsonFromFile(json, DockerConfigTemplate.class));
 
     Assert.assertEquals(
-        Paths.get("docker-credential-some credential store"),
-        dockerConfig.getCredentialHelperFor("with.suffix").getCredentialHelper());
+        Paths.get("docker-credential-credHelper for with.suffix.in.helpers/v2/"),
+        dockerConfig.getCredentialHelperFor("with.suffix.in.helpers").getCredentialHelper());
   }
 
   @Test
@@ -142,8 +136,11 @@ public class DockerConfigTest {
         new DockerConfig(JsonTemplateMapper.readJsonFromFile(json, DockerConfigTemplate.class));
 
     Assert.assertEquals(
-        Paths.get("docker-credential-some credential store"),
-        dockerConfig.getCredentialHelperFor("with.protocol.and.suffix").getCredentialHelper());
+        Paths.get(
+            "docker-credential-credHelper for https://with.protocol.and.suffix.in.helpers/suffix"),
+        dockerConfig
+            .getCredentialHelperFor("with.protocol.and.suffix.in.helpers")
+            .getCredentialHelper());
   }
 
   @Test
@@ -154,7 +151,12 @@ public class DockerConfigTest {
     DockerConfig dockerConfig =
         new DockerConfig(JsonTemplateMapper.readJsonFromFile(json, DockerConfigTemplate.class));
 
-    Assert.assertNull(dockerConfig.getCredentialHelperFor("example"));
-    Assert.assertNull(dockerConfig.getCredentialHelperFor("another.example"));
+    // Should fall back to credsStore
+    Assert.assertEquals(
+        Paths.get("docker-credential-some credential store"),
+        dockerConfig.getCredentialHelperFor("example").getCredentialHelper());
+    Assert.assertEquals(
+        Paths.get("docker-credential-some credential store"),
+        dockerConfig.getCredentialHelperFor("another.example").getCredentialHelper());
   }
 }

--- a/jib-core/src/test/resources/core/json/dockerconfig.json
+++ b/jib-core/src/test/resources/core/json/dockerconfig.json
@@ -13,10 +13,10 @@
     "index.docker.io":"index.docker.io credential helper",
 
     "just.registry.in.helpers":"credHelper for just.registry.in.helpers",
-    "https://with.protocol.in.helpers":"credHelper for https://with.protocol.in.helpers",
+    "https://with.protocol.in.helpers":"credHelper for https__with.protocol.in.helpers",
     "with.suffix.in.helpers/v2/":"credHelper for with.suffix.in.helpers/v2/",
     "https://with.protocol.and.suffix.in.helpers/suffix":
-        "credHelper for https://with.protocol.and.suffix.in.helpers/suffix",
+        "credHelper for https__with.protocol.and.suffix.in.helpers/suffix",
 
     "another.example.com.in.helpers":"should not match example"
   }

--- a/jib-core/src/test/resources/core/json/dockerconfig.json
+++ b/jib-core/src/test/resources/core/json/dockerconfig.json
@@ -4,11 +4,6 @@
     "some registry":{"auth":"c29tZTphdXRo","password":"ignored"},
     "https://registry":{"auth":"dG9rZW4="},
 
-    "just registry":{},
-    "https://with.protocol":{},
-    "with.suffix/suffix/":{},
-    "https://with.protocol.and.suffix/v10/":{},
-
     "example.com":{"auth":"should not match example"}
   },
   "credsStore":"some credential store",

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- For retrieving credentials from Docker config (`~/.docker/config.json`), `credHelpers` now takes precedence over `credsStore`, followed by `auths`. Moreover, the legacy `credsStore` no longer requires defining empty registry entries in `auths` to be used. This means that if `credsStore` is defined, `auths` will be completely ignored. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
+
 ### Fixed
 
 ## 1.5.1

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- For retrieving credentials from Docker config (`~/.docker/config.json`), `credHelpers` now takes precedence over `credsStore`, followed by `auths`. Moreover, the legacy `credsStore` no longer requires defining empty registry entries in `auths` to be used. This means that if `credsStore` is defined, `auths` will be completely ignored. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
+- For retrieving credentials from Docker config (`~/.docker/config.json`), `credHelpers` now takes precedence over `credsStore`, followed by `auths`. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
+- The legacy `credsStore` no longer requires defining empty registry entries in `auths` to be used. This now means that if `credsStore` is defined, `auths` will be completely ignored. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
 
 ### Fixed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- For retrieving credentials from Docker config (`~/.docker/config.json`), `credHelpers` now takes precedence over `credsStore`, followed by `auths`. Moreover, the legacy `credsStore` no longer requires defining empty registry entries in `auths` to be used. This means that if `credsStore` is defined, `auths` will be completely ignored. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
+
 ### Fixed
 
 ## 1.5.1

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- For retrieving credentials from Docker config (`~/.docker/config.json`), `credHelpers` now takes precedence over `credsStore`, followed by `auths`. Moreover, the legacy `credsStore` no longer requires defining empty registry entries in `auths` to be used. This means that if `credsStore` is defined, `auths` will be completely ignored. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
+- For retrieving credentials from Docker config (`~/.docker/config.json`), `credHelpers` now takes precedence over `credsStore`, followed by `auths`. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
+- The legacy `credsStore` no longer requires defining empty registry entries in `auths` to be used. This now means that if `credsStore` is defined, `auths` will be completely ignored. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
 
 ### Fixed
 


### PR DESCRIPTION
Fixes #1819.

This is actually more than that. The priority is now `credHelper` --> `credsStore` --> `auths`. According to https://github.com/moby/moby/pull/25851 (and assuming it wasn't reverted), looks like at least `credHelper` should take precedence over `credsStore`:

> This change adds a "credentialHelpers" member to the config file where users can specify credential helpers on a per-registry basis. This does not over-load the "credsStore" field, which now acts as the 'default' credential store in the event that one is not explicitly specified for the registry in question.

Also, I've lifted the restriction that there should be a matching `auths` registry entry for `credsStore` to be returned. The practice to define an empty `auths` entry is documented in [here](https://github.com/GoogleCloudPlatform/docker-credential-gcr#using-the-credsstore-for-docker-clients-since-v1110), but my guess is that this is attributed to a quick workaround to prevent a failure in certain circumstances: https://github.com/awslabs/amazon-ecr-credential-helper/issues/9#issuecomment-241184224 Nonetheless, it seems to me the workaround is no longer relevant anymore with [this change](https://github.com/moby/moby/pull/26354) in recent Docker versions where Docker queries the credential helper to populate a list of supported registries instead of using the registries in the `auths` section. This is also explained in https://github.com/awslabs/amazon-ecr-credential-helper/issues/9#issuecomment-310515232

Will update CHANGELOG soon.