### PR TITLE
Use Github URLs to create PR directly

### DIFF
--- a/jib-core/scripts/prepare_release.sh
+++ b/jib-core/scripts/prepare_release.sh
@@ -55,6 +55,6 @@ git push origin v${VERSION}-core
 
 # File a PR on Github for the new branch. Have someone LGTM it, which gives you permission to continue.
 EchoGreen 'File a PR for the new release branch:'
-echo https://github.com/GoogleContainerTools/jib/compare/${BRANCH}
+echo https://github.com/GoogleContainerTools/jib/pull/new/${BRANCH}
 
 EchoGreen "Merge the PR after the library is released."

--- a/jib-gradle-plugin/scripts/prepare_release.sh
+++ b/jib-gradle-plugin/scripts/prepare_release.sh
@@ -55,7 +55,7 @@ git push origin v${VERSION}-gradle
 
 # File a PR on Github for the new branch. Have someone LGTM it, which gives you permission to continue.
 EchoGreen 'File a PR for the new release branch:'
-echo https://github.com/GoogleContainerTools/jib/compare/${BRANCH}
+echo https://github.com/GoogleContainerTools/jib/pull/new/${BRANCH}
 
 EchoGreen "Once approved, checkout the 'v${VERSION}-gradle' tag and run './gradlew jib-gradle-plugin:publishPlugins'."
 EchoGreen "Merge the PR after the plugin is released."

--- a/jib-maven-plugin/scripts/prepare_release.sh
+++ b/jib-maven-plugin/scripts/prepare_release.sh
@@ -55,6 +55,6 @@ git push origin v${VERSION}-maven
 
 # File a PR on Github for the new branch. Have someone LGTM it, which gives you permission to continue.
 EchoGreen 'File a PR for the new release branch:'
-echo https://github.com/GoogleContainerTools/jib/compare/${BRANCH}
+echo https://github.com/GoogleContainerTools/jib/pull/new/${BRANCH}
 
 EchoGreen "Merge the PR after the plugin is released."


### PR DESCRIPTION
Noticed in #1992 that the process can cut a step by using Github's `pull/new`-style URLs.  For example, it suggested https://github.com/GoogleContainerTools/jib/pull/new/prurls for this PR.