### PR TITLE
Add warning for configuring mainClass/extraClasspath/jvmFlags on WAR projects

### DIFF
--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -339,6 +339,12 @@ public class PluginConfigurationProcessor {
     }
 
     if (projectProperties.isWarProject()) {
+      if (rawConfiguration.getMainClass().isPresent()
+          || !rawConfiguration.getJvmFlags().isEmpty()
+          || !rawExtraClasspath.isEmpty()) {
+        projectProperties.log(
+            LogEvent.warn("mainClass, extraClasspath, and jvmFlags are ignored for WAR projects"));
+      }
       return null;
     }
 

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -411,6 +411,24 @@ public class PluginConfigurationProcessorTest {
   }
 
   @Test
+  public void testEntrypoint_warningOnMainclassForWar()
+      throws IOException, InvalidCreationTimeException, InvalidImageReferenceException,
+          IncompatibleBaseImageJavaVersionException, InvalidContainerVolumeException,
+          MainClassInferenceException, InvalidAppRootException, InvalidWorkingDirectoryException,
+          InvalidFilesModificationTimeException, InvalidContainerizingModeException,
+          CacheDirectoryCreationException {
+    Mockito.when(rawConfiguration.getMainClass()).thenReturn(Optional.of("java.util.Object"));
+    Mockito.when(projectProperties.isWarProject()).thenReturn(true);
+
+    BuildConfiguration buildConfiguration = getBuildConfiguration(processCommonConfiguration());
+
+    Assert.assertNotNull(buildConfiguration.getContainerConfiguration());
+    Assert.assertNull(buildConfiguration.getContainerConfiguration().getEntrypoint());
+    Mockito.verify(projectProperties)
+        .log(LogEvent.warn("mainClass, extraClasspath, and jvmFlags are ignored for WAR projects"));
+  }
+
+  @Test
   public void testEntrypointClasspath_nonDefaultAppRoot()
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException,
           MainClassInferenceException, InvalidAppRootException, InvalidWorkingDirectoryException,


### PR DESCRIPTION
Fixes #1939.