### PR TITLE
Parallelize local base image compression

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Local base image layers are now processed in parallel, speeding up builds using large local base images. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))
+
 ### Fixed
 
 - Fixed temporary directory cleanup during builds using local base images. ([#2016](https://github.com/GoogleContainerTools/jib/issues/2016))

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStep.java
@@ -116,7 +116,7 @@ class ObtainBaseImageLayerStep implements Callable<PreparedLayer> {
   private final @Nullable Authorization pullAuthorization;
   private final BlobExistenceChecker blobExistenceChecker;
 
-  ObtainBaseImageLayerStep(
+  private ObtainBaseImageLayerStep(
       BuildConfiguration buildConfiguration,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
       Layer layer,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -257,6 +257,7 @@ public class StepsRunner {
         executorService.submit(
             () ->
                 new ExtractTarStep(
+                        executorService,
                         buildConfiguration,
                         results.tarPath.get(),
                         childProgressDispatcherFactory,

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/ExtractTarStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/ExtractTarStepTest.java
@@ -19,17 +19,18 @@ package com.google.cloud.tools.jib.builder.steps;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.steps.ExtractTarStep.LocalImage;
 import com.google.cloud.tools.jib.cache.Cache;
-import com.google.cloud.tools.jib.cache.CacheCorruptedException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
 import com.google.cloud.tools.jib.image.LayerCountMismatchException;
 import com.google.cloud.tools.jib.image.json.BadContainerConfigurationFormatException;
 import com.google.common.io.Resources;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.concurrent.ExecutionException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -71,10 +72,12 @@ public class ExtractTarStepTest {
   @Test
   public void testCall_validDocker()
       throws URISyntaxException, LayerCountMismatchException,
-          BadContainerConfigurationFormatException, IOException, CacheCorruptedException {
+          BadContainerConfigurationFormatException, IOException, ExecutionException,
+          InterruptedException {
     Path dockerBuild = getResource("core/extraction/docker-save.tar");
     LocalImage result =
         new ExtractTarStep(
+                MoreExecutors.newDirectExecutorService(),
                 buildConfiguration,
                 dockerBuild,
                 progressEventDispatcherFactory,
@@ -101,10 +104,12 @@ public class ExtractTarStepTest {
   @Test
   public void testCall_validTar()
       throws URISyntaxException, LayerCountMismatchException,
-          BadContainerConfigurationFormatException, IOException, CacheCorruptedException {
+          BadContainerConfigurationFormatException, IOException, ExecutionException,
+          InterruptedException {
     Path tarBuild = getResource("core/extraction/jib-image.tar");
     LocalImage result =
         new ExtractTarStep(
+                MoreExecutors.newDirectExecutorService(),
                 buildConfiguration,
                 tarBuild,
                 progressEventDispatcherFactory,

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Local base image layers are now processed in parallel, speeding up builds using large local base images. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))
+
 ### Fixed
 
 - Fixed temporary directory cleanup during builds using local base images. ([#2016](https://github.com/GoogleContainerTools/jib/issues/2016))

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Local base image layers are now processed in parallel, speeding up builds using large local base images. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))
+
 ### Fixed
 
 - Fixed temporary directory cleanup during builds using local base images. ([#2016](https://github.com/GoogleContainerTools/jib/issues/2016))


### PR DESCRIPTION
Towards #1913. This only really makes a difference for un-cached local base image layers, but it provides a decent speedup in that case. Here were the build times using maven + a clean cache on the master branch vs. these changes:

`docker://gcr.io/distroless/java` 
* master: **7.6 seconds**
* this PR: **6.8 seconds**

`docker://openjdk:8`
* master: **29.2 seconds**
* this PR: **16.4 seconds**