### PR TITLE
Add cache methods for writing/reading local base image container config

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
@@ -131,7 +131,13 @@ public class Cache {
   }
 
   /**
-   * Writes a container configuration to {@code (cache directory)/local/config/(image id)}.
+   * Writes a container configuration to {@code (cache directory)/local/config/(image id)}. An image
+   * ID is a SHA hash of a container configuration JSON. The value is also shown as IMAGE ID in
+   * {@code docker images}.
+   *
+   * <p>Note: the {@code imageID} to the {@code containerConfiguration} is a one-way relationship;
+   * there is no guarantee that {@code containerConfiguration}'s SHA will be {@code imageID}, since
+   * the original container configuration is being rewritten here rather than being moved.
    *
    * @param imageId the ID of the image to store the container configuration for
    * @param containerConfiguration the container configuration
@@ -202,7 +208,14 @@ public class Cache {
   }
 
   /**
-   * Retrieves the {@link ContainerConfigurationTemplate} for the image with the given image ID.
+   * Retrieves the {@link ContainerConfigurationTemplate} for the image saved from the given image
+   * ID. An image ID is a SHA hash of a container configuration JSON. The value is also shown as
+   * IMAGE ID in {@code docker images}.
+   *
+   * <p>Note: the {@code imageID} is only used to find the {@code containerConfiguration}, and is
+   * not necessarily the actual SHA of {@code containerConfiguration}. There is no guarantee that
+   * {@code containerConfiguration}'s SHA will be {@code imageID}, since the saved container
+   * configuration is not a direct copy of the base image's original configuration.
    *
    * @param imageId the image ID
    * @return the {@link ContainerConfigurationTemplate} referenced by the image ID, if found

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
@@ -131,6 +131,19 @@ public class Cache {
   }
 
   /**
+   * Writes a container configuration to {@code (cache directory)/local/config/(image id)}.
+   *
+   * @param imageId the ID of the image to store the container configuration for
+   * @param containerConfiguration the container configuration
+   * @throws IOException if an I/O exception occurs
+   */
+  void writeLocalConfig(
+      DescriptorDigest imageId, ContainerConfigurationTemplate containerConfiguration)
+      throws IOException {
+    cacheStorageWriter.writeLocalConfig(imageId, containerConfiguration);
+  }
+
+  /**
    * Retrieves the cached manifest and container configuration for an image reference.
    *
    * @param imageReference the image reference
@@ -186,5 +199,17 @@ public class Cache {
   public Optional<CachedLayer> retrieveTarLayer(DescriptorDigest diffId)
       throws IOException, CacheCorruptedException {
     return cacheStorageReader.retrieveTarLayer(diffId);
+  }
+
+  /**
+   * Retrieves the {@link ContainerConfigurationTemplate} for the image with the given image ID.
+   *
+   * @param imageId the image ID
+   * @return the {@link ContainerConfigurationTemplate} referenced by the image ID, if found
+   * @throws IOException if an I/O exception occurs
+   */
+  public Optional<ContainerConfigurationTemplate> retrieveLocalConfig(DescriptorDigest imageId)
+      throws IOException {
+    return cacheStorageReader.retrieveLocalConfig(imageId);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
@@ -233,7 +233,11 @@ class CacheStorageReader {
   Optional<ContainerConfigurationTemplate> retrieveLocalConfig(DescriptorDigest imageId)
       throws IOException {
     Path configPath =
-        cacheStorageFiles.getLocalDirectory().resolve("config").resolve(imageId.getHash());
+        cacheStorageFiles
+            .getLocalDirectory()
+            .resolve("config")
+            .resolve(imageId.getHash())
+            .resolve("config.json");
     if (!Files.exists(configPath)) {
       return Optional.empty();
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
@@ -233,11 +233,7 @@ class CacheStorageReader {
   Optional<ContainerConfigurationTemplate> retrieveLocalConfig(DescriptorDigest imageId)
       throws IOException {
     Path configPath =
-        cacheStorageFiles
-            .getLocalDirectory()
-            .resolve("config")
-            .resolve(imageId.getHash())
-            .resolve("config.json");
+        cacheStorageFiles.getLocalDirectory().resolve("config").resolve(imageId.getHash());
     if (!Files.exists(configPath)) {
       return Optional.empty();
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
@@ -224,6 +224,26 @@ class CacheStorageReader {
   }
 
   /**
+   * Retrieves the {@link ContainerConfigurationTemplate} for the image with the given image ID.
+   *
+   * @param imageId the image ID
+   * @return the {@link ContainerConfigurationTemplate} referenced by the image ID, if found
+   * @throws IOException if an I/O exception occurs
+   */
+  Optional<ContainerConfigurationTemplate> retrieveLocalConfig(DescriptorDigest imageId)
+      throws IOException {
+    Path configPath =
+        cacheStorageFiles.getLocalDirectory().resolve("config").resolve(imageId.getHash());
+    if (!Files.exists(configPath)) {
+      return Optional.empty();
+    }
+
+    ContainerConfigurationTemplate config =
+        JsonTemplateMapper.readJsonFromFile(configPath, ContainerConfigurationTemplate.class);
+    return Optional.of(config);
+  }
+
+  /**
    * Retrieves the layer digest selected by the {@code selector}.
    *
    * @param selector the selector

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageWriter.java
@@ -333,6 +333,21 @@ class CacheStorageWriter {
   }
 
   /**
+   * Writes a container configuration to {@code (cache directory)/local/config/(image id)}.
+   *
+   * @param imageId the ID of the image to store the container configuration for
+   * @param containerConfiguration the container configuration
+   * @throws IOException if an I/O exception occurs
+   */
+  void writeLocalConfig(
+      DescriptorDigest imageId, ContainerConfigurationTemplate containerConfiguration)
+      throws IOException {
+    Path configDirectory = cacheStorageFiles.getLocalDirectory().resolve("config");
+    Files.createDirectories(configDirectory);
+    writeMetadata(containerConfiguration, configDirectory.resolve(imageId.getHash()));
+  }
+
+  /**
    * Writes a compressed {@code layerBlob} to the {@code layerDirectory}.
    *
    * @param compressedLayerBlob the compressed layer {@link Blob}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageWriter.java
@@ -342,24 +342,9 @@ class CacheStorageWriter {
   void writeLocalConfig(
       DescriptorDigest imageId, ContainerConfigurationTemplate containerConfiguration)
       throws IOException {
-    Files.createDirectories(cacheStorageFiles.getLocalDirectory().resolve("config"));
-    Files.createDirectories(cacheStorageFiles.getTemporaryDirectory());
-    try (TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider()) {
-      Path temporaryLayerDirectory =
-          tempDirectoryProvider.newDirectory(cacheStorageFiles.getTemporaryDirectory());
-      Path temporaryConfig = temporaryLayerDirectory.resolve("config.json");
-      temporaryConfig.toFile().deleteOnExit();
-
-      try (OutputStream outputStream = Files.newOutputStream(temporaryConfig)) {
-        JsonTemplateMapper.writeTo(containerConfiguration, outputStream);
-      }
-
-      // Moves the temporary directory to directory named with image ID
-      // (temp/config.json -> <imageID>/config.json)
-      Path destination =
-          cacheStorageFiles.getLocalDirectory().resolve("config").resolve(imageId.getHash());
-      moveIfDoesNotExist(temporaryLayerDirectory, destination);
-    }
+    Path configDirectory = cacheStorageFiles.getLocalDirectory().resolve("config");
+    Files.createDirectories(configDirectory);
+    writeMetadata(containerConfiguration, configDirectory.resolve(imageId.getHash()));
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageWriter.java
@@ -342,9 +342,24 @@ class CacheStorageWriter {
   void writeLocalConfig(
       DescriptorDigest imageId, ContainerConfigurationTemplate containerConfiguration)
       throws IOException {
-    Path configDirectory = cacheStorageFiles.getLocalDirectory().resolve("config");
-    Files.createDirectories(configDirectory);
-    writeMetadata(containerConfiguration, configDirectory.resolve(imageId.getHash()));
+    Files.createDirectories(cacheStorageFiles.getLocalDirectory().resolve("config"));
+    Files.createDirectories(cacheStorageFiles.getTemporaryDirectory());
+    try (TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider()) {
+      Path temporaryLayerDirectory =
+          tempDirectoryProvider.newDirectory(cacheStorageFiles.getTemporaryDirectory());
+      Path temporaryConfig = temporaryLayerDirectory.resolve("config.json");
+      temporaryConfig.toFile().deleteOnExit();
+
+      try (OutputStream outputStream = Files.newOutputStream(temporaryConfig)) {
+        JsonTemplateMapper.writeTo(containerConfiguration, outputStream);
+      }
+
+      // Moves the temporary directory to directory named with image ID
+      // (temp/config.json -> <imageID>/config.json)
+      Path destination =
+          cacheStorageFiles.getLocalDirectory().resolve("config").resolve(imageId.getHash());
+      moveIfDoesNotExist(temporaryLayerDirectory, destination);
+    }
   }
 
   /**

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageReaderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageReaderTest.java
@@ -251,12 +251,15 @@ public class CacheStorageReaderTest {
   @Test
   public void testRetrieveLocalConfig() throws IOException, URISyntaxException, DigestException {
     Path cacheDirectory = temporaryFolder.newFolder().toPath();
-    Path configDirectory = cacheDirectory.resolve("local").resolve("config");
+    Path configDirectory =
+        cacheDirectory
+            .resolve("local")
+            .resolve("config")
+            .resolve("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     Files.createDirectories(configDirectory);
     Files.copy(
         Paths.get(Resources.getResource("core/json/containerconfig.json").toURI()),
-        configDirectory.resolve(
-            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
+        configDirectory.resolve("config.json"));
 
     CacheStorageFiles cacheStorageFiles = new CacheStorageFiles(cacheDirectory);
     CacheStorageReader cacheStorageReader = new CacheStorageReader(cacheStorageFiles);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageReaderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageReaderTest.java
@@ -251,15 +251,12 @@ public class CacheStorageReaderTest {
   @Test
   public void testRetrieveLocalConfig() throws IOException, URISyntaxException, DigestException {
     Path cacheDirectory = temporaryFolder.newFolder().toPath();
-    Path configDirectory =
-        cacheDirectory
-            .resolve("local")
-            .resolve("config")
-            .resolve("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    Path configDirectory = cacheDirectory.resolve("local").resolve("config");
     Files.createDirectories(configDirectory);
     Files.copy(
         Paths.get(Resources.getResource("core/json/containerconfig.json").toURI()),
-        configDirectory.resolve("config.json"));
+        configDirectory.resolve(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
 
     CacheStorageFiles cacheStorageFiles = new CacheStorageFiles(cacheDirectory);
     CacheStorageReader cacheStorageReader = new CacheStorageReader(cacheStorageFiles);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
@@ -205,8 +205,7 @@ public class CacheStorageWriterTest {
         cacheStorageFiles
             .getLocalDirectory()
             .resolve("config")
-            .resolve("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-            .resolve("config.json");
+            .resolve("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
     Assert.assertTrue(Files.exists(savedConfigPath));
     ContainerConfigurationTemplate savedContainerConfig =
         JsonTemplateMapper.readJsonFromFile(savedConfigPath, ContainerConfigurationTemplate.class);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
@@ -205,7 +205,8 @@ public class CacheStorageWriterTest {
         cacheStorageFiles
             .getLocalDirectory()
             .resolve("config")
-            .resolve("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+            .resolve("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+            .resolve("config.json");
     Assert.assertTrue(Files.exists(savedConfigPath));
     ContainerConfigurationTemplate savedContainerConfig =
         JsonTemplateMapper.readJsonFromFile(savedConfigPath, ContainerConfigurationTemplate.class);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
@@ -34,6 +34,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.DigestException;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import org.junit.Assert;
@@ -180,6 +181,32 @@ public class CacheStorageWriterTest {
         "8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad",
         savedManifest.getContainerConfiguration().getDigest().getHash());
 
+    ContainerConfigurationTemplate savedContainerConfig =
+        JsonTemplateMapper.readJsonFromFile(savedConfigPath, ContainerConfigurationTemplate.class);
+    Assert.assertEquals("wasm", savedContainerConfig.getArchitecture());
+  }
+
+  @Test
+  public void testWriteLocalConfig() throws IOException, URISyntaxException, DigestException {
+    Path containerConfigurationJsonFile =
+        Paths.get(
+            getClass().getClassLoader().getResource("core/json/containerconfig.json").toURI());
+    ContainerConfigurationTemplate containerConfigurationTemplate =
+        JsonTemplateMapper.readJsonFromFile(
+            containerConfigurationJsonFile, ContainerConfigurationTemplate.class);
+
+    new CacheStorageWriter(cacheStorageFiles)
+        .writeLocalConfig(
+            DescriptorDigest.fromHash(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            containerConfigurationTemplate);
+
+    Path savedConfigPath =
+        cacheStorageFiles
+            .getLocalDirectory()
+            .resolve("config")
+            .resolve("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    Assert.assertTrue(Files.exists(savedConfigPath));
     ContainerConfigurationTemplate savedContainerConfig =
         JsonTemplateMapper.readJsonFromFile(savedConfigPath, ContainerConfigurationTemplate.class);
     Assert.assertEquals("wasm", savedContainerConfig.getArchitecture());


### PR DESCRIPTION
Part of `docker save` portion of #1912. Adds methods for writing/retrieving container configuration to/from the cache using an image ID.