### PR TITLE
Add Kotlin support for Skaffold-Jib integration

### DIFF
--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2.java
@@ -33,14 +33,12 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.FileSet;
 import org.apache.maven.model.Plugin;
-import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Component;
@@ -82,8 +80,6 @@ public class FilesMojoV2 extends SkaffoldBindingMojo {
 
     Path projectBaseDir = project.getBasedir().toPath();
 
-    Predicate<PluginExecution> noTestCompileGoal =
-        execution -> !execution.getGoals().contains("test-compile");
     // Extract <sourceDir> values from <configuration> in the plugin <executions>. Sample:
     // <executions><execution><configuration>
     //   <sourceDirs>
@@ -95,7 +91,7 @@ public class FilesMojoV2 extends SkaffoldBindingMojo {
         kotlinPlugin
             .getExecutions()
             .stream()
-            .filter(noTestCompileGoal)
+            .filter(execution -> !execution.getGoals().contains("test-compile"))
             .map(execution -> (Xpp3Dom) execution.getConfiguration())
             .filter(Objects::nonNull)
             .map(configuration -> configuration.getChild("sourceDirs"))
@@ -105,7 +101,7 @@ public class FilesMojoV2 extends SkaffoldBindingMojo {
             .map(Xpp3Dom::getValue)
             .filter(value -> !Strings.isNullOrEmpty(value))
             .map(Paths::get)
-            .map(path -> path.isAbsolute() ? path : project.getBasedir().toPath().resolve(path))
+            .map(path -> path.isAbsolute() ? path : projectBaseDir.resolve(path))
             .collect(Collectors.toSet());
 
     Path conventionalDirectory = projectBaseDir.resolve(Paths.get("src", "main", "kotlin"));

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2KotlinTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2KotlinTest.java
@@ -37,18 +37,19 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class FilesMojoV2KotlinTest {
 
+  private final Xpp3Dom configuration1 = new Xpp3Dom("configuration");
+  private final Xpp3Dom configuration2 = new Xpp3Dom("configuration");
+  private final Xpp3Dom sourceDirs1 = new Xpp3Dom("sourceDirs");
+  private final Xpp3Dom sourceDirs2 = new Xpp3Dom("sourceDirs");
+  private final Xpp3Dom sourceDir1 = new Xpp3Dom("sourceDir");
+  private final Xpp3Dom sourceDir2 = new Xpp3Dom("sourceDir");
+  private final Xpp3Dom sourceDir3 = new Xpp3Dom("sourceDir");
+  private final Xpp3Dom sourceDir4 = new Xpp3Dom("sourceDir");
+
   @Mock private MavenProject mavenProject;
   @Mock private Plugin kotlinPlugin;
   @Mock private PluginExecution pluginExecution1;
   @Mock private PluginExecution pluginExecution2;
-  @Mock private Xpp3Dom configuration1;
-  @Mock private Xpp3Dom configuration2;
-  @Mock private Xpp3Dom sourceDirs1;
-  @Mock private Xpp3Dom sourceDirs2;
-  @Mock private Xpp3Dom sourceDir1;
-  @Mock private Xpp3Dom sourceDir2;
-  @Mock private Xpp3Dom sourceDir3;
-  @Mock private Xpp3Dom sourceDir4;
 
   @Before
   public void setUp() {
@@ -95,8 +96,7 @@ public class FilesMojoV2KotlinTest {
   public void getKotlinSourceDirectories_noSourceDirsChildren() {
     Mockito.when(kotlinPlugin.getExecutions()).thenReturn(Arrays.asList(pluginExecution1));
     Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
-    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
-    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[0]);
+    configuration1.addChild(sourceDirs1);
 
     Assert.assertEquals(
         ImmutableSet.of(Paths.get("/base/src/main/kotlin")),
@@ -107,9 +107,8 @@ public class FilesMojoV2KotlinTest {
   public void getKotlinSourceDirectories_nullSourceDir() {
     Mockito.when(kotlinPlugin.getExecutions()).thenReturn(Arrays.asList(pluginExecution1));
     Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
-    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
-    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir1});
-    Mockito.when(sourceDir1.getValue()).thenReturn(null);
+    configuration1.addChild(sourceDirs1);
+    sourceDirs1.addChild(sourceDir1);
 
     Assert.assertEquals(
         ImmutableSet.of(Paths.get("/base/src/main/kotlin")),
@@ -120,9 +119,9 @@ public class FilesMojoV2KotlinTest {
   public void getKotlinSourceDirectories_emptySourceDir() {
     Mockito.when(kotlinPlugin.getExecutions()).thenReturn(Arrays.asList(pluginExecution1));
     Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
-    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
-    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir1});
-    Mockito.when(sourceDir1.getValue()).thenReturn("");
+    configuration1.addChild(sourceDirs1);
+    sourceDirs1.addChild(sourceDir1);
+    sourceDir1.setValue("");
 
     Assert.assertEquals(
         ImmutableSet.of(Paths.get("/base/src/main/kotlin")),
@@ -133,9 +132,9 @@ public class FilesMojoV2KotlinTest {
   public void getKotlinSourceDirectories_relativePath() {
     Mockito.when(kotlinPlugin.getExecutions()).thenReturn(Arrays.asList(pluginExecution1));
     Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
-    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
-    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir1});
-    Mockito.when(sourceDir1.getValue()).thenReturn("kotlin/src");
+    configuration1.addChild(sourceDirs1);
+    sourceDirs1.addChild(sourceDir1);
+    sourceDir1.setValue("kotlin/src");
 
     Assert.assertEquals(
         ImmutableSet.of(Paths.get("/base/src/main/kotlin"), Paths.get("/base/kotlin/src")),
@@ -146,9 +145,9 @@ public class FilesMojoV2KotlinTest {
   public void getKotlinSourceDirectories_absolutePath() {
     Mockito.when(kotlinPlugin.getExecutions()).thenReturn(Arrays.asList(pluginExecution1));
     Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
-    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
-    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir1});
-    Mockito.when(sourceDir1.getValue()).thenReturn("/absolute/src");
+    configuration1.addChild(sourceDirs1);
+    sourceDirs1.addChild(sourceDir1);
+    sourceDir1.setValue("/absolute/src");
 
     Assert.assertEquals(
         ImmutableSet.of(Paths.get("/base/src/main/kotlin"), Paths.get("/absolute/src")),
@@ -161,14 +160,16 @@ public class FilesMojoV2KotlinTest {
         .thenReturn(Arrays.asList(pluginExecution1, pluginExecution2));
     Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
     Mockito.when(pluginExecution2.getConfiguration()).thenReturn(configuration2);
-    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
-    Mockito.when(configuration2.getChild("sourceDirs")).thenReturn(sourceDirs2);
-    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir1, sourceDir2});
-    Mockito.when(sourceDirs2.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir3, sourceDir4});
-    Mockito.when(sourceDir1.getValue()).thenReturn("/absolute/src1");
-    Mockito.when(sourceDir2.getValue()).thenReturn("relative/src2");
-    Mockito.when(sourceDir3.getValue()).thenReturn("/absolute/src3");
-    Mockito.when(sourceDir4.getValue()).thenReturn("relative/src4");
+    configuration1.addChild(sourceDirs1);
+    configuration2.addChild(sourceDirs2);
+    sourceDirs1.addChild(sourceDir1);
+    sourceDirs1.addChild(sourceDir2);
+    sourceDirs2.addChild(sourceDir3);
+    sourceDirs2.addChild(sourceDir4);
+    sourceDir1.setValue("/absolute/src1");
+    sourceDir2.setValue("relative/src2");
+    sourceDir3.setValue("/absolute/src3");
+    sourceDir4.setValue("relative/src4");
 
     Assert.assertEquals(
         ImmutableSet.of(
@@ -186,14 +187,16 @@ public class FilesMojoV2KotlinTest {
         .thenReturn(Arrays.asList(pluginExecution1, pluginExecution2));
     Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
     Mockito.when(pluginExecution2.getConfiguration()).thenReturn(configuration2);
-    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
-    Mockito.when(configuration2.getChild("sourceDirs")).thenReturn(sourceDirs2);
-    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir1, sourceDir2});
-    Mockito.when(sourceDirs2.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir3, sourceDir4});
-    Mockito.when(sourceDir1.getValue()).thenReturn("src/main/kotlin");
-    Mockito.when(sourceDir2.getValue()).thenReturn("/base/another/src");
-    Mockito.when(sourceDir3.getValue()).thenReturn("another/src");
-    Mockito.when(sourceDir4.getValue()).thenReturn("/base/src/main/kotlin");
+    configuration1.addChild(sourceDirs1);
+    configuration1.addChild(sourceDirs2);
+    sourceDirs1.addChild(sourceDir1);
+    sourceDirs1.addChild(sourceDir2);
+    sourceDirs2.addChild(sourceDir3);
+    sourceDirs2.addChild(sourceDir4);
+    sourceDir1.setValue("src/main/kotlin");
+    sourceDir2.setValue("/base/another/src");
+    sourceDir3.setValue("another/src");
+    sourceDir4.setValue("/base/src/main/kotlin");
 
     Assert.assertEquals(
         ImmutableSet.of(Paths.get("/base/src/main/kotlin"), Paths.get("/base/another/src")),

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2KotlinTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/FilesMojoV2KotlinTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven.skaffold;
+
+import com.google.common.collect.ImmutableSet;
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Kotlin-related tests for {@link FilesMojoV2}. */
+@RunWith(MockitoJUnitRunner.class)
+public class FilesMojoV2KotlinTest {
+
+  @Mock private MavenProject mavenProject;
+  @Mock private Plugin kotlinPlugin;
+  @Mock private PluginExecution pluginExecution1;
+  @Mock private PluginExecution pluginExecution2;
+  @Mock private Xpp3Dom configuration1;
+  @Mock private Xpp3Dom configuration2;
+  @Mock private Xpp3Dom sourceDirs1;
+  @Mock private Xpp3Dom sourceDirs2;
+  @Mock private Xpp3Dom sourceDir1;
+  @Mock private Xpp3Dom sourceDir2;
+  @Mock private Xpp3Dom sourceDir3;
+  @Mock private Xpp3Dom sourceDir4;
+
+  @Before
+  public void setUp() {
+    Mockito.when(mavenProject.getPlugin("org.jetbrains.kotlin:kotlin-maven-plugin"))
+        .thenReturn(kotlinPlugin);
+    Mockito.when(mavenProject.getBasedir()).thenReturn(new File("/base"));
+  }
+
+  @Test
+  public void getKotlinSourceDirectories_noKotlinPlugin() {
+    Mockito.when(mavenProject.getPlugin(Mockito.anyString())).thenReturn(null);
+    Assert.assertEquals(ImmutableSet.of(), FilesMojoV2.getKotlinSourceDirectories(mavenProject));
+  }
+
+  @Test
+  public void getKotlinSourceDirectories_noExecutions() {
+    Mockito.when(kotlinPlugin.getExecutions()).thenReturn(Collections.emptyList());
+
+    Assert.assertEquals(
+        ImmutableSet.of(Paths.get("/base/src/main/kotlin")),
+        FilesMojoV2.getKotlinSourceDirectories(mavenProject));
+  }
+
+  @Test
+  public void getKotlinSourceDirectories_noConfiguration() {
+    Mockito.when(kotlinPlugin.getExecutions()).thenReturn(Arrays.asList(pluginExecution1));
+
+    Assert.assertEquals(
+        ImmutableSet.of(Paths.get("/base/src/main/kotlin")),
+        FilesMojoV2.getKotlinSourceDirectories(mavenProject));
+  }
+
+  @Test
+  public void getKotlinSourceDirectories_noSourceDirs() {
+    Mockito.when(kotlinPlugin.getExecutions()).thenReturn(Arrays.asList(pluginExecution1));
+    Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
+
+    Assert.assertEquals(
+        ImmutableSet.of(Paths.get("/base/src/main/kotlin")),
+        FilesMojoV2.getKotlinSourceDirectories(mavenProject));
+  }
+
+  @Test
+  public void getKotlinSourceDirectories_noSourceDirsChildren() {
+    Mockito.when(kotlinPlugin.getExecutions()).thenReturn(Arrays.asList(pluginExecution1));
+    Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
+    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
+    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[0]);
+
+    Assert.assertEquals(
+        ImmutableSet.of(Paths.get("/base/src/main/kotlin")),
+        FilesMojoV2.getKotlinSourceDirectories(mavenProject));
+  }
+
+  @Test
+  public void getKotlinSourceDirectories_nullSourceDir() {
+    Mockito.when(kotlinPlugin.getExecutions()).thenReturn(Arrays.asList(pluginExecution1));
+    Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
+    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
+    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir1});
+    Mockito.when(sourceDir1.getValue()).thenReturn(null);
+
+    Assert.assertEquals(
+        ImmutableSet.of(Paths.get("/base/src/main/kotlin")),
+        FilesMojoV2.getKotlinSourceDirectories(mavenProject));
+  }
+
+  @Test
+  public void getKotlinSourceDirectories_emptySourceDir() {
+    Mockito.when(kotlinPlugin.getExecutions()).thenReturn(Arrays.asList(pluginExecution1));
+    Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
+    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
+    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir1});
+    Mockito.when(sourceDir1.getValue()).thenReturn("");
+
+    Assert.assertEquals(
+        ImmutableSet.of(Paths.get("/base/src/main/kotlin")),
+        FilesMojoV2.getKotlinSourceDirectories(mavenProject));
+  }
+
+  @Test
+  public void getKotlinSourceDirectories_relativePath() {
+    Mockito.when(kotlinPlugin.getExecutions()).thenReturn(Arrays.asList(pluginExecution1));
+    Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
+    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
+    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir1});
+    Mockito.when(sourceDir1.getValue()).thenReturn("kotlin/src");
+
+    Assert.assertEquals(
+        ImmutableSet.of(Paths.get("/base/src/main/kotlin"), Paths.get("/base/kotlin/src")),
+        FilesMojoV2.getKotlinSourceDirectories(mavenProject));
+  }
+
+  @Test
+  public void getKotlinSourceDirectories_absolutePath() {
+    Mockito.when(kotlinPlugin.getExecutions()).thenReturn(Arrays.asList(pluginExecution1));
+    Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
+    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
+    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir1});
+    Mockito.when(sourceDir1.getValue()).thenReturn("/absolute/src");
+
+    Assert.assertEquals(
+        ImmutableSet.of(Paths.get("/base/src/main/kotlin"), Paths.get("/absolute/src")),
+        FilesMojoV2.getKotlinSourceDirectories(mavenProject));
+  }
+
+  @Test
+  public void getKotlinSourceDirectories_complex() {
+    Mockito.when(kotlinPlugin.getExecutions())
+        .thenReturn(Arrays.asList(pluginExecution1, pluginExecution2));
+    Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
+    Mockito.when(pluginExecution2.getConfiguration()).thenReturn(configuration2);
+    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
+    Mockito.when(configuration2.getChild("sourceDirs")).thenReturn(sourceDirs2);
+    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir1, sourceDir2});
+    Mockito.when(sourceDirs2.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir3, sourceDir4});
+    Mockito.when(sourceDir1.getValue()).thenReturn("/absolute/src1");
+    Mockito.when(sourceDir2.getValue()).thenReturn("relative/src2");
+    Mockito.when(sourceDir3.getValue()).thenReturn("/absolute/src3");
+    Mockito.when(sourceDir4.getValue()).thenReturn("relative/src4");
+
+    Assert.assertEquals(
+        ImmutableSet.of(
+            Paths.get("/base/src/main/kotlin"),
+            Paths.get("/absolute/src1"),
+            Paths.get("/absolute/src3"),
+            Paths.get("/base/relative/src2"),
+            Paths.get("/base/relative/src4")),
+        FilesMojoV2.getKotlinSourceDirectories(mavenProject));
+  }
+
+  @Test
+  public void getKotlinSourceDirectories_noDuplicates() {
+    Mockito.when(kotlinPlugin.getExecutions())
+        .thenReturn(Arrays.asList(pluginExecution1, pluginExecution2));
+    Mockito.when(pluginExecution1.getConfiguration()).thenReturn(configuration1);
+    Mockito.when(pluginExecution2.getConfiguration()).thenReturn(configuration2);
+    Mockito.when(configuration1.getChild("sourceDirs")).thenReturn(sourceDirs1);
+    Mockito.when(configuration2.getChild("sourceDirs")).thenReturn(sourceDirs2);
+    Mockito.when(sourceDirs1.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir1, sourceDir2});
+    Mockito.when(sourceDirs2.getChildren()).thenReturn(new Xpp3Dom[] {sourceDir3, sourceDir4});
+    Mockito.when(sourceDir1.getValue()).thenReturn("src/main/kotlin");
+    Mockito.when(sourceDir2.getValue()).thenReturn("/base/another/src");
+    Mockito.when(sourceDir3.getValue()).thenReturn("another/src");
+    Mockito.when(sourceDir4.getValue()).thenReturn("/base/src/main/kotlin");
+
+    Assert.assertEquals(
+        ImmutableSet.of(Paths.get("/base/src/main/kotlin"), Paths.get("/base/another/src")),
+        FilesMojoV2.getKotlinSourceDirectories(mavenProject));
+  }
+}


### PR DESCRIPTION
Fixes #2006.

After reading the [Kotlin Maven plugin reference](https://kotlinlang.org/docs/reference/using-maven.html) (especially the part "Compiling Kotlin and Java sources" for mixing Java and Kotlin code), I decided to include every `<sourceDir>` configured. Duplicates are removed.

Also this always includes the conventional default `src/main/kotlin` whether or not it exists.

I assume there is no harm in over-approximating and listing non-existing directories.