### PR TITLE
Return both manifest and digest for pull manifest

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
@@ -44,7 +44,7 @@ public class BlobCheckerIntegrationTest {
             .setAllowInsecureRegistries(true)
             .newRegistryClient();
     V22ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V22ManifestTemplate.class);
+        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
     DescriptorDigest blobDigest = manifestTemplate.getLayers().get(0).getDigest();
 
     Assert.assertEquals(blobDigest, registryClient.checkBlob(blobDigest).get().getDigest());

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
@@ -52,7 +52,7 @@ public class BlobPullerIntegrationTest {
             .setAllowInsecureRegistries(true)
             .newRegistryClient();
     V21ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V21ManifestTemplate.class);
+        registryClient.pullManifest("latest", V21ManifestTemplate.class).getManifest();
 
     DescriptorDigest realDigest = manifestTemplate.getLayerDigests().get(0);
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -51,7 +51,7 @@ public class ManifestPullerIntegrationTest {
             .setAllowInsecureRegistries(true)
             .newRegistryClient();
     V21ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V21ManifestTemplate.class);
+        registryClient.pullManifest("latest", V21ManifestTemplate.class).getManifest();
 
     Assert.assertEquals(1, manifestTemplate.getSchemaVersion());
     Assert.assertTrue(manifestTemplate.getFsLayers().size() > 0);
