### PR TITLE
Fix root build.gradle being reported in skaffold init for multi-module projects

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed reporting parent build file when `skaffold init` is run on multi-module projects.
+
 ## 1.7.0
 
 ### Added

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTask.java
@@ -21,6 +21,7 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import javax.annotation.Nullable;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
 import org.gradle.api.tasks.TaskAction;
 
 /**
@@ -39,10 +40,15 @@ public class SkaffoldInitTask extends DefaultTask {
 
   @TaskAction
   public void listModulesAndTargets() throws IOException {
+    Project project = getProject();
+    // Ignore parent projects
+    if (project.getSubprojects().size() > 0) {
+      return;
+    }
     SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput();
     skaffoldInitOutput.setImage(Preconditions.checkNotNull(jibExtension).getTo().getImage());
-    if (!getProject().equals(getProject().getRootProject())) {
-      skaffoldInitOutput.setProject(getProject().getName());
+    if (!project.equals(project.getRootProject())) {
+      skaffoldInitOutput.setProject(project.getName());
     }
     System.out.println("\nBEGIN JIB JSON");
     System.out.println(skaffoldInitOutput.getJsonString());

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTaskTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/SkaffoldInitTaskTest.java
@@ -77,17 +77,13 @@ public class SkaffoldInitTaskTest {
   @Test
   public void testFilesTask_multiProject() throws IOException {
     List<String> outputs = getJsons(multiTestProject);
-    Assert.assertEquals(3, outputs.size());
+    Assert.assertEquals(2, outputs.size());
 
     SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(0));
     Assert.assertEquals("testimage", skaffoldInitOutput.getImage());
-    Assert.assertNull(skaffoldInitOutput.getProject());
-
-    skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(1));
-    Assert.assertEquals("testimage", skaffoldInitOutput.getImage());
     Assert.assertEquals("complex-service", skaffoldInitOutput.getProject());
 
-    skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(2));
+    skaffoldInitOutput = new SkaffoldInitOutput(outputs.get(1));
     Assert.assertEquals("testimage", skaffoldInitOutput.getImage());
     Assert.assertEquals("simple-service", skaffoldInitOutput.getProject());
   }

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed reporting wrong module name when `skaffold init` is run on multi-module projects ([#2088](https://github.com/GoogleContainerTools/jib/issues/2088)).
+
 ## 1.7.0
 
 ### Added


### PR DESCRIPTION
This was an issue that was fixed in #1974 on the maven side, but I forgot to change the gradle side as well.

This PR also updates the changelog for #2090.