### PR TITLE
Fix release by ignoring SNAPSHOT deps on core/plugins-common

### DIFF
--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 // Prepare release
 release {
   tagTemplate = 'v$version-gradle'
+  ignoredSnapshotDependencies = ["com.google.cloud.tools:jib-core", "com.google.cloud.tools:jib-plugins-common"]
   git {
     requireBranch = /^gradle_release_v\d+.*$/  //regex
   }

--- a/jib-maven-plugin/build.gradle
+++ b/jib-maven-plugin/build.gradle
@@ -56,7 +56,8 @@ publishing {
 
 
 release {
-  tagTemplate = 'v$version-gradle'
+  tagTemplate = 'v$version-maven'
+  ignoredSnapshotDependencies = ["com.google.cloud.tools:jib-core", "com.google.cloud.tools:jib-plugins-common"]
   git {
     requireBranch = /^maven_release_v\d+.*$/  //regex
   }


### PR DESCRIPTION
the SNAPSHOT dependencies are a consequence of the monolith, the
release plugin just needs to ingore those projects, ideally the
plugin wouldn't care that compileOnly dependencies are SNAPSHOTS
but whatever, they might have a reason for that.

oh also this fixes the tagging on the maven plugin

This should fix the problem for now.... also filed: https://github.com/researchgate/gradle-release/issues/310