### PR TITLE
Fix skaffold init for multimodule maven projects

### DIFF
--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -313,7 +313,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
    * @return the configured target image reference
    */
   @Nullable
-  protected String getTargetImage() {
+  public String getTargetImage() {
     String propertyAlternate = getProperty(PropertyNames.TO_IMAGE_ALTERNATE);
     if (propertyAlternate != null) {
       return propertyAlternate;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -313,7 +313,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
    * @return the configured target image reference
    */
   @Nullable
-  public String getTargetImage() {
+  protected String getTargetImage() {
     String propertyAlternate = getProperty(PropertyNames.TO_IMAGE_ALTERNATE);
     if (propertyAlternate != null) {
       return propertyAlternate;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
@@ -19,35 +19,75 @@ package com.google.cloud.tools.jib.maven.skaffold;
 import com.google.cloud.tools.jib.maven.JibPluginConfiguration;
 import com.google.cloud.tools.jib.plugins.common.SkaffoldInitOutput;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.io.IOException;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 /**
  * Prints out to.image configuration and project name, used for Jib project detection in Skaffold.
  *
  * <p>Expected use: {@code ./mvnw jib:_skaffold-init -q}
  */
-@Mojo(name = SkaffoldInitMojo.GOAL_NAME, requiresDependencyCollection = ResolutionScope.NONE)
+@Mojo(
+    name = SkaffoldInitMojo.GOAL_NAME,
+    requiresDependencyCollection = ResolutionScope.NONE,
+    aggregator = true)
 public class SkaffoldInitMojo extends JibPluginConfiguration {
 
   @VisibleForTesting static final String GOAL_NAME = "_skaffold-init";
 
+  @Nullable
+  @Parameter(defaultValue = "${reactorProjects}", required = true, readonly = true)
+  private List<MavenProject> projects;
+
   @Override
   public void execute() throws MojoExecutionException {
-    checkJibVersion();
-    SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput();
-    skaffoldInitOutput.setImage(getTargetImage());
-    if (getProject().getParent() != null) {
-      skaffoldInitOutput.setProject(getProject().getName());
-    }
+    Preconditions.checkNotNull(projects);
 
-    System.out.println("\nBEGIN JIB JSON");
-    try {
-      System.out.println(skaffoldInitOutput.getJsonString());
-    } catch (IOException ex) {
-      throw new MojoExecutionException(ex.getMessage(), ex);
+    checkJibVersion();
+
+    for (MavenProject project : projects) {
+      // Ignore parent projects
+      if (project.getModules().size() > 0) {
+        continue;
+      }
+
+      // Find "<to><image>"
+      SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput();
+      for (Plugin plugin : project.getBuildPlugins()) {
+        if (plugin.getArtifactId().equals("jib-maven-plugin")) {
+          Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+          if (configuration != null) {
+            Xpp3Dom to = configuration.getChild("to");
+            if (to != null) {
+              Xpp3Dom image = to.getChild("image");
+              if (image != null) {
+                skaffoldInitOutput.setImage(image.getValue());
+                break;
+              }
+            }
+          }
+        }
+      }
+
+      if (projects.size() > 1) {
+        skaffoldInitOutput.setProject(project.getName());
+      }
+
+      System.out.println("\nBEGIN JIB JSON");
+      try {
+        System.out.println(skaffoldInitOutput.getJsonString());
+      } catch (IOException ex) {
+        throw new MojoExecutionException(ex.getMessage(), ex);
+      }
     }
   }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
@@ -17,11 +17,15 @@
 package com.google.cloud.tools.jib.maven.skaffold;
 
 import com.google.cloud.tools.jib.maven.JibPluginConfiguration;
+import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.cloud.tools.jib.plugins.common.SkaffoldInitOutput;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
 import javax.annotation.Nullable;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -60,18 +64,32 @@ public class SkaffoldInitMojo extends JibPluginConfiguration {
         continue;
       }
 
-      // Find "<to><image>"
       SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput();
-      for (Plugin plugin : project.getBuildPlugins()) {
-        if (plugin.getArtifactId().equals("jib-maven-plugin")) {
-          Xpp3Dom configuration = (Xpp3Dom) plugin.getConfiguration();
+
+      Properties properties = project.getProperties();
+      String toImageProperty = properties.getProperty(PropertyNames.TO_IMAGE);
+      if (Strings.isNullOrEmpty(toImageProperty)) {
+        toImageProperty = properties.getProperty(PropertyNames.TO_IMAGE_ALTERNATE);
+      }
+
+      if (!Strings.isNullOrEmpty(toImageProperty)) {
+        skaffoldInitOutput.setImage(toImageProperty);
+      } else {
+        // Find "<to><image>"
+        Optional<Plugin> optionalPlugin =
+            project
+                .getBuildPlugins()
+                .stream()
+                .filter(p -> p.getArtifactId().equals("jib-maven-plugin"))
+                .findFirst();
+        if (optionalPlugin.isPresent()) {
+          Xpp3Dom configuration = (Xpp3Dom) optionalPlugin.get().getConfiguration();
           if (configuration != null) {
             Xpp3Dom to = configuration.getChild("to");
             if (to != null) {
               Xpp3Dom image = to.getChild("image");
               if (image != null) {
                 skaffoldInitOutput.setImage(image.getValue());
-                break;
               }
             }
           }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
@@ -17,95 +17,43 @@
 package com.google.cloud.tools.jib.maven.skaffold;
 
 import com.google.cloud.tools.jib.maven.JibPluginConfiguration;
-import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.cloud.tools.jib.plugins.common.SkaffoldInitOutput;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import java.io.IOException;
-import java.util.List;
-import java.util.Optional;
-import java.util.Properties;
-import javax.annotation.Nullable;
-import org.apache.maven.model.Plugin;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.util.xml.Xpp3Dom;
 
 /**
  * Prints out to.image configuration and project name, used for Jib project detection in Skaffold.
  *
  * <p>Expected use: {@code ./mvnw jib:_skaffold-init -q}
  */
-@Mojo(
-    name = SkaffoldInitMojo.GOAL_NAME,
-    requiresDependencyCollection = ResolutionScope.NONE,
-    aggregator = true)
+@Mojo(name = SkaffoldInitMojo.GOAL_NAME, requiresDependencyCollection = ResolutionScope.NONE)
 public class SkaffoldInitMojo extends JibPluginConfiguration {
 
   @VisibleForTesting static final String GOAL_NAME = "_skaffold-init";
 
-  @Nullable
-  @Parameter(defaultValue = "${reactorProjects}", required = true, readonly = true)
-  private List<MavenProject> projects;
-
   @Override
   public void execute() throws MojoExecutionException {
-    Preconditions.checkNotNull(projects);
-
     checkJibVersion();
+    MavenProject project = getProject();
+    // Ignore parent projects
+    if (project.getModules().size() > 0) {
+      return;
+    }
 
-    for (MavenProject project : projects) {
-      // Ignore parent projects
-      if (project.getModules().size() > 0) {
-        continue;
-      }
-
-      SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput();
-
-      Properties properties = project.getProperties();
-      String toImageProperty = properties.getProperty(PropertyNames.TO_IMAGE);
-      if (Strings.isNullOrEmpty(toImageProperty)) {
-        toImageProperty = properties.getProperty(PropertyNames.TO_IMAGE_ALTERNATE);
-      }
-
-      if (!Strings.isNullOrEmpty(toImageProperty)) {
-        skaffoldInitOutput.setImage(toImageProperty);
-      } else {
-        // Find "<to><image>"
-        Optional<Plugin> optionalPlugin =
-            project
-                .getBuildPlugins()
-                .stream()
-                .filter(p -> p.getArtifactId().equals("jib-maven-plugin"))
-                .findFirst();
-        if (optionalPlugin.isPresent()) {
-          Xpp3Dom configuration = (Xpp3Dom) optionalPlugin.get().getConfiguration();
-          if (configuration != null) {
-            Xpp3Dom to = configuration.getChild("to");
-            if (to != null) {
-              Xpp3Dom image = to.getChild("image");
-              if (image != null) {
-                skaffoldInitOutput.setImage(image.getValue());
-              }
-            }
-          }
-        }
-      }
-
-      if (projects.size() > 1) {
-        skaffoldInitOutput.setProject(project.getName());
-      }
-
-      System.out.println("\nBEGIN JIB JSON");
-      try {
-        System.out.println(skaffoldInitOutput.getJsonString());
-      } catch (IOException ex) {
-        throw new MojoExecutionException(ex.getMessage(), ex);
-      }
+    SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput();
+    skaffoldInitOutput.setImage(getTargetImage());
+    if (project.getParent() != null && project.getParent().getFile() != null) {
+      skaffoldInitOutput.setProject(project.getName());
+    }
+    System.out.println("\nBEGIN JIB JSON");
+    try {
+      System.out.println(skaffoldInitOutput.getJsonString());
+    } catch (IOException ex) {
+      throw new MojoExecutionException(ex.getMessage(), ex);
     }
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojoTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojoTest.java
@@ -84,13 +84,9 @@ public class SkaffoldInitMojoTest {
   @Test
   public void testFilesMojo_multiModule() throws IOException, VerificationException {
     List<String> outputs = getJsons(multiTestProject);
-    Assert.assertEquals(4, outputs.size());
+    Assert.assertEquals(3, outputs.size());
 
-    SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(0));
-    Assert.assertEquals("testimage", skaffoldInitOutput.getImage());
-    Assert.assertNull(skaffoldInitOutput.getProject());
-
-    skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(1));
+    SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(1));
     Assert.assertEquals("testimage", skaffoldInitOutput.getImage());
     Assert.assertEquals("name-service", skaffoldInitOutput.getProject());
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojoTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojoTest.java
@@ -86,15 +86,15 @@ public class SkaffoldInitMojoTest {
     List<String> outputs = getJsons(multiTestProject);
     Assert.assertEquals(3, outputs.size());
 
-    SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(1));
+    SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(0));
     Assert.assertEquals("testimage", skaffoldInitOutput.getImage());
     Assert.assertEquals("name-service", skaffoldInitOutput.getProject());
 
-    skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(2));
+    skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(1));
     Assert.assertEquals("testimage", skaffoldInitOutput.getImage());
     Assert.assertEquals("lib", skaffoldInitOutput.getProject());
 
-    skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(3));
+    skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(2));
     Assert.assertEquals("testimage", skaffoldInitOutput.getImage());
     Assert.assertEquals("service", skaffoldInitOutput.getProject());
   }


### PR DESCRIPTION
Quick idea to fix https://github.com/GoogleContainerTools/skaffold/issues/2844.

Instead of running `jib:_skaffold-init` separately on every module including the root project, we use an aggregator to run the goal once across all modules. This lets us more easily detect the root project, which helps prevent `skaffold init` from setting the `module` field when we don't want it to.

The problem with this approach is that using an aggregator makes getting the `<to><image>` configuration on sub-projects harder; in this case we can only parse it from the configuration block and ignore system properties.

wdyt?