### PR TITLE
Add extra tags to tar image

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed temporary directory cleanup during builds using local base images. ([#2016](https://github.com/GoogleContainerTools/jib/issues/2016))
+- Fixed additional tags being ignored when building to a tarball. ([#2043](https://github.com/GoogleContainerTools/jib/issues/2043))
 
 ## 0.11.0
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ReproducibleImageTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ReproducibleImageTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Multimap;
 import com.google.common.io.CharStreams;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -111,26 +110,22 @@ public class ReproducibleImageTest {
 
   @Test
   public void testManifest() throws IOException {
-    try (InputStream ignored = Files.newInputStream(imageTar.toPath())) {
-      String exectedManifest =
-          "[{\"config\":\"config.json\",\"repoTags\":[\"jib-core/reproducible:latest\"],"
-              + "\"layers\":[\"c46572ef74f58d95e44dd36c1fbdfebd3752e8b56a794a13c11cfed35a1a6e1c.tar.gz\",\"6d2763b0f3940d324ea6b55386429e5b173899608abf7d1bff62e25dd2e4dcea.tar.gz\",\"530c1954a2b087d0b989895ea56435c9dc739a973f2d2b6cb9bb98e55bbea7ac.tar.gz\"]}]";
-      String generatedManifest = extractFromTarFileAsString(imageTar, "manifest.json");
-      Assert.assertEquals(exectedManifest, generatedManifest);
-    }
+    String exectedManifest =
+        "[{\"config\":\"config.json\",\"repoTags\":[\"jib-core/reproducible:latest\"],"
+            + "\"layers\":[\"c46572ef74f58d95e44dd36c1fbdfebd3752e8b56a794a13c11cfed35a1a6e1c.tar.gz\",\"6d2763b0f3940d324ea6b55386429e5b173899608abf7d1bff62e25dd2e4dcea.tar.gz\",\"530c1954a2b087d0b989895ea56435c9dc739a973f2d2b6cb9bb98e55bbea7ac.tar.gz\"]}]";
+    String generatedManifest = extractFromTarFileAsString(imageTar, "manifest.json");
+    Assert.assertEquals(exectedManifest, generatedManifest);
   }
 
   @Test
   public void testConfiguration() throws IOException {
-    try (InputStream ignored = Files.newInputStream(imageTar.toPath())) {
-      String exectedConfig =
-          "{\"created\":\"1970-01-01T00:00:00Z\",\"architecture\":\"amd64\",\"os\":\"linux\","
-              + "\"config\":{\"Env\":[],\"Entrypoint\":[\"echo\",\"Hello World\"],\"ExposedPorts\":{},\"Labels\":{},\"Volumes\":{}},"
-              + "\"history\":[{\"created\":\"1970-01-01T00:00:00Z\",\"author\":\"Jib\",\"created_by\":\"jib-core:null\",\"comment\":\"\"},{\"created\":\"1970-01-01T00:00:00Z\",\"author\":\"Jib\",\"created_by\":\"jib-core:null\",\"comment\":\"\"},{\"created\":\"1970-01-01T00:00:00Z\",\"author\":\"Jib\",\"created_by\":\"jib-core:null\",\"comment\":\"\"}],"
-              + "\"rootfs\":{\"type\":\"layers\",\"diff_ids\":[\"sha256:18e4f44e6d1835bd968339b166057bd17ab7d4cbb56dc7262a5cafea7cf8d405\",\"sha256:13369c34f073f2b9c1fa6431e23d925f1a8eac65b1726c8cc8fcc2596c69b414\",\"sha256:4f92c507112d7880ca0f504ef8272b7fdee107263270125036a260a741565923\"]}}";
-      String generatedConfig = extractFromTarFileAsString(imageTar, "config.json");
-      Assert.assertEquals(exectedConfig, generatedConfig);
-    }
+    String exectedConfig =
+        "{\"created\":\"1970-01-01T00:00:00Z\",\"architecture\":\"amd64\",\"os\":\"linux\","
+            + "\"config\":{\"Env\":[],\"Entrypoint\":[\"echo\",\"Hello World\"],\"ExposedPorts\":{},\"Labels\":{},\"Volumes\":{}},"
+            + "\"history\":[{\"created\":\"1970-01-01T00:00:00Z\",\"author\":\"Jib\",\"created_by\":\"jib-core:null\",\"comment\":\"\"},{\"created\":\"1970-01-01T00:00:00Z\",\"author\":\"Jib\",\"created_by\":\"jib-core:null\",\"comment\":\"\"},{\"created\":\"1970-01-01T00:00:00Z\",\"author\":\"Jib\",\"created_by\":\"jib-core:null\",\"comment\":\"\"}],"
+            + "\"rootfs\":{\"type\":\"layers\",\"diff_ids\":[\"sha256:18e4f44e6d1835bd968339b166057bd17ab7d4cbb56dc7262a5cafea7cf8d405\",\"sha256:13369c34f073f2b9c1fa6431e23d925f1a8eac65b1726c8cc8fcc2596c69b414\",\"sha256:4f92c507112d7880ca0f504ef8272b7fdee107263270125036a260a741565923\"]}}";
+    String generatedConfig = extractFromTarFileAsString(imageTar, "config.json");
+    Assert.assertEquals(exectedConfig, generatedConfig);
   }
 
   @Test

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ReproducibleImageTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ReproducibleImageTest.java
@@ -111,7 +111,7 @@ public class ReproducibleImageTest {
 
   @Test
   public void testManifest() throws IOException {
-    try (InputStream input = Files.newInputStream(imageTar.toPath())) {
+    try (InputStream ignored = Files.newInputStream(imageTar.toPath())) {
       String exectedManifest =
           "[{\"config\":\"config.json\",\"repoTags\":[\"jib-core/reproducible:latest\"],"
               + "\"layers\":[\"c46572ef74f58d95e44dd36c1fbdfebd3752e8b56a794a13c11cfed35a1a6e1c.tar.gz\",\"6d2763b0f3940d324ea6b55386429e5b173899608abf7d1bff62e25dd2e4dcea.tar.gz\",\"530c1954a2b087d0b989895ea56435c9dc739a973f2d2b6cb9bb98e55bbea7ac.tar.gz\"]}]";
@@ -122,7 +122,7 @@ public class ReproducibleImageTest {
 
   @Test
   public void testConfiguration() throws IOException {
-    try (InputStream input = Files.newInputStream(imageTar.toPath())) {
+    try (InputStream ignored = Files.newInputStream(imageTar.toPath())) {
       String exectedConfig =
           "{\"created\":\"1970-01-01T00:00:00Z\",\"architecture\":\"amd64\",\"os\":\"linux\","
               + "\"config\":{\"Env\":[],\"Entrypoint\":[\"echo\",\"Hello World\"],\"ExposedPorts\":{},\"Labels\":{},\"Volumes\":{}},"

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
@@ -54,7 +54,11 @@ class LoadDockerStep implements Callable<BuildResult> {
     try (TimerEventDispatcher ignored =
         new TimerEventDispatcher(eventHandlers, "Loading to Docker daemon")) {
       eventHandlers.dispatch(LogEvent.progress("Loading to Docker daemon..."));
-      ImageTarball imageTarball = new ImageTarball(builtImage, buildConfiguration);
+      ImageTarball imageTarball =
+          new ImageTarball(
+              builtImage,
+              buildConfiguration.getTargetImageConfiguration().getImage(),
+              buildConfiguration.getAllTargetImageTags());
 
       // Note: The progress reported here is not entirely accurate. The total allocation units is
       // the size of the layers, but the progress being reported includes the config and manifest

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LoadDockerStep.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.builder.steps;
 
-import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
@@ -55,10 +54,7 @@ class LoadDockerStep implements Callable<BuildResult> {
     try (TimerEventDispatcher ignored =
         new TimerEventDispatcher(eventHandlers, "Loading to Docker daemon")) {
       eventHandlers.dispatch(LogEvent.progress("Loading to Docker daemon..."));
-
-      ImageReference targetImageReference =
-          buildConfiguration.getTargetImageConfiguration().getImage();
-      ImageTarball imageTarball = new ImageTarball(builtImage, targetImageReference);
+      ImageTarball imageTarball = new ImageTarball(builtImage, buildConfiguration);
 
       // Note: The progress reported here is not entirely accurate. The total allocation units is
       // the size of the layers, but the progress being reported includes the config and manifest
@@ -72,16 +68,6 @@ class LoadDockerStep implements Callable<BuildResult> {
         // Load the image to docker daemon.
         eventHandlers.dispatch(
             LogEvent.debug(dockerClient.load(imageTarball, throttledProgressReporter)));
-
-        // Tags the image with all the additional tags, skipping the one 'docker load' already
-        // loaded.
-        for (String tag : buildConfiguration.getAllTargetImageTags()) {
-          if (tag.equals(targetImageReference.getTag())) {
-            continue;
-          }
-
-          dockerClient.tag(targetImageReference, targetImageReference.withTag(tag));
-        }
 
         return BuildResult.fromImage(builtImage, buildConfiguration.getTargetFormat());
       }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
@@ -28,7 +28,6 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 
 public class WriteTarFileStep implements Callable<BuildResult> {
 
@@ -50,7 +49,7 @@ public class WriteTarFileStep implements Callable<BuildResult> {
   }
 
   @Override
-  public BuildResult call() throws ExecutionException, InterruptedException, IOException {
+  public BuildResult call() throws IOException {
     buildConfiguration
         .getEventHandlers()
         .dispatch(LogEvent.progress("Building image to tar file..."));
@@ -63,8 +62,7 @@ public class WriteTarFileStep implements Callable<BuildResult> {
       }
       try (OutputStream outputStream =
           new BufferedOutputStream(FileOperations.newLockingOutputStream(outputPath))) {
-        new ImageTarball(builtImage, buildConfiguration.getTargetImageConfiguration().getImage())
-            .writeTo(outputStream);
+        new ImageTarball(builtImage, buildConfiguration).writeTo(outputStream);
       }
 
       return BuildResult.fromImage(builtImage, buildConfiguration.getTargetFormat());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
@@ -62,7 +62,11 @@ public class WriteTarFileStep implements Callable<BuildResult> {
       }
       try (OutputStream outputStream =
           new BufferedOutputStream(FileOperations.newLockingOutputStream(outputPath))) {
-        new ImageTarball(builtImage, buildConfiguration).writeTo(outputStream);
+        new ImageTarball(
+                builtImage,
+                buildConfiguration.getTargetImageConfiguration().getImage(),
+                buildConfiguration.getAllTargetImageTags())
+            .writeTo(outputStream);
       }
 
       return BuildResult.fromImage(builtImage, buildConfiguration.getTargetFormat());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClient.java
@@ -244,28 +244,6 @@ public class DockerClient {
   }
 
   /**
-   * Tags the image referenced by {@code originalImageReference} with a new image reference {@code
-   * newImageReference}.
-   *
-   * @param originalImageReference the existing image reference on the Docker daemon
-   * @param newImageReference the new image reference
-   * @see <a
-   *     href="https://docs.docker.com/engine/reference/commandline/tag/">https://docs.docker.com/engine/reference/commandline/tag/</a>
-   * @throws InterruptedException if the 'docker tag' process is interrupted
-   * @throws IOException if an I/O exception occurs or {@code docker tag} failed
-   */
-  public void tag(ImageReference originalImageReference, ImageReference newImageReference)
-      throws IOException, InterruptedException {
-    // Runs 'docker tag'.
-    Process dockerProcess =
-        docker("tag", originalImageReference.toString(), newImageReference.toString());
-    if (dockerProcess.waitFor() != 0) {
-      throw new IOException(
-          "'docker tag' command failed with error: " + getStderrOutput(dockerProcess));
-    }
-  }
-
-  /**
    * Gets the size, image ID, and diff IDs of an image in the Docker daemon.
    *
    * @param imageReference the image to inspect

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/ImageTarball.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/ImageTarball.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.docker;
 
 import com.google.cloud.tools.jib.api.ImageReference;
+import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.docker.json.DockerManifestEntryTemplate;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.Layer;
@@ -41,17 +42,17 @@ public class ImageTarball {
   private static final String LAYER_FILE_EXTENSION = ".tar.gz";
 
   private final Image image;
-  private final ImageReference imageReference;
+  private final BuildConfiguration buildConfiguration;
 
   /**
    * Instantiate with an {@link Image}.
    *
    * @param image the image to convert into a tarball
-   * @param imageReference image reference to set in the manifest
+   * @param buildConfiguration used for setting target image information in manifest
    */
-  public ImageTarball(Image image, ImageReference imageReference) {
+  public ImageTarball(Image image, BuildConfiguration buildConfiguration) {
     this.image = image;
-    this.imageReference = imageReference;
+    this.buildConfiguration = buildConfiguration;
   }
 
   public void writeTo(OutputStream out) throws IOException {
@@ -75,7 +76,10 @@ public class ImageTarball {
         CONTAINER_CONFIGURATION_JSON_FILE_NAME);
 
     // Adds the manifest to tarball.
-    manifestTemplate.setRepoTags(imageReference.toStringWithTag());
+    ImageReference imageReference = buildConfiguration.getTargetImageConfiguration().getImage();
+    for (String tag : buildConfiguration.getAllTargetImageTags()) {
+      manifestTemplate.addRepoTag(imageReference.withTag(tag).toStringWithTag());
+    }
     tarStreamBuilder.addByteEntry(
         JsonTemplateMapper.toByteArray(Collections.singletonList(manifestTemplate)),
         MANIFEST_JSON_FILE_NAME);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/ImageTarball.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/ImageTarball.java
@@ -49,7 +49,8 @@ public class ImageTarball {
    * Instantiate with an {@link Image}.
    *
    * @param image the image to convert into a tarball
-   * @param imageReference image reference to set in the manifest
+   * @param imageReference image reference to set in the manifest (note that the tag portion of the
+   *     image reference is ignored)
    * @param allTargetImageTags the tags to tag the image with
    */
   public ImageTarball(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplate.java
@@ -56,7 +56,7 @@ public class DockerManifestEntryTemplate implements JsonTemplate {
   }
 
   public void addRepoTag(String repoTag) {
-    this.repoTags.add(repoTag);
+    repoTags.add(repoTag);
   }
 
   public void addLayerFile(String layer) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplate.java
@@ -17,8 +17,8 @@
 package com.google.cloud.tools.jib.docker.json;
 
 import com.google.cloud.tools.jib.json.JsonTemplate;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -48,15 +48,15 @@ import java.util.List;
 public class DockerManifestEntryTemplate implements JsonTemplate {
 
   private String config = "config.json";
-  private List<String> repoTags = Collections.singletonList(null);
+  private List<String> repoTags = new ArrayList<>();
   private final List<String> layers = new ArrayList<>();
 
   public void setConfig(String config) {
     this.config = config;
   }
 
-  public void setRepoTags(String repoTags) {
-    this.repoTags = Collections.singletonList(repoTags);
+  public void addRepoTag(String repoTag) {
+    this.repoTags.add(repoTag);
   }
 
   public void addLayerFile(String layer) {
@@ -69,5 +69,10 @@ public class DockerManifestEntryTemplate implements JsonTemplate {
 
   public List<String> getLayerFiles() {
     return layers;
+  }
+
+  @VisibleForTesting
+  public List<String> getRepoTags() {
+    return repoTags;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplate.java
@@ -48,7 +48,7 @@ import java.util.List;
 public class DockerManifestEntryTemplate implements JsonTemplate {
 
   private String config = "config.json";
-  private List<String> repoTags = new ArrayList<>();
+  private final List<String> repoTags = new ArrayList<>();
   private final List<String> layers = new ArrayList<>();
 
   public void setConfig(String config) {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.jib.docker;
 
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.ImageReference;
-import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.docker.DockerClient.DockerImageDetails;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
@@ -210,19 +209,6 @@ public class DockerClientTest {
   }
 
   @Test
-  public void testTag() throws InterruptedException, IOException, InvalidImageReferenceException {
-    DockerClient testDockerClient =
-        new DockerClient(
-            subcommand -> {
-              Assert.assertEquals(Arrays.asList("tag", "original", "new"), subcommand);
-              return mockProcessBuilder;
-            });
-    Mockito.when(mockProcess.waitFor()).thenReturn(0);
-
-    testDockerClient.tag(ImageReference.of(null, "original", null), ImageReference.parse("new"));
-  }
-
-  @Test
   public void testDefaultProcessorBuilderFactory_customExecutable() {
     ProcessBuilder processBuilder =
         DockerClient.defaultProcessBuilderFactory("docker-executable", ImmutableMap.of())
@@ -245,28 +231,6 @@ public class DockerClientTest {
             .apply(Collections.emptyList());
 
     Assert.assertEquals(expectedEnvironment, processBuilder.environment());
-  }
-
-  @Test
-  public void testTag_fail() throws InterruptedException, InvalidImageReferenceException {
-    DockerClient testDockerClient =
-        new DockerClient(
-            subcommand -> {
-              Assert.assertEquals(Arrays.asList("tag", "original", "new"), subcommand);
-              return mockProcessBuilder;
-            });
-    Mockito.when(mockProcess.waitFor()).thenReturn(1);
-
-    Mockito.when(mockProcess.getErrorStream())
-        .thenReturn(new ByteArrayInputStream("error".getBytes(StandardCharsets.UTF_8)));
-
-    try {
-      testDockerClient.tag(ImageReference.of(null, "original", null), ImageReference.parse("new"));
-      Assert.fail("docker tag should have failed");
-
-    } catch (IOException ex) {
-      Assert.assertEquals("'docker tag' command failed with error: error", ex.getMessage());
-    }
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/ImageTarballTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/ImageTarballTest.java
@@ -93,7 +93,7 @@ public class ImageTarballTest {
     Mockito.when(mockBuildConfiguration.getAllTargetImageTags())
         .thenReturn(ImmutableSet.of("tag", "another-tag", "tag3"));
     Mockito.when(mockTargetImageConfiguration.getImage())
-        .thenReturn(ImageReference.parse("my/image"));
+        .thenReturn(ImageReference.parse("my/image:tag"));
 
     ImageTarball imageToTarball = new ImageTarball(testImage, mockBuildConfiguration);
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/ImageTarballTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/ImageTarballTest.java
@@ -21,8 +21,6 @@ import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.blob.Blobs;
-import com.google.cloud.tools.jib.configuration.BuildConfiguration;
-import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.docker.json.DockerManifestEntryTemplate;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.Layer;
@@ -57,8 +55,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class ImageTarballTest {
 
-  @Mock private BuildConfiguration mockBuildConfiguration;
-  @Mock private ImageConfiguration mockTargetImageConfiguration;
   @Mock private Layer mockLayer1;
   @Mock private Layer mockLayer2;
 
@@ -88,14 +84,11 @@ public class ImageTarballTest {
     Mockito.when(mockLayer2.getDiffId()).thenReturn(fakeDigestB);
     Image testImage =
         Image.builder(V22ManifestTemplate.class).addLayer(mockLayer1).addLayer(mockLayer2).build();
-    Mockito.when(mockBuildConfiguration.getTargetImageConfiguration())
-        .thenReturn(mockTargetImageConfiguration);
-    Mockito.when(mockBuildConfiguration.getAllTargetImageTags())
-        .thenReturn(ImmutableSet.of("tag", "another-tag", "tag3"));
-    Mockito.when(mockTargetImageConfiguration.getImage())
-        .thenReturn(ImageReference.parse("my/image:tag"));
-
-    ImageTarball imageToTarball = new ImageTarball(testImage, mockBuildConfiguration);
+    ImageTarball imageToTarball =
+        new ImageTarball(
+            testImage,
+            ImageReference.parse("my/image:tag"),
+            ImmutableSet.of("tag", "another-tag", "tag3"));
 
     ByteArrayOutputStream out = new ByteArrayOutputStream();
     imageToTarball.writeTo(out);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplateTest.java
@@ -33,7 +33,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /** Tests for {@link DockerManifestEntryTemplate}. */
-public class DockerManifestTemplateTest {
+public class DockerManifestEntryTemplateTest {
 
   @Test
   public void testToJson() throws URISyntaxException, IOException {
@@ -42,8 +42,7 @@ public class DockerManifestTemplateTest {
     String expectedJson = new String(Files.readAllBytes(jsonFile), StandardCharsets.UTF_8);
 
     DockerManifestEntryTemplate template = new DockerManifestEntryTemplate();
-    template.setRepoTags(
-        ImageReference.of("testregistry", "testrepo", "testtag").toStringWithTag());
+    template.addRepoTag(ImageReference.of("testregistry", "testrepo", "testtag").toStringWithTag());
     template.addLayerFile("layer1.tar.gz");
     template.addLayerFile("layer2.tar.gz");
     template.addLayerFile("layer3.tar.gz");

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed temporary directory cleanup during builds using local base images. ([#2016](https://github.com/GoogleContainerTools/jib/issues/2016))
+- Fixed additional tags being ignored when building to a tarball. ([#2043](https://github.com/GoogleContainerTools/jib/issues/2043))
 
 ## 1.6.1
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed temporary directory cleanup during builds using local base images. ([#2016](https://github.com/GoogleContainerTools/jib/issues/2016))
+- Fixed additional tags being ignored when building to a tarball. ([#2043](https://github.com/GoogleContainerTools/jib/issues/2043))
 
 ## 1.6.1
 


### PR DESCRIPTION
Fixes #2043.

Adds `jib.to.tags` to tars built with jib so `docker load`ing the tar will tag the image appropriately. This also removes the need for `DockerClient#tag`, since it's done automatically now.