### PR TITLE
Update examples/java-agent plugin versions

### DIFF
--- a/examples/java-agent/build.gradle
+++ b/examples/java-agent/build.gradle
@@ -1,8 +1,8 @@
 plugins {
   id 'java'
   id 'com.google.cloud.tools.jib' version '1.6.1'
-  id 'de.undercouch.download' version '3.4.0'
-  id "com.gorylenko.gradle-git-properties" version "1.5.2"
+  id 'de.undercouch.download' version '4.0.0'
+  id "com.gorylenko.gradle-git-properties" version "2.2.0"
 }
 
 ext {
@@ -24,8 +24,8 @@ repositories {
 }
 
 dependencies {
-  compile "com.sparkjava:spark-core:2.7.2"
-  compile "org.slf4j:slf4j-simple:1.7.21"
+  compile "com.sparkjava:spark-core:2.9.1"
+  compile "org.slf4j:slf4j-simple:1.7.28"
 }
 
 // Download and extract the Cloud Debugger Java Agent

--- a/examples/java-agent/build.gradle
+++ b/examples/java-agent/build.gradle
@@ -42,7 +42,7 @@ jib {
   to {
     image = 'gcr.io/REPLACE-WITH-YOUR-GCP-PROJECT/image-built-with-jib'
   }
-  extraDirectory = file(jibExtraDirectory)
+  extraDirectories.paths = [file(jibExtraDirectory)]
   container {
     ports = ['4567']
     jvmFlags = [

--- a/examples/java-agent/pom.xml
+++ b/examples/java-agent/pom.xml
@@ -11,8 +11,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jib-maven-plugin.version>1.6.1</jib-maven-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
-    <download-maven-plugin.version>1.4.1</download-maven-plugin.version>
-    <git-commit-id-plugin.version>2.2.5</git-commit-id-plugin.version>
+    <download-maven-plugin.version>1.4.2</download-maven-plugin.version>
+    <git-commit-id-plugin.version>3.0.1</git-commit-id-plugin.version>
 
     <!-- agents will be extracted relative to this build location -->
     <agent-extraction-root>${project.build.directory}/jib-agents</agent-extraction-root>
@@ -28,12 +28,12 @@
     <dependency>
       <groupId>com.sparkjava</groupId>
       <artifactId>spark-core</artifactId>
-      <version>2.7.2</version>
+      <version>2.9.1</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.21</version>
+      <version>1.7.28</version>
     </dependency>
   </dependencies>
 
@@ -77,7 +77,9 @@
           <to>
             <image>gcr.io/REPLACE-WITH-YOUR-GCP-PROJECT/image-built-with-jib</image>
           </to>
-          <extraDirectory>${agent-extraction-root}</extraDirectory>
+          <extraDirectories>
+            <paths>${agent-extraction-root}</paths>
+          </extraDirectories>
           <container>
             <ports>4567</ports>
             <jvmFlags>

--- a/examples/java-agent/src/main/java/example/HelloWorld.java
+++ b/examples/java-agent/src/main/java/example/HelloWorld.java
@@ -23,7 +23,7 @@ public class HelloWorld {
   public static void main(String[] args) {
     // Allow use with Cloud Run which requires listening on the value in PORT
     String portEnv = System.getenv("PORT");
-    if(portEnv != null) {
+    if (portEnv != null) {
       port(Integer.parseInt(portEnv));
     }
 

--- a/examples/java-agent/src/main/java/example/HelloWorld.java
+++ b/examples/java-agent/src/main/java/example/HelloWorld.java
@@ -21,10 +21,12 @@ import static spark.Spark.port;
 
 public class HelloWorld {
   public static void main(String[] args) {
+    // Allow use with Cloud Run which requires listening on the value in PORT
     String portEnv = System.getenv("PORT");
     if(portEnv != null) {
       port(Integer.parseInt(portEnv));
     }
-    get("/hello", (req, res) -> "Hello World");
+
+    get("/", (req, res) -> "Hello World");
   }
 }

--- a/examples/java-agent/src/main/java/example/HelloWorld.java
+++ b/examples/java-agent/src/main/java/example/HelloWorld.java
@@ -17,9 +17,14 @@
 package example;
 
 import static spark.Spark.get;
+import static spark.Spark.port;
 
 public class HelloWorld {
   public static void main(String[] args) {
+    String portEnv = System.getenv("PORT");
+    if(portEnv != null) {
+      port(Integer.parseInt(portEnv));
+    }
     get("/hello", (req, res) -> "Hello World");
   }
 }


### PR DESCRIPTION
Update plugin versions for `examples/java-agent`, and tweak the example to listen on `$PORT` if provided, as provided by Cloud Run.