### PR TITLE
Consolidate error handling in plugins

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -16,22 +16,10 @@
 
 package com.google.cloud.tools.jib.gradle;
 
-import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
-import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.docker.DockerClient;
-import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
-import com.google.cloud.tools.jib.plugins.common.IncompatibleBaseImageJavaVersionException;
-import com.google.cloud.tools.jib.plugins.common.InvalidAppRootException;
-import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidContainerizingModeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidCreationTimeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidFilesModificationTimeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
-import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.common.base.Preconditions;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -87,9 +75,7 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
   }
 
   @TaskAction
-  public void buildDocker()
-      throws IOException, BuildStepsExecutionException, CacheDirectoryCreationException,
-          MainClassInferenceException {
+  public void buildDocker() {
     Preconditions.checkNotNull(jibExtension);
 
     // Check deprecated parameters
@@ -137,48 +123,8 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
               new GradleHelpfulSuggestions(HELPFUL_SUGGESTIONS_PREFIX))
           .runBuild();
 
-    } catch (InvalidAppRootException ex) {
-      throw new GradleException(
-          "container.appRoot is not an absolute Unix-style path: " + ex.getInvalidPathValue(), ex);
-
-    } catch (InvalidContainerizingModeException ex) {
-      throw new GradleException(
-          "invalid value for containerizingMode: " + ex.getInvalidContainerizingMode(), ex);
-
-    } catch (InvalidWorkingDirectoryException ex) {
-      throw new GradleException(
-          "container.workingDirectory is not an absolute Unix-style path: "
-              + ex.getInvalidPathValue(),
-          ex);
-
-    } catch (InvalidContainerVolumeException ex) {
-      throw new GradleException(
-          "container.volumes is not an absolute Unix-style path: " + ex.getInvalidVolume(), ex);
-
-    } catch (InvalidFilesModificationTimeException ex) {
-      throw new GradleException(
-          "container.filesModificationTime should be an ISO 8601 date-time (see "
-              + "DateTimeFormatter.ISO_DATE_TIME) or special keyword \"EPOCH_PLUS_SECOND\": "
-              + ex.getInvalidFilesModificationTime(),
-          ex);
-
-    } catch (InvalidCreationTimeException ex) {
-      throw new GradleException(
-          "container.creationTime should be an ISO 8601 date-time (see "
-              + "DateTimeFormatter.ISO_DATE_TIME) or a special keyword (\"EPOCH\", "
-              + "\"USE_CURRENT_TIMESTAMP\"): "
-              + ex.getInvalidCreationTime(),
-          ex);
-
-    } catch (IncompatibleBaseImageJavaVersionException ex) {
-      throw new GradleException(
-          HelpfulSuggestions.forIncompatibleBaseImageJavaVersionForGradle(
-              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()),
-          ex);
-
-    } catch (InvalidImageReferenceException ex) {
-      throw new GradleException(
-          HelpfulSuggestions.forInvalidImageReference(ex.getInvalidReference()), ex);
+    } catch (Exception ex) {
+      TaskCommon.rethrowJibException(ex);
 
     } finally {
       projectProperties.waitForLoggingThread();

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -16,22 +16,10 @@
 
 package com.google.cloud.tools.jib.gradle;
 
-import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
-import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
-import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
-import com.google.cloud.tools.jib.plugins.common.IncompatibleBaseImageJavaVersionException;
-import com.google.cloud.tools.jib.plugins.common.InvalidAppRootException;
-import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidContainerizingModeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidCreationTimeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidFilesModificationTimeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
-import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import java.io.IOException;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.gradle.api.DefaultTask;
@@ -70,9 +58,7 @@ public class BuildImageTask extends DefaultTask implements JibTask {
   }
 
   @TaskAction
-  public void buildImage()
-      throws IOException, BuildStepsExecutionException, CacheDirectoryCreationException,
-          MainClassInferenceException {
+  public void buildImage() {
     // Asserts required @Input parameters are not null.
     Preconditions.checkNotNull(jibExtension);
     TaskCommon.checkDeprecatedUsage(jibExtension, getLogger());
@@ -97,48 +83,8 @@ public class BuildImageTask extends DefaultTask implements JibTask {
               new GradleHelpfulSuggestions(HELPFUL_SUGGESTIONS_PREFIX))
           .runBuild();
 
-    } catch (InvalidAppRootException ex) {
-      throw new GradleException(
-          "container.appRoot is not an absolute Unix-style path: " + ex.getInvalidPathValue(), ex);
-
-    } catch (InvalidContainerizingModeException ex) {
-      throw new GradleException(
-          "invalid value for containerizingMode: " + ex.getInvalidContainerizingMode(), ex);
-
-    } catch (InvalidWorkingDirectoryException ex) {
-      throw new GradleException(
-          "container.workingDirectory is not an absolute Unix-style path: "
-              + ex.getInvalidPathValue(),
-          ex);
-
-    } catch (InvalidContainerVolumeException ex) {
-      throw new GradleException(
-          "container.volumes is not an absolute Unix-style path: " + ex.getInvalidVolume(), ex);
-
-    } catch (InvalidFilesModificationTimeException ex) {
-      throw new GradleException(
-          "container.filesModificationTime should be an ISO 8601 date-time (see "
-              + "DateTimeFormatter.ISO_DATE_TIME) or special keyword \"EPOCH_PLUS_SECOND\": "
-              + ex.getInvalidFilesModificationTime(),
-          ex);
-
-    } catch (InvalidCreationTimeException ex) {
-      throw new GradleException(
-          "container.creationTime should be an ISO 8601 date-time (see "
-              + "DateTimeFormatter.ISO_DATE_TIME) or a special keyword (\"EPOCH\", "
-              + "\"USE_CURRENT_TIMESTAMP\"): "
-              + ex.getInvalidCreationTime(),
-          ex);
-
-    } catch (IncompatibleBaseImageJavaVersionException ex) {
-      throw new GradleException(
-          HelpfulSuggestions.forIncompatibleBaseImageJavaVersionForGradle(
-              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()),
-          ex);
-
-    } catch (InvalidImageReferenceException ex) {
-      throw new GradleException(
-          HelpfulSuggestions.forInvalidImageReference(ex.getInvalidReference()), ex);
+    } catch (Exception ex) {
+      TaskCommon.rethrowJibException(ex);
 
     } finally {
       projectProperties.waitForLoggingThread();

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -16,27 +16,13 @@
 
 package com.google.cloud.tools.jib.gradle;
 
-import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
-import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
-import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
-import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
-import com.google.cloud.tools.jib.plugins.common.IncompatibleBaseImageJavaVersionException;
-import com.google.cloud.tools.jib.plugins.common.InvalidAppRootException;
-import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidContainerizingModeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidCreationTimeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidFilesModificationTimeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
-import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.common.base.Preconditions;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.gradle.api.DefaultTask;
-import org.gradle.api.GradleException;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Nested;
@@ -95,9 +81,7 @@ public class BuildTarTask extends DefaultTask implements JibTask {
   }
 
   @TaskAction
-  public void buildTar()
-      throws BuildStepsExecutionException, IOException, CacheDirectoryCreationException,
-          MainClassInferenceException {
+  public void buildTar() {
     // Asserts required @Input parameters are not null.
     Preconditions.checkNotNull(jibExtension);
     TaskCommon.checkDeprecatedUsage(jibExtension, getLogger());
@@ -113,48 +97,8 @@ public class BuildTarTask extends DefaultTask implements JibTask {
               new GradleHelpfulSuggestions(HELPFUL_SUGGESTIONS_PREFIX))
           .runBuild();
 
-    } catch (InvalidAppRootException ex) {
-      throw new GradleException(
-          "container.appRoot is not an absolute Unix-style path: " + ex.getInvalidPathValue(), ex);
-
-    } catch (InvalidContainerizingModeException ex) {
-      throw new GradleException(
-          "invalid value for containerizingMode: " + ex.getInvalidContainerizingMode(), ex);
-
-    } catch (InvalidWorkingDirectoryException ex) {
-      throw new GradleException(
-          "container.workingDirectory is not an absolute Unix-style path: "
-              + ex.getInvalidPathValue(),
-          ex);
-
-    } catch (InvalidContainerVolumeException ex) {
-      throw new GradleException(
-          "container.volumes is not an absolute Unix-style path: " + ex.getInvalidVolume(), ex);
-
-    } catch (InvalidFilesModificationTimeException ex) {
-      throw new GradleException(
-          "container.filesModificationTime should be an ISO 8601 date-time (see "
-              + "DateTimeFormatter.ISO_DATE_TIME) or special keyword \"EPOCH_PLUS_SECOND\": "
-              + ex.getInvalidFilesModificationTime(),
-          ex);
-
-    } catch (InvalidCreationTimeException ex) {
-      throw new GradleException(
-          "container.creationTime should be an ISO 8601 date-time (see "
-              + "DateTimeFormatter.ISO_DATE_TIME) or a special keyword (\"EPOCH\", "
-              + "\"USE_CURRENT_TIMESTAMP\"): "
-              + ex.getInvalidCreationTime(),
-          ex);
-
-    } catch (IncompatibleBaseImageJavaVersionException ex) {
-      throw new GradleException(
-          HelpfulSuggestions.forIncompatibleBaseImageJavaVersionForGradle(
-              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()),
-          ex);
-
-    } catch (InvalidImageReferenceException ex) {
-      throw new GradleException(
-          HelpfulSuggestions.forInvalidImageReference(ex.getInvalidReference()), ex);
+    } catch (Exception ex) {
+      TaskCommon.rethrowJibException(ex);
 
     } finally {
       projectProperties.waitForLoggingThread();

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -16,24 +16,12 @@
 
 package com.google.cloud.tools.jib.maven;
 
-import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
-import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.docker.DockerClient;
 import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
-import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
-import com.google.cloud.tools.jib.plugins.common.IncompatibleBaseImageJavaVersionException;
-import com.google.cloud.tools.jib.plugins.common.InvalidAppRootException;
-import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidContainerizingModeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidCreationTimeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidFilesModificationTimeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
-import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.common.annotations.VisibleForTesting;
-import java.io.IOException;
 import java.nio.file.Path;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -97,55 +85,8 @@ public class BuildDockerMojo extends JibPluginConfiguration {
               new MavenHelpfulSuggestions(HELPFUL_SUGGESTIONS_PREFIX))
           .runBuild();
 
-    } catch (InvalidAppRootException ex) {
-      throw new MojoExecutionException(
-          "<container><appRoot> is not an absolute Unix-style path: " + ex.getInvalidPathValue(),
-          ex);
-
-    } catch (InvalidContainerizingModeException ex) {
-      throw new MojoExecutionException(
-          "invalid value for <containerizingMode>: " + ex.getInvalidContainerizingMode(), ex);
-
-    } catch (InvalidWorkingDirectoryException ex) {
-      throw new MojoExecutionException(
-          "<container><workingDirectory> is not an absolute Unix-style path: "
-              + ex.getInvalidPathValue(),
-          ex);
-
-    } catch (InvalidContainerVolumeException ex) {
-      throw new MojoExecutionException(
-          "<container><volumes> is not an absolute Unix-style path: " + ex.getInvalidVolume(), ex);
-
-    } catch (InvalidFilesModificationTimeException ex) {
-      throw new MojoExecutionException(
-          "<container><filesModificationTime> should be an ISO 8601 date-time (see "
-              + "DateTimeFormatter.ISO_DATE_TIME) or special keyword \"EPOCH_PLUS_SECOND\": "
-              + ex.getInvalidFilesModificationTime(),
-          ex);
-
-    } catch (InvalidCreationTimeException ex) {
-      throw new MojoExecutionException(
-          "<container><creationTime> should be an ISO 8601 date-time (see "
-              + "DateTimeFormatter.ISO_DATE_TIME) or a special keyword (\"EPOCH\", "
-              + "\"USE_CURRENT_TIMESTAMP\"): "
-              + ex.getInvalidCreationTime(),
-          ex);
-
-    } catch (IncompatibleBaseImageJavaVersionException ex) {
-      throw new MojoExecutionException(
-          HelpfulSuggestions.forIncompatibleBaseImageJavaVersionForMaven(
-              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()),
-          ex);
-
-    } catch (InvalidImageReferenceException ex) {
-      throw new MojoExecutionException(
-          HelpfulSuggestions.forInvalidImageReference(ex.getInvalidReference()), ex);
-
-    } catch (IOException | CacheDirectoryCreationException | MainClassInferenceException ex) {
-      throw new MojoExecutionException(ex.getMessage(), ex);
-
-    } catch (BuildStepsExecutionException ex) {
-      throw new MojoExecutionException(ex.getMessage(), ex.getCause());
+    } catch (Exception ex) {
+      MojoCommon.rethrowJibException(ex);
 
     } finally {
       tempDirectoryProvider.close();

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -16,25 +16,13 @@
 
 package com.google.cloud.tools.jib.maven;
 
-import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.ImageFormat;
-import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
-import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
 import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
-import com.google.cloud.tools.jib.plugins.common.IncompatibleBaseImageJavaVersionException;
-import com.google.cloud.tools.jib.plugins.common.InvalidAppRootException;
-import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidContainerizingModeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidCreationTimeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidFilesModificationTimeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
-import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import java.io.IOException;
 import java.util.Arrays;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -111,55 +99,8 @@ public class BuildImageMojo extends JibPluginConfiguration {
               new MavenHelpfulSuggestions(HELPFUL_SUGGESTIONS_PREFIX))
           .runBuild();
 
-    } catch (InvalidAppRootException ex) {
-      throw new MojoExecutionException(
-          "<container><appRoot> is not an absolute Unix-style path: " + ex.getInvalidPathValue(),
-          ex);
-
-    } catch (InvalidContainerizingModeException ex) {
-      throw new MojoExecutionException(
-          "invalid value for <containerizingMode>: " + ex.getInvalidContainerizingMode(), ex);
-
-    } catch (InvalidWorkingDirectoryException ex) {
-      throw new MojoExecutionException(
-          "<container><workingDirectory> is not an absolute Unix-style path: "
-              + ex.getInvalidPathValue(),
-          ex);
-
-    } catch (InvalidContainerVolumeException ex) {
-      throw new MojoExecutionException(
-          "<container><volumes> is not an absolute Unix-style path: " + ex.getInvalidVolume(), ex);
-
-    } catch (InvalidFilesModificationTimeException ex) {
-      throw new MojoExecutionException(
-          "<container><filesModificationTime> should be an ISO 8601 date-time (see "
-              + "DateTimeFormatter.ISO_DATE_TIME) or special keyword \"EPOCH_PLUS_SECOND\": "
-              + ex.getInvalidFilesModificationTime(),
-          ex);
-
-    } catch (InvalidCreationTimeException ex) {
-      throw new MojoExecutionException(
-          "<container><creationTime> should be an ISO 8601 date-time (see "
-              + "DateTimeFormatter.ISO_DATE_TIME) or a special keyword (\"EPOCH\", "
-              + "\"USE_CURRENT_TIMESTAMP\"): "
-              + ex.getInvalidCreationTime(),
-          ex);
-
-    } catch (IncompatibleBaseImageJavaVersionException ex) {
-      throw new MojoExecutionException(
-          HelpfulSuggestions.forIncompatibleBaseImageJavaVersionForMaven(
-              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()),
-          ex);
-
-    } catch (InvalidImageReferenceException ex) {
-      throw new MojoExecutionException(
-          HelpfulSuggestions.forInvalidImageReference(ex.getInvalidReference()), ex);
-
-    } catch (IOException | CacheDirectoryCreationException | MainClassInferenceException ex) {
-      throw new MojoExecutionException(ex.getMessage(), ex);
-
-    } catch (BuildStepsExecutionException ex) {
-      throw new MojoExecutionException(ex.getMessage(), ex.getCause());
+    } catch (Exception ex) {
+      MojoCommon.rethrowJibException(ex);
 
     } finally {
       tempDirectoryProvider.close();

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -16,23 +16,10 @@
 
 package com.google.cloud.tools.jib.maven;
 
-import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
-import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
-import com.google.cloud.tools.jib.plugins.common.BuildStepsExecutionException;
-import com.google.cloud.tools.jib.plugins.common.HelpfulSuggestions;
-import com.google.cloud.tools.jib.plugins.common.IncompatibleBaseImageJavaVersionException;
-import com.google.cloud.tools.jib.plugins.common.InvalidAppRootException;
-import com.google.cloud.tools.jib.plugins.common.InvalidContainerVolumeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidContainerizingModeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidCreationTimeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidFilesModificationTimeException;
-import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
-import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.common.annotations.VisibleForTesting;
-import java.io.IOException;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -89,55 +76,8 @@ public class BuildTarMojo extends JibPluginConfiguration {
               new MavenHelpfulSuggestions(HELPFUL_SUGGESTIONS_PREFIX))
           .runBuild();
 
-    } catch (InvalidAppRootException ex) {
-      throw new MojoExecutionException(
-          "<container><appRoot> is not an absolute Unix-style path: " + ex.getInvalidPathValue(),
-          ex);
-
-    } catch (InvalidContainerizingModeException ex) {
-      throw new MojoExecutionException(
-          "invalid value for <containerizingMode>: " + ex.getInvalidContainerizingMode(), ex);
-
-    } catch (InvalidWorkingDirectoryException ex) {
-      throw new MojoExecutionException(
-          "<container><workingDirectory> is not an absolute Unix-style path: "
-              + ex.getInvalidPathValue(),
-          ex);
-
-    } catch (InvalidContainerVolumeException ex) {
-      throw new MojoExecutionException(
-          "<container><volumes> is not an absolute Unix-style path: " + ex.getInvalidVolume(), ex);
-
-    } catch (InvalidFilesModificationTimeException ex) {
-      throw new MojoExecutionException(
-          "<container><filesModificationTime> should be an ISO 8601 date-time (see "
-              + "DateTimeFormatter.ISO_DATE_TIME) or special keyword \"EPOCH_PLUS_SECOND\": "
-              + ex.getInvalidFilesModificationTime(),
-          ex);
-
-    } catch (InvalidCreationTimeException ex) {
-      throw new MojoExecutionException(
-          "<container><creationTime> should be an ISO 8601 date-time (see "
-              + "DateTimeFormatter.ISO_DATE_TIME) or a special keyword (\"EPOCH\", "
-              + "\"USE_CURRENT_TIMESTAMP\"): "
-              + ex.getInvalidCreationTime(),
-          ex);
-
-    } catch (IncompatibleBaseImageJavaVersionException ex) {
-      throw new MojoExecutionException(
-          HelpfulSuggestions.forIncompatibleBaseImageJavaVersionForMaven(
-              ex.getBaseImageMajorJavaVersion(), ex.getProjectMajorJavaVersion()),
-          ex);
-
-    } catch (InvalidImageReferenceException ex) {
-      throw new MojoExecutionException(
-          HelpfulSuggestions.forInvalidImageReference(ex.getInvalidReference()), ex);
-
-    } catch (IOException | CacheDirectoryCreationException | MainClassInferenceException ex) {
-      throw new MojoExecutionException(ex.getMessage(), ex);
-
-    } catch (BuildStepsExecutionException ex) {
-      throw new MojoExecutionException(ex.getMessage(), ex.getCause());
+    } catch (Exception ex) {
+      MojoCommon.rethrowJibException(ex);
 
     } finally {
       tempDirectoryProvider.close();


### PR DESCRIPTION
An idea that makes #1868 less of a big issue. I don't think it fixes it completely, because `PluginConfigurationProcessor` still throws a ton of different exceptions, and the liberal use of `instanceof` feels hacky, but the code reduction here is pretty nice. Wondering if we should use this until we find a more solid solution for `PluginConfigurationProcessor` throwing so many different exceptions.