### PR TITLE
Advanced configuration avoidance (jib-gradle-plugin)

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -30,6 +30,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.War;
 import org.gradle.util.GradleVersion;
 
@@ -114,71 +115,76 @@ public class JibPlugin implements Plugin<Project> {
     JibExtension jibExtension =
         project.getExtensions().create(JIB_EXTENSION_NAME, JibExtension.class, project);
 
-    Task buildImageTask =
+    TaskProvider<BuildImageTask> buildImageProviderTask =
         project
             .getTasks()
-            .create(
+            .register(
                 BUILD_IMAGE_TASK_NAME,
                 BuildImageTask.class,
                 task -> {
                   task.setGroup("Jib");
                   task.setDescription("Builds a container image to a registry.");
-                })
-            .setJibExtension(jibExtension);
-    Task buildDockerTask =
-        project
-            .getTasks()
-            .create(
-                BUILD_DOCKER_TASK_NAME,
-                BuildDockerTask.class,
-                task -> {
-                  task.setGroup("Jib");
-                  task.setDescription("Builds a container image to a Docker daemon.");
-                })
-            .setJibExtension(jibExtension);
-    Task buildTarTask =
-        project
-            .getTasks()
-            .create(
-                BUILD_TAR_TASK_NAME,
-                BuildTarTask.class,
-                task -> {
-                  task.setGroup("Jib");
-                  task.setDescription("Builds a container image to a tarball.");
-                })
-            .setJibExtension(jibExtension);
-    project.getTasks().create(FILES_TASK_NAME, FilesTask.class).setJibExtension(jibExtension);
-    project.getTasks().create(FILES_TASK_V2_NAME, FilesTaskV2.class).setJibExtension(jibExtension);
-    project.getTasks().create(INIT_TASK_NAME, SkaffoldInitTask.class).setJibExtension(jibExtension);
+                  task.setJibExtension(jibExtension);
+                });
+
+  TaskProvider<BuildDockerTask> buildDockerProviderTask =
+    project
+        .getTasks()
+        .register(
+            BUILD_DOCKER_TASK_NAME,
+            BuildDockerTask.class,
+            task -> {
+              task.setGroup("Jib");
+              task.setDescription("Builds a container image to a Docker daemon.");
+              task.setJibExtension(jibExtension);
+        });
+
+  TaskProvider<BuildTarTask> buildTarProviderTask =
+    project
+        .getTasks()
+        .register(
+            BUILD_TAR_TASK_NAME,
+            BuildTarTask.class,
+            task -> {
+              task.setGroup("Jib");
+              task.setDescription("Builds a container image to a tarball.");
+              task.setJibExtension(jibExtension);
+            });
+
+    project.getTasks().register(FILES_TASK_NAME, FilesTask.class).configure(t -> t.setJibExtension(jibExtension));
+    project.getTasks().register(FILES_TASK_V2_NAME, FilesTaskV2.class).configure(t -> t.setJibExtension(jibExtension));
+    project.getTasks().register(INIT_TASK_NAME, SkaffoldInitTask.class).configure(t -> t.setJibExtension(jibExtension));
 
     // A check to catch older versions of Jib.  This can be removed once we are certain people
     // are using Jib 1.3.1 or later.
-    project.getTasks().create(CHECK_REQUIRED_VERSION_TASK_NAME, CheckJibVersionTask.class);
+    project.getTasks().register(CHECK_REQUIRED_VERSION_TASK_NAME, CheckJibVersionTask.class);
 
     project.afterEvaluate(
         projectAfterEvaluation -> {
           try {
-            War warTask = TaskCommon.getWarTask(project);
-            Task dependsOnTask;
-            if (warTask != null) {
-              ExplodedWarTask explodedWarTask =
-                  project.getTasks().create(EXPLODED_WAR_TASK_NAME, ExplodedWarTask.class);
-              explodedWarTask.dependsOn(warTask);
-              explodedWarTask.setWarFile(warTask.getArchivePath().toPath());
-              explodedWarTask.setExplodedWarDirectory(
+            TaskProvider<Task> warProviderTask = TaskCommon.getWarProviderTask(project);
+            TaskProvider<?> dependsOnTaskProvider;
+            if (warProviderTask != null) {
+              TaskProvider<ExplodedWarTask> explodedWarProviderTask =
+                  project.getTasks().register(EXPLODED_WAR_TASK_NAME, ExplodedWarTask.class);
+              explodedWarProviderTask.configure(task -> {
+                task.dependsOn(warProviderTask);
+                task.setWarFile(((War) warProviderTask.get()).getArchivePath().toPath());
+                task.setExplodedWarDirectory(
                   GradleProjectProperties.getExplodedWarDirectory(projectAfterEvaluation));
+              });
               // Have all tasks depend on the 'jibExplodedWar' task.
-              dependsOnTask = explodedWarTask;
+              dependsOnTaskProvider = explodedWarProviderTask;
             } else if ("packaged".equals(jibExtension.getContainerizingMode())) {
               // Have all tasks depend on the 'jar' task.
-              dependsOnTask = projectAfterEvaluation.getTasks().getByPath("jar");
+              dependsOnTaskProvider = projectAfterEvaluation.getTasks().named("jar");
             } else {
               // Have all tasks depend on the 'classes' task.
-              dependsOnTask = projectAfterEvaluation.getTasks().getByPath("classes");
+              dependsOnTaskProvider = projectAfterEvaluation.getTasks().named("classes");
             }
-            buildImageTask.dependsOn(dependsOnTask);
-            buildDockerTask.dependsOn(dependsOnTask);
-            buildTarTask.dependsOn(dependsOnTask);
+            buildImageProviderTask.configure(t -> t.dependsOn(dependsOnTaskProvider));
+            buildDockerProviderTask.configure(t -> t.dependsOn(dependsOnTaskProvider));
+            buildTarProviderTask.configure(t -> t.dependsOn(dependsOnTaskProvider));
 
             // Find project dependencies and add a dependency to their assemble task. We make sure
             // to only add the dependency after BasePlugin is evaluated as otherwise the assemble
@@ -190,11 +196,11 @@ public class JibPlugin implements Plugin<Project> {
                   .withType(
                       BasePlugin.class,
                       unused -> {
-                        Task assembleTask =
-                            dependencyProject.getTasks().getByPath(BasePlugin.ASSEMBLE_TASK_NAME);
-                        buildImageTask.dependsOn(assembleTask);
-                        buildDockerTask.dependsOn(assembleTask);
-                        buildTarTask.dependsOn(assembleTask);
+                        TaskProvider<Task> assembleProviderTask =
+                            dependencyProject.getTasks().named(BasePlugin.ASSEMBLE_TASK_NAME);
+                        buildImageProviderTask.configure(t -> t.dependsOn(assembleProviderTask));
+                        buildDockerProviderTask.configure(t -> t.dependsOn(assembleProviderTask));
+                        buildTarProviderTask.configure(t -> t.dependsOn(assembleProviderTask));
                       });
             }
           } catch (UnknownTaskException ex) {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -127,33 +127,42 @@ public class JibPlugin implements Plugin<Project> {
                   task.setJibExtension(jibExtension);
                 });
 
-  TaskProvider<BuildDockerTask> buildDockerProviderTask =
+    TaskProvider<BuildDockerTask> buildDockerProviderTask =
+        project
+            .getTasks()
+            .register(
+                BUILD_DOCKER_TASK_NAME,
+                BuildDockerTask.class,
+                task -> {
+                  task.setGroup("Jib");
+                  task.setDescription("Builds a container image to a Docker daemon.");
+                  task.setJibExtension(jibExtension);
+                });
+
+    TaskProvider<BuildTarTask> buildTarProviderTask =
+        project
+            .getTasks()
+            .register(
+                BUILD_TAR_TASK_NAME,
+                BuildTarTask.class,
+                task -> {
+                  task.setGroup("Jib");
+                  task.setDescription("Builds a container image to a tarball.");
+                  task.setJibExtension(jibExtension);
+                });
+
     project
         .getTasks()
-        .register(
-            BUILD_DOCKER_TASK_NAME,
-            BuildDockerTask.class,
-            task -> {
-              task.setGroup("Jib");
-              task.setDescription("Builds a container image to a Docker daemon.");
-              task.setJibExtension(jibExtension);
-        });
-
-  TaskProvider<BuildTarTask> buildTarProviderTask =
+        .register(FILES_TASK_NAME, FilesTask.class)
+        .configure(t -> t.setJibExtension(jibExtension));
     project
         .getTasks()
-        .register(
-            BUILD_TAR_TASK_NAME,
-            BuildTarTask.class,
-            task -> {
-              task.setGroup("Jib");
-              task.setDescription("Builds a container image to a tarball.");
-              task.setJibExtension(jibExtension);
-            });
-
-    project.getTasks().register(FILES_TASK_NAME, FilesTask.class).configure(t -> t.setJibExtension(jibExtension));
-    project.getTasks().register(FILES_TASK_V2_NAME, FilesTaskV2.class).configure(t -> t.setJibExtension(jibExtension));
-    project.getTasks().register(INIT_TASK_NAME, SkaffoldInitTask.class).configure(t -> t.setJibExtension(jibExtension));
+        .register(FILES_TASK_V2_NAME, FilesTaskV2.class)
+        .configure(t -> t.setJibExtension(jibExtension));
+    project
+        .getTasks()
+        .register(INIT_TASK_NAME, SkaffoldInitTask.class)
+        .configure(t -> t.setJibExtension(jibExtension));
 
     // A check to catch older versions of Jib.  This can be removed once we are certain people
     // are using Jib 1.3.1 or later.
@@ -167,12 +176,13 @@ public class JibPlugin implements Plugin<Project> {
             if (warProviderTask != null) {
               TaskProvider<ExplodedWarTask> explodedWarProviderTask =
                   project.getTasks().register(EXPLODED_WAR_TASK_NAME, ExplodedWarTask.class);
-              explodedWarProviderTask.configure(task -> {
-                task.dependsOn(warProviderTask);
-                task.setWarFile(((War) warProviderTask.get()).getArchivePath().toPath());
-                task.setExplodedWarDirectory(
-                  GradleProjectProperties.getExplodedWarDirectory(projectAfterEvaluation));
-              });
+              explodedWarProviderTask.configure(
+                  task -> {
+                    task.dependsOn(warProviderTask);
+                    task.setWarFile(((War) warProviderTask.get()).getArchivePath().toPath());
+                    task.setExplodedWarDirectory(
+                        GradleProjectProperties.getExplodedWarDirectory(projectAfterEvaluation));
+                  });
               // Have all tasks depend on the 'jibExplodedWar' task.
               dependsOnTaskProvider = explodedWarProviderTask;
             } else if ("packaged".equals(jibExtension.getContainerizingMode())) {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -36,7 +36,7 @@ import org.gradle.util.GradleVersion;
 
 public class JibPlugin implements Plugin<Project> {
 
-  @VisibleForTesting static final GradleVersion GRADLE_MIN_VERSION = GradleVersion.version("4.6");
+  @VisibleForTesting static final GradleVersion GRADLE_MIN_VERSION = GradleVersion.version("4.9");
 
   @VisibleForTesting static final String JIB_EXTENSION_NAME = "jib";
   @VisibleForTesting static final String BUILD_IMAGE_TASK_NAME = "jib";

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -40,19 +40,18 @@ class TaskCommon {
 
   @Nullable
   static TaskProvider<Task> getWarProviderTask(Project project) {
-
     if (!project.getPlugins().hasPlugin(WarPlugin.class)) {
       return null;
     }
 
-    try {
-      if (project.getPlugins().hasPlugin("org.springframework.boot")) {
+    if (project.getPlugins().hasPlugin("org.springframework.boot")) {
+      try {
         return project.getTasks().named("bootWar");
+      } catch (UnknownTaskException ignored) {
       }
-      return project.getTasks().named(WarPlugin.WAR_TASK_NAME);
-    } catch (UnknownTaskException ignored) {
-      return null;
     }
+
+    return project.getTasks().named(WarPlugin.WAR_TASK_NAME);
   }
 
   /** Disables annoying Apache HTTP client logging. */

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -30,7 +30,6 @@ import org.gradle.api.UnknownTaskException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.tasks.TaskProvider;
-import org.gradle.api.tasks.bundling.War;
 import org.gradle.internal.logging.events.LogEvent;
 import org.gradle.internal.logging.events.OutputEventListener;
 import org.gradle.internal.logging.slf4j.OutputEventListenerBackedLoggerContext;
@@ -51,7 +50,7 @@ class TaskCommon {
         return project.getTasks().named("bootWar");
       }
       return project.getTasks().named(WarPlugin.WAR_TASK_NAME);
-    } catch(UnknownTaskException ignored) {
+    } catch (UnknownTaskException ignored) {
       return null;
     }
   }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -26,8 +26,10 @@ import java.util.logging.Level;
 import javax.annotation.Nullable;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.UnknownTaskException;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.WarPlugin;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.War;
 import org.gradle.internal.logging.events.LogEvent;
 import org.gradle.internal.logging.events.OutputEventListener;
@@ -38,20 +40,20 @@ import org.slf4j.LoggerFactory;
 class TaskCommon {
 
   @Nullable
-  static War getWarTask(Project project) {
+  static TaskProvider<Task> getWarProviderTask(Project project) {
 
     if (!project.getPlugins().hasPlugin(WarPlugin.class)) {
       return null;
     }
 
-    if (project.getPlugins().hasPlugin("org.springframework.boot")) {
-      Task bootWar = project.getTasks().findByName("bootWar");
-      if (bootWar != null) { // Spring Boot > 2.0
-        return (War) bootWar;
+    try {
+      if (project.getPlugins().hasPlugin("org.springframework.boot")) {
+        return project.getTasks().named("bootWar");
       }
+      return project.getTasks().named(WarPlugin.WAR_TASK_NAME);
+    } catch(UnknownTaskException ignored) {
+      return null;
     }
-
-    return (War) project.getTasks().findByName(WarPlugin.WAR_TASK_NAME);
   }
 
   /** Disables annoying Apache HTTP client logging. */

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -52,6 +52,7 @@ import java.util.stream.Collectors;
 import org.gradle.StartParameter;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
@@ -72,7 +73,7 @@ import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskDependency;
-import org.gradle.api.tasks.bundling.War;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.tasks.Jar;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -193,7 +194,7 @@ public class GradleProjectPropertiesTest {
   @Mock private SourceSetContainer mockSourceSetContainer;
   @Mock private SourceSet mockMainSourceSet;
   @Mock private SourceSetOutput mockMainSourceSetOutput;
-  @Mock private War war;
+  @Mock private TaskProvider<Task> warTaskProvider;
 
   private Manifest manifest;
   private GradleProjectProperties gradleProjectProperties;
@@ -598,7 +599,7 @@ public class GradleProjectPropertiesTest {
 
   private void setUpWarProject(Path webAppDirectory) {
     Mockito.when(mockProject.getBuildDir()).thenReturn(webAppDirectory.toFile());
-    Mockito.when(mockTaskContainer.findByName("war")).thenReturn(war);
+    Mockito.when(mockTaskContainer.named("war")).thenReturn(warTaskProvider);
     Mockito.when(mockPluginContainer.hasPlugin(WarPlugin.class)).thenReturn(true);
   }
 }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -278,7 +278,7 @@ public class GradleProjectPropertiesTest {
   @Test
   public void testGetWar_warProject() throws URISyntaxException {
     setUpWarProject(getResource("gradle/webapp"));
-    Assert.assertNotNull(TaskCommon.getWarTask(mockProject));
+    Assert.assertNotNull(TaskCommon.getWarProviderTask(mockProject));
   }
 
   @Test
@@ -286,12 +286,12 @@ public class GradleProjectPropertiesTest {
     setUpWarProject(getResource("gradle/webapp"));
     Mockito.when(mockPluginContainer.hasPlugin(WarPlugin.class)).thenReturn(false);
 
-    Assert.assertNull(TaskCommon.getWarTask(mockProject));
+    Assert.assertNull(TaskCommon.getWarProviderTask(mockProject));
   }
 
   @Test
   public void testGetWar_noWarTask() {
-    Assert.assertNull(TaskCommon.getWarTask(mockProject));
+    Assert.assertNull(TaskCommon.getWarProviderTask(mockProject));
   }
 
   @Test

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -32,6 +32,7 @@ import org.gradle.api.Task;
 import org.gradle.api.UnknownTaskException;
 import org.gradle.api.internal.project.ProjectInternal;
 import org.gradle.api.tasks.TaskContainer;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.UnexpectedBuildFailure;
@@ -177,7 +178,7 @@ public class JibPluginTest {
     rootProject.getPluginManager().apply("com.google.cloud.tools.jib");
 
     // add a custom task that our jib tasks depend on to ensure we do not overwrite this dependsOn
-    Task dependencyTask = rootProject.getTasks().create("myCustomTask", task -> {});
+    TaskProvider<Task> dependencyTask = rootProject.getTasks().register("myCustomTask", task -> {});
     KNOWN_JIB_TASKS.forEach(
         taskName -> rootProject.getTasks().getByPath(taskName).dependsOn(dependencyTask));
 
@@ -192,6 +193,8 @@ public class JibPluginTest {
                     .getByPath(taskName)
                     .getDependsOn()
                     .stream()
+                    .map(TaskProvider.class::cast)
+                    .map(TaskProvider::get)
                     .map(Task.class::cast)
                     .map(Task::getPath)
                     .collect(Collectors.toSet())));
@@ -214,28 +217,34 @@ public class JibPluginTest {
 
     Assert.assertEquals(
         explodedWarTask,
-        rootProject
-            .getTasks()
-            .getByPath(JibPlugin.BUILD_IMAGE_TASK_NAME)
-            .getDependsOn()
-            .iterator()
-            .next());
+        ((TaskProvider<Task>)
+                rootProject
+                    .getTasks()
+                    .getByPath(JibPlugin.BUILD_IMAGE_TASK_NAME)
+                    .getDependsOn()
+                    .iterator()
+                    .next())
+            .get());
     Assert.assertEquals(
         explodedWarTask,
-        rootProject
-            .getTasks()
-            .getByPath(JibPlugin.BUILD_DOCKER_TASK_NAME)
-            .getDependsOn()
-            .iterator()
-            .next());
+        ((TaskProvider<Task>)
+                rootProject
+                    .getTasks()
+                    .getByPath(JibPlugin.BUILD_DOCKER_TASK_NAME)
+                    .getDependsOn()
+                    .iterator()
+                    .next())
+            .get());
     Assert.assertEquals(
         explodedWarTask,
-        rootProject
-            .getTasks()
-            .getByPath(JibPlugin.BUILD_TAR_TASK_NAME)
-            .getDependsOn()
-            .iterator()
-            .next());
+        ((TaskProvider<Task>)
+                rootProject
+                    .getTasks()
+                    .getByPath(JibPlugin.BUILD_TAR_TASK_NAME)
+                    .getDependsOn()
+                    .iterator()
+                    .next())
+            .get());
   }
 
   @Test

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/TaskCommonTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/TaskCommonTest.java
@@ -17,9 +17,11 @@
 package com.google.cloud.tools.jib.gradle;
 
 import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.WarPlugin;
+import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.War;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Assert;
@@ -159,9 +161,9 @@ public class TaskCommonTest {
     Project project = ProjectBuilder.builder().build();
     project.getPlugins().apply(JavaPlugin.class);
 
-    War warTask = TaskCommon.getWarTask(project);
+    TaskProvider<Task> warProviderTask = TaskCommon.getWarProviderTask(project);
 
-    Assert.assertNull(warTask);
+    Assert.assertNull(warProviderTask);
   }
 
   @Test
@@ -170,9 +172,9 @@ public class TaskCommonTest {
     project.getPlugins().apply(JavaPlugin.class);
     project.getPlugins().apply(SpringBootPlugin.class);
 
-    War warTask = TaskCommon.getWarTask(project);
+    TaskProvider<Task> warTaskProvider = TaskCommon.getWarProviderTask(project);
 
-    Assert.assertNull(warTask);
+    Assert.assertNull(warTaskProvider);
   }
 
   @Test
@@ -180,9 +182,9 @@ public class TaskCommonTest {
     Project project = ProjectBuilder.builder().build();
     project.getPlugins().apply(WarPlugin.class);
 
-    War warTask = TaskCommon.getWarTask(project);
+    TaskProvider<Task> warTaskProvider = TaskCommon.getWarProviderTask(project);
 
-    Assert.assertNotNull(warTask);
+    Assert.assertNotNull(warTaskProvider);
   }
 
   @Test
@@ -191,9 +193,9 @@ public class TaskCommonTest {
     project.getPlugins().apply(WarPlugin.class);
     project.getPlugins().apply(SpringBootPlugin.class);
 
-    War warTask = TaskCommon.getWarTask(project);
+    TaskProvider<Task> warTaskProviderProvider = TaskCommon.getWarProviderTask(project);
 
-    Assert.assertNotNull(warTask);
-    Assert.assertTrue(warTask instanceof BootWar);
+    Assert.assertNotNull(warTaskProviderProvider);
+    Assert.assertTrue(warTaskProviderProvider.get() instanceof BootWar);
   }
 }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/TaskCommonTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/TaskCommonTest.java
@@ -22,7 +22,6 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.tasks.TaskProvider;
-import org.gradle.api.tasks.bundling.War;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Assert;
 import org.junit.Before;


### PR DESCRIPTION
Avoid creating jib tasks (also dependents like jar, assemble, war, etc) when not needed.

Before,
![image](https://user-images.githubusercontent.com/3428023/67015215-7c53d280-f0f6-11e9-9b02-8ed1b8d3443d.png)

After,
![image](https://user-images.githubusercontent.com/3428023/67015220-7eb62c80-f0f6-11e9-8172-c894c3f75957.png)

Resolves #2072 

<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->
