### PR TITLE
Don't pass redundant parameter

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -443,12 +443,6 @@ public class RegistryClient {
     return repositoryGrants == null || repositoryGrants.containsEntry(repository, "pull");
   }
 
-  /** @return the registry endpoint's API root, without the protocol */
-  @VisibleForTesting
-  String getApiRouteBase() {
-    return registryEndpointRequestProperties.getServerUrl() + "/v2/";
-  }
-
   @VisibleForTesting
   String getUserAgent() {
     return userAgent;
@@ -466,7 +460,6 @@ public class RegistryClient {
     return new RegistryEndpointCaller<>(
             eventHandlers,
             userAgent,
-            getApiRouteBase(),
             registryEndpointProvider,
             authorization,
             registryEndpointRequestProperties,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -56,8 +56,6 @@ class RegistryEndpointCaller<T> {
    */
   @VisibleForTesting static final int STATUS_CODE_PERMANENT_REDIRECT = 308;
 
-  private static final String DEFAULT_PROTOCOL = "https";
-
   private static boolean isHttpsProtocol(URL url) {
     return "https".equals(url.getProtocol());
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -81,7 +81,6 @@ class RegistryEndpointCaller<T> {
   }
 
   private final EventHandlers eventHandlers;
-  private final URL initialRequestUrl;
   private final String userAgent;
   private final RegistryEndpointProvider<T> registryEndpointProvider;
   @Nullable private final Authorization authorization;
@@ -99,7 +98,6 @@ class RegistryEndpointCaller<T> {
    *
    * @param eventHandlers the event dispatcher used for dispatching log events
    * @param userAgent {@code User-Agent} header to send with the request
-   * @param apiRouteBase the endpoint's API root, without the protocol
    * @param registryEndpointProvider the {@link RegistryEndpointProvider} to the endpoint
    * @param authorization optional authentication credentials to use
    * @param registryEndpointRequestProperties properties of the registry endpoint request
@@ -109,7 +107,6 @@ class RegistryEndpointCaller<T> {
   RegistryEndpointCaller(
       EventHandlers eventHandlers,
       String userAgent,
-      String apiRouteBase,
       RegistryEndpointProvider<T> registryEndpointProvider,
       @Nullable Authorization authorization,
       RegistryEndpointRequestProperties registryEndpointRequestProperties,
@@ -118,7 +115,6 @@ class RegistryEndpointCaller<T> {
     this(
         eventHandlers,
         userAgent,
-        apiRouteBase,
         registryEndpointProvider,
         authorization,
         registryEndpointRequestProperties,
@@ -131,7 +127,6 @@ class RegistryEndpointCaller<T> {
   RegistryEndpointCaller(
       EventHandlers eventHandlers,
       String userAgent,
-      String apiRouteBase,
       RegistryEndpointProvider<T> registryEndpointProvider,
       @Nullable Authorization authorization,
       RegistryEndpointRequestProperties registryEndpointRequestProperties,
@@ -140,8 +135,6 @@ class RegistryEndpointCaller<T> {
       @Nullable Function<URL, Connection> insecureConnectionFactory)
       throws MalformedURLException {
     this.eventHandlers = eventHandlers;
-    this.initialRequestUrl =
-        registryEndpointProvider.getApiRoute(DEFAULT_PROTOCOL + "://" + apiRouteBase);
     this.userAgent = userAgent;
     this.registryEndpointProvider = registryEndpointProvider;
     this.authorization = authorization;
@@ -160,6 +153,8 @@ class RegistryEndpointCaller<T> {
    */
   T call() throws IOException, RegistryException {
     try {
+      String apiRouteBase = "https://" + registryEndpointRequestProperties.getServerUrl() + "/v2/";
+      URL initialRequestUrl = registryEndpointProvider.getApiRoute(apiRouteBase);
       return callWithAllowInsecureRegistryHandling(initialRequestUrl);
 
     } catch (IOException ex) {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
@@ -89,14 +89,4 @@ public class RegistryClientTest {
     Assert.assertTrue(registryClient.getUserAgent().startsWith("jib "));
     Assert.assertTrue(registryClient.getUserAgent().endsWith(" skaffold/0.34.0"));
   }
-
-  @Test
-  public void testGetApiRouteBase() {
-    Assert.assertEquals(
-        "some.server.url/v2/",
-        testRegistryClientFactory
-            .setAllowInsecureRegistries(true)
-            .newRegistryClient()
-            .getApiRouteBase());
-  }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
@@ -146,7 +146,7 @@ public class RegistryEndpointCallerTest {
       Assert.fail("Secure caller should fail if cannot verify server");
     } catch (InsecureRegistryException ex) {
       Assert.assertEquals(
-          "Failed to verify the server at https://apiRouteBase/api because only secure connections are allowed.",
+          "Failed to verify the server at https://serverUrl/v2//api because only secure connections are allowed.",
           ex.getMessage());
     }
   }
@@ -163,10 +163,10 @@ public class RegistryEndpointCallerTest {
 
     ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(0));
 
     Mockito.verify(mockInsecureConnectionFactory).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(1));
+    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(1));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);
     Mockito.verifyNoMoreInteractions(mockInsecureConnectionFactory);
@@ -174,7 +174,7 @@ public class RegistryEndpointCallerTest {
     Mockito.verify(mockEventHandlers)
         .dispatch(
             LogEvent.info(
-                "Cannot verify server at https://apiRouteBase/api. Attempting again with no TLS verification."));
+                "Cannot verify server at https://serverUrl/v2//api. Attempting again with no TLS verification."));
   }
 
   @Test
@@ -190,11 +190,11 @@ public class RegistryEndpointCallerTest {
 
     ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory, Mockito.times(2)).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(0));
-    Assert.assertEquals(new URL("http://apiRouteBase/api"), urlCaptor.getAllValues().get(1));
+    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("http://serverUrl/v2//api"), urlCaptor.getAllValues().get(1));
 
     Mockito.verify(mockInsecureConnectionFactory).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(2));
+    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(2));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);
     Mockito.verifyNoMoreInteractions(mockInsecureConnectionFactory);
@@ -202,11 +202,11 @@ public class RegistryEndpointCallerTest {
     Mockito.verify(mockEventHandlers)
         .dispatch(
             LogEvent.info(
-                "Cannot verify server at https://apiRouteBase/api. Attempting again with no TLS verification."));
+                "Cannot verify server at https://serverUrl/v2//api. Attempting again with no TLS verification."));
     Mockito.verify(mockEventHandlers)
         .dispatch(
             LogEvent.info(
-                "Failed to connect to https://apiRouteBase/api over HTTPS. Attempting again with HTTP: http://apiRouteBase/api"));
+                "Failed to connect to https://serverUrl/v2//api over HTTPS. Attempting again with HTTP: http://serverUrl/v2//api"));
   }
 
   @Test
@@ -221,8 +221,8 @@ public class RegistryEndpointCallerTest {
 
     ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory, Mockito.times(2)).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(0));
