### PR TITLE
Upgrade commons-compress to 1.19

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ subprojects {
     GOOGLE_AUTH_LIBRARY_OAUTH2_HTTP: '0.16.2',
     GUAVA: '28.0-jre',
 
-    COMMONS_COMPRESS: '1.18',
+    COMMONS_COMPRESS: '1.19',
     JACKSON_DATABIND: '2.9.9.2',
     ASM: '7.1',
 


### PR DESCRIPTION
There is a denial of service vulnerability in commons-compress 1.15 through 1.18. Apache recommends upgrading to 1.19 to mitigate. For reference, see here: https://lists.apache.org/thread.html/308cc15f1f1dc53e97046fddbac240e6cd16de89a2746cf257be7f5b@%3Cdev.commons.apache.org%3E

Fixes #2029
