### PR TITLE
Add configuration for custom output file locations

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
@@ -58,7 +58,9 @@ public class WriteTarFileStep implements Callable<BuildResult> {
     try (ProgressEventDispatcher ignored =
         progressEventDispatcherFactory.create("writing to tar file", 1)) {
       // Builds the image to a tarball.
-      Files.createDirectories(outputPath.getParent());
+      if (outputPath.getParent() != null) {
+        Files.createDirectories(outputPath.getParent());
+      }
       try (OutputStream outputStream =
           new BufferedOutputStream(FileOperations.newLockingOutputStream(outputPath))) {
         new ImageTarball(builtImage, buildConfiguration.getTargetImageConfiguration().getImage())

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `jib.outputFiles` object for configuration output file locations ([#1561](https://github.com/GoogleContainerTools/jib/issues/1561))
-  - `jib.outputFiles.tar` configures output path of `jibBuildTar` (`build/jib-image.tar` by default)
-  - `jib.outputFiles.digest` configures the output path of the image digest (`build/jib-image.digest` by default)
-  - `jib.outputFiles.id` configures output path of the image id  (`build/jib-image.id` by default)
+- `jib.outputPaths` object for configuration output file locations ([#1561](https://github.com/GoogleContainerTools/jib/issues/1561))
+  - `jib.outputPaths.tar` configures output path of `jibBuildTar` (`build/jib-image.tar` by default)
+  - `jib.outputPaths.digest` configures the output path of the image digest (`build/jib-image.digest` by default)
+  - `jib.outputPaths.imageId` configures output path of the image id  (`build/jib-image.id` by default)
 
 ### Changed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `jib.outputFiles` object for configuration output file locations ([#1561](https://github.com/GoogleContainerTools/jib/issues/1561))
+  - `jib.outputFiles.tar` configures output path of `jibBuildTar` (`build/jib-image.tar` by default)
+  - `jib.outputFiles.digest` configures the output path of the image digest (`build/jib-image.digest` by default)
+  - `jib.outputFiles.id` configures output path of the image id  (`build/jib-image.id` by default)
+
 ### Changed
 
 - Local base image layers are now processed in parallel, speeding up builds using large local base images. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibRunHelper.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibRunHelper.java
@@ -196,7 +196,7 @@ public class JibRunHelper {
    * @throws IOException if an I/O exception occurs
    * @throws InterruptedException if the process was interrupted
    */
-  private static String pullAndRunBuiltImage(String imageReference, String... extraRunArguments)
+  static String pullAndRunBuiltImage(String imageReference, String... extraRunArguments)
       throws IOException, InterruptedException {
     new Command("docker", "pull", imageReference).run();
     String history = new Command("docker", "history", imageReference).run();

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -376,7 +376,7 @@ public class SingleProjectIntegrationTest {
         output, new Command("docker", "run", "--rm", imageReferenceWithDigest).run());
 
     String id =
-        readDigestFile(simpleTestProject.getProjectRoot().resolve("build/different-jib-image.id"));
+        readDigestFile(simpleTestProject.getProjectRoot().resolve("different-jib-image.id"));
     Assert.assertNotEquals(digest, id);
     Assert.assertEquals(output, new Command("docker", "run", "--rm", id).run());
 

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -121,7 +121,7 @@ public class SingleProjectIntegrationTest {
                 + "            }"));
   }
 
-  static String assertDigestFile(Path digestPath) throws IOException, DigestException {
+  static String readDigestFile(Path digestPath) throws IOException, DigestException {
     Assert.assertTrue(Files.exists(digestPath));
     String digest = new String(Files.readAllBytes(digestPath), StandardCharsets.UTF_8);
     return DescriptorDigest.fromDigest(digest).toString();
@@ -217,12 +217,12 @@ public class SingleProjectIntegrationTest {
         output);
 
     String digest =
-        assertDigestFile(simpleTestProject.getProjectRoot().resolve("build/jib-image.digest"));
+        readDigestFile(simpleTestProject.getProjectRoot().resolve("build/jib-image.digest"));
     String imageReferenceWithDigest = ImageReference.parse(targetImage).withTag(digest).toString();
     Assert.assertEquals(
         output, JibRunHelper.buildAndRun(simpleTestProject, imageReferenceWithDigest));
 
-    String id = assertDigestFile(simpleTestProject.getProjectRoot().resolve("build/jib-image.id"));
+    String id = readDigestFile(simpleTestProject.getProjectRoot().resolve("build/jib-image.id"));
     Assert.assertNotEquals(digest, id);
     Assert.assertEquals(output, new Command("docker", "run", "--rm", id).run());
 
@@ -369,7 +369,7 @@ public class SingleProjectIntegrationTest {
     String output = buildAndRunComplex(targetImage, "testuser2", "testpassword2", localRegistry2);
 
     String digest =
-        assertDigestFile(
+        readDigestFile(
             simpleTestProject.getProjectRoot().resolve("build/different-jib-image.digest"));
     String imageReferenceWithDigest = ImageReference.parse(targetImage).withTag(digest).toString();
     localRegistry2.pull(imageReferenceWithDigest);
@@ -377,8 +377,7 @@ public class SingleProjectIntegrationTest {
         output, new Command("docker", "run", "--rm", imageReferenceWithDigest).run());
 
     String id =
-        assertDigestFile(
-            simpleTestProject.getProjectRoot().resolve("build/different-jib-image.id"));
+        readDigestFile(simpleTestProject.getProjectRoot().resolve("build/different-jib-image.id"));
     Assert.assertNotEquals(digest, id);
     Assert.assertEquals(output, new Command("docker", "run", "--rm", id).run());
 

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -219,8 +219,7 @@ public class SingleProjectIntegrationTest {
     String digest =
         readDigestFile(simpleTestProject.getProjectRoot().resolve("build/jib-image.digest"));
     String imageReferenceWithDigest = ImageReference.parse(targetImage).withTag(digest).toString();
-    Assert.assertEquals(
-        output, JibRunHelper.buildAndRun(simpleTestProject, imageReferenceWithDigest));
+    Assert.assertEquals(output, JibRunHelper.pullAndRunBuiltImage(imageReferenceWithDigest));
 
     String id = readDigestFile(simpleTestProject.getProjectRoot().resolve("build/jib-image.id"));
     Assert.assertNotEquals(digest, id);

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build.gradle
@@ -28,5 +28,8 @@ jib {
     workingDirectory = '/home'
     extraClasspath = ['/d1','/d2']
   }
+  outputFiles {
+    tar = file("$buildDir/different-jib-image.tar")
+  }
   extraDirectories.paths = file('src/main/custom-extra-dir')
 }

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build.gradle
@@ -28,7 +28,7 @@ jib {
     workingDirectory = '/home'
     extraClasspath = ['/d1','/d2']
   }
-  outputFiles {
+  outputPaths {
     tar = file("$buildDir/different-jib-image.tar")
   }
   extraDirectories.paths = file('src/main/custom-extra-dir')

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/complex-build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/complex-build.gradle
@@ -45,7 +45,7 @@ jib {
   }
   outputPaths {
     digest = file("$buildDir/different-jib-image.digest")
-    imageId = file("$buildDir/different-jib-image.id")
+    imageId = file("different-jib-image.id")
   }
   allowInsecureRegistries = true
 }

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/complex-build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/complex-build.gradle
@@ -43,9 +43,9 @@ jib {
     paths = file('src/main/custom-extra-dir')
     permissions = ['/foo':'755', '/bar/cat':'777']
   }
-  outputFiles {
+  outputPaths {
     digest = file("$buildDir/different-jib-image.digest")
-    id = file("$buildDir/different-jib-image.id")
+    imageId = file("$buildDir/different-jib-image.id")
   }
   allowInsecureRegistries = true
 }

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/complex-build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/complex-build.gradle
@@ -43,5 +43,9 @@ jib {
     paths = file('src/main/custom-extra-dir')
     permissions = ['/foo':'755', '/bar/cat':'777']
   }
+  outputFiles {
+    digest = file("$buildDir/different-jib-image.digest")
+    id = file("$buildDir/different-jib-image.id")
+  }
   allowInsecureRegistries = true
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -91,7 +91,7 @@ public class BuildTarTask extends DefaultTask implements JibTask {
    */
   @OutputFile
   public String getOutputFile() {
-    return Preconditions.checkNotNull(jibExtension).getOutputFiles().getTarPath().toString();
+    return Preconditions.checkNotNull(jibExtension).getOutputPaths().getTarPath().toString();
   }
 
   @TaskAction

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -91,7 +91,7 @@ public class BuildTarTask extends DefaultTask implements JibTask {
    */
   @OutputFile
   public String getOutputFile() {
-    return getTargetPath().toString();
+    return Preconditions.checkNotNull(jibExtension).getOutputFiles().getTarPath().toString();
   }
 
   @TaskAction
@@ -165,14 +165,5 @@ public class BuildTarTask extends DefaultTask implements JibTask {
   public BuildTarTask setJibExtension(JibExtension jibExtension) {
     this.jibExtension = jibExtension;
     return this;
-  }
-
-  /**
-   * Returns the output directory for the tarball. By default, it is {@code build/jib-image.tar}.
-   *
-   * @return the output directory
-   */
-  private Path getTargetPath() {
-    return getProject().getBuildDir().toPath().resolve("jib-image.tar");
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerClientParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/DockerClientParameters.java
@@ -28,8 +28,8 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 
 /**
- * Object in {@link BuildDockerTask} that configures the Docker executable and the additional
- * environment variables to use when executing the executable.
+ * Object that configures the Docker executable and the additional environment variables to use when
+ * executing the executable.
  */
 public class DockerClientParameters {
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -197,7 +197,7 @@ class GradleRawConfiguration implements RawConfiguration {
   }
 
   @Override
-  public Path getIdOutputPath() {
+  public Path getImageIdOutputPath() {
     return jibExtension.getOutputPaths().getImageIdPath();
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -185,4 +185,19 @@ class GradleRawConfiguration implements RawConfiguration {
   public String getContainerizingMode() {
     return jibExtension.getContainerizingMode();
   }
+
+  @Override
+  public Path getTarOutputPath() {
+    return jibExtension.getOutputFiles().getTarPath();
+  }
+
+  @Override
+  public Path getDigestOutputPath() {
+    return jibExtension.getOutputFiles().getDigestPath();
+  }
+
+  @Override
+  public Path getIdOutputPath() {
+    return jibExtension.getOutputFiles().getIdPath();
+  }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -188,16 +188,16 @@ class GradleRawConfiguration implements RawConfiguration {
 
   @Override
   public Path getTarOutputPath() {
-    return jibExtension.getOutputFiles().getTarPath();
+    return jibExtension.getOutputPaths().getTarPath();
   }
 
   @Override
   public Path getDigestOutputPath() {
-    return jibExtension.getOutputFiles().getDigestPath();
+    return jibExtension.getOutputPaths().getDigestPath();
   }
 
   @Override
   public Path getIdOutputPath() {
-    return jibExtension.getOutputFiles().getIdPath();
+    return jibExtension.getOutputPaths().getImageIdPath();
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -56,6 +56,11 @@ import org.gradle.api.tasks.Optional;
  *       '/path/on/container/file2': 123
  *     ]
  *   }
+ *   outputFiles {
+ *     tar = file('jib-image.tar')
+ *     digest = file('jib-image.digest')
+ *     id = file('jib-image.id')
+ *   }
  *   allowInsecureRegistries = false
  *   containerizingMode = 'exploded'
  * }
@@ -72,6 +77,7 @@ public class JibExtension {
   private final ContainerParameters container;
   private final ExtraDirectoriesParameters extraDirectories;
   private final DockerClientParameters dockerClient;
+  private final OutputFilesParameters outputFiles;
   private final Property<Boolean> allowInsecureRegistries;
   private final Property<String> containerizingMode;
 
@@ -86,6 +92,7 @@ public class JibExtension {
     container = objectFactory.newInstance(ContainerParameters.class);
     extraDirectories = objectFactory.newInstance(ExtraDirectoriesParameters.class, project, this);
     dockerClient = objectFactory.newInstance(DockerClientParameters.class);
+    outputFiles = objectFactory.newInstance(OutputFilesParameters.class, project);
 
     allowInsecureRegistries = objectFactory.property(Boolean.class);
     containerizingMode = objectFactory.property(String.class);
@@ -120,6 +127,10 @@ public class JibExtension {
 
   public void dockerClient(Action<? super DockerClientParameters> action) {
     action.execute(dockerClient);
+  }
+
+  public void outputFiles(Action<? super OutputFilesParameters> action) {
+    action.execute(outputFiles);
   }
 
   @Deprecated
@@ -172,6 +183,12 @@ public class JibExtension {
   @Optional
   public DockerClientParameters getDockerClient() {
     return dockerClient;
+  }
+
+  @Nested
+  @Optional
+  public OutputFilesParameters getOutputFiles() {
+    return outputFiles;
   }
 
   @Input

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -56,10 +56,10 @@ import org.gradle.api.tasks.Optional;
  *       '/path/on/container/file2': 123
  *     ]
  *   }
- *   outputFiles {
+ *   outputPaths {
  *     tar = file('jib-image.tar')
  *     digest = file('jib-image.digest')
- *     id = file('jib-image.id')
+ *     imageId = file('jib-image.id')
  *   }
  *   allowInsecureRegistries = false
  *   containerizingMode = 'exploded'
@@ -77,7 +77,7 @@ public class JibExtension {
   private final ContainerParameters container;
   private final ExtraDirectoriesParameters extraDirectories;
   private final DockerClientParameters dockerClient;
-  private final OutputFilesParameters outputFiles;
+  private final OutputPathsParameters outputPaths;
   private final Property<Boolean> allowInsecureRegistries;
   private final Property<String> containerizingMode;
 
@@ -92,7 +92,7 @@ public class JibExtension {
     container = objectFactory.newInstance(ContainerParameters.class);
     extraDirectories = objectFactory.newInstance(ExtraDirectoriesParameters.class, project, this);
     dockerClient = objectFactory.newInstance(DockerClientParameters.class);
-    outputFiles = objectFactory.newInstance(OutputFilesParameters.class, project);
+    outputPaths = objectFactory.newInstance(OutputPathsParameters.class, project);
 
     allowInsecureRegistries = objectFactory.property(Boolean.class);
     containerizingMode = objectFactory.property(String.class);
@@ -129,8 +129,8 @@ public class JibExtension {
     action.execute(dockerClient);
   }
 
-  public void outputFiles(Action<? super OutputFilesParameters> action) {
-    action.execute(outputFiles);
+  public void outputPaths(Action<? super OutputPathsParameters> action) {
+    action.execute(outputPaths);
   }
 
   @Deprecated
@@ -187,8 +187,8 @@ public class JibExtension {
 
   @Nested
   @Optional
-  public OutputFilesParameters getOutputFiles() {
-    return outputFiles;
+  public OutputPathsParameters getOutputPaths() {
+    return outputPaths;
   }
 
   @Input

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -57,9 +57,9 @@ import org.gradle.api.tasks.Optional;
  *     ]
  *   }
  *   outputPaths {
- *     tar = file('jib-image.tar')
- *     digest = file('jib-image.digest')
- *     imageId = file('jib-image.id')
+ *     tar = file('reative/to/project/root/jib-image.tar')
+ *     digest = file('/absolute/path/jib-image.digest')
+ *     imageId = file("$buildDir/jib-image.id")
  *   }
  *   allowInsecureRegistries = false
  *   containerizingMode = 'exploded'

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/OutputFilesParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/OutputFilesParameters.java
@@ -27,16 +27,12 @@ import org.gradle.api.tasks.Internal;
 /** Object that configures where Jib should create its build output files. */
 public class OutputFilesParameters {
 
-  private final Project project;
-
   private Path digest;
   private Path tar;
   private Path id;
 
   @Inject
   public OutputFilesParameters(Project project) {
-    this.project = project;
-
     digest = project.getBuildDir().toPath().resolve("jib-image.digest");
     id = project.getBuildDir().toPath().resolve("jib-image.id");
     tar = project.getBuildDir().toPath().resolve("jib-image.tar");

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/OutputFilesParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/OutputFilesParameters.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.gradle;
+
+import com.google.cloud.tools.jib.plugins.common.PropertyNames;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import javax.inject.Inject;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+
+/** Object that configures where Jib should create its build output files. */
+public class OutputFilesParameters {
+
+  private final Project project;
+
+  private Path digest;
+  private Path tar;
+  private Path id;
+
+  @Inject
+  public OutputFilesParameters(Project project) {
+    this.project = project;
+
+    digest = project.getBuildDir().toPath().resolve("jib-image.digest");
+    id = project.getBuildDir().toPath().resolve("jib-image.id");
+    tar = project.getBuildDir().toPath().resolve("jib-image.tar");
+  }
+
+  @Input
+  public String getDigest() {
+    String property = System.getProperty(PropertyNames.OUTPUT_FILES_DIGEST);
+    return property == null ? digest.toString() : property;
+  }
+
+  @Internal
+  Path getDigestPath() {
+    String property = System.getProperty(PropertyNames.OUTPUT_FILES_DIGEST);
+    return property == null ? digest : Paths.get(property);
+  }
+
+  public void setDigest(String digest) {
+    this.digest = Paths.get(digest);
+  }
+
+  @Input
+  public String getId() {
+    String property = System.getProperty(PropertyNames.OUTPUT_FILES_ID);
+    return property == null ? id.toString() : property;
+  }
+
+  @Internal
+  Path getIdPath() {
+    String property = System.getProperty(PropertyNames.OUTPUT_FILES_ID);
+    return property == null ? id : Paths.get(property);
+  }
+
+  public void setId(String id) {
+    this.id = Paths.get(id);
+  }
+
+  @Input
+  public String getTar() {
+    String property = System.getProperty(PropertyNames.OUTPUT_FILES_TAR);
+    return property == null ? tar.toString() : property;
+  }
+
+  @Internal
+  Path getTarPath() {
+    String property = System.getProperty(PropertyNames.OUTPUT_FILES_TAR);
+    return property == null ? tar : Paths.get(property);
+  }
+
+  public void setTar(String tar) {
+    this.tar = Paths.get(tar);
+  }
+}

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/OutputPathsParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/OutputPathsParameters.java
@@ -27,27 +27,28 @@ import org.gradle.api.tasks.Internal;
 /** Object that configures where Jib should create its build output files. */
 public class OutputPathsParameters {
 
+  private final Project project;
+
   private Path digest;
   private Path tar;
-  private Path id;
+  private Path imageId;
 
   @Inject
   public OutputPathsParameters(Project project) {
+    this.project = project;
     digest = project.getBuildDir().toPath().resolve("jib-image.digest");
-    id = project.getBuildDir().toPath().resolve("jib-image.id");
+    imageId = project.getBuildDir().toPath().resolve("jib-image.id");
     tar = project.getBuildDir().toPath().resolve("jib-image.tar");
   }
 
   @Input
   public String getDigest() {
-    String property = System.getProperty(PropertyNames.OUTPUT_PATHS_DIGEST);
-    return property == null ? digest.toString() : property;
+    return getRelativeToProjectRoot(digest, PropertyNames.OUTPUT_PATHS_DIGEST).toString();
   }
 
   @Internal
   Path getDigestPath() {
-    String property = System.getProperty(PropertyNames.OUTPUT_PATHS_DIGEST);
-    return property == null ? digest : Paths.get(property);
+    return getRelativeToProjectRoot(digest, PropertyNames.OUTPUT_PATHS_DIGEST);
   }
 
   public void setDigest(String digest) {
@@ -56,33 +57,35 @@ public class OutputPathsParameters {
 
   @Input
   public String getImageId() {
-    String property = System.getProperty(PropertyNames.OUTPUT_PATHS_IMAGE_ID);
-    return property == null ? id.toString() : property;
+    return getRelativeToProjectRoot(imageId, PropertyNames.OUTPUT_PATHS_IMAGE_ID).toString();
   }
 
   @Internal
   Path getImageIdPath() {
-    String property = System.getProperty(PropertyNames.OUTPUT_PATHS_IMAGE_ID);
-    return property == null ? id : Paths.get(property);
+    return getRelativeToProjectRoot(imageId, PropertyNames.OUTPUT_PATHS_IMAGE_ID);
   }
 
   public void setImageId(String id) {
-    this.id = Paths.get(id);
+    this.imageId = Paths.get(id);
   }
 
   @Input
   public String getTar() {
-    String property = System.getProperty(PropertyNames.OUTPUT_PATHS_TAR);
-    return property == null ? tar.toString() : property;
+    return getRelativeToProjectRoot(tar, PropertyNames.OUTPUT_PATHS_TAR).toString();
   }
 
   @Internal
   Path getTarPath() {
-    String property = System.getProperty(PropertyNames.OUTPUT_PATHS_TAR);
-    return property == null ? tar : Paths.get(property);
+    return getRelativeToProjectRoot(tar, PropertyNames.OUTPUT_PATHS_TAR);
   }
 
   public void setTar(String tar) {
     this.tar = Paths.get(tar);
+  }
+
+  private Path getRelativeToProjectRoot(Path configuration, String propertyName) {
+    String property = System.getProperty(propertyName);
+    Path path = property != null ? Paths.get(property) : configuration;
+    return path.isAbsolute() ? path : project.getProjectDir().toPath().resolve(path);
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/OutputPathsParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/OutputPathsParameters.java
@@ -25,14 +25,14 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 
 /** Object that configures where Jib should create its build output files. */
-public class OutputFilesParameters {
+public class OutputPathsParameters {
 
   private Path digest;
   private Path tar;
   private Path id;
 
   @Inject
-  public OutputFilesParameters(Project project) {
+  public OutputPathsParameters(Project project) {
     digest = project.getBuildDir().toPath().resolve("jib-image.digest");
     id = project.getBuildDir().toPath().resolve("jib-image.id");
     tar = project.getBuildDir().toPath().resolve("jib-image.tar");
@@ -40,13 +40,13 @@ public class OutputFilesParameters {
 
   @Input
   public String getDigest() {
-    String property = System.getProperty(PropertyNames.OUTPUT_FILES_DIGEST);
+    String property = System.getProperty(PropertyNames.OUTPUT_PATHS_DIGEST);
     return property == null ? digest.toString() : property;
   }
 
   @Internal
   Path getDigestPath() {
-    String property = System.getProperty(PropertyNames.OUTPUT_FILES_DIGEST);
+    String property = System.getProperty(PropertyNames.OUTPUT_PATHS_DIGEST);
     return property == null ? digest : Paths.get(property);
   }
 
@@ -55,30 +55,30 @@ public class OutputFilesParameters {
   }
 
   @Input
-  public String getId() {
-    String property = System.getProperty(PropertyNames.OUTPUT_FILES_ID);
+  public String getImageId() {
+    String property = System.getProperty(PropertyNames.OUTPUT_PATHS_IMAGE_ID);
     return property == null ? id.toString() : property;
   }
 
   @Internal
-  Path getIdPath() {
-    String property = System.getProperty(PropertyNames.OUTPUT_FILES_ID);
+  Path getImageIdPath() {
+    String property = System.getProperty(PropertyNames.OUTPUT_PATHS_IMAGE_ID);
     return property == null ? id : Paths.get(property);
   }
 
-  public void setId(String id) {
+  public void setImageId(String id) {
     this.id = Paths.get(id);
   }
 
   @Input
   public String getTar() {
-    String property = System.getProperty(PropertyNames.OUTPUT_FILES_TAR);
+    String property = System.getProperty(PropertyNames.OUTPUT_PATHS_TAR);
     return property == null ? tar.toString() : property;
   }
 
   @Internal
   Path getTarPath() {
-    String property = System.getProperty(PropertyNames.OUTPUT_FILES_TAR);
+    String property = System.getProperty(PropertyNames.OUTPUT_PATHS_TAR);
     return property == null ? tar : Paths.get(property);
   }
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
@@ -39,7 +39,7 @@ public class GradleRawConfigurationTest {
     TargetImageParameters targetImageParameters = Mockito.mock(TargetImageParameters.class);
     ContainerParameters containerParameters = Mockito.mock(ContainerParameters.class);
     DockerClientParameters dockerClientParameters = Mockito.mock(DockerClientParameters.class);
-    OutputFilesParameters outputFilesParameters = Mockito.mock(OutputFilesParameters.class);
+    OutputPathsParameters outputPathsParameters = Mockito.mock(OutputPathsParameters.class);
 
     Mockito.when(authParameters.getUsername()).thenReturn("user");
     Mockito.when(authParameters.getPassword()).thenReturn("password");
@@ -51,7 +51,7 @@ public class GradleRawConfigurationTest {
     Mockito.when(jibExtension.getTo()).thenReturn(targetImageParameters);
     Mockito.when(jibExtension.getContainer()).thenReturn(containerParameters);
     Mockito.when(jibExtension.getDockerClient()).thenReturn(dockerClientParameters);
-    Mockito.when(jibExtension.getOutputFiles()).thenReturn(outputFilesParameters);
+    Mockito.when(jibExtension.getOutputPaths()).thenReturn(outputPathsParameters);
     Mockito.when(jibExtension.getAllowInsecureRegistries()).thenReturn(true);
 
     Mockito.when(baseImageParameters.getCredHelper()).thenReturn("gcr");
@@ -79,9 +79,9 @@ public class GradleRawConfigurationTest {
     Mockito.when(dockerClientParameters.getEnvironment())
         .thenReturn(new HashMap<>(ImmutableMap.of("docker", "client")));
 
-    Mockito.when(outputFilesParameters.getDigestPath()).thenReturn(Paths.get("digest/path"));
-    Mockito.when(outputFilesParameters.getIdPath()).thenReturn(Paths.get("id/path"));
-    Mockito.when(outputFilesParameters.getTarPath()).thenReturn(Paths.get("tar/path"));
+    Mockito.when(outputPathsParameters.getDigestPath()).thenReturn(Paths.get("digest/path"));
+    Mockito.when(outputPathsParameters.getImageIdPath()).thenReturn(Paths.get("id/path"));
+    Mockito.when(outputPathsParameters.getTarPath()).thenReturn(Paths.get("tar/path"));
 
     GradleRawConfiguration rawConfiguration = new GradleRawConfiguration(jibExtension);
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
@@ -116,7 +116,7 @@ public class GradleRawConfigurationTest {
         new HashMap<>(ImmutableMap.of("docker", "client")),
         rawConfiguration.getDockerEnvironment());
     Assert.assertEquals(Paths.get("digest/path"), rawConfiguration.getDigestOutputPath());
-    Assert.assertEquals(Paths.get("id/path"), rawConfiguration.getIdOutputPath());
+    Assert.assertEquals(Paths.get("id/path"), rawConfiguration.getImageIdOutputPath());
     Assert.assertEquals(Paths.get("tar/path"), rawConfiguration.getTarOutputPath());
   }
 }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
@@ -39,6 +39,7 @@ public class GradleRawConfigurationTest {
     TargetImageParameters targetImageParameters = Mockito.mock(TargetImageParameters.class);
     ContainerParameters containerParameters = Mockito.mock(ContainerParameters.class);
     DockerClientParameters dockerClientParameters = Mockito.mock(DockerClientParameters.class);
+    OutputFilesParameters outputFilesParameters = Mockito.mock(OutputFilesParameters.class);
 
     Mockito.when(authParameters.getUsername()).thenReturn("user");
     Mockito.when(authParameters.getPassword()).thenReturn("password");
@@ -50,6 +51,7 @@ public class GradleRawConfigurationTest {
     Mockito.when(jibExtension.getTo()).thenReturn(targetImageParameters);
     Mockito.when(jibExtension.getContainer()).thenReturn(containerParameters);
     Mockito.when(jibExtension.getDockerClient()).thenReturn(dockerClientParameters);
+    Mockito.when(jibExtension.getOutputFiles()).thenReturn(outputFilesParameters);
     Mockito.when(jibExtension.getAllowInsecureRegistries()).thenReturn(true);
 
     Mockito.when(baseImageParameters.getCredHelper()).thenReturn("gcr");
@@ -76,6 +78,10 @@ public class GradleRawConfigurationTest {
     Mockito.when(dockerClientParameters.getExecutablePath()).thenReturn(Paths.get("test"));
     Mockito.when(dockerClientParameters.getEnvironment())
         .thenReturn(new HashMap<>(ImmutableMap.of("docker", "client")));
+
+    Mockito.when(outputFilesParameters.getDigestPath()).thenReturn(Paths.get("digest/path"));
+    Mockito.when(outputFilesParameters.getIdPath()).thenReturn(Paths.get("id/path"));
+    Mockito.when(outputFilesParameters.getTarPath()).thenReturn(Paths.get("tar/path"));
 
     GradleRawConfiguration rawConfiguration = new GradleRawConfiguration(jibExtension);
 
@@ -109,5 +115,8 @@ public class GradleRawConfigurationTest {
     Assert.assertEquals(
         new HashMap<>(ImmutableMap.of("docker", "client")),
         rawConfiguration.getDockerEnvironment());
+    Assert.assertEquals(Paths.get("digest/path"), rawConfiguration.getDigestOutputPath());
+    Assert.assertEquals(Paths.get("id/path"), rawConfiguration.getIdOutputPath());
+    Assert.assertEquals(Paths.get("tar/path"), rawConfiguration.getTarOutputPath());
   }
 }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -242,17 +242,18 @@ public class JibExtensionTest {
 
   @Test
   public void testOutputFiles() {
-    testJibExtension.outputFiles(
+    testJibExtension.outputPaths(
         outputFiles -> {
           outputFiles.setDigest("path/to/digest");
-          outputFiles.setId("path/to/id");
+          outputFiles.setImageId("path/to/id");
           outputFiles.setTar("path/to/tar");
         });
 
     Assert.assertEquals(
-        Paths.get("path/to/digest"), testJibExtension.getOutputFiles().getDigestPath());
-    Assert.assertEquals(Paths.get("path/to/id"), testJibExtension.getOutputFiles().getIdPath());
-    Assert.assertEquals(Paths.get("path/to/tar"), testJibExtension.getOutputFiles().getTarPath());
+        Paths.get("path/to/digest"), testJibExtension.getOutputPaths().getDigestPath());
+    Assert.assertEquals(
+        Paths.get("path/to/id"), testJibExtension.getOutputPaths().getImageIdPath());
+    Assert.assertEquals(Paths.get("path/to/tar"), testJibExtension.getOutputPaths().getTarPath());
   }
 
   @Test
@@ -327,13 +328,13 @@ public class JibExtensionTest {
         ImmutableMap.of("env1", "val1", "env2", "val2"),
         testJibExtension.getDockerClient().getEnvironment());
 
-    System.setProperty("jib.outputFiles.digest", "digest/path");
+    System.setProperty("jib.outputPaths.digest", "digest/path");
     Assert.assertEquals(
-        Paths.get("digest/path"), testJibExtension.getOutputFiles().getDigestPath());
-    System.setProperty("jib.outputFiles.id", "id/path");
-    Assert.assertEquals(Paths.get("id/path"), testJibExtension.getOutputFiles().getIdPath());
-    System.setProperty("jib.outputFiles.tar", "tar/path");
-    Assert.assertEquals(Paths.get("tar/path"), testJibExtension.getOutputFiles().getTarPath());
+        Paths.get("digest/path"), testJibExtension.getOutputPaths().getDigestPath());
+    System.setProperty("jib.outputPaths.imageId", "id/path");
+    Assert.assertEquals(Paths.get("id/path"), testJibExtension.getOutputPaths().getImageIdPath());
+    System.setProperty("jib.outputPaths.tar", "tar/path");
+    Assert.assertEquals(Paths.get("tar/path"), testJibExtension.getOutputPaths().getTarPath());
   }
 
   @Test

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -244,16 +244,18 @@ public class JibExtensionTest {
   public void testOutputFiles() {
     testJibExtension.outputPaths(
         outputFiles -> {
-          outputFiles.setDigest("path/to/digest");
-          outputFiles.setImageId("path/to/id");
+          outputFiles.setDigest("/path/to/digest");
+          outputFiles.setImageId("/path/to/id");
           outputFiles.setTar("path/to/tar");
         });
 
     Assert.assertEquals(
-        Paths.get("path/to/digest"), testJibExtension.getOutputPaths().getDigestPath());
+        Paths.get("/path/to/digest"), testJibExtension.getOutputPaths().getDigestPath());
     Assert.assertEquals(
-        Paths.get("path/to/id"), testJibExtension.getOutputPaths().getImageIdPath());
-    Assert.assertEquals(Paths.get("path/to/tar"), testJibExtension.getOutputPaths().getTarPath());
+        Paths.get("/path/to/id"), testJibExtension.getOutputPaths().getImageIdPath());
+    Assert.assertEquals(
+        fakeProject.getProjectDir().toPath().resolve(Paths.get("path/to/tar")),
+        testJibExtension.getOutputPaths().getTarPath());
   }
 
   @Test
@@ -328,13 +330,27 @@ public class JibExtensionTest {
         ImmutableMap.of("env1", "val1", "env2", "val2"),
         testJibExtension.getDockerClient().getEnvironment());
 
+    // Absolute paths
+    System.setProperty("jib.outputPaths.digest", "/digest/path");
+    Assert.assertEquals(
+        Paths.get("/digest/path"), testJibExtension.getOutputPaths().getDigestPath());
+    System.setProperty("jib.outputPaths.imageId", "/id/path");
+    Assert.assertEquals(Paths.get("/id/path"), testJibExtension.getOutputPaths().getImageIdPath());
+    System.setProperty("jib.outputPaths.tar", "/tar/path");
+    Assert.assertEquals(Paths.get("/tar/path"), testJibExtension.getOutputPaths().getTarPath());
+    // Relative paths
     System.setProperty("jib.outputPaths.digest", "digest/path");
     Assert.assertEquals(
-        Paths.get("digest/path"), testJibExtension.getOutputPaths().getDigestPath());
+        fakeProject.getProjectDir().toPath().resolve(Paths.get("digest/path")),
+        testJibExtension.getOutputPaths().getDigestPath());
     System.setProperty("jib.outputPaths.imageId", "id/path");
-    Assert.assertEquals(Paths.get("id/path"), testJibExtension.getOutputPaths().getImageIdPath());
+    Assert.assertEquals(
+        fakeProject.getProjectDir().toPath().resolve(Paths.get("id/path")),
+        testJibExtension.getOutputPaths().getImageIdPath());
     System.setProperty("jib.outputPaths.tar", "tar/path");
-    Assert.assertEquals(Paths.get("tar/path"), testJibExtension.getOutputPaths().getTarPath());
+    Assert.assertEquals(
+        fakeProject.getProjectDir().toPath().resolve(Paths.get("tar/path")),
+        testJibExtension.getOutputPaths().getTarPath());
   }
 
   @Test

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -250,9 +250,11 @@ public class JibExtensionTest {
         });
 
     Assert.assertEquals(
-        Paths.get("/path/to/digest"), testJibExtension.getOutputPaths().getDigestPath());
+        Paths.get("/path/to/digest").toAbsolutePath(),
+        testJibExtension.getOutputPaths().getDigestPath());
     Assert.assertEquals(
-        Paths.get("/path/to/id"), testJibExtension.getOutputPaths().getImageIdPath());
+        Paths.get("/path/to/id").toAbsolutePath(),
+        testJibExtension.getOutputPaths().getImageIdPath());
     Assert.assertEquals(
         fakeProject.getProjectDir().toPath().resolve(Paths.get("path/to/tar")),
         testJibExtension.getOutputPaths().getTarPath());
@@ -333,11 +335,14 @@ public class JibExtensionTest {
     // Absolute paths
     System.setProperty("jib.outputPaths.digest", "/digest/path");
     Assert.assertEquals(
-        Paths.get("/digest/path"), testJibExtension.getOutputPaths().getDigestPath());
+        Paths.get("/digest/path").toAbsolutePath(),
+        testJibExtension.getOutputPaths().getDigestPath());
     System.setProperty("jib.outputPaths.imageId", "/id/path");
-    Assert.assertEquals(Paths.get("/id/path"), testJibExtension.getOutputPaths().getImageIdPath());
+    Assert.assertEquals(
+        Paths.get("/id/path").toAbsolutePath(), testJibExtension.getOutputPaths().getImageIdPath());
     System.setProperty("jib.outputPaths.tar", "/tar/path");
-    Assert.assertEquals(Paths.get("/tar/path"), testJibExtension.getOutputPaths().getTarPath());
+    Assert.assertEquals(
+        Paths.get("/tar/path").toAbsolutePath(), testJibExtension.getOutputPaths().getTarPath());
     // Relative paths
     System.setProperty("jib.outputPaths.digest", "digest/path");
     Assert.assertEquals(

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -241,6 +241,21 @@ public class JibExtensionTest {
   }
 
   @Test
+  public void testOutputFiles() {
+    testJibExtension.outputFiles(
+        outputFiles -> {
+          outputFiles.setDigest("path/to/digest");
+          outputFiles.setId("path/to/id");
+          outputFiles.setTar("path/to/tar");
+        });
+
+    Assert.assertEquals(
+        Paths.get("path/to/digest"), testJibExtension.getOutputFiles().getDigestPath());
+    Assert.assertEquals(Paths.get("path/to/id"), testJibExtension.getOutputFiles().getIdPath());
+    Assert.assertEquals(Paths.get("path/to/tar"), testJibExtension.getOutputFiles().getTarPath());
+  }
+
+  @Test
   public void testProperties() {
     System.setProperty("jib.from.image", "fromImage");
     Assert.assertEquals("fromImage", testJibExtension.getFrom().getImage());
@@ -311,6 +326,14 @@ public class JibExtensionTest {
     Assert.assertEquals(
         ImmutableMap.of("env1", "val1", "env2", "val2"),
         testJibExtension.getDockerClient().getEnvironment());
+
+    System.setProperty("jib.outputFiles.digest", "digest/path");
+    Assert.assertEquals(
+        Paths.get("digest/path"), testJibExtension.getOutputFiles().getDigestPath());
+    System.setProperty("jib.outputFiles.id", "id/path");
+    Assert.assertEquals(Paths.get("id/path"), testJibExtension.getOutputFiles().getIdPath());
+    System.setProperty("jib.outputFiles.tar", "tar/path");
+    Assert.assertEquals(Paths.get("tar/path"), testJibExtension.getOutputFiles().getTarPath());
   }
 
   @Test

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -5,10 +5,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- `<outputFiles>` object for configuration output file locations ([#1561](https://github.com/GoogleContainerTools/jib/issues/1561))
-  - `<outputFiles><tar>` configures output path of `jib:buildTar` (`target/jib-image.tar` by default)
-  - `<outputFiles><digest>` configures the output path of the image digest (`target/jib-image.digest` by default)
-  - `<outputFiles><id>` configures output path of the image id  (`target/jib-image.id` by default)
+- `<outputPaths>` object for configuration output file locations ([#1561](https://github.com/GoogleContainerTools/jib/issues/1561))
+  - `<outputPaths><tar>` configures output path of `jib:buildTar` (`target/jib-image.tar` by default)
+  - `<outputPaths><digest>` configures the output path of the image digest (`target/jib-image.digest` by default)
+  - `<outputPaths><imageId>` configures output path of the image id  (`target/jib-image.id` by default)
 
 ### Changed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `<outputFiles>` object for configuration output file locations ([#1561](https://github.com/GoogleContainerTools/jib/issues/1561))
+  - `<outputFiles><tar>` configures output path of `jib:buildTar` (`target/jib-image.tar` by default)
+  - `<outputFiles><digest>` configures the output path of the image digest (`target/jib-image.digest` by default)
+  - `<outputFiles><id>` configures output path of the image id  (`target/jib-image.id` by default)
+
 ### Changed
 
 - Local base image layers are now processed in parallel, speeding up builds using large local base images. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
@@ -51,7 +51,7 @@ public class BuildDockerMojoIntegrationTest {
     verifier.executeGoal("jib:dockerBuild");
     verifier.verifyErrorFreeLog();
 
-    BuildImageMojoIntegrationTest.assertImageDigest(projectRoot);
+    BuildImageMojoIntegrationTest.assertDigestFile(projectRoot.resolve("target/jib-image.digest"));
   }
 
   /**

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
@@ -51,7 +51,7 @@ public class BuildDockerMojoIntegrationTest {
     verifier.executeGoal("jib:dockerBuild");
     verifier.verifyErrorFreeLog();
 
-    BuildImageMojoIntegrationTest.assertDigestFile(projectRoot.resolve("target/jib-image.digest"));
+    BuildImageMojoIntegrationTest.readDigestFile(projectRoot.resolve("target/jib-image.digest"));
   }
 
   /**

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -76,7 +76,7 @@ public class BuildImageMojoIntegrationTest {
     return nameBase + label + System.nanoTime();
   }
 
-  static String assertDigestFile(Path digestPath) throws IOException, DigestException {
+  static String readDigestFile(Path digestPath) throws IOException, DigestException {
     Assert.assertTrue(Files.exists(digestPath));
     String digest = new String(Files.readAllBytes(digestPath), StandardCharsets.UTF_8);
     return DescriptorDigest.fromDigest(digest).toString();
@@ -133,13 +133,13 @@ public class BuildImageMojoIntegrationTest {
 
     try {
       // Test pulling/running using image digest
-      String digest = assertDigestFile(projectRoot.resolve("target/jib-image.digest"));
+      String digest = readDigestFile(projectRoot.resolve("target/jib-image.digest"));
       String imageReferenceWithDigest =
           ImageReference.parse(imageReference).withTag(digest).toString();
       Assert.assertEquals(output, pullAndRunBuiltImage(imageReferenceWithDigest));
 
       // Test running using image id
-      String id = assertDigestFile(projectRoot.resolve("target/jib-image.id"));
+      String id = readDigestFile(projectRoot.resolve("target/jib-image.id"));
       Assert.assertNotEquals(digest, id);
       Assert.assertEquals(output, new Command("docker", "run", "--rm", id).run());
 
@@ -202,7 +202,7 @@ public class BuildImageMojoIntegrationTest {
     String additionalOutput = pullAndRunBuiltImage(additionalImageReference);
     Assert.assertEquals(output, additionalOutput);
 
-    String digest = assertDigestFile(projectRoot.resolve("target/jib-image.digest"));
+    String digest = readDigestFile(projectRoot.resolve("target/jib-image.digest"));
     String digestImageReference = ImageReference.parse(imageReference).withTag(digest).toString();
     String digestOutput = pullAndRunBuiltImage(digestImageReference);
     Assert.assertEquals(output, digestOutput);
@@ -582,11 +582,10 @@ public class BuildImageMojoIntegrationTest {
             + "-Xms512m\n-Xdebug\nenvvalue1\nenvvalue2\n",
         output);
     String digest =
-        assertDigestFile(
+        readDigestFile(
             simpleTestProject.getProjectRoot().resolve("target/different-jib-image.digest"));
     String id =
-        assertDigestFile(
-            simpleTestProject.getProjectRoot().resolve("target/different-jib-image.id"));
+        readDigestFile(simpleTestProject.getProjectRoot().resolve("target/different-jib-image.id"));
     Assert.assertNotEquals(digest, id);
     Assert.assertEquals(output, new Command("docker", "run", "--rm", id).run());
 

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -77,7 +77,7 @@ public class BuildImageMojoIntegrationTest {
   }
 
   static String readDigestFile(Path digestPath) throws IOException, DigestException {
-    Assert.assertTrue(Files.exists(digestPath));
+    Assert.assertTrue("File missing: " + digestPath, Files.exists(digestPath));
     String digest = new String(Files.readAllBytes(digestPath), StandardCharsets.UTF_8);
     return DescriptorDigest.fromDigest(digest).toString();
   }
@@ -585,7 +585,7 @@ public class BuildImageMojoIntegrationTest {
         readDigestFile(
             simpleTestProject.getProjectRoot().resolve("target/different-jib-image.digest"));
     String id =
-        readDigestFile(simpleTestProject.getProjectRoot().resolve("target/different-jib-image.id"));
+        readDigestFile(simpleTestProject.getProjectRoot().resolve("different-jib-image.id"));
     Assert.assertNotEquals(digest, id);
     Assert.assertEquals(output, new Command("docker", "run", "--rm", id).run());
 

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
@@ -47,7 +47,7 @@ public class BuildTarMojoIntegrationTest {
     verifier.executeGoal("jib:" + BuildTarMojo.GOAL_NAME);
     verifier.verifyErrorFreeLog();
 
-    BuildImageMojoIntegrationTest.assertDigestFile(
+    BuildImageMojoIntegrationTest.readDigestFile(
         simpleTestProject.getProjectRoot().resolve("target/jib-image.digest"));
 
     new Command(

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
@@ -47,7 +47,8 @@ public class BuildTarMojoIntegrationTest {
     verifier.executeGoal("jib:" + BuildTarMojo.GOAL_NAME);
     verifier.verifyErrorFreeLog();
 
-    BuildImageMojoIntegrationTest.assertImageDigest(simpleTestProject.getProjectRoot());
+    BuildImageMojoIntegrationTest.assertImageDigest(
+        simpleTestProject.getProjectRoot().resolve("jib-image.digest"));
 
     new Command(
             "docker",
@@ -56,7 +57,7 @@ public class BuildTarMojoIntegrationTest {
             simpleTestProject
                 .getProjectRoot()
                 .resolve("target")
-                .resolve("jib-image.tar")
+                .resolve("different-jib-image.tar")
                 .toString())
         .run();
     Assert.assertEquals(

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
@@ -47,8 +47,8 @@ public class BuildTarMojoIntegrationTest {
     verifier.executeGoal("jib:" + BuildTarMojo.GOAL_NAME);
     verifier.verifyErrorFreeLog();
 
-    BuildImageMojoIntegrationTest.assertImageDigest(
-        simpleTestProject.getProjectRoot().resolve("jib-image.digest"));
+    BuildImageMojoIntegrationTest.assertDigestFile(
+        simpleTestProject.getProjectRoot().resolve("target/jib-image.digest"));
 
     new Command(
             "docker",

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -38,7 +38,8 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
 /**
- * Builds a container image and exports to disk at {@code ${project.build.directory}/jib-image.tar}.
+ * Builds a container image and exports to disk at the configured location ({@code
+ * ${project.build.directory}/jib-image.tar} by default).
  */
 @Mojo(
     name = BuildTarMojo.GOAL_NAME,

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -233,6 +233,15 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
     @Parameter private Map<String, String> environment = Collections.emptyMap();
   }
 
+  public static class OutputFilesParameters {
+
+    @Nullable @Parameter private File tar;
+
+    @Nullable @Parameter private File digest;
+
+    @Nullable @Parameter private File id;
+  }
+
   @Nullable
   @Parameter(defaultValue = "${session}", readonly = true)
   private MavenSession session;
@@ -259,6 +268,8 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   @Parameter private ExtraDirectoriesParameters extraDirectories = new ExtraDirectoriesParameters();
 
   @Parameter private DockerClientParameters dockerClient = new DockerClientParameters();
+
+  @Parameter private OutputFilesParameters outputFiles = new OutputFilesParameters();
 
   @Parameter(property = PropertyNames.ALLOW_INSECURE_REGISTRIES)
   private boolean allowInsecureRegistries;
@@ -682,6 +693,39 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
       return ConfigurationPropertyValidator.parseMapProperty(property);
     }
     return dockerClient.environment;
+  }
+
+  Path getTarOutputPath() {
+    String property = getProperty(PropertyNames.OUTPUT_FILES_TAR);
+    if (property != null) {
+      return Paths.get(property);
+    }
+    return outputFiles.tar == null
+        ? Paths.get(Preconditions.checkNotNull(project).getBuild().getOutputDirectory())
+            .resolve("jib-image.tar")
+        : outputFiles.tar.toPath();
+  }
+
+  Path getDigestOutputPath() {
+    String property = getProperty(PropertyNames.OUTPUT_FILES_DIGEST);
+    if (property != null) {
+      return Paths.get(property);
+    }
+    return outputFiles.digest == null
+        ? Paths.get(Preconditions.checkNotNull(project).getBuild().getOutputDirectory())
+            .resolve("jib-image.digest")
+        : outputFiles.digest.toPath();
+  }
+
+  Path getIdOutputPath() {
+    String property = getProperty(PropertyNames.OUTPUT_FILES_ID);
+    if (property != null) {
+      return Paths.get(property);
+    }
+    return outputFiles.id == null
+        ? Paths.get(Preconditions.checkNotNull(project).getBuild().getOutputDirectory())
+            .resolve("jib-image.id")
+        : outputFiles.id.toPath();
   }
 
   boolean getAllowInsecureRegistries() {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -701,8 +701,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
       return Paths.get(property);
     }
     return outputPaths.tar == null
-        ? Paths.get(Preconditions.checkNotNull(project).getBuild().getDirectory())
-            .resolve("jib-image.tar")
+        ? Paths.get(getProject().getBuild().getDirectory()).resolve("jib-image.tar")
         : outputPaths.tar.toPath();
   }
 
@@ -712,19 +711,17 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
       return Paths.get(property);
     }
     return outputPaths.digest == null
-        ? Paths.get(Preconditions.checkNotNull(project).getBuild().getDirectory())
-            .resolve("jib-image.digest")
+        ? Paths.get(getProject().getBuild().getDirectory()).resolve("jib-image.digest")
         : outputPaths.digest.toPath();
   }
 
-  Path getIdOutputPath() {
+  Path getImageIdOutputPath() {
     String property = getProperty(PropertyNames.OUTPUT_PATHS_IMAGE_ID);
     if (property != null) {
       return Paths.get(property);
     }
     return outputPaths.imageId == null
-        ? Paths.get(Preconditions.checkNotNull(project).getBuild().getDirectory())
-            .resolve("jib-image.id")
+        ? Paths.get(getProject().getBuild().getDirectory()).resolve("jib-image.id")
         : outputPaths.imageId.toPath();
   }
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -701,7 +701,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
       return Paths.get(property);
     }
     return outputFiles.tar == null
-        ? Paths.get(Preconditions.checkNotNull(project).getBuild().getOutputDirectory())
+        ? Paths.get(Preconditions.checkNotNull(project).getBuild().getDirectory())
             .resolve("jib-image.tar")
         : outputFiles.tar.toPath();
   }
@@ -712,7 +712,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
       return Paths.get(property);
     }
     return outputFiles.digest == null
-        ? Paths.get(Preconditions.checkNotNull(project).getBuild().getOutputDirectory())
+        ? Paths.get(Preconditions.checkNotNull(project).getBuild().getDirectory())
             .resolve("jib-image.digest")
         : outputFiles.digest.toPath();
   }
@@ -723,7 +723,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
       return Paths.get(property);
     }
     return outputFiles.id == null
-        ? Paths.get(Preconditions.checkNotNull(project).getBuild().getOutputDirectory())
+        ? Paths.get(Preconditions.checkNotNull(project).getBuild().getDirectory())
             .resolve("jib-image.id")
         : outputFiles.id.toPath();
   }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -696,33 +696,33 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   }
 
   Path getTarOutputPath() {
-    String property = getProperty(PropertyNames.OUTPUT_PATHS_TAR);
-    if (property != null) {
-      return Paths.get(property);
-    }
-    return outputPaths.tar == null
-        ? Paths.get(getProject().getBuild().getDirectory()).resolve("jib-image.tar")
-        : outputPaths.tar.toPath();
+    Path configuredPath =
+        outputPaths.tar == null
+            ? Paths.get(getProject().getBuild().getDirectory()).resolve("jib-image.tar")
+            : outputPaths.tar.toPath();
+    return getRelativeToProjectRoot(configuredPath, PropertyNames.OUTPUT_PATHS_TAR);
   }
 
   Path getDigestOutputPath() {
-    String property = getProperty(PropertyNames.OUTPUT_PATHS_DIGEST);
-    if (property != null) {
-      return Paths.get(property);
-    }
-    return outputPaths.digest == null
-        ? Paths.get(getProject().getBuild().getDirectory()).resolve("jib-image.digest")
-        : outputPaths.digest.toPath();
+    Path configuredPath =
+        outputPaths.digest == null
+            ? Paths.get(getProject().getBuild().getDirectory()).resolve("jib-image.digest")
+            : outputPaths.digest.toPath();
+    return getRelativeToProjectRoot(configuredPath, PropertyNames.OUTPUT_PATHS_DIGEST);
   }
 
   Path getImageIdOutputPath() {
-    String property = getProperty(PropertyNames.OUTPUT_PATHS_IMAGE_ID);
-    if (property != null) {
-      return Paths.get(property);
-    }
-    return outputPaths.imageId == null
-        ? Paths.get(getProject().getBuild().getDirectory()).resolve("jib-image.id")
-        : outputPaths.imageId.toPath();
+    Path configuredPath =
+        outputPaths.imageId == null
+            ? Paths.get(getProject().getBuild().getDirectory()).resolve("jib-image.id")
+            : outputPaths.imageId.toPath();
+    return getRelativeToProjectRoot(configuredPath, PropertyNames.OUTPUT_PATHS_IMAGE_ID);
+  }
+
+  private Path getRelativeToProjectRoot(Path configuration, String propertyName) {
+    String property = getProperty(propertyName);
+    Path path = property != null ? Paths.get(property) : configuration;
+    return path.isAbsolute() ? path : getProject().getBasedir().toPath().resolve(path);
   }
 
   boolean getAllowInsecureRegistries() {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -233,13 +233,13 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
     @Parameter private Map<String, String> environment = Collections.emptyMap();
   }
 
-  public static class OutputFilesParameters {
+  public static class OutputPathsParameters {
 
     @Nullable @Parameter private File tar;
 
     @Nullable @Parameter private File digest;
 
-    @Nullable @Parameter private File id;
+    @Nullable @Parameter private File imageId;
   }
 
   @Nullable
@@ -269,7 +269,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
 
   @Parameter private DockerClientParameters dockerClient = new DockerClientParameters();
 
-  @Parameter private OutputFilesParameters outputFiles = new OutputFilesParameters();
+  @Parameter private OutputPathsParameters outputPaths = new OutputPathsParameters();
 
   @Parameter(property = PropertyNames.ALLOW_INSECURE_REGISTRIES)
   private boolean allowInsecureRegistries;
@@ -696,36 +696,36 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   }
 
   Path getTarOutputPath() {
-    String property = getProperty(PropertyNames.OUTPUT_FILES_TAR);
+    String property = getProperty(PropertyNames.OUTPUT_PATHS_TAR);
     if (property != null) {
       return Paths.get(property);
     }
-    return outputFiles.tar == null
+    return outputPaths.tar == null
         ? Paths.get(Preconditions.checkNotNull(project).getBuild().getDirectory())
             .resolve("jib-image.tar")
-        : outputFiles.tar.toPath();
+        : outputPaths.tar.toPath();
   }
 
   Path getDigestOutputPath() {
-    String property = getProperty(PropertyNames.OUTPUT_FILES_DIGEST);
+    String property = getProperty(PropertyNames.OUTPUT_PATHS_DIGEST);
     if (property != null) {
       return Paths.get(property);
     }
-    return outputFiles.digest == null
+    return outputPaths.digest == null
         ? Paths.get(Preconditions.checkNotNull(project).getBuild().getDirectory())
             .resolve("jib-image.digest")
-        : outputFiles.digest.toPath();
+        : outputPaths.digest.toPath();
   }
 
   Path getIdOutputPath() {
-    String property = getProperty(PropertyNames.OUTPUT_FILES_ID);
+    String property = getProperty(PropertyNames.OUTPUT_PATHS_IMAGE_ID);
     if (property != null) {
       return Paths.get(property);
     }
-    return outputFiles.id == null
+    return outputPaths.imageId == null
         ? Paths.get(Preconditions.checkNotNull(project).getBuild().getDirectory())
             .resolve("jib-image.id")
-        : outputFiles.id.toPath();
+        : outputPaths.imageId.toPath();
   }
 
   boolean getAllowInsecureRegistries() {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
@@ -202,7 +202,7 @@ class MavenRawConfiguration implements RawConfiguration {
   }
 
   @Override
-  public Path getIdOutputPath() {
-    return jibPluginConfiguration.getIdOutputPath();
+  public Path getImageIdOutputPath() {
+    return jibPluginConfiguration.getImageIdOutputPath();
   }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
@@ -190,4 +190,19 @@ class MavenRawConfiguration implements RawConfiguration {
   public String getContainerizingMode() {
     return jibPluginConfiguration.getContainerizingMode();
   }
+
+  @Override
+  public Path getTarOutputPath() {
+    return jibPluginConfiguration.getTarOutputPath();
+  }
+
+  @Override
+  public Path getDigestOutputPath() {
+    return jibPluginConfiguration.getDigestOutputPath();
+  }
+
+  @Override
+  public Path getIdOutputPath() {
+    return jibPluginConfiguration.getIdOutputPath();
+  }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
@@ -154,7 +154,7 @@ public class JibPluginConfigurationTest {
     sessionProperties.put("jib.outputPaths.digest", "digest/path");
     Assert.assertEquals(Paths.get("digest/path"), testPluginConfiguration.getDigestOutputPath());
     sessionProperties.put("jib.outputPaths.imageId", "id/path");
-    Assert.assertEquals(Paths.get("id/path"), testPluginConfiguration.getIdOutputPath());
+    Assert.assertEquals(Paths.get("id/path"), testPluginConfiguration.getImageIdOutputPath());
     sessionProperties.put("jib.outputPaths.tar", "tar/path");
     Assert.assertEquals(Paths.get("tar/path"), testPluginConfiguration.getTarOutputPath());
   }
@@ -244,7 +244,7 @@ public class JibPluginConfigurationTest {
     project.getProperties().setProperty("jib.outputPaths.digest", "digest/path");
     Assert.assertEquals(Paths.get("digest/path"), testPluginConfiguration.getDigestOutputPath());
     project.getProperties().setProperty("jib.outputPaths.imageId", "id/path");
-    Assert.assertEquals(Paths.get("id/path"), testPluginConfiguration.getIdOutputPath());
+    Assert.assertEquals(Paths.get("id/path"), testPluginConfiguration.getImageIdOutputPath());
     project.getProperties().setProperty("jib.outputPaths.tar", "tar/path");
     Assert.assertEquals(Paths.get("tar/path"), testPluginConfiguration.getTarOutputPath());
   }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
@@ -151,11 +151,11 @@ public class JibPluginConfigurationTest {
         ImmutableMap.of("env1", "val1", "env2", "val2"),
         testPluginConfiguration.getDockerClientEnvironment());
 
-    sessionProperties.put("jib.outputFiles.digest", "digest/path");
+    sessionProperties.put("jib.outputPaths.digest", "digest/path");
     Assert.assertEquals(Paths.get("digest/path"), testPluginConfiguration.getDigestOutputPath());
-    sessionProperties.put("jib.outputFiles.id", "id/path");
+    sessionProperties.put("jib.outputPaths.imageId", "id/path");
     Assert.assertEquals(Paths.get("id/path"), testPluginConfiguration.getIdOutputPath());
-    sessionProperties.put("jib.outputFiles.tar", "tar/path");
+    sessionProperties.put("jib.outputPaths.tar", "tar/path");
     Assert.assertEquals(Paths.get("tar/path"), testPluginConfiguration.getTarOutputPath());
   }
 
@@ -241,11 +241,11 @@ public class JibPluginConfigurationTest {
         ImmutableMap.of("env1", "val1", "env2", "val2"),
         testPluginConfiguration.getDockerClientEnvironment());
 
-    project.getProperties().setProperty("jib.outputFiles.digest", "digest/path");
+    project.getProperties().setProperty("jib.outputPaths.digest", "digest/path");
     Assert.assertEquals(Paths.get("digest/path"), testPluginConfiguration.getDigestOutputPath());
-    project.getProperties().setProperty("jib.outputFiles.id", "id/path");
+    project.getProperties().setProperty("jib.outputPaths.imageId", "id/path");
     Assert.assertEquals(Paths.get("id/path"), testPluginConfiguration.getIdOutputPath());
-    project.getProperties().setProperty("jib.outputFiles.tar", "tar/path");
+    project.getProperties().setProperty("jib.outputPaths.tar", "tar/path");
     Assert.assertEquals(Paths.get("tar/path"), testPluginConfiguration.getTarOutputPath());
   }
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
@@ -150,6 +150,13 @@ public class JibPluginConfigurationTest {
     Assert.assertEquals(
         ImmutableMap.of("env1", "val1", "env2", "val2"),
         testPluginConfiguration.getDockerClientEnvironment());
+
+    sessionProperties.put("jib.outputFiles.digest", "digest/path");
+    Assert.assertEquals(Paths.get("digest/path"), testPluginConfiguration.getDigestOutputPath());
+    sessionProperties.put("jib.outputFiles.id", "id/path");
+    Assert.assertEquals(Paths.get("id/path"), testPluginConfiguration.getIdOutputPath());
+    sessionProperties.put("jib.outputFiles.tar", "tar/path");
+    Assert.assertEquals(Paths.get("tar/path"), testPluginConfiguration.getTarOutputPath());
   }
 
   @Test
@@ -233,6 +240,13 @@ public class JibPluginConfigurationTest {
     Assert.assertEquals(
         ImmutableMap.of("env1", "val1", "env2", "val2"),
         testPluginConfiguration.getDockerClientEnvironment());
+
+    project.getProperties().setProperty("jib.outputFiles.digest", "digest/path");
+    Assert.assertEquals(Paths.get("digest/path"), testPluginConfiguration.getDigestOutputPath());
+    project.getProperties().setProperty("jib.outputFiles.id", "id/path");
+    Assert.assertEquals(Paths.get("id/path"), testPluginConfiguration.getIdOutputPath());
+    project.getProperties().setProperty("jib.outputFiles.tar", "tar/path");
+    Assert.assertEquals(Paths.get("tar/path"), testPluginConfiguration.getTarOutputPath());
   }
 
   @Test

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenRawConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenRawConfigurationTest.java
@@ -83,7 +83,7 @@ public class MavenRawConfigurationTest {
     Mockito.when(jibPluginConfiguration.getDockerClientEnvironment())
         .thenReturn(new HashMap<>(ImmutableMap.of("docker", "client")));
     Mockito.when(jibPluginConfiguration.getDigestOutputPath()).thenReturn(Paths.get("digest/path"));
-    Mockito.when(jibPluginConfiguration.getIdOutputPath()).thenReturn(Paths.get("id/path"));
+    Mockito.when(jibPluginConfiguration.getImageIdOutputPath()).thenReturn(Paths.get("id/path"));
     Mockito.when(jibPluginConfiguration.getTarOutputPath()).thenReturn(Paths.get("tar/path"));
 
     MavenRawConfiguration rawConfiguration = new MavenRawConfiguration(jibPluginConfiguration);
@@ -119,7 +119,7 @@ public class MavenRawConfigurationTest {
         new HashMap<>(ImmutableMap.of("docker", "client")),
         rawConfiguration.getDockerEnvironment());
     Assert.assertEquals(Paths.get("digest/path"), jibPluginConfiguration.getDigestOutputPath());
-    Assert.assertEquals(Paths.get("id/path"), jibPluginConfiguration.getIdOutputPath());
+    Assert.assertEquals(Paths.get("id/path"), jibPluginConfiguration.getImageIdOutputPath());
     Assert.assertEquals(Paths.get("tar/path"), jibPluginConfiguration.getTarOutputPath());
 
     Mockito.verifyNoMoreInteractions(eventHandlers);

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenRawConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenRawConfigurationTest.java
@@ -82,6 +82,9 @@ public class MavenRawConfigurationTest {
     Mockito.when(jibPluginConfiguration.getDockerClientExecutable()).thenReturn(Paths.get("test"));
     Mockito.when(jibPluginConfiguration.getDockerClientEnvironment())
         .thenReturn(new HashMap<>(ImmutableMap.of("docker", "client")));
+    Mockito.when(jibPluginConfiguration.getDigestOutputPath()).thenReturn(Paths.get("digest/path"));
+    Mockito.when(jibPluginConfiguration.getIdOutputPath()).thenReturn(Paths.get("id/path"));
+    Mockito.when(jibPluginConfiguration.getTarOutputPath()).thenReturn(Paths.get("tar/path"));
 
     MavenRawConfiguration rawConfiguration = new MavenRawConfiguration(jibPluginConfiguration);
 
@@ -115,6 +118,9 @@ public class MavenRawConfigurationTest {
     Assert.assertEquals(
         new HashMap<>(ImmutableMap.of("docker", "client")),
         rawConfiguration.getDockerEnvironment());
+    Assert.assertEquals(Paths.get("digest/path"), jibPluginConfiguration.getDigestOutputPath());
+    Assert.assertEquals(Paths.get("id/path"), jibPluginConfiguration.getIdOutputPath());
+    Assert.assertEquals(Paths.get("tar/path"), jibPluginConfiguration.getTarOutputPath());
 
     Mockito.verifyNoMoreInteractions(eventHandlers);
   }

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex.xml
@@ -97,7 +97,7 @@
           </extraDirectory>
           <outputPaths>
             <digest>${project.build.directory}/different-jib-image.digest</digest>
-            <imageId>${project.build.directory}/different-jib-image.id</imageId>
+            <imageId>different-jib-image.id</imageId>
           </outputPaths>
           <allowInsecureRegistries>true</allowInsecureRegistries>
         </configuration>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex.xml
@@ -95,10 +95,10 @@
               </permission>
             </permissions>
           </extraDirectory>
-          <outputFiles>
+          <outputPaths>
             <digest>${project.build.directory}/different-jib-image.digest</digest>
-            <id>${project.build.directory}/different-jib-image.id</id>
-          </outputFiles>
+            <imageId>${project.build.directory}/different-jib-image.id</imageId>
+          </outputPaths>
           <allowInsecureRegistries>true</allowInsecureRegistries>
         </configuration>
       </plugin>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-complex.xml
@@ -95,6 +95,10 @@
               </permission>
             </permissions>
           </extraDirectory>
+          <outputFiles>
+            <digest>${project.build.directory}/different-jib-image.digest</digest>
+            <id>${project.build.directory}/different-jib-image.id</id>
+          </outputFiles>
           <allowInsecureRegistries>true</allowInsecureRegistries>
         </configuration>
       </plugin>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom.xml
@@ -60,9 +60,9 @@
             <workingDirectory>/home</workingDirectory>
           </container>
           <extraDirectory>${project.basedir}/src/main/jib-custom</extraDirectory>
-          <outputFiles>
+          <outputPaths>
             <tar>${project.build.directory}/different-jib-image.tar</tar>
-          </outputFiles>
+          </outputPaths>
         </configuration>
       </plugin>
     </plugins>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom.xml
@@ -60,6 +60,9 @@
             <workingDirectory>/home</workingDirectory>
           </container>
           <extraDirectory>${project.basedir}/src/main/jib-custom</extraDirectory>
+          <outputFiles>
+            <tar>${project.basedir}/different-jib-image.tar</tar>
+          </outputFiles>
         </configuration>
       </plugin>
     </plugins>

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom.xml
@@ -61,7 +61,7 @@
           </container>
           <extraDirectory>${project.basedir}/src/main/jib-custom</extraDirectory>
           <outputFiles>
-            <tar>${project.basedir}/different-jib-image.tar</tar>
+            <tar>${project.build.directory}/different-jib-image.tar</tar>
           </outputFiles>
         </configuration>
       </plugin>

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -87,8 +87,8 @@ public class PluginConfigurationProcessor {
             helpfulSuggestions,
             targetImageReference,
             rawConfiguration.getToTags())
-        .writeImageDigest(projectProperties.getOutputDirectory().resolve("jib-image.digest"))
-        .writeImageId(projectProperties.getOutputDirectory().resolve("jib-image.id"));
+        .writeImageDigest(rawConfiguration.getDigestOutputPath())
+        .writeImageId(rawConfiguration.getIdOutputPath());
   }
 
   public static JibBuildRunner createJibBuildRunnerForTarImage(
@@ -101,10 +101,10 @@ public class PluginConfigurationProcessor {
           IncompatibleBaseImageJavaVersionException, NumberFormatException,
           InvalidContainerizingModeException, InvalidFilesModificationTimeException,
           InvalidCreationTimeException {
-    Path tarImagePath = projectProperties.getOutputDirectory().resolve("jib-image.tar");
     ImageReference targetImageReference =
         getGeneratedTargetDockerTag(rawConfiguration, projectProperties, helpfulSuggestions);
-    TarImage targetImage = TarImage.at(tarImagePath).named(targetImageReference);
+    TarImage targetImage =
+        TarImage.at(rawConfiguration.getTarOutputPath()).named(targetImageReference);
 
     Containerizer containerizer = Containerizer.to(targetImage);
     JibContainerBuilder jibContainerBuilder =
@@ -116,9 +116,9 @@ public class PluginConfigurationProcessor {
             containerizer,
             projectProperties::log,
             helpfulSuggestions,
-            tarImagePath)
-        .writeImageDigest(projectProperties.getOutputDirectory().resolve("jib-image.digest"))
-        .writeImageId(projectProperties.getOutputDirectory().resolve("jib-image.id"));
+            rawConfiguration.getTarOutputPath())
+        .writeImageDigest(rawConfiguration.getDigestOutputPath())
+        .writeImageId(rawConfiguration.getIdOutputPath());
   }
 
   public static JibBuildRunner createJibBuildRunnerForRegistryImage(
@@ -162,8 +162,8 @@ public class PluginConfigurationProcessor {
             helpfulSuggestions,
             targetImageReference,
             rawConfiguration.getToTags())
-        .writeImageDigest(projectProperties.getOutputDirectory().resolve("jib-image.digest"))
-        .writeImageId(projectProperties.getOutputDirectory().resolve("jib-image.id"));
+        .writeImageDigest(rawConfiguration.getDigestOutputPath())
+        .writeImageId(rawConfiguration.getIdOutputPath());
   }
 
   @VisibleForTesting

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -88,7 +88,7 @@ public class PluginConfigurationProcessor {
             targetImageReference,
             rawConfiguration.getToTags())
         .writeImageDigest(rawConfiguration.getDigestOutputPath())
-        .writeImageId(rawConfiguration.getIdOutputPath());
+        .writeImageId(rawConfiguration.getImageIdOutputPath());
   }
 
   public static JibBuildRunner createJibBuildRunnerForTarImage(
@@ -118,7 +118,7 @@ public class PluginConfigurationProcessor {
             helpfulSuggestions,
             rawConfiguration.getTarOutputPath())
         .writeImageDigest(rawConfiguration.getDigestOutputPath())
-        .writeImageId(rawConfiguration.getIdOutputPath());
+        .writeImageId(rawConfiguration.getImageIdOutputPath());
   }
 
   public static JibBuildRunner createJibBuildRunnerForRegistryImage(
@@ -163,7 +163,7 @@ public class PluginConfigurationProcessor {
             targetImageReference,
             rawConfiguration.getToTags())
         .writeImageDigest(rawConfiguration.getDigestOutputPath())
-        .writeImageId(rawConfiguration.getIdOutputPath());
+        .writeImageId(rawConfiguration.getImageIdOutputPath());
   }
 
   @VisibleForTesting

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
@@ -53,9 +53,9 @@ public class PropertyNames {
   public static final String EXTRA_DIRECTORIES_PERMISSIONS = "jib.extraDirectories.permissions";
   public static final String DOCKER_CLIENT_EXECUTABLE = "jib.dockerClient.executable";
   public static final String DOCKER_CLIENT_ENVIRONMENT = "jib.dockerClient.environment";
-  public static final String OUTPUT_FILES_DIGEST = "jib.outputFiles.digest";
-  public static final String OUTPUT_FILES_ID = "jib.outputFiles.id";
-  public static final String OUTPUT_FILES_TAR = "jib.outputFiles.tar";
+  public static final String OUTPUT_PATHS_DIGEST = "jib.outputPaths.digest";
+  public static final String OUTPUT_PATHS_IMAGE_ID = "jib.outputPaths.imageId";
+  public static final String OUTPUT_PATHS_TAR = "jib.outputPaths.tar";
   public static final String CONTAINERIZING_MODE = "jib.containerizingMode";
   public static final String SKIP = "jib.skip";
   public static final String CONSOLE = "jib.console";

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
@@ -53,6 +53,9 @@ public class PropertyNames {
   public static final String EXTRA_DIRECTORIES_PERMISSIONS = "jib.extraDirectories.permissions";
   public static final String DOCKER_CLIENT_EXECUTABLE = "jib.dockerClient.executable";
   public static final String DOCKER_CLIENT_ENVIRONMENT = "jib.dockerClient.environment";
+  public static final String OUTPUT_FILES_DIGEST = "jib.outputFiles.digest";
+  public static final String OUTPUT_FILES_ID = "jib.outputFiles.id";
+  public static final String OUTPUT_FILES_TAR = "jib.outputFiles.tar";
   public static final String CONTAINERIZING_MODE = "jib.containerizingMode";
   public static final String SKIP = "jib.skip";
   public static final String CONSOLE = "jib.console";

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
@@ -96,5 +96,5 @@ public interface RawConfiguration {
 
   Path getDigestOutputPath();
 
-  Path getIdOutputPath();
+  Path getImageIdOutputPath();
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
@@ -91,4 +91,10 @@ public interface RawConfiguration {
   Map<String, String> getDockerEnvironment();
 
   String getContainerizingMode();
+
+  Path getTarOutputPath();
+
+  Path getDigestOutputPath();
+
+  Path getIdOutputPath();
 }


### PR DESCRIPTION
Fixes #1561.

Adds `outputPaths` configuration block with `tar`, `digest`, and `imageId` fields for setting output file locations.