@@ -61,7 +61,7 @@ public class ManifestPullerIntegrationTest {
   public void testPull_v22() throws IOException, RegistryException {
     RegistryClient registryClient =
         RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/java").newRegistryClient();
-    ManifestTemplate manifestTemplate = registryClient.pullManifest("latest");
+    ManifestTemplate manifestTemplate = registryClient.pullManifest("latest").getManifest();
 
     Assert.assertEquals(2, manifestTemplate.getSchemaVersion());
     V22ManifestTemplate v22ManifestTemplate = (V22ManifestTemplate) manifestTemplate;
@@ -78,12 +78,12 @@ public class ManifestPullerIntegrationTest {
 
     // Ensure 11-jre-slim is a manifest list
     V22ManifestListTemplate manifestListTemplate =
-        registryClient.pullManifest("11-jre-slim", V22ManifestListTemplate.class);
+        registryClient.pullManifest("11-jre-slim", V22ManifestListTemplate.class).getManifest();
     Assert.assertEquals(2, manifestListTemplate.getSchemaVersion());
     Assert.assertTrue(manifestListTemplate.getManifests().size() > 0);
 
     // Generic call to 11-jre-slim should NOT pull a manifest list (delegate to registry default)
-    ManifestTemplate manifestTemplate = registryClient.pullManifest("11-jre-slim");
+    ManifestTemplate manifestTemplate = registryClient.pullManifest("11-jre-slim").getManifest();
     Assert.assertEquals(2, manifestTemplate.getSchemaVersion());
     Assert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V22ManifestTemplate.class));
 
@@ -96,7 +96,8 @@ public class ManifestPullerIntegrationTest {
     }
 
     // Referencing a manifest list by sha256, should return a manifest list
-    ManifestTemplate sha256ManifestList = registryClient.pullManifest(KNOWN_MANIFEST_LIST_SHA);
+    ManifestTemplate sha256ManifestList =
+        registryClient.pullManifest(KNOWN_MANIFEST_LIST_SHA).getManifest();
     Assert.assertEquals(2, sha256ManifestList.getSchemaVersion());
     Assert.assertThat(sha256ManifestList, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
     Assert.assertTrue(((V22ManifestListTemplate) sha256ManifestList).getManifests().size() > 0);

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPusherIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPusherIntegrationTest.java
@@ -47,7 +47,7 @@ public class ManifestPusherIntegrationTest {
   public void testPush_missingBlobs() throws IOException, RegistryException {
     RegistryClient registryClient =
         RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/java").newRegistryClient();
-    ManifestTemplate manifestTemplate = registryClient.pullManifest("latest");
+    ManifestTemplate manifestTemplate = registryClient.pullManifest("latest").getManifest();
 
     registryClient =
         RegistryClient.factory(EventHandlers.NONE, "localhost:5000", "busybox")
@@ -101,7 +101,7 @@ public class ManifestPusherIntegrationTest {
 
     // Pulls the manifest.
     V22ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V22ManifestTemplate.class);
+        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
     Assert.assertEquals(1, manifestTemplate.getLayers().size());
     Assert.assertEquals(testLayerBlobDigest, manifestTemplate.getLayers().get(0).getDigest());
     Assert.assertNotNull(manifestTemplate.getContainerConfiguration());
@@ -111,7 +111,9 @@ public class ManifestPusherIntegrationTest {
 
     // Pulls the manifest by digest.
     V22ManifestTemplate manifestTemplateByDigest =
-        registryClient.pullManifest(imageDigest.toString(), V22ManifestTemplate.class);
+        registryClient
+            .pullManifest(imageDigest.toString(), V22ManifestTemplate.class)
+            .getManifest();
     Assert.assertEquals(
         Digests.computeJsonDigest(manifestTemplate),
         Digests.computeJsonDigest(manifestTemplateByDigest));

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ManifestAndDigest.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ManifestAndDigest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.registry;
+
+import com.google.cloud.tools.jib.api.DescriptorDigest;
+import com.google.cloud.tools.jib.image.json.ManifestTemplate;
+
+/** Stores a manifest and digest. */
+public class ManifestAndDigest<T extends ManifestTemplate> {
+
+  private final T manifest;
+  private final DescriptorDigest digest;
+
+  public ManifestAndDigest(T manifest, DescriptorDigest digest) {
+    this.manifest = manifest;
+    this.digest = digest;
+  }
+
+  /**
+   * Gets the manifest.
+   *
+   * @return the manifest
+   */
+  public T getManifest() {
+    return manifest;
+  }
+
+  /**
+   * Gets the digest.
+   *
+   * @return the digest
+   */
+  public DescriptorDigest getDigest() {
+    return digest;
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -171,6 +171,7 @@ public class RegistryClient {
    */
   @JsonIgnoreProperties(ignoreUnknown = true)
   private static class TokenPayloadTemplate implements JsonTemplate {
+
     @Nullable private List<AccessClaim> access;
   }
 
@@ -181,6 +182,7 @@ public class RegistryClient {
    */
   @JsonIgnoreProperties(ignoreUnknown = true)
   private static class AccessClaim implements JsonTemplate {
+
     @Nullable private String type;
     @Nullable private String name;
     @Nullable private List<String> actions;
@@ -279,25 +281,26 @@ public class RegistryClient {
   }
 
   /**
-   * Pulls the image manifest for a specific tag.
+   * Pulls the image manifest and digest for a specific tag.
    *
    * @param <T> child type of ManifestTemplate
    * @param imageTag the tag to pull on
    * @param manifestTemplateClass the specific version of manifest template to pull, or {@link
    *     ManifestTemplate} to pull predefined subclasses; see: {@link
    *     ManifestPuller#handleResponse(Response)}
-   * @return the manifest template
+   * @return the {@link ManifestAndDigest}
    * @throws IOException if communicating with the endpoint fails
    * @throws RegistryException if communicating with the endpoint fails
    */
-  public <T extends ManifestTemplate> T pullManifest(
+  public <T extends ManifestTemplate> ManifestAndDigest<T> pullManifest(
       String imageTag, Class<T> manifestTemplateClass) throws IOException, RegistryException {
     ManifestPuller<T> manifestPuller =
         new ManifestPuller<>(registryEndpointRequestProperties, imageTag, manifestTemplateClass);
     return callRegistryEndpoint(manifestPuller);
   }
 
-  public ManifestTemplate pullManifest(String imageTag) throws IOException, RegistryException {
+  public ManifestAndDigest<ManifestTemplate> pullManifest(String imageTag)
+      throws IOException, RegistryException {
     return pullManifest(imageTag, ManifestTemplate.class);
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPullerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPullerTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.jib.registry;
 
+import com.google.cloud.tools.jib.api.DescriptorDigest;
+import com.google.cloud.tools.jib.hash.Digests;
 import com.google.cloud.tools.jib.http.Response;
 import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.OCIManifestTemplate;
@@ -52,13 +54,13 @@ public class ManifestPullerTest {
     return new ByteArrayInputStream(string.getBytes(StandardCharsets.UTF_8));
   }
 
-  @Mock private Response mockResponse;
-
   private final RegistryEndpointRequestProperties fakeRegistryEndpointRequestProperties =
       new RegistryEndpointRequestProperties("someServerUrl", "someImageName");
   private final ManifestPuller<ManifestTemplate> testManifestPuller =
       new ManifestPuller<>(
           fakeRegistryEndpointRequestProperties, "test-image-tag", ManifestTemplate.class);
+
+  @Mock private Response mockResponse;
 
   @Test
   public void testHandleResponse_v21()
@@ -66,13 +68,18 @@ public class ManifestPullerTest {
     Path v21ManifestFile = Paths.get(Resources.getResource("core/json/v21manifest.json").toURI());
     InputStream v21Manifest = new ByteArrayInputStream(Files.readAllBytes(v21ManifestFile));
 
+    DescriptorDigest expectedDigest = Digests.computeDigest(v21Manifest).getDigest();
+    v21Manifest.reset();
+
     Mockito.when(mockResponse.getBody()).thenReturn(v21Manifest);
-    ManifestTemplate manifestTemplate =
+    ManifestAndDigest manifestAndDigest =
         new ManifestPuller<>(
                 fakeRegistryEndpointRequestProperties, "test-image-tag", V21ManifestTemplate.class)
             .handleResponse(mockResponse);
 
-    Assert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V21ManifestTemplate.class));
+    Assert.assertThat(
+        manifestAndDigest.getManifest(), CoreMatchers.instanceOf(V21ManifestTemplate.class));
+    Assert.assertEquals(expectedDigest, manifestAndDigest.getDigest());
   }
 
   @Test
@@ -81,13 +88,18 @@ public class ManifestPullerTest {
     Path v22ManifestFile = Paths.get(Resources.getResource("core/json/v22manifest.json").toURI());
     InputStream v22Manifest = new ByteArrayInputStream(Files.readAllBytes(v22ManifestFile));
 
+    DescriptorDigest expectedDigest = Digests.computeDigest(v22Manifest).getDigest();
+    v22Manifest.reset();
+
     Mockito.when(mockResponse.getBody()).thenReturn(v22Manifest);
-    ManifestTemplate manifestTemplate =
+    ManifestAndDigest manifestAndDigest =
         new ManifestPuller<>(
                 fakeRegistryEndpointRequestProperties, "test-image-tag", V22ManifestTemplate.class)
             .handleResponse(mockResponse);
 
-    Assert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V22ManifestTemplate.class));
+    Assert.assertThat(
+        manifestAndDigest.getManifest(), CoreMatchers.instanceOf(V22ManifestTemplate.class));
+    Assert.assertEquals(expectedDigest, manifestAndDigest.getDigest());
   }
 
   @Test
@@ -114,15 +126,19 @@ public class ManifestPullerTest {
     Path v22ManifestListFile =
         Paths.get(Resources.getResource("core/json/v22manifest_list.json").toURI());
     InputStream v22ManifestList = new ByteArrayInputStream(Files.readAllBytes(v22ManifestListFile));
+    DescriptorDigest expectedDigest = Digests.computeDigest(v22ManifestList).getDigest();
+    v22ManifestList.reset();
 
     Mockito.when(mockResponse.getBody()).thenReturn(v22ManifestList);
-    ManifestTemplate manifestTemplate =
+    ManifestAndDigest manifestAndDigest =
         new ManifestPuller<>(
                 fakeRegistryEndpointRequestProperties, "test-image-tag", ManifestTemplate.class)
             .handleResponse(mockResponse);
+    ManifestTemplate manifestTemplate = manifestAndDigest.getManifest();
 
     Assert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
     Assert.assertTrue(((V22ManifestListTemplate) manifestTemplate).getManifests().size() > 0);
+    Assert.assertEquals(expectedDigest, manifestAndDigest.getDigest());
   }
 
   @Test
@@ -132,16 +148,21 @@ public class ManifestPullerTest {
         Paths.get(Resources.getResource("core/json/v22manifest_list.json").toURI());
     InputStream v22ManifestList = new ByteArrayInputStream(Files.readAllBytes(v22ManifestListFile));
 
+    DescriptorDigest expectedDigest = Digests.computeDigest(v22ManifestList).getDigest();
+    v22ManifestList.reset();
+
     Mockito.when(mockResponse.getBody()).thenReturn(v22ManifestList);
-    V22ManifestListTemplate manifestTemplate =
+    ManifestAndDigest<V22ManifestListTemplate> manifestAndDigest =
         new ManifestPuller<>(
                 fakeRegistryEndpointRequestProperties,
                 "test-image-tag",
                 V22ManifestListTemplate.class)
             .handleResponse(mockResponse);
+    V22ManifestListTemplate manifestTemplate = manifestAndDigest.getManifest();
 
     Assert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
     Assert.assertTrue(manifestTemplate.getManifests().size() > 0);
+    Assert.assertEquals(expectedDigest, manifestAndDigest.getDigest());
   }
 
   @Test


### PR DESCRIPTION
Pull manifest now will return the digest along with the manifest of the base image. This will be helpful for logging the base image digest #1884.
Fixes - #2034 