### PR TITLE
Update Blobs#compress javadoc

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blobs.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blobs.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.blob;
 
 import com.google.cloud.tools.jib.hash.WritableContents;
 import com.google.cloud.tools.jib.json.JsonTemplate;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -79,11 +80,13 @@ public class Blobs {
   }
 
   /**
-   * Gets a {@link Blob} that is {@code blob} compressed.
+   * Gets a {@link Blob} that is {@code blob} compressed. Note that the output stream is closed when
+   * the blob is written.
    *
    * @param blob the {@link Blob} to compress
    * @return the compressed {@link Blob}
    */
+  @VisibleForTesting
   public static Blob compress(Blob blob) {
     return Blobs.from(
         outputStream -> {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blobs.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blobs.java
@@ -18,13 +18,11 @@ package com.google.cloud.tools.jib.blob;
 
 import com.google.cloud.tools.jib.hash.WritableContents;
 import com.google.cloud.tools.jib.json.JsonTemplate;
-import com.google.common.annotations.VisibleForTesting;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.zip.GZIPOutputStream;
 
 /** Static methods for {@link Blob}. */
 public class Blobs {
@@ -77,23 +75,6 @@ public class Blobs {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     blob.writeTo(byteArrayOutputStream);
     return byteArrayOutputStream.toByteArray();
-  }
-
-  /**
-   * Gets a {@link Blob} that is {@code blob} compressed. Note that the output stream is closed when
-   * the blob is written.
-   *
-   * @param blob the {@link Blob} to compress
-   * @return the compressed {@link Blob}
-   */
-  @VisibleForTesting
-  public static Blob compress(Blob blob) {
-    return Blobs.from(
-        outputStream -> {
-          try (GZIPOutputStream compressorStream = new GZIPOutputStream(outputStream)) {
-            blob.writeTo(compressorStream);
-          }
-        });
   }
 
   private Blobs() {}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
@@ -35,6 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -46,6 +47,15 @@ public class CacheStorageWriterTest {
 
   private static BlobDescriptor getDigest(Blob blob) throws IOException {
     return blob.writeTo(ByteStreams.nullOutputStream());
+  }
+
+  private static Blob compress(Blob blob) {
+    return Blobs.from(
+        outputStream -> {
+          try (GZIPOutputStream compressorStream = new GZIPOutputStream(outputStream)) {
+            blob.writeTo(compressorStream);
+          }
+        });
   }
 
   private static Blob decompress(Blob blob) throws IOException {
@@ -68,8 +78,7 @@ public class CacheStorageWriterTest {
     Blob uncompressedLayerBlob = Blobs.from("uncompressedLayerBlob");
 
     CachedLayer cachedLayer =
-        new CacheStorageWriter(cacheStorageFiles)
-            .writeCompressed(Blobs.compress(uncompressedLayerBlob));
+        new CacheStorageWriter(cacheStorageFiles).writeCompressed(compress(uncompressedLayerBlob));
 
     verifyCachedLayer(cachedLayer, uncompressedLayerBlob);
   }
@@ -77,7 +86,7 @@ public class CacheStorageWriterTest {
   @Test
   public void testWrite_uncompressed() throws IOException {
     Blob uncompressedLayerBlob = Blobs.from("uncompressedLayerBlob");
-    DescriptorDigest layerDigest = getDigest(Blobs.compress(uncompressedLayerBlob)).getDigest();
+    DescriptorDigest layerDigest = getDigest(compress(uncompressedLayerBlob)).getDigest();
     DescriptorDigest selector = getDigest(Blobs.from("selector")).getDigest();
 
     CachedLayer cachedLayer =
@@ -150,7 +159,7 @@ public class CacheStorageWriterTest {
 
   private void verifyCachedLayer(CachedLayer cachedLayer, Blob uncompressedLayerBlob)
       throws IOException {
-    BlobDescriptor layerBlobDescriptor = getDigest(Blobs.compress(uncompressedLayerBlob));
+    BlobDescriptor layerBlobDescriptor = getDigest(compress(uncompressedLayerBlob));
     DescriptorDigest layerDiffId = getDigest(uncompressedLayerBlob).getDigest();
 
     // Verifies cachedLayer is correct.


### PR DESCRIPTION
Fixes #1944. 

The issue assumed several blobs close their output streams, contrary to the javadoc in `Blob`, but this wasn't true (several implementations like `FileBlob` close the input stream, not the output stream). `Blobs#compress` does contradict the javadoc, but since this is only used in tests, I just decided to update the javadoc for `compress` and add `@VisibleForTesting` instead of changing the original `Blob` javadoc.