### PR TITLE
Use artifact ID instead of project name in SkaffoldInitMojo

### DIFF
--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SkaffoldInitMojo.java
@@ -47,7 +47,7 @@ public class SkaffoldInitMojo extends JibPluginConfiguration {
     SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput();
     skaffoldInitOutput.setImage(getTargetImage());
     if (project.getParent() != null && project.getParent().getFile() != null) {
-      skaffoldInitOutput.setProject(project.getName());
+      skaffoldInitOutput.setProject(project.getArtifactId());
     }
     System.out.println("\nBEGIN JIB JSON");
     try {


### PR DESCRIPTION
Towards #2088.

I *think* `project.name` is still the correct field to use with gradle, but I'm not 100% sure.