### PR TITLE
Clarify log messages for skipped layers

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/ObtainBaseImageLayerStep.java
@@ -144,9 +144,8 @@ class ObtainBaseImageLayerStep implements Callable<PreparedLayer> {
       if (stateInTarget == StateInTarget.EXISTING) {
         eventHandlers.dispatch(
             LogEvent.info(
-                "Pull skipped for BLOB : "
-                    + layer.getBlobDescriptor()
-                    + " already exists on target registry"));
+                "Skipping pull; BLOB already exists on target registry : "
+                    + layer.getBlobDescriptor()));
         return new PreparedLayer.Builder(layer).setStateInTarget(stateInTarget).build();
       }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -106,7 +106,8 @@ class PullBaseImageStep implements Callable<ImageAndAuthorization> {
           Image.builder(buildConfiguration.getTargetFormat()).build(), null);
     }
 
-    eventHandlers.dispatch(LogEvent.progress("Getting base image " + imageReference + "..."));
+    eventHandlers.dispatch(
+        LogEvent.progress("Getting manifest for base image " + imageReference + "..."));
 
     if (buildConfiguration.isOffline() || imageReference.isTagDigest()) {
       Optional<Image> image = getCachedBaseImage();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -81,9 +81,7 @@ class PushBlobStep implements Callable<BlobDescriptor> {
       if (!forcePush && registryClient.checkBlob(blobDigest).isPresent()) {
         eventHandlers.dispatch(
             LogEvent.info(
-                "Push skipped for BLOB : "
-                    + blobDescriptor
-                    + " already exists on target registry"));
+                "Skipping push; BLOB already exists on target registry : " + blobDescriptor));
         return blobDescriptor;
       }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushBlobStep.java
@@ -80,7 +80,10 @@ class PushBlobStep implements Callable<BlobDescriptor> {
       // check if the BLOB is available
       if (!forcePush && registryClient.checkBlob(blobDigest).isPresent()) {
         eventHandlers.dispatch(
-            LogEvent.info("BLOB : " + blobDescriptor + " already exists on registry"));
+            LogEvent.info(
+                "Push skipped for BLOB : "
+                    + blobDescriptor
+                    + " already exists on target registry"));
         return blobDescriptor;
       }
 


### PR DESCRIPTION
Fixes #2053.

* Clarified `Getting base image...` -> `Getting manifest for base image...`
* Added logging for skipped base image layer pulls
* Clarified logging for skipped layer pushes