### PR TITLE
Upgrade jackson-databind to 2.9.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects {
     GUAVA: '28.0-jre',
 
     COMMONS_COMPRESS: '1.19',
-    JACKSON_DATABIND: '2.9.9.2',
+    JACKSON_DATABIND: '2.9.10',
     ASM: '7.1',
 
     //test


### PR DESCRIPTION
jackson-databind 2.9.9.2 is vulnerable to several deserialization vulnerabilities. The latest stable version of 2.9 (2.9.10) mitigates these.

Fixes #2031 