-    Assert.assertEquals(new URL("http://apiRouteBase/api"), urlCaptor.getAllValues().get(1));
+    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("http://serverUrl/v2//api"), urlCaptor.getAllValues().get(1));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);
     Mockito.verifyNoMoreInteractions(mockInsecureConnectionFactory);
@@ -230,7 +230,7 @@ public class RegistryEndpointCallerTest {
     Mockito.verify(mockEventHandlers)
         .dispatch(
             LogEvent.info(
-                "Failed to connect to https://apiRouteBase/api over HTTPS. Attempting again with HTTP: http://apiRouteBase/api"));
+                "Failed to connect to https://serverUrl/v2//api over HTTPS. Attempting again with HTTP: http://serverUrl/v2//api"));
   }
 
   @Test
@@ -248,7 +248,7 @@ public class RegistryEndpointCallerTest {
 
     ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(0));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);
     Mockito.verifyNoMoreInteractions(mockInsecureConnectionFactory);
@@ -271,7 +271,7 @@ public class RegistryEndpointCallerTest {
 
     ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://apiRouteBase:5000/api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("https://serverUrl:5000/v2//api"), urlCaptor.getAllValues().get(0));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);
     Mockito.verifyNoMoreInteractions(mockInsecureConnectionFactory);
@@ -360,12 +360,12 @@ public class RegistryEndpointCallerTest {
 
     ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory, Mockito.times(3)).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(0));
-    Assert.assertEquals(new URL("http://apiRouteBase/api"), urlCaptor.getAllValues().get(1));
+    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("http://serverUrl/v2//api"), urlCaptor.getAllValues().get(1));
     Assert.assertEquals(new URL("http://newlocation"), urlCaptor.getAllValues().get(2));
 
     Mockito.verify(mockInsecureConnectionFactory).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://apiRouteBase/api"), urlCaptor.getAllValues().get(3));
+    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(3));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);
     Mockito.verifyNoMoreInteractions(mockInsecureConnectionFactory);
@@ -373,11 +373,11 @@ public class RegistryEndpointCallerTest {
     Mockito.verify(mockEventHandlers)
         .dispatch(
             LogEvent.info(
-                "Cannot verify server at https://apiRouteBase/api. Attempting again with no TLS verification."));
+                "Cannot verify server at https://serverUrl/v2//api. Attempting again with no TLS verification."));
     Mockito.verify(mockEventHandlers)
         .dispatch(
             LogEvent.info(
-                "Failed to connect to https://apiRouteBase/api over HTTPS. Attempting again with HTTP: http://apiRouteBase/api"));
+                "Failed to connect to https://serverUrl/v2//api over HTTPS. Attempting again with HTTP: http://serverUrl/v2//api"));
   }
 
   @Test
@@ -693,7 +693,7 @@ public class RegistryEndpointCallerTest {
     ArgumentCaptor<URL> urlArgumentCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory, Mockito.times(2)).apply(urlArgumentCaptor.capture());
     Assert.assertEquals(
-        new URL("https://apiRouteBase/api"), urlArgumentCaptor.getAllValues().get(0));
+        new URL("https://serverUrl/v2//api"), urlArgumentCaptor.getAllValues().get(0));
     Assert.assertEquals(new URL("https://newlocation"), urlArgumentCaptor.getAllValues().get(1));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);
@@ -705,10 +705,10 @@ public class RegistryEndpointCallerTest {
     return new RegistryEndpointCaller<>(
         mockEventHandlers,
         "userAgent",
-        (port == -1) ? "apiRouteBase" : ("apiRouteBase:" + port),
         new TestRegistryEndpointProvider(),
         Authorization.fromBasicToken("token"),
-        new RegistryEndpointRequestProperties("serverUrl", "imageName"),
+        new RegistryEndpointRequestProperties(
+            (port == -1 ? "serverUrl" : "serverUrl:" + port), "imageName"),
         allowInsecure,
         mockConnectionFactory,
         mockInsecureConnectionFactory);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
@@ -73,7 +73,7 @@ public class RegistryEndpointCallerTest {
 
     @Override
     public URL getApiRoute(String apiRouteBase) throws MalformedURLException {
-      return new URL(apiRouteBase + "/api");
+      return new URL(apiRouteBase + "api");
     }
 
     @Nullable
@@ -146,7 +146,7 @@ public class RegistryEndpointCallerTest {
       Assert.fail("Secure caller should fail if cannot verify server");
     } catch (InsecureRegistryException ex) {
       Assert.assertEquals(
-          "Failed to verify the server at https://serverUrl/v2//api because only secure connections are allowed.",
+          "Failed to verify the server at https://serverUrl/v2/api because only secure connections are allowed.",
           ex.getMessage());
     }
   }
@@ -163,10 +163,10 @@ public class RegistryEndpointCallerTest {
 
     ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("https://serverUrl/v2/api"), urlCaptor.getAllValues().get(0));
 
     Mockito.verify(mockInsecureConnectionFactory).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(1));
+    Assert.assertEquals(new URL("https://serverUrl/v2/api"), urlCaptor.getAllValues().get(1));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);
     Mockito.verifyNoMoreInteractions(mockInsecureConnectionFactory);
@@ -174,7 +174,7 @@ public class RegistryEndpointCallerTest {
     Mockito.verify(mockEventHandlers)
         .dispatch(
             LogEvent.info(
-                "Cannot verify server at https://serverUrl/v2//api. Attempting again with no TLS verification."));
+                "Cannot verify server at https://serverUrl/v2/api. Attempting again with no TLS verification."));
   }
 
   @Test
@@ -190,11 +190,11 @@ public class RegistryEndpointCallerTest {
 
     ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory, Mockito.times(2)).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(0));
-    Assert.assertEquals(new URL("http://serverUrl/v2//api"), urlCaptor.getAllValues().get(1));
+    Assert.assertEquals(new URL("https://serverUrl/v2/api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("http://serverUrl/v2/api"), urlCaptor.getAllValues().get(1));
 
     Mockito.verify(mockInsecureConnectionFactory).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(2));
+    Assert.assertEquals(new URL("https://serverUrl/v2/api"), urlCaptor.getAllValues().get(2));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);
     Mockito.verifyNoMoreInteractions(mockInsecureConnectionFactory);
@@ -202,11 +202,11 @@ public class RegistryEndpointCallerTest {
     Mockito.verify(mockEventHandlers)
         .dispatch(
             LogEvent.info(
-                "Cannot verify server at https://serverUrl/v2//api. Attempting again with no TLS verification."));
+                "Cannot verify server at https://serverUrl/v2/api. Attempting again with no TLS verification."));
     Mockito.verify(mockEventHandlers)
         .dispatch(
             LogEvent.info(
-                "Failed to connect to https://serverUrl/v2//api over HTTPS. Attempting again with HTTP: http://serverUrl/v2//api"));
+                "Failed to connect to https://serverUrl/v2/api over HTTPS. Attempting again with HTTP: http://serverUrl/v2/api"));
   }
 
   @Test
@@ -221,8 +221,8 @@ public class RegistryEndpointCallerTest {
 
     ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory, Mockito.times(2)).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(0));
-    Assert.assertEquals(new URL("http://serverUrl/v2//api"), urlCaptor.getAllValues().get(1));
+    Assert.assertEquals(new URL("https://serverUrl/v2/api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("http://serverUrl/v2/api"), urlCaptor.getAllValues().get(1));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);
     Mockito.verifyNoMoreInteractions(mockInsecureConnectionFactory);
@@ -230,7 +230,7 @@ public class RegistryEndpointCallerTest {
     Mockito.verify(mockEventHandlers)
         .dispatch(
             LogEvent.info(
-                "Failed to connect to https://serverUrl/v2//api over HTTPS. Attempting again with HTTP: http://serverUrl/v2//api"));
+                "Failed to connect to https://serverUrl/v2/api over HTTPS. Attempting again with HTTP: http://serverUrl/v2/api"));
   }
 
   @Test
@@ -248,7 +248,7 @@ public class RegistryEndpointCallerTest {
 
     ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("https://serverUrl/v2/api"), urlCaptor.getAllValues().get(0));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);
     Mockito.verifyNoMoreInteractions(mockInsecureConnectionFactory);
@@ -271,7 +271,7 @@ public class RegistryEndpointCallerTest {
 
     ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://serverUrl:5000/v2//api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("https://serverUrl:5000/v2/api"), urlCaptor.getAllValues().get(0));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);
     Mockito.verifyNoMoreInteractions(mockInsecureConnectionFactory);
@@ -360,12 +360,12 @@ public class RegistryEndpointCallerTest {
 
     ArgumentCaptor<URL> urlCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory, Mockito.times(3)).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(0));
-    Assert.assertEquals(new URL("http://serverUrl/v2//api"), urlCaptor.getAllValues().get(1));
+    Assert.assertEquals(new URL("https://serverUrl/v2/api"), urlCaptor.getAllValues().get(0));
+    Assert.assertEquals(new URL("http://serverUrl/v2/api"), urlCaptor.getAllValues().get(1));
     Assert.assertEquals(new URL("http://newlocation"), urlCaptor.getAllValues().get(2));
 
     Mockito.verify(mockInsecureConnectionFactory).apply(urlCaptor.capture());
-    Assert.assertEquals(new URL("https://serverUrl/v2//api"), urlCaptor.getAllValues().get(3));
+    Assert.assertEquals(new URL("https://serverUrl/v2/api"), urlCaptor.getAllValues().get(3));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);
     Mockito.verifyNoMoreInteractions(mockInsecureConnectionFactory);
@@ -373,11 +373,11 @@ public class RegistryEndpointCallerTest {
     Mockito.verify(mockEventHandlers)
         .dispatch(
             LogEvent.info(
-                "Cannot verify server at https://serverUrl/v2//api. Attempting again with no TLS verification."));
+                "Cannot verify server at https://serverUrl/v2/api. Attempting again with no TLS verification."));
     Mockito.verify(mockEventHandlers)
         .dispatch(
             LogEvent.info(
-                "Failed to connect to https://serverUrl/v2//api over HTTPS. Attempting again with HTTP: http://serverUrl/v2//api"));
+                "Failed to connect to https://serverUrl/v2/api over HTTPS. Attempting again with HTTP: http://serverUrl/v2/api"));
   }
 
   @Test
@@ -693,7 +693,7 @@ public class RegistryEndpointCallerTest {
     ArgumentCaptor<URL> urlArgumentCaptor = ArgumentCaptor.forClass(URL.class);
     Mockito.verify(mockConnectionFactory, Mockito.times(2)).apply(urlArgumentCaptor.capture());
     Assert.assertEquals(
-        new URL("https://serverUrl/v2//api"), urlArgumentCaptor.getAllValues().get(0));
+        new URL("https://serverUrl/v2/api"), urlArgumentCaptor.getAllValues().get(0));
     Assert.assertEquals(new URL("https://newlocation"), urlArgumentCaptor.getAllValues().get(1));
 
     Mockito.verifyNoMoreInteractions(mockConnectionFactory);


### PR DESCRIPTION
The API route base can be computed and is always "server URL + /v2/".

I also noted every `getApiRoute()` implementation does not put an extra leading slash, so I updated the method in tests reflect the reality more closely. An example implementation:
```java
  public URL getApiRoute(String apiRouteBase) throws MalformedURLException {
    return new URL(
        apiRouteBase + registryEndpointRequestProperties.getImageName() + "/manifests/" + imageTag);
  }
```