### PR TITLE
Upgrade ASM to 7.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ subprojects {
 
     COMMONS_COMPRESS: '1.19',
     JACKSON_DATABIND: '2.9.10',
-    ASM: '7.1',
+    ASM: '7.2',
 
     //test
     JUNIT: '4.12',

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Java 14 main class inference support. ([#2015](https://github.com/GoogleContainerTools/jib/issues/2015))
+
 ### Changed
 
 - Local base image layers are now processed in parallel, speeding up builds using large local base images. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Java 14 main class inference support. ([#2015](https://github.com/GoogleContainerTools/jib/issues/2015))
+- Main class inference support for Java 13/14. ([#2015](https://github.com/GoogleContainerTools/jib/issues/2015))
 
 ### Changed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
   - `jib.outputPaths.tar` configures output path of `jibBuildTar` (`build/jib-image.tar` by default)
   - `jib.outputPaths.digest` configures the output path of the image digest (`build/jib-image.digest` by default)
   - `jib.outputPaths.imageId` configures output path of the image id  (`build/jib-image.id` by default)
+- Java 14 main class inference support. ([#2015](https://github.com/GoogleContainerTools/jib/issues/2015))
 
 ### Changed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
   - `jib.outputPaths.tar` configures output path of `jibBuildTar` (`build/jib-image.tar` by default)
   - `jib.outputPaths.digest` configures the output path of the image digest (`build/jib-image.digest` by default)
   - `jib.outputPaths.imageId` configures output path of the image id  (`build/jib-image.id` by default)
-- Java 14 main class inference support. ([#2015](https://github.com/GoogleContainerTools/jib/issues/2015))
+- Main class inference support for Java 13/14. ([#2015](https://github.com/GoogleContainerTools/jib/issues/2015))
 
 ### Changed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
   - `<outputPaths><tar>` configures output path of `jib:buildTar` (`target/jib-image.tar` by default)
   - `<outputPaths><digest>` configures the output path of the image digest (`target/jib-image.digest` by default)
   - `<outputPaths><imageId>` configures output path of the image id  (`target/jib-image.id` by default)
-- Java 14 main class inference support. ([#2015](https://github.com/GoogleContainerTools/jib/issues/2015))
+- Main class inference support for Java 13/14. ([#2015](https://github.com/GoogleContainerTools/jib/issues/2015))
 
 ### Changed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
   - `<outputPaths><tar>` configures output path of `jib:buildTar` (`target/jib-image.tar` by default)
   - `<outputPaths><digest>` configures the output path of the image digest (`target/jib-image.digest` by default)
   - `<outputPaths><imageId>` configures output path of the image id  (`target/jib-image.id` by default)
+- Java 14 main class inference support. ([#2015](https://github.com/GoogleContainerTools/jib/issues/2015))
 
 ### Changed
 


### PR DESCRIPTION
The Java 14 support is out of beta, so we may as well update. Also adds the Java 13/14 support to the changelog.