### PR TITLE
Update progress and timer messages

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
@@ -52,7 +52,7 @@ class BuildAndCacheApplicationLayerStep implements Callable<PreparedLayer> {
                 "launching application layer builders", layerConfigurations.size());
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(
-                buildConfiguration.getEventHandlers(), "Launching application layer builders")) {
+                buildConfiguration.getEventHandlers(), "Preparing application layer builders")) {
       return layerConfigurations
           .stream()
           // Skips the layer if empty.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
@@ -49,10 +49,10 @@ class BuildAndCacheApplicationLayerStep implements Callable<PreparedLayer> {
 
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create(
-                "preparing application layer builders", layerConfigurations.size());
+                "launching application layer builders", layerConfigurations.size());
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(
-                buildConfiguration.getEventHandlers(), "Preparing application layer builders")) {
+                buildConfiguration.getEventHandlers(), "Launching application layer builders")) {
       return layerConfigurations
           .stream()
           // Skips the layer if empty.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStep.java
@@ -93,7 +93,7 @@ class ObtainBaseImageLayerStep implements Callable<PreparedLayer> {
                 "launching base image layer pullers", baseImageLayers.size());
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(
-                buildConfiguration.getEventHandlers(), "Launching base image layer pullers")) {
+                buildConfiguration.getEventHandlers(), "Preparing base image layer pullers")) {
 
       List<ObtainBaseImageLayerStep> layerPullers = new ArrayList<>();
       for (Layer layer : baseImageLayers) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStep.java
@@ -90,10 +90,10 @@ class ObtainBaseImageLayerStep implements Callable<PreparedLayer> {
 
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create(
-                "preparing base image layer pullers", baseImageLayers.size());
+                "launching base image layer pullers", baseImageLayers.size());
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(
-                buildConfiguration.getEventHandlers(), "Preparing base image layer pullers")) {
+                buildConfiguration.getEventHandlers(), "Launching base image layer pullers")) {
 
       List<ObtainBaseImageLayerStep> layerPullers = new ArrayList<>();
       for (Layer layer : baseImageLayers) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -55,9 +55,9 @@ class PushImageStep implements Callable<BuildResult> {
 
     try (TimerEventDispatcher ignored =
             new TimerEventDispatcher(
-                buildConfiguration.getEventHandlers(), "Preparing manifest pushers");
+                buildConfiguration.getEventHandlers(), "Launching manifest pushers");
         ProgressEventDispatcher progressEventDispatcher =
-            progressEventDispatcherFactory.create("preparing manifest pushers", tags.size())) {
+            progressEventDispatcherFactory.create("launching manifest pushers", tags.size())) {
 
       // Gets the image manifest to push.
       BuildableManifestTemplate manifestTemplate =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -55,7 +55,7 @@ class PushImageStep implements Callable<BuildResult> {
 
     try (TimerEventDispatcher ignored =
             new TimerEventDispatcher(
-                buildConfiguration.getEventHandlers(), "Launching manifest pushers");
+                buildConfiguration.getEventHandlers(), "Preparing manifest pushers");
         ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create("launching manifest pushers", tags.size())) {
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
@@ -40,7 +40,7 @@ class PushLayerStep implements Callable<BlobDescriptor> {
       List<Future<PreparedLayer>> cachedLayers) {
     try (TimerEventDispatcher ignored =
             new TimerEventDispatcher(
-                buildConfiguration.getEventHandlers(), "Launching layer pushers");
+                buildConfiguration.getEventHandlers(), "Preparing layer pushers");
         ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create("launching layer pushers", cachedLayers.size())) {
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
@@ -40,10 +40,9 @@ class PushLayerStep implements Callable<BlobDescriptor> {
       List<Future<PreparedLayer>> cachedLayers) {
     try (TimerEventDispatcher ignored =
             new TimerEventDispatcher(
-                buildConfiguration.getEventHandlers(), "Preparing application layer pushers");
+                buildConfiguration.getEventHandlers(), "Launching layer pushers");
         ProgressEventDispatcher progressEventDispatcher =
-            progressEventDispatcherFactory.create(
-                "preparing application layer pushers", cachedLayers.size())) {
+            progressEventDispatcherFactory.create("launching layer pushers", cachedLayers.size())) {
 
       // Constructs a PushBlobStep for each layer.
       return cachedLayers


### PR DESCRIPTION
It was incorrectly saying "application layers" even for the base image layers.

And for the timer messages, the message "preparing pushers/pullers/builders" makes sense, but I just realized the word "preparing" doesn't really fit for the progress update. Closing the progress dispatcher doesn't competes the progress in this method. Rather, the progress becomes complete (100%) when their children are complete. So I'm retaining "preparing" for the timer but changing to "launching" for progress.