### PR TITLE
Move docker client configuration to all tasks and goals

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 - For retrieving credentials from Docker config (`~/.docker/config.json`), `credHelpers` now takes precedence over `credsStore`, followed by `auths`. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
 - The legacy `credsStore` no longer requires defining empty registry entries in `auths` to be used. This now means that if `credsStore` is defined, `auths` will be completely ignored. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
 - `jib.dockerClient` is now configurable on all tasks, not just `jibDockerBuild`. ([#1932](https://github.com/GoogleContainerTools/jib/issues/1932))
+- `jibDockerBuild.dockerClient` is deprecated in favor of `jib.dockerClient`.
 
 ### Fixed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - To disable parallel execution, the property `jib.serialize` should be used instead of `jibSerialize`. ([#1968](https://github.com/GoogleContainerTools/jib/issues/1968))
 - For retrieving credentials from Docker config (`~/.docker/config.json`), `credHelpers` now takes precedence over `credsStore`, followed by `auths`. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
 - The legacy `credsStore` no longer requires defining empty registry entries in `auths` to be used. This now means that if `credsStore` is defined, `auths` will be completely ignored. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
+- `jib.dockerClient` is now configurable on all tasks, not just `jibDockerBuild`. ([#1932](https://github.com/GoogleContainerTools/jib/issues/1932))
 
 ### Fixed
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -91,10 +91,10 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
       throws IOException, BuildStepsExecutionException, CacheDirectoryCreationException,
           MainClassInferenceException {
     Preconditions.checkNotNull(jibExtension);
-    Path dockerExecutable = jibExtension.getDockerClient().getExecutablePath();
-    Map<String, String> dockerEnvironment = jibExtension.getDockerClient().getEnvironment();
 
     // Check deprecated parameters
+    Path dockerExecutable = jibExtension.getDockerClient().getExecutablePath();
+    Map<String, String> dockerEnvironment = jibExtension.getDockerClient().getEnvironment();
     if (getDockerClient().getExecutable() != null) {
       jibExtension.getDockerClient().setExecutable(getDockerClient().getExecutable());
       getProject()

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -95,27 +95,16 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
     Map<String, String> dockerEnvironment = jibExtension.getDockerClient().getEnvironment();
 
     // Check deprecated parameters
-    if (getDockerClient().getExecutable() != null) {
-      if (dockerExecutable != null) {
-        throw new GradleException(
-            "Cannot configure 'jibDockerBuild.dockerClient.executable' and 'jib.dockerClient.executable' simultaneously");
-      }
+    if (getDockerClient().getExecutable() != null
+        || !getDockerClient().getEnvironment().isEmpty()) {
       getProject()
           .getLogger()
-          .warn(
-              "'jibDockerBuild.dockerClient.executable' is deprecated; use 'jib.dockerClient.executable' instead.");
-      dockerExecutable = getDockerClient().getExecutablePath();
+          .warn("'jibDockerBuild.dockerClient' is deprecated; use 'jib.dockerClient' instead.");
     }
-    if (getDockerClient().getEnvironment().size() > 0) {
-      if (dockerEnvironment.size() > 0) {
-        throw new GradleException(
-            "Cannot configure 'jibDockerBuild.dockerClient.environment' and 'jib.dockerClient.environment' simultaneously");
-      }
-      getProject()
-          .getLogger()
-          .warn(
-              "'jibDockerBuild.dockerClient.environment' is deprecated; use 'jib.dockerClient.environment' instead.");
-      dockerEnvironment = getDockerClient().getEnvironment();
+    if ((getDockerClient().getExecutable() != null && dockerExecutable != null)
+        || (!getDockerClient().getEnvironment().isEmpty() && !dockerEnvironment.isEmpty())) {
+      throw new GradleException(
+          "Cannot configure 'jibDockerBuild.dockerClient' and 'jib.dockerClient' simultaneously");
     }
 
     boolean isDockerInstalled =
@@ -127,7 +116,6 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
           HelpfulSuggestions.forDockerNotInstalled(HELPFUL_SUGGESTIONS_PREFIX));
     }
 
-    // Asserts required @Input parameters are not null.
     TaskCommon.checkDeprecatedUsage(jibExtension, getLogger());
     TaskCommon.disableHttpLogging();
 
@@ -138,8 +126,6 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
               new GradleRawConfiguration(jibExtension),
               ignored -> java.util.Optional.empty(),
               projectProperties,
-              dockerExecutable,
-              dockerEnvironment,
               new GradleHelpfulSuggestions(HELPFUL_SUGGESTIONS_PREFIX))
           .runBuild();
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -95,11 +95,19 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
     Map<String, String> dockerEnvironment = jibExtension.getDockerClient().getEnvironment();
 
     // Check deprecated parameters
-    if (getDockerClient().getExecutable() != null
-        || !getDockerClient().getEnvironment().isEmpty()) {
+    if (getDockerClient().getExecutable() != null) {
+      jibExtension.getDockerClient().setExecutable(getDockerClient().getExecutable());
       getProject()
           .getLogger()
-          .warn("'jibDockerBuild.dockerClient' is deprecated; use 'jib.dockerClient' instead.");
+          .warn(
+              "'jibDockerBuild.dockerClient.executable' is deprecated; use 'jib.dockerClient.executable' instead.");
+    }
+    if (!getDockerClient().getEnvironment().isEmpty()) {
+      jibExtension.getDockerClient().setEnvironment(getDockerClient().getEnvironment());
+      getProject()
+          .getLogger()
+          .warn(
+              "'jibDockerBuild.dockerClient.environment' is deprecated; use 'jib.dockerClient.environment' instead.");
     }
     if ((getDockerClient().getExecutable() != null && dockerExecutable != null)
         || (!getDockerClient().getEnvironment().isEmpty() && !dockerEnvironment.isEmpty())) {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerClientParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerClientParameters.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.gradle.api.tasks.Input;
@@ -33,7 +34,7 @@ import org.gradle.api.tasks.Optional;
 public class DockerClientParameters {
 
   @Nullable private Path executable;
-  @Nullable private Map<String, String> environment;
+  private Map<String, String> environment = Collections.emptyMap();
 
   @Input
   @Nullable
@@ -48,6 +49,9 @@ public class DockerClientParameters {
   @Internal
   @Nullable
   Path getExecutablePath() {
+    if (System.getProperty(PropertyNames.DOCKER_CLIENT_EXECUTABLE) != null) {
+      return Paths.get(System.getProperty(PropertyNames.DOCKER_CLIENT_EXECUTABLE));
+    }
     return executable;
   }
 
@@ -56,7 +60,6 @@ public class DockerClientParameters {
   }
 
   @Input
-  @Nullable
   @Optional
   public Map<String, String> getEnvironment() {
     if (System.getProperty(PropertyNames.DOCKER_CLIENT_ENVIRONMENT) != null) {
@@ -66,7 +69,7 @@ public class DockerClientParameters {
     return environment;
   }
 
-  public void setEnvironment(@Nullable Map<String, String> environment) {
+  public void setEnvironment(Map<String, String> environment) {
     this.environment = environment;
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -172,6 +172,16 @@ class GradleRawConfiguration implements RawConfiguration {
   }
 
   @Override
+  public Optional<Path> getDockerExecutable() {
+    return Optional.ofNullable(jibExtension.getDockerClient().getExecutablePath());
+  }
+
+  @Override
+  public Map<String, String> getDockerEnvironment() {
+    return jibExtension.getDockerClient().getEnvironment();
+  }
+
+  @Override
   public String getContainerizingMode() {
     return jibExtension.getContainerizingMode();
   }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -71,6 +71,7 @@ public class JibExtension {
   private final TargetImageParameters to;
   private final ContainerParameters container;
   private final ExtraDirectoriesParameters extraDirectories;
+  private final DockerClientParameters dockerClient;
   private final Property<Boolean> allowInsecureRegistries;
   private final Property<String> containerizingMode;
 
@@ -84,6 +85,7 @@ public class JibExtension {
     to = objectFactory.newInstance(TargetImageParameters.class);
     container = objectFactory.newInstance(ContainerParameters.class);
     extraDirectories = objectFactory.newInstance(ExtraDirectoriesParameters.class, project, this);
+    dockerClient = objectFactory.newInstance(DockerClientParameters.class);
 
     allowInsecureRegistries = objectFactory.property(Boolean.class);
     containerizingMode = objectFactory.property(String.class);
@@ -114,6 +116,10 @@ public class JibExtension {
   public void extraDirectories(Action<? super ExtraDirectoriesParameters> action) {
     extraDirectoriesConfigured = true;
     action.execute(extraDirectories);
+  }
+
+  public void dockerClient(Action<? super DockerClientParameters> action) {
+    action.execute(dockerClient);
   }
 
   @Deprecated
@@ -160,6 +166,12 @@ public class JibExtension {
   @Optional
   public ExtraDirectoriesParameters getExtraDirectories() {
     return extraDirectories;
+  }
+
+  @Nested
+  @Optional
+  public DockerClientParameters getDockerClient() {
+    return dockerClient;
   }
 
   @Input

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.gradle;
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,6 +38,7 @@ public class GradleRawConfigurationTest {
     BaseImageParameters baseImageParameters = Mockito.mock(BaseImageParameters.class);
     TargetImageParameters targetImageParameters = Mockito.mock(TargetImageParameters.class);
     ContainerParameters containerParameters = Mockito.mock(ContainerParameters.class);
+    DockerClientParameters dockerClientParameters = Mockito.mock(DockerClientParameters.class);
 
     Mockito.when(authParameters.getUsername()).thenReturn("user");
     Mockito.when(authParameters.getPassword()).thenReturn("password");
@@ -47,6 +49,7 @@ public class GradleRawConfigurationTest {
     Mockito.when(jibExtension.getFrom()).thenReturn(baseImageParameters);
     Mockito.when(jibExtension.getTo()).thenReturn(targetImageParameters);
     Mockito.when(jibExtension.getContainer()).thenReturn(containerParameters);
+    Mockito.when(jibExtension.getDockerClient()).thenReturn(dockerClientParameters);
     Mockito.when(jibExtension.getAllowInsecureRegistries()).thenReturn(true);
 
     Mockito.when(baseImageParameters.getCredHelper()).thenReturn("gcr");
@@ -69,6 +72,10 @@ public class GradleRawConfigurationTest {
     Mockito.when(containerParameters.getUseCurrentTimestamp()).thenReturn(true);
     Mockito.when(containerParameters.getUser()).thenReturn("admin:wheel");
     Mockito.when(containerParameters.getFilesModificationTime()).thenReturn("2011-12-03T22:42:05Z");
+
+    Mockito.when(dockerClientParameters.getExecutablePath()).thenReturn(Paths.get("test"));
+    Mockito.when(dockerClientParameters.getEnvironment())
+        .thenReturn(new HashMap<>(ImmutableMap.of("docker", "client")));
 
     GradleRawConfiguration rawConfiguration = new GradleRawConfiguration(jibExtension);
 
@@ -98,5 +105,9 @@ public class GradleRawConfigurationTest {
     Assert.assertTrue(rawConfiguration.getUseCurrentTimestamp());
     Assert.assertEquals("admin:wheel", rawConfiguration.getUser().get());
     Assert.assertEquals("2011-12-03T22:42:05Z", rawConfiguration.getFilesModificationTime());
+    Assert.assertEquals(Paths.get("test"), rawConfiguration.getDockerExecutable().get());
+    Assert.assertEquals(
+        new HashMap<>(ImmutableMap.of("docker", "client")),
+        rawConfiguration.getDockerEnvironment());
   }
 }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -226,6 +226,21 @@ public class JibExtensionTest {
   }
 
   @Test
+  public void testDockerClient() {
+    testJibExtension.dockerClient(
+        dockerClient -> {
+          dockerClient.setExecutable("test-executable");
+          dockerClient.setEnvironment(ImmutableMap.of("key1", "val1", "key2", "val2"));
+        });
+
+    Assert.assertEquals(
+        Paths.get("test-executable"), testJibExtension.getDockerClient().getExecutablePath());
+    Assert.assertEquals(
+        ImmutableMap.of("key1", "val1", "key2", "val2"),
+        testJibExtension.getDockerClient().getEnvironment());
+  }
+
+  @Test
   public void testProperties() {
     System.setProperty("jib.from.image", "fromImage");
     Assert.assertEquals("fromImage", testJibExtension.getFrom().getImage());
@@ -279,6 +294,7 @@ public class JibExtensionTest {
         "2011-12-03T22:42:05Z", testJibExtension.getContainer().getFilesModificationTime());
     System.setProperty("jib.containerizingMode", "packaged");
     Assert.assertEquals("packaged", testJibExtension.getContainerizingMode());
+
     System.setProperty("jib.extraDirectories.paths", "/foo,/bar/baz");
     Assert.assertEquals(
         Arrays.asList(Paths.get("/foo"), Paths.get("/bar/baz")),
@@ -287,6 +303,14 @@ public class JibExtensionTest {
     Assert.assertEquals(
         ImmutableMap.of("/foo/bar", "707", "/baz", "456"),
         testJibExtension.getExtraDirectories().getPermissions());
+
+    System.setProperty("jib.dockerClient.executable", "test-exec");
+    Assert.assertEquals(
+        Paths.get("test-exec"), testJibExtension.getDockerClient().getExecutablePath());
+    System.setProperty("jib.dockerClient.environment", "env1=val1,env2=val2");
+    Assert.assertEquals(
+        ImmutableMap.of("env1", "val1", "env2", "val2"),
+        testJibExtension.getDockerClient().getEnvironment());
   }
 
   @Test

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - To disable parallel execution, the property `jib.serialize` should be used instead of `jibSerialize`. ([#1968](https://github.com/GoogleContainerTools/jib/issues/1968))
 - For retrieving credentials from Docker config (`~/.docker/config.json`), `credHelpers` now takes precedence over `credsStore`, followed by `auths`. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
 - The legacy `credsStore` no longer requires defining empty registry entries in `auths` to be used. This now means that if `credsStore` is defined, `auths` will be completely ignored. ([#1958](https://github.com/GoogleContainerTools/jib/pull/1958))
+- `<dockerClient>` is now configurable on all goals, not just `jib:dockerBuild`. ([#1932](https://github.com/GoogleContainerTools/jib/issues/1932))
 
 ### Fixed
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -90,8 +90,6 @@ public class BuildDockerMojo extends JibPluginConfiguration {
               new MavenSettingsServerCredentials(
                   getSession().getSettings(), getSettingsDecrypter()),
               projectProperties,
-              dockerExecutable,
-              getDockerClientEnvironment(),
               new MavenHelpfulSuggestions(HELPFUL_SUGGESTIONS_PREFIX))
           .runBuild();
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -20,7 +20,6 @@ import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.docker.DockerClient;
 import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
-import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
 import com.google.cloud.tools.jib.plugins.common.IncompatibleBaseImageJavaVersionException;
 import com.google.cloud.tools.jib.plugins.common.InvalidAppRootException;
@@ -33,16 +32,11 @@ import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.common.annotations.VisibleForTesting;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Map;
-import javax.annotation.Nullable;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
-import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /** Builds a container image and exports to the default Docker daemon. */
@@ -51,20 +45,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
     requiresDependencyResolution = ResolutionScope.RUNTIME_PLUS_SYSTEM)
 public class BuildDockerMojo extends JibPluginConfiguration {
 
-  /**
-   * Object that configures the Docker executable and the additional environment variables to use
-   * when executing the executable.
-   */
-  public static class DockerClientConfiguration {
-
-    @Nullable @Parameter private File executable;
-    @Nullable @Parameter private Map<String, String> environment;
-  }
-
   @VisibleForTesting static final String GOAL_NAME = "dockerBuild";
   private static final String HELPFUL_SUGGESTIONS_PREFIX = "Build to Docker daemon failed";
-
-  @Parameter private DockerClientConfiguration dockerClient = new DockerClientConfiguration();
 
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
@@ -167,23 +149,5 @@ public class BuildDockerMojo extends JibPluginConfiguration {
       projectProperties.waitForLoggingThread();
       getLog().info("");
     }
-  }
-
-  @Nullable
-  private Path getDockerClientExecutable() {
-    String property = getProperty(PropertyNames.DOCKER_CLIENT_EXECUTABLE);
-    if (property != null) {
-      return Paths.get(property);
-    }
-    return dockerClient.executable == null ? null : dockerClient.executable.toPath();
-  }
-
-  @Nullable
-  private Map<String, String> getDockerClientEnvironment() {
-    String property = getProperty(PropertyNames.DOCKER_CLIENT_ENVIRONMENT);
-    if (property != null) {
-      return ConfigurationPropertyValidator.parseMapProperty(property);
-    }
-    return dockerClient.environment;
   }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -225,6 +225,14 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
     }
   }
 
+  /** Configuration for the {@code dockerClient} parameter. */
+  public static class DockerClientParameters {
+
+    @Nullable @Parameter private File executable;
+
+    @Parameter private Map<String, String> environment = Collections.emptyMap();
+  }
+
   @Nullable
   @Parameter(defaultValue = "${session}", readonly = true)
   private MavenSession session;
@@ -249,6 +257,8 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
 
   // this parameter is cloned in FilesMojo
   @Parameter private ExtraDirectoriesParameters extraDirectories = new ExtraDirectoriesParameters();
+
+  @Parameter private DockerClientParameters dockerClient = new DockerClientParameters();
 
   @Parameter(property = PropertyNames.ALLOW_INSECURE_REGISTRIES)
   private boolean allowInsecureRegistries;
@@ -655,6 +665,23 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
     return !extraDirectories.getPaths().isEmpty()
         ? extraDirectories.permissions
         : extraDirectory.permissions;
+  }
+
+  @Nullable
+  Path getDockerClientExecutable() {
+    String property = getProperty(PropertyNames.DOCKER_CLIENT_EXECUTABLE);
+    if (property != null) {
+      return Paths.get(property);
+    }
+    return dockerClient.executable == null ? null : dockerClient.executable.toPath();
+  }
+
+  Map<String, String> getDockerClientEnvironment() {
+    String property = getProperty(PropertyNames.DOCKER_CLIENT_ENVIRONMENT);
+    if (property != null) {
+      return ConfigurationPropertyValidator.parseMapProperty(property);
+    }
+    return dockerClient.environment;
   }
 
   boolean getAllowInsecureRegistries() {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
@@ -177,6 +177,16 @@ class MavenRawConfiguration implements RawConfiguration {
   }
 
   @Override
+  public Optional<Path> getDockerExecutable() {
+    return Optional.ofNullable(jibPluginConfiguration.getDockerClientExecutable());
+  }
+
+  @Override
+  public Map<String, String> getDockerEnvironment() {
+    return jibPluginConfiguration.getDockerClientEnvironment();
+  }
+
+  @Override
   public String getContainerizingMode() {
     return jibPluginConfiguration.getContainerizingMode();
   }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
@@ -142,6 +142,14 @@ public class JibPluginConfigurationTest {
     Assert.assertEquals("123", permissions.get(0).getMode().get());
     Assert.assertEquals("/another/file", permissions.get(1).getFile().get());
     Assert.assertEquals("456", permissions.get(1).getMode().get());
+
+    sessionProperties.put("jib.dockerClient.executable", "test-exec");
+    Assert.assertEquals(
+        Paths.get("test-exec"), testPluginConfiguration.getDockerClientExecutable());
+    sessionProperties.put("jib.dockerClient.environment", "env1=val1,env2=val2");
+    Assert.assertEquals(
+        ImmutableMap.of("env1", "val1", "env2", "val2"),
+        testPluginConfiguration.getDockerClientEnvironment());
   }
 
   @Test
@@ -217,6 +225,14 @@ public class JibPluginConfigurationTest {
     Assert.assertEquals("123", permissions.get(0).getMode().get());
     Assert.assertEquals("/another/file", permissions.get(1).getFile().get());
     Assert.assertEquals("456", permissions.get(1).getMode().get());
+
+    project.getProperties().setProperty("jib.dockerClient.executable", "test-exec");
+    Assert.assertEquals(
+        Paths.get("test-exec"), testPluginConfiguration.getDockerClientExecutable());
+    project.getProperties().setProperty("jib.dockerClient.environment", "env1=val1,env2=val2");
+    Assert.assertEquals(
+        ImmutableMap.of("env1", "val1", "env2", "val2"),
+        testPluginConfiguration.getDockerClientEnvironment());
   }
 
   @Test

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenRawConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenRawConfigurationTest.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.maven.JibPluginConfiguration.FromAuthConfigura
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -78,6 +79,9 @@ public class MavenRawConfigurationTest {
     Mockito.when(jibPluginConfiguration.getUser()).thenReturn("admin:wheel");
     Mockito.when(jibPluginConfiguration.getFilesModificationTime())
         .thenReturn("2011-12-03T22:42:05Z");
+    Mockito.when(jibPluginConfiguration.getDockerClientExecutable()).thenReturn(Paths.get("test"));
+    Mockito.when(jibPluginConfiguration.getDockerClientEnvironment())
+        .thenReturn(new HashMap<>(ImmutableMap.of("docker", "client")));
 
     MavenRawConfiguration rawConfiguration = new MavenRawConfiguration(jibPluginConfiguration);
 
@@ -107,6 +111,10 @@ public class MavenRawConfigurationTest {
     Assert.assertTrue(rawConfiguration.getUseCurrentTimestamp());
     Assert.assertEquals("admin:wheel", rawConfiguration.getUser().get());
     Assert.assertEquals("2011-12-03T22:42:05Z", rawConfiguration.getFilesModificationTime());
+    Assert.assertEquals(Paths.get("test"), rawConfiguration.getDockerExecutable().get());
+    Assert.assertEquals(
+        new HashMap<>(ImmutableMap.of("docker", "client")),
+        rawConfiguration.getDockerEnvironment());
 
     Mockito.verifyNoMoreInteractions(eventHandlers);
   }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -46,7 +46,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -62,8 +61,6 @@ public class PluginConfigurationProcessor {
       RawConfiguration rawConfiguration,
       InferredAuthProvider inferredAuthProvider,
       ProjectProperties projectProperties,
-      @Nullable Path dockerExecutable,
-      Map<String, String> dockerEnvironment,
       HelpfulSuggestions helpfulSuggestions)
       throws InvalidImageReferenceException, MainClassInferenceException, InvalidAppRootException,
           IOException, InvalidWorkingDirectoryException, InvalidContainerVolumeException,
@@ -73,10 +70,10 @@ public class PluginConfigurationProcessor {
     ImageReference targetImageReference =
         getGeneratedTargetDockerTag(rawConfiguration, projectProperties, helpfulSuggestions);
     DockerDaemonImage targetImage = DockerDaemonImage.named(targetImageReference);
-    if (dockerExecutable != null) {
-      targetImage.setDockerExecutable(dockerExecutable);
+    if (rawConfiguration.getDockerExecutable().isPresent()) {
+      targetImage.setDockerExecutable(rawConfiguration.getDockerExecutable().get());
     }
-    targetImage.setDockerEnvironment(dockerEnvironment);
+    targetImage.setDockerEnvironment(rawConfiguration.getDockerEnvironment());
 
     Containerizer containerizer = Containerizer.to(targetImage);
     JibContainerBuilder jibContainerBuilder =

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
@@ -86,5 +86,9 @@ public interface RawConfiguration {
 
   Map<AbsoluteUnixPath, FilePermissions> getExtraDirectoryPermissions();
 
+  Optional<Path> getDockerExecutable();
+
+  Map<String, String> getDockerEnvironment();
+
   String getContainerizingMode();
 }


### PR DESCRIPTION
Fixes #1932.

This PR moves the `jib.dockerClient` configuration from `BuildDockerTask` and `BuildDockerMojo` to `JibExtension` and `JibPluginConfiguration` to be accessible from all tasks and goals, allowing users to configure the docker client for docker daemon base images.