### PR TITLE
Fix progress allocation when given non-positive size

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/Allocation.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/progress/Allocation.java
@@ -65,10 +65,10 @@ public class Allocation {
 
   private Allocation(String description, long allocationUnits, @Nullable Allocation parent) {
     this.description = description;
-    this.allocationUnits = allocationUnits < 0 ? 0 : allocationUnits;
+    this.allocationUnits = allocationUnits < 1 ? 1 : allocationUnits;
     this.parent = parent;
 
-    this.fractionOfRoot = (parent == null ? 1.0 : parent.fractionOfRoot) / allocationUnits;
+    this.fractionOfRoot = (parent == null ? 1.0 : parent.fractionOfRoot) / this.allocationUnits;
   }
 
   /**

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/AllocationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/event/progress/AllocationTest.java
@@ -90,4 +90,21 @@ public class AllocationTest {
             + rightDown.getFractionOfRoot() * rightDown.getAllocationUnits();
     Assert.assertEquals(1.0, total, DOUBLE_ERROR_MARGIN);
   }
+
+  @Test
+  public void testNonPositiveAllocationUnits() {
+    Allocation root = Allocation.newRoot("ignored", 2);
+
+    Allocation left = root.newChild("ignored", -30);
+    Allocation right = root.newChild("ignored", 0);
+
+    Assert.assertEquals(0.5, root.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
+    Assert.assertEquals(2, root.getAllocationUnits());
+
+    Assert.assertEquals(0.5, left.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
+    Assert.assertEquals(1, left.getAllocationUnits());
+
+    Assert.assertEquals(0.5, right.getFractionOfRoot(), DOUBLE_ERROR_MARGIN);
+    Assert.assertEquals(1, right.getAllocationUnits());
+  }
 }


### PR DESCRIPTION
Fixes #1972.

I think setting the minimum unit to 1 still makes sense; the progress dispatcher in this case would represent the task as a work to be completed. Also, dividing by 0 makes `fractionOfRoot` infinity, so it's better to avoid it. 

And it should definitely divide the parent fraction by `this.allocation` instead of the argument `allocation`. This has to be fixed.