### PR TITLE
Fix progress bar logger for Gradle

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -112,7 +112,7 @@ class GradleProjectProperties implements ProjectProperties {
     this.logger = logger;
     ConsoleLoggerBuilder consoleLoggerBuilder =
         (isProgressFooterEnabled(project)
-                ? ConsoleLoggerBuilder.rich(singleThreadedExecutor)
+                ? ConsoleLoggerBuilder.rich(singleThreadedExecutor, false)
                 : ConsoleLoggerBuilder.plain(singleThreadedExecutor).progress(logger::lifecycle))
             .lifecycle(logger::lifecycle);
     if (logger.isDebugEnabled()) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -163,7 +163,7 @@ public class MavenProjectProperties implements ProjectProperties {
     this.session = session;
     ConsoleLoggerBuilder consoleLoggerBuilder =
         (isProgressFooterEnabled(session)
-                ? ConsoleLoggerBuilder.rich(singleThreadedExecutor)
+                ? ConsoleLoggerBuilder.rich(singleThreadedExecutor, true)
                 : ConsoleLoggerBuilder.plain(singleThreadedExecutor).progress(log::info))
             .lifecycle(log::info);
     if (log.isDebugEnabled()) {

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooter.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooter.java
@@ -40,7 +40,7 @@ class AnsiLoggerWithFooter implements ConsoleLogger {
   /** ANSI escape sequence template for moving the cursor up multiple lines. */
   private static final String CURSOR_UP_SEQUENCE_TEMPLATE = "\033[%dA";
 
-  /** ANSI escape sequence template for moving the cursor up multiple lines. */
+  /** ANSI escape sequence for moving the cursor up. */
   private static final String CURSOR_UP_SEQUENCE = String.format(CURSOR_UP_SEQUENCE_TEMPLATE, 1);
 
   /** ANSI escape sequence for erasing to end of display. */
@@ -102,7 +102,7 @@ class AnsiLoggerWithFooter implements ConsoleLogger {
         messageConsumers.containsKey(Level.LIFECYCLE),
         "Cannot construct AnsiLoggerFooter without LIFECYCLE message consumer");
     this.messageConsumers = messageConsumers;
-    this.lifecycleConsumer = Preconditions.checkNotNull(messageConsumers.get(Level.LIFECYCLE));
+    lifecycleConsumer = Preconditions.checkNotNull(messageConsumers.get(Level.LIFECYCLE));
     this.singleThreadedExecutor = singleThreadedExecutor;
     this.twoCursorUpOverwrite = twoCursorUpOverwrite;
   }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooter.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooter.java
@@ -79,7 +79,7 @@ class AnsiLoggerWithFooter implements ConsoleLogger {
 
   private List<String> footerLines = Collections.emptyList();
 
-  // When a footer was erased, go up two lines (and then down one line by calling "accept()" once)
+  // When a footer is erased, go up two lines (and then down one line by calling "accept()" once)
   // before printing the next message to correct an issue in Maven:
   // https://github.com/GoogleContainerTools/jib/issues/1952
   private boolean twoCursorUpOverwrite;
@@ -118,10 +118,10 @@ class AnsiLoggerWithFooter implements ConsoleLogger {
         () -> {
           boolean didErase = eraseFooter();
 
-          // If a previous footer was erased, the message needs to go up a line.
+          // If a previous footer was erased, the message needs to go up a line. But only do so when
+          // not doing the two-cursor-up fix.
           String prefix = didErase && !twoCursorUpOverwrite ? CURSOR_UP_SEQUENCE : "";
           if (didErase && twoCursorUpOverwrite) {
-            // https://github.com/GoogleContainerTools/jib/issues/1952
             messageConsumer.accept(String.format(CURSOR_UP_SEQUENCE_TEMPLATE, 2));
           }
 
@@ -151,16 +151,16 @@ class AnsiLoggerWithFooter implements ConsoleLogger {
         () -> {
           boolean didErase = eraseFooter();
 
-          // If a previous footer was erased, the first new footer line needs to go up a line.
-          String prefix = didErase && !twoCursorUpOverwrite ? CURSOR_UP_SEQUENCE : "";
+          // If a previous footer was erased, the first new footer line needs to go up a line. But
+          // only do so when not doing the two-cursor-up fix.
+          String firstLinePrefix = didErase && !twoCursorUpOverwrite ? CURSOR_UP_SEQUENCE : "";
           if (didErase && twoCursorUpOverwrite) {
-            // https://github.com/GoogleContainerTools/jib/issues/1952
             lifecycleConsumer.accept(String.format(CURSOR_UP_SEQUENCE_TEMPLATE, 2));
           }
 
           for (int i = 0; i < truncatedNewFooterLines.size(); i++) {
             String line = BOLD + truncatedNewFooterLines.get(i) + UNBOLD;
-            lifecycleConsumer.accept((i == 0 ? prefix : "") + line);
+            lifecycleConsumer.accept((i == 0 ? firstLinePrefix : "") + line);
           }
 
           footerLines = truncatedNewFooterLines;

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooter.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooter.java
@@ -90,7 +90,7 @@ class AnsiLoggerWithFooter implements ConsoleLogger {
    * @param messageConsumers map from each {@link Level} to a corresponding message logger
    * @param singleThreadedExecutor a {@link SingleThreadedExecutor} to ensure that all messages are
    *     logged in a sequential, deterministic order
-   * @param enableTwoCursorUpJump allows the logger move the cursor up twice at once. Fixes a
+   * @param enableTwoCursorUpJump allows the logger to move the cursor up twice at once. Fixes a
    *     logging issue in Maven (https://github.com/GoogleContainerTools/jib/issues/1952) but causes
    *     a problem in Gradle (https://github.com/GoogleContainerTools/jib/issues/1963)
    */

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLoggerBuilder.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLoggerBuilder.java
@@ -39,11 +39,15 @@ public class ConsoleLoggerBuilder {
    *
    * @param singleThreadedExecutor a {@link SingleThreadedExecutor} to ensure that all messages are
    *     logged in a sequential, deterministic order
+   * @param mavenFix fixes logging issue in Maven
+   *     (https://github.com/GoogleContainerTools/jib/issues/1952)
    * @return a new {@link ConsoleLoggerBuilder}
    */
-  public static ConsoleLoggerBuilder rich(SingleThreadedExecutor singleThreadedExecutor) {
+  public static ConsoleLoggerBuilder rich(
+      SingleThreadedExecutor singleThreadedExecutor, boolean mavenFix) {
     return new ConsoleLoggerBuilder(
-        messageConsumers -> new AnsiLoggerWithFooter(messageConsumers, singleThreadedExecutor));
+        messageConsumers ->
+            new AnsiLoggerWithFooter(messageConsumers, singleThreadedExecutor, mavenFix));
   }
 
   /**

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLoggerBuilder.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLoggerBuilder.java
@@ -39,7 +39,7 @@ public class ConsoleLoggerBuilder {
    *
    * @param singleThreadedExecutor a {@link SingleThreadedExecutor} to ensure that all messages are
    *     logged in a sequential, deterministic order
-   * @param enableTwoCursorUpJump allows the logger move the cursor up twice at once. Fixes a
+   * @param enableTwoCursorUpJump allows the logger to move the cursor up twice at once. Fixes a
    *     logging issue in Maven (https://github.com/GoogleContainerTools/jib/issues/1952) but causes
    *     a problem in Gradle (https://github.com/GoogleContainerTools/jib/issues/1963)
    * @return a new {@link ConsoleLoggerBuilder}

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLoggerBuilder.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLoggerBuilder.java
@@ -39,15 +39,17 @@ public class ConsoleLoggerBuilder {
    *
    * @param singleThreadedExecutor a {@link SingleThreadedExecutor} to ensure that all messages are
    *     logged in a sequential, deterministic order
-   * @param mavenFix fixes logging issue in Maven
-   *     (https://github.com/GoogleContainerTools/jib/issues/1952)
+   * @param enableTwoCursorUpJump allows the logger move the cursor up twice at once. Fixes a
+   *     logging issue in Maven (https://github.com/GoogleContainerTools/jib/issues/1952) but causes
+   *     a problem in Gradle (https://github.com/GoogleContainerTools/jib/issues/1963)
    * @return a new {@link ConsoleLoggerBuilder}
    */
   public static ConsoleLoggerBuilder rich(
-      SingleThreadedExecutor singleThreadedExecutor, boolean mavenFix) {
+      SingleThreadedExecutor singleThreadedExecutor, boolean enableTwoCursorUpJump) {
     return new ConsoleLoggerBuilder(
         messageConsumers ->
-            new AnsiLoggerWithFooter(messageConsumers, singleThreadedExecutor, mavenFix));
+            new AnsiLoggerWithFooter(
+                messageConsumers, singleThreadedExecutor, enableTwoCursorUpJump));
   }
 
   /**

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooterTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooterTest.java
@@ -146,7 +146,7 @@ public class AnsiLoggerWithFooterTest {
   }
 
   @Test
-  public void testLog_sameFooterWithTwoCursorUpOverwrite() {
+  public void testLog_sameFooterWithEnableTwoCursorUpJump() {
     AnsiLoggerWithFooter testAnsiLoggerWithFooter = createTestLogger(true);
     testAnsiLoggerWithFooter.setFooter(Collections.singletonList("footer"));
     testAnsiLoggerWithFooter.log(Level.INFO, "message");
@@ -231,7 +231,7 @@ public class AnsiLoggerWithFooterTest {
   }
 
   @Test
-  public void testLog_changingFooterWithTwoCursorUpOverwrite() {
+  public void testLog_changingFooterWithEnableTwoCursorUpJump() {
     AnsiLoggerWithFooter testAnsiLoggerWithFooter = createTestLogger(true);
     testAnsiLoggerWithFooter.setFooter(Collections.singletonList("footer"));
     testAnsiLoggerWithFooter.log(Level.WARN, "message");

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooterTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooterTest.java
@@ -282,13 +282,13 @@ public class AnsiLoggerWithFooterTest {
         levels);
   }
 
-  private AnsiLoggerWithFooter createTestLogger(boolean twoCursorUpOverwrite) {
+  private AnsiLoggerWithFooter createTestLogger(boolean enableTwoCursorUpJump) {
     ImmutableMap.Builder<Level, Consumer<String>> messageConsumers = ImmutableMap.builder();
     for (Level level : Level.values()) {
       messageConsumers.put(level, messageConsumerFactory.apply(level));
     }
 
     return new AnsiLoggerWithFooter(
-        messageConsumers.build(), singleThreadedExecutor, twoCursorUpOverwrite);
+        messageConsumers.build(), singleThreadedExecutor, enableTwoCursorUpJump);
   }
 }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooterTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooterTest.java
@@ -230,6 +230,7 @@ public class AnsiLoggerWithFooterTest {
         levels);
   }
 
+  @Test
   public void testLog_changingFooterWithTwoCursorUpOverwrite() {
     AnsiLoggerWithFooter testAnsiLoggerWithFooter = createTestLogger(true);
     testAnsiLoggerWithFooter.setFooter(Collections.singletonList("footer"));

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooterTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/AnsiLoggerWithFooterTest.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 
 /** Tests for {@link AnsiLoggerWithFooter}. */
@@ -45,19 +44,6 @@ public class AnsiLoggerWithFooterTest {
             messages.add(message);
           };
 
-  private AnsiLoggerWithFooter testAnsiLoggerWithFooter;
-
-  @Before
-  public void setUp() {
-    ImmutableMap.Builder<Level, Consumer<String>> messageConsumers = ImmutableMap.builder();
-    for (Level level : Level.values()) {
-      messageConsumers.put(level, messageConsumerFactory.apply(level));
-    }
-
-    testAnsiLoggerWithFooter =
-        new AnsiLoggerWithFooter(messageConsumers.build(), singleThreadedExecutor);
-  }
-
   @Test
   public void testTruncateToMaxWidth() {
     List<String> lines =
@@ -74,7 +60,7 @@ public class AnsiLoggerWithFooterTest {
   @Test
   public void testNoLifecycle() {
     try {
-      new AnsiLoggerWithFooter(ImmutableMap.of(), singleThreadedExecutor);
+      new AnsiLoggerWithFooter(ImmutableMap.of(), singleThreadedExecutor, false);
       Assert.fail();
 
     } catch (IllegalArgumentException ex) {
@@ -85,6 +71,7 @@ public class AnsiLoggerWithFooterTest {
 
   @Test
   public void testLog_noFooter() {
+    AnsiLoggerWithFooter testAnsiLoggerWithFooter = createTestLogger(false);
     testAnsiLoggerWithFooter.log(Level.LIFECYCLE, "lifecycle");
     testAnsiLoggerWithFooter.log(Level.PROGRESS, "progress");
     testAnsiLoggerWithFooter.log(Level.INFO, "info");
@@ -107,7 +94,8 @@ public class AnsiLoggerWithFooterTest {
     AnsiLoggerWithFooter testAnsiLoggerWithFooter =
         new AnsiLoggerWithFooter(
             ImmutableMap.of(Level.LIFECYCLE, messageConsumerFactory.apply(Level.LIFECYCLE)),
-            singleThreadedExecutor);
+            singleThreadedExecutor,
+            false);
 
     testAnsiLoggerWithFooter.log(Level.LIFECYCLE, "lifecycle");
     testAnsiLoggerWithFooter.log(Level.PROGRESS, "progress");
@@ -124,6 +112,7 @@ public class AnsiLoggerWithFooterTest {
 
   @Test
   public void testLog_sameFooter() {
+    AnsiLoggerWithFooter testAnsiLoggerWithFooter = createTestLogger(true);
     testAnsiLoggerWithFooter.setFooter(Collections.singletonList("footer"));
     testAnsiLoggerWithFooter.log(Level.INFO, "message");
     testAnsiLoggerWithFooter.log(Level.INFO, "another message");
@@ -162,6 +151,7 @@ public class AnsiLoggerWithFooterTest {
 
   @Test
   public void testLog_changingFooter() {
+    AnsiLoggerWithFooter testAnsiLoggerWithFooter = createTestLogger(true);
     testAnsiLoggerWithFooter.setFooter(Collections.singletonList("footer"));
     testAnsiLoggerWithFooter.log(Level.WARN, "message");
     testAnsiLoggerWithFooter.setFooter(Arrays.asList("two line", "footer"));
@@ -209,5 +199,15 @@ public class AnsiLoggerWithFooterTest {
             Level.LIFECYCLE,
             Level.LIFECYCLE),
         levels);
+  }
+
+  private AnsiLoggerWithFooter createTestLogger(boolean twoCursorUpOverwrite) {
+    ImmutableMap.Builder<Level, Consumer<String>> messageConsumers = ImmutableMap.builder();
+    for (Level level : Level.values()) {
+      messageConsumers.put(level, messageConsumerFactory.apply(level));
+    }
+
+    return new AnsiLoggerWithFooter(
+        messageConsumers.build(), singleThreadedExecutor, twoCursorUpOverwrite);
   }
 }


### PR DESCRIPTION
Fixes #1963.

#1963 was a regression introduced in #1953 that fixed a logging issue in Maven. But it broke Gradle.

Unfortunately, I can't think of a better and safer way than to maintain two separate paths for Maven and Gradle. I restored the original trick to fix the Gradle issue.