### PR TITLE
Tell to merge the PR created by prepare_release.sh script after release is complete

### DIFF
--- a/jib-core/scripts/prepare_release.sh
+++ b/jib-core/scripts/prepare_release.sh
@@ -56,3 +56,5 @@ git push origin v${VERSION}-core
 # File a PR on Github for the new branch. Have someone LGTM it, which gives you permission to continue.
 EchoGreen 'File a PR for the new release branch:'
 echo https://github.com/GoogleContainerTools/jib/compare/${BRANCH}
+
+EchoGreen "Merge the PR after the library is released."

--- a/jib-gradle-plugin/scripts/prepare_release.sh
+++ b/jib-gradle-plugin/scripts/prepare_release.sh
@@ -57,4 +57,5 @@ git push origin v${VERSION}-gradle
 EchoGreen 'File a PR for the new release branch:'
 echo https://github.com/GoogleContainerTools/jib/compare/${BRANCH}
 
-EchoGreen "Once approved and merged, checkout the 'v${VERSION}-gradle' tag and run './gradlew jib-gradle-plugin:publishPlugins'."
+EchoGreen "Once approved, checkout the 'v${VERSION}-gradle' tag and run './gradlew jib-gradle-plugin:publishPlugins'."
+EchoGreen "Merge the PR after the plugin is released."

--- a/jib-maven-plugin/scripts/prepare_release.sh
+++ b/jib-maven-plugin/scripts/prepare_release.sh
@@ -56,3 +56,5 @@ git push origin v${VERSION}-maven
 # File a PR on Github for the new branch. Have someone LGTM it, which gives you permission to continue.
 EchoGreen 'File a PR for the new release branch:'
 echo https://github.com/GoogleContainerTools/jib/compare/${BRANCH}
+
+EchoGreen "Merge the PR after the plugin is released."


### PR DESCRIPTION
This is to avoid having to revert the PRs when something that should be fixed comes up during the release. It's also aligned with the current internal release doc.