### PR TITLE
Refactoring and renaming

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/Request.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/Request.java
@@ -50,9 +50,7 @@ public class Request {
      * @return this
      */
     public Builder setAuthorization(@Nullable Authorization authorization) {
-      if (authorization != null) {
-        headers.setAuthorization(authorization.toString());
-      }
+      headers.setAuthorization(authorization == null ? null : authorization.toString());
       return this;
     }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetriever.java
@@ -81,17 +81,17 @@ class AuthenticationMethodRetriever
 
   @Override
   public Optional<RegistryAuthenticator> handleHttpResponseException(
-      HttpResponseException httpResponseException)
+      HttpResponseException responseException)
       throws HttpResponseException, RegistryErrorException {
     // Only valid for status code of '401 Unauthorized'.
-    if (httpResponseException.getStatusCode() != HttpStatusCodes.STATUS_CODE_UNAUTHORIZED) {
-      throw httpResponseException;
+    if (responseException.getStatusCode() != HttpStatusCodes.STATUS_CODE_UNAUTHORIZED) {
+      throw responseException;
     }
 
     // Checks if the 'WWW-Authenticate' header is present.
-    String authenticationMethod = httpResponseException.getHeaders().getAuthenticate();
+    String authenticationMethod = responseException.getHeaders().getAuthenticate();
     if (authenticationMethod == null) {
-      throw new RegistryErrorExceptionBuilder(getActionDescription(), httpResponseException)
+      throw new RegistryErrorExceptionBuilder(getActionDescription(), responseException)
           .addReason("'WWW-Authenticate' header not found")
           .build();
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/BlobChecker.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/BlobChecker.java
@@ -61,25 +61,25 @@ class BlobChecker implements RegistryEndpointProvider<Optional<BlobDescriptor>> 
 
   @Override
   public Optional<BlobDescriptor> handleHttpResponseException(
-      HttpResponseException httpResponseException) throws HttpResponseException {
-    if (httpResponseException.getStatusCode() != HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
-      throw httpResponseException;
+      HttpResponseException responseException) throws HttpResponseException {
+    if (responseException.getStatusCode() != HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
+      throw responseException;
     }
 
     // Finds a BLOB_UNKNOWN error response code.
-    if (httpResponseException.getContent() == null) {
+    if (responseException.getContent() == null) {
       // TODO: The Google HTTP client gives null content for HEAD requests. Make the content never
       // be null, even for HEAD requests.
       return Optional.empty();
     }
 
-    ErrorCodes errorCode = ErrorResponseUtil.getErrorCode(httpResponseException);
+    ErrorCodes errorCode = ErrorResponseUtil.getErrorCode(responseException);
     if (errorCode == ErrorCodes.BLOB_UNKNOWN) {
       return Optional.empty();
     }
 
     // BLOB_UNKNOWN was not found as a error response code.
-    throw httpResponseException;
+    throw responseException;
   }
 
   @Override

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ErrorResponseUtil.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ErrorResponseUtil.java
@@ -30,17 +30,17 @@ public class ErrorResponseUtil {
    * Extract an {@link ErrorCodes} response from the error object encoded in an {@link
    * HttpResponseException}.
    *
-   * @param httpResponseException the response exception
+   * @param responseException the response exception
    * @return the parsed {@link ErrorCodes} if found
    * @throws HttpResponseException rethrows the original exception if an error object could not be
    *     parsed, if there were multiple error objects, or if the error code is unknown.
    */
-  public static ErrorCodes getErrorCode(HttpResponseException httpResponseException)
+  public static ErrorCodes getErrorCode(HttpResponseException responseException)
       throws HttpResponseException {
     // Obtain the error response code.
-    String errorContent = httpResponseException.getContent();
+    String errorContent = responseException.getContent();
     if (errorContent == null) {
-      throw httpResponseException;
+      throw responseException;
     }
 
     try {
@@ -62,7 +62,7 @@ public class ErrorResponseUtil {
     }
 
     // rethrow the original exception
-    throw httpResponseException;
+    throw responseException;
   }
 
   // not intended to be instantiated

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ManifestPusher.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/ManifestPusher.java
@@ -92,7 +92,7 @@ class ManifestPusher implements RegistryEndpointProvider<DescriptorDigest> {
   }
 
   @Override
-  public DescriptorDigest handleHttpResponseException(HttpResponseException httpResponseException)
+  public DescriptorDigest handleHttpResponseException(HttpResponseException responseException)
       throws HttpResponseException, RegistryErrorException {
     // docker registry 2.0 and 2.1 returns:
     //   400 Bad Request
@@ -105,21 +105,21 @@ class ManifestPusher implements RegistryEndpointProvider<DescriptorDigest> {
     //   {"errors":[{"code":"MANIFEST_INVALID","detail":
     //   {"message":"manifest schema version not supported"},"message":"manifest invalid"}]}
 
-    if (httpResponseException.getStatusCode() != HttpStatus.SC_BAD_REQUEST
-        && httpResponseException.getStatusCode() != HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE) {
-      throw httpResponseException;
+    if (responseException.getStatusCode() != HttpStatus.SC_BAD_REQUEST
+        && responseException.getStatusCode() != HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE) {
+      throw responseException;
     }
 
-    ErrorCodes errorCode = ErrorResponseUtil.getErrorCode(httpResponseException);
+    ErrorCodes errorCode = ErrorResponseUtil.getErrorCode(responseException);
     if (errorCode == ErrorCodes.MANIFEST_INVALID || errorCode == ErrorCodes.TAG_INVALID) {
-      throw new RegistryErrorExceptionBuilder(getActionDescription(), httpResponseException)
+      throw new RegistryErrorExceptionBuilder(getActionDescription(), responseException)
           .addReason(
               "Registry may not support pushing OCI Manifest or "
                   + "Docker Image Manifest Version 2, Schema 2")
           .build();
     }
     // rethrow: unhandled error response code.
-    throw httpResponseException;
+    throw responseException;
   }
 
   @Override

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -146,24 +146,9 @@ class RegistryEndpointCaller<T> {
    * @throws RegistryException for known exceptions when interacting with the registry
    */
   T call() throws IOException, RegistryException {
-    try {
-      String apiRouteBase = "https://" + registryEndpointRequestProperties.getServerUrl() + "/v2/";
-      URL initialRequestUrl = registryEndpointProvider.getApiRoute(apiRouteBase);
-      return callWithAllowInsecureRegistryHandling(initialRequestUrl);
-
-    } catch (IOException ex) {
-      String registry = registryEndpointRequestProperties.getServerUrl();
-      String repository = registryEndpointRequestProperties.getImageName();
-      logError("I/O error for image [" + registry + "/" + repository + "]:");
-      logError("    " + ex.getMessage());
-      if (isBrokenPipe(ex)) {
-        logError(
-            "broken pipe: the server shut down the connection. Check the server log if possible. "
-                + "This could also be a proxy issue. For example, a proxy may prevent sending "
-                + "packets that are too large.");
-      }
-      throw ex;
-    }
+    String apiRouteBase = "https://" + registryEndpointRequestProperties.getServerUrl() + "/v2/";
+    URL initialRequestUrl = registryEndpointProvider.getApiRoute(apiRouteBase);
+    return callWithAllowInsecureRegistryHandling(initialRequestUrl);
   }
 
   private T callWithAllowInsecureRegistryHandling(URL url) throws IOException, RegistryException {
@@ -307,6 +292,19 @@ class RegistryEndpointCaller<T> {
           throw httpResponseException;
         }
       }
+
+    } catch (IOException ex) {
+      String registry = registryEndpointRequestProperties.getServerUrl();
+      String repository = registryEndpointRequestProperties.getImageName();
+      logError("I/O error for image [" + registry + "/" + repository + "]:");
+      logError("    " + ex.getMessage());
+      if (isBrokenPipe(ex)) {
+        logError(
+            "broken pipe: the server shut down the connection. Check the server log if possible. "
+                + "This could also be a proxy issue. For example, a proxy may prevent sending "
+                + "packets that are too large.");
+      }
+      throw ex;
     }
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -286,17 +286,13 @@ class RegistryEndpointCaller<T> {
       }
 
     } catch (SSLException ex) {
+      logErrorIfBrokenPipe(ex);
       throw ex;
 
     } catch (IOException ex) {
       logError("I/O error for image [" + serverUrl + "/" + imageName + "]:");
       logError("    " + ex.getMessage());
-      if (isBrokenPipe(ex)) {
-        logError(
-            "broken pipe: the server shut down the connection. Check the server log if possible. "
-                + "This could also be a proxy issue. For example, a proxy may prevent sending "
-                + "packets that are too large.");
-      }
+      logErrorIfBrokenPipe(ex);
       throw ex;
     }
   }
@@ -328,5 +324,14 @@ class RegistryEndpointCaller<T> {
   /** Logs error message in red. */
   private void logError(String message) {
     eventHandlers.dispatch(LogEvent.error("\u001B[31;1m" + message + "\u001B[0m"));
+  }
+
+  private void logErrorIfBrokenPipe(IOException ex) {
+    if (isBrokenPipe(ex)) {
+      logError(
+          "broken pipe: the server shut down the connection. Check the server log if possible. "
+              + "This could also be a proxy issue. For example, a proxy may prevent sending "
+              + "packets that are too large.");
+    }
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointCaller.java
@@ -285,6 +285,9 @@ class RegistryEndpointCaller<T> {
         }
       }
 
+    } catch (SSLException ex) {
+      throw ex;
+
     } catch (IOException ex) {
       logError("I/O error for image [" + serverUrl + "/" + imageName + "]:");
       logError("    " + ex.getMessage());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointProvider.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryEndpointProvider.java
@@ -55,14 +55,14 @@ interface RegistryEndpointProvider<T> {
   /**
    * Handles an {@link HttpResponseException} that occurs.
    *
-   * @param httpResponseException the {@link HttpResponseException} to handle
-   * @throws HttpResponseException {@code httpResponseException} if {@code httpResponseException}
-   *     could not be handled
+   * @param responseException the {@link HttpResponseException} to handle
+   * @throws HttpResponseException {@code responseException} if {@code responseException} could not
+   *     be handled
    * @throws RegistryErrorException if there is an error with a remote registry
    */
-  default T handleHttpResponseException(HttpResponseException httpResponseException)
+  default T handleHttpResponseException(HttpResponseException responseException)
       throws HttpResponseException, RegistryErrorException {
-    throw httpResponseException;
+    throw responseException;
   }
 
   /**

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverTest.java
@@ -36,7 +36,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class AuthenticationMethodRetrieverTest {
 
-  @Mock private HttpResponseException mockHttpResponseException;
+  @Mock private HttpResponseException mockResponseException;
   @Mock private HttpHeaders mockHeaders;
 
   private final RegistryEndpointRequestProperties fakeRegistryEndpointRequestProperties =
@@ -81,27 +81,27 @@ public class AuthenticationMethodRetrieverTest {
 
   @Test
   public void testHandleHttpResponseException_invalidStatusCode() throws RegistryErrorException {
-    Mockito.when(mockHttpResponseException.getStatusCode()).thenReturn(-1);
+    Mockito.when(mockResponseException.getStatusCode()).thenReturn(-1);
 
     try {
-      testAuthenticationMethodRetriever.handleHttpResponseException(mockHttpResponseException);
+      testAuthenticationMethodRetriever.handleHttpResponseException(mockResponseException);
       Assert.fail(
           "Authentication method retriever should only handle HTTP 401 Unauthorized errors");
 
     } catch (HttpResponseException ex) {
-      Assert.assertEquals(mockHttpResponseException, ex);
+      Assert.assertEquals(mockResponseException, ex);
     }
   }
 
   @Test
   public void tsetHandleHttpResponseException_noHeader() throws HttpResponseException {
-    Mockito.when(mockHttpResponseException.getStatusCode())
+    Mockito.when(mockResponseException.getStatusCode())
         .thenReturn(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
-    Mockito.when(mockHttpResponseException.getHeaders()).thenReturn(mockHeaders);
+    Mockito.when(mockResponseException.getHeaders()).thenReturn(mockHeaders);
     Mockito.when(mockHeaders.getAuthenticate()).thenReturn(null);
 
     try {
-      testAuthenticationMethodRetriever.handleHttpResponseException(mockHttpResponseException);
+      testAuthenticationMethodRetriever.handleHttpResponseException(mockResponseException);
       Assert.fail(
           "Authentication method retriever should fail if 'WWW-Authenticate' header is not found");
 
@@ -116,13 +116,13 @@ public class AuthenticationMethodRetrieverTest {
       throws HttpResponseException {
     String authenticationMethod = "bad authentication method";
 
-    Mockito.when(mockHttpResponseException.getStatusCode())
+    Mockito.when(mockResponseException.getStatusCode())
         .thenReturn(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
-    Mockito.when(mockHttpResponseException.getHeaders()).thenReturn(mockHeaders);
+    Mockito.when(mockResponseException.getHeaders()).thenReturn(mockHeaders);
     Mockito.when(mockHeaders.getAuthenticate()).thenReturn(authenticationMethod);
 
     try {
-      testAuthenticationMethodRetriever.handleHttpResponseException(mockHttpResponseException);
+      testAuthenticationMethodRetriever.handleHttpResponseException(mockResponseException);
       Assert.fail(
           "Authentication method retriever should fail if 'WWW-Authenticate' header failed to parse");
 
@@ -140,15 +140,13 @@ public class AuthenticationMethodRetrieverTest {
     String authenticationMethod =
         "Bearer realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"";
 
-    Mockito.when(mockHttpResponseException.getStatusCode())
+    Mockito.when(mockResponseException.getStatusCode())
         .thenReturn(HttpStatusCodes.STATUS_CODE_UNAUTHORIZED);
-    Mockito.when(mockHttpResponseException.getHeaders()).thenReturn(mockHeaders);
+    Mockito.when(mockResponseException.getHeaders()).thenReturn(mockHeaders);
     Mockito.when(mockHeaders.getAuthenticate()).thenReturn(authenticationMethod);
 
     RegistryAuthenticator registryAuthenticator =
-        testAuthenticationMethodRetriever
-            .handleHttpResponseException(mockHttpResponseException)
-            .get();
+        testAuthenticationMethodRetriever.handleHttpResponseException(mockResponseException).get();
 
     Assert.assertEquals(
         new URL("https://somerealm?service=someservice&scope=repository:someImageName:someScope"),

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobCheckerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobCheckerTest.java
@@ -82,75 +82,73 @@ public class BlobCheckerTest {
   }
 
   @Test
-  public void testHandleHttpResponseException() throws IOException, RegistryErrorException {
-    HttpResponseException mockHttpResponseException = Mockito.mock(HttpResponseException.class);
-    Mockito.when(mockHttpResponseException.getStatusCode())
+  public void testHandleHttpResponseException() throws IOException {
+    HttpResponseException mockResponseException = Mockito.mock(HttpResponseException.class);
+    Mockito.when(mockResponseException.getStatusCode())
         .thenReturn(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
 
     ErrorResponseTemplate emptyErrorResponseTemplate =
         new ErrorResponseTemplate()
             .addError(new ErrorEntryTemplate(ErrorCodes.BLOB_UNKNOWN.name(), "some message"));
-    Mockito.when(mockHttpResponseException.getContent())
+    Mockito.when(mockResponseException.getContent())
         .thenReturn(JsonTemplateMapper.toUtf8String(emptyErrorResponseTemplate));
 
     Assert.assertFalse(
-        testBlobChecker.handleHttpResponseException(mockHttpResponseException).isPresent());
+        testBlobChecker.handleHttpResponseException(mockResponseException).isPresent());
   }
 
   @Test
-  public void testHandleHttpResponseException_hasOtherErrors()
-      throws IOException, RegistryErrorException {
-    HttpResponseException mockHttpResponseException = Mockito.mock(HttpResponseException.class);
-    Mockito.when(mockHttpResponseException.getStatusCode())
+  public void testHandleHttpResponseException_hasOtherErrors() throws IOException {
+    HttpResponseException mockResponseException = Mockito.mock(HttpResponseException.class);
+    Mockito.when(mockResponseException.getStatusCode())
         .thenReturn(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
 
     ErrorResponseTemplate emptyErrorResponseTemplate =
         new ErrorResponseTemplate()
             .addError(new ErrorEntryTemplate(ErrorCodes.BLOB_UNKNOWN.name(), "some message"))
             .addError(new ErrorEntryTemplate(ErrorCodes.MANIFEST_UNKNOWN.name(), "some message"));
-    Mockito.when(mockHttpResponseException.getContent())
+    Mockito.when(mockResponseException.getContent())
         .thenReturn(JsonTemplateMapper.toUtf8String(emptyErrorResponseTemplate));
 
     try {
-      testBlobChecker.handleHttpResponseException(mockHttpResponseException);
+      testBlobChecker.handleHttpResponseException(mockResponseException);
       Assert.fail("Non-BLOB_UNKNOWN errors should not be handled");
 
     } catch (HttpResponseException ex) {
-      Assert.assertEquals(mockHttpResponseException, ex);
+      Assert.assertEquals(mockResponseException, ex);
     }
   }
 
   @Test
-  public void testHandleHttpResponseException_notBlobUnknown()
-      throws IOException, RegistryErrorException {
-    HttpResponseException mockHttpResponseException = Mockito.mock(HttpResponseException.class);
-    Mockito.when(mockHttpResponseException.getStatusCode())
+  public void testHandleHttpResponseException_notBlobUnknown() throws IOException {
+    HttpResponseException mockResponseException = Mockito.mock(HttpResponseException.class);
+    Mockito.when(mockResponseException.getStatusCode())
         .thenReturn(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
 
     ErrorResponseTemplate emptyErrorResponseTemplate = new ErrorResponseTemplate();
-    Mockito.when(mockHttpResponseException.getContent())
+    Mockito.when(mockResponseException.getContent())
         .thenReturn(JsonTemplateMapper.toUtf8String(emptyErrorResponseTemplate));
 
     try {
-      testBlobChecker.handleHttpResponseException(mockHttpResponseException);
+      testBlobChecker.handleHttpResponseException(mockResponseException);
       Assert.fail("Non-BLOB_UNKNOWN errors should not be handled");
 
     } catch (HttpResponseException ex) {
-      Assert.assertEquals(mockHttpResponseException, ex);
+      Assert.assertEquals(mockResponseException, ex);
     }
   }
 
   @Test
-  public void testHandleHttpResponseException_invalidStatusCode() throws RegistryErrorException {
-    HttpResponseException mockHttpResponseException = Mockito.mock(HttpResponseException.class);
-    Mockito.when(mockHttpResponseException.getStatusCode()).thenReturn(-1);
+  public void testHandleHttpResponseException_invalidStatusCode() {
+    HttpResponseException mockResponseException = Mockito.mock(HttpResponseException.class);
+    Mockito.when(mockResponseException.getStatusCode()).thenReturn(-1);
 
     try {
-      testBlobChecker.handleHttpResponseException(mockHttpResponseException);
+      testBlobChecker.handleHttpResponseException(mockResponseException);
       Assert.fail("Non-404 status codes should not be handled");
 
     } catch (HttpResponseException ex) {
-      Assert.assertEquals(mockHttpResponseException, ex);
+      Assert.assertEquals(mockResponseException, ex);
     }
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ErrorResponseUtilTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ErrorResponseUtilTest.java
@@ -16,78 +16,71 @@
 
 package com.google.cloud.tools.jib.registry;
 
-import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
-import org.apache.http.HttpStatus;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /** Test for {@link ErrorReponseUtil}. */
+@RunWith(MockitoJUnitRunner.class)
 public class ErrorResponseUtilTest {
+
+  @Mock HttpResponseException responseException;
 
   @Test
   public void testGetErrorCode_knownErrorCode() throws HttpResponseException {
-    HttpResponseException httpResponseException =
-        new HttpResponseException.Builder(
-                HttpStatus.SC_BAD_REQUEST, "Bad Request", new HttpHeaders())
-            .setContent(
-                "{\"errors\":[{\"code\":\"MANIFEST_INVALID\",\"message\":\"manifest invalid\",\"detail\":{}}]}")
-            .build();
+    Mockito.when(responseException.getContent())
+        .thenReturn(
+            "{\"errors\":[{\"code\":\"MANIFEST_INVALID\",\"message\":\"manifest invalid\",\"detail\":{}}]}");
 
     Assert.assertSame(
-        ErrorCodes.MANIFEST_INVALID, ErrorResponseUtil.getErrorCode(httpResponseException));
+        ErrorCodes.MANIFEST_INVALID, ErrorResponseUtil.getErrorCode(responseException));
   }
 
   /** An unknown {@link ErrorCodes} should cause original exception to be rethrown. */
   @Test
   public void testGetErrorCode_unknownErrorCode() {
-    HttpResponseException httpResponseException =
-        new HttpResponseException.Builder(
-                HttpStatus.SC_BAD_REQUEST, "Bad Request", new HttpHeaders())
-            .setContent(
-                "{\"errors\":[{\"code\":\"INVALID_ERROR_CODE\",\"message\":\"invalid code\",\"detail\":{}}]}")
-            .build();
+    Mockito.when(responseException.getContent())
+        .thenReturn(
+            "{\"errors\":[{\"code\":\"INVALID_ERROR_CODE\",\"message\":\"invalid code\",\"detail\":{}}]}");
     try {
-      ErrorResponseUtil.getErrorCode(httpResponseException);
+      ErrorResponseUtil.getErrorCode(responseException);
       Assert.fail();
     } catch (HttpResponseException ex) {
-      Assert.assertSame(httpResponseException, ex);
+      Assert.assertSame(responseException, ex);
     }
   }
 
   /** Multiple error objects should cause original exception to be rethrown. */
   @Test
   public void testGetErrorCode_multipleErrors() {
-    HttpResponseException httpResponseException =
-        new HttpResponseException.Builder(
-                HttpStatus.SC_BAD_REQUEST, "Bad Request", new HttpHeaders())
-            .setContent(
-                "{\"errors\":["
-                    + "{\"code\":\"MANIFEST_INVALID\",\"message\":\"message 1\",\"detail\":{}},"
-                    + "{\"code\":\"TAG_INVALID\",\"message\":\"message 2\",\"detail\":{}}"
-                    + "]}")
-            .build();
+    Mockito.when(responseException.getContent())
+        .thenReturn(
+            "{\"errors\":["
+                + "{\"code\":\"MANIFEST_INVALID\",\"message\":\"message 1\",\"detail\":{}},"
+                + "{\"code\":\"TAG_INVALID\",\"message\":\"message 2\",\"detail\":{}}"
+                + "]}");
     try {
-      ErrorResponseUtil.getErrorCode(httpResponseException);
+      ErrorResponseUtil.getErrorCode(responseException);
       Assert.fail();
     } catch (HttpResponseException ex) {
-      Assert.assertSame(httpResponseException, ex);
+      Assert.assertSame(responseException, ex);
     }
   }
 
   /** An non-error object should cause original exception to be rethrown. */
   @Test
   public void testGetErrorCode_invalidErrorObject() {
-    HttpResponseException httpResponseException =
-        new HttpResponseException.Builder(
-                HttpStatus.SC_BAD_REQUEST, "Bad Request", new HttpHeaders())
-            .setContent("{\"type\":\"other\",\"message\":\"some other object\"}")
-            .build();
+    Mockito.when(responseException.getContent())
+        .thenReturn("{\"type\":\"other\",\"message\":\"some other object\"}");
     try {
-      ErrorResponseUtil.getErrorCode(httpResponseException);
+      ErrorResponseUtil.getErrorCode(responseException);
       Assert.fail();
     } catch (HttpResponseException ex) {
-      Assert.assertSame(httpResponseException, ex);
+      Assert.assertSame(responseException, ex);
     }
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.registry;
 
-import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.LogEvent;
@@ -159,13 +158,12 @@ public class ManifestPusherTest {
   @Test
   public void testHandleHttpResponseException_dockerRegistry_tagInvalid()
       throws HttpResponseException {
-    HttpResponseException exception =
-        new HttpResponseException.Builder(
-                HttpStatus.SC_BAD_REQUEST, "Bad Request", new HttpHeaders())
-            .setContent(
-                "{\"errors\":[{\"code\":\"TAG_INVALID\","
-                    + "\"message\":\"manifest tag did not match URI\"}]}")
-            .build();
+    HttpResponseException exception = Mockito.mock(HttpResponseException.class);
+    Mockito.when(exception.getStatusCode()).thenReturn(HttpStatus.SC_BAD_REQUEST);
+    Mockito.when(exception.getContent())
+        .thenReturn(
+            "{\"errors\":[{\"code\":\"TAG_INVALID\","
+                + "\"message\":\"manifest tag did not match URI\"}]}");
     try {
       testManifestPusher.handleHttpResponseException(exception);
       Assert.fail();
@@ -183,13 +181,12 @@ public class ManifestPusherTest {
   @Test
   public void testHandleHttpResponseException_dockerRegistry_manifestInvalid()
       throws HttpResponseException {
-    HttpResponseException exception =
-        new HttpResponseException.Builder(
-                HttpStatus.SC_BAD_REQUEST, "Bad Request", new HttpHeaders())
-            .setContent(
-                "{\"errors\":[{\"code\":\"MANIFEST_INVALID\","
-                    + "\"message\":\"manifest invalid\",\"detail\":{}}]}")
-            .build();
+    HttpResponseException exception = Mockito.mock(HttpResponseException.class);
+    Mockito.when(exception.getStatusCode()).thenReturn(HttpStatus.SC_BAD_REQUEST);
+    Mockito.when(exception.getContent())
+        .thenReturn(
+            "{\"errors\":[{\"code\":\"MANIFEST_INVALID\","
+                + "\"message\":\"manifest invalid\",\"detail\":{}}]}");
     try {
       testManifestPusher.handleHttpResponseException(exception);
       Assert.fail();
@@ -206,14 +203,13 @@ public class ManifestPusherTest {
   /** Quay.io returns an undocumented 415 / MANIFEST_INVALID. */
   @Test
   public void testHandleHttpResponseException_quayIo() throws HttpResponseException {
-    HttpResponseException exception =
-        new HttpResponseException.Builder(
-                HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE, "UNSUPPORTED MEDIA TYPE", new HttpHeaders())
-            .setContent(
-                "{\"errors\":[{\"code\":\"MANIFEST_INVALID\","
-                    + "\"detail\":{\"message\":\"manifest schema version not supported\"},"
-                    + "\"message\":\"manifest invalid\"}]}")
-            .build();
+    HttpResponseException exception = Mockito.mock(HttpResponseException.class);
+    Mockito.when(exception.getStatusCode()).thenReturn(HttpStatus.SC_UNSUPPORTED_MEDIA_TYPE);
+    Mockito.when(exception.getContent())
+        .thenReturn(
+            "{\"errors\":[{\"code\":\"MANIFEST_INVALID\","
+                + "\"detail\":{\"message\":\"manifest schema version not supported\"},"
+                + "\"message\":\"manifest invalid\"}]}");
     try {
       testManifestPusher.handleHttpResponseException(exception);
       Assert.fail();
@@ -229,11 +225,8 @@ public class ManifestPusherTest {
 
   @Test
   public void testHandleHttpResponseException_otherError() throws RegistryErrorException {
-    HttpResponseException exception =
-        new HttpResponseException.Builder(
-                HttpStatus.SC_UNAUTHORIZED, "Unauthorized", new HttpHeaders())
-            .setContent("{\"errors\":[{\"code\":\"UNAUTHORIZED\",\"message\":\"Unauthorized\"]}}")
-            .build();
+    HttpResponseException exception = Mockito.mock(HttpResponseException.class);
+    Mockito.when(exception.getStatusCode()).thenReturn(HttpStatus.SC_UNAUTHORIZED);
     try {
       testManifestPusher.handleHttpResponseException(exception);
       Assert.fail();


### PR DESCRIPTION
Trying to reduce the diff of the upcoming PR for changing Jib HTTP framework.

A lot of changes are renaming `httpResponseException`: I'll most likely introduce `ResponseException` that wraps `HttpResponseException` (somewhat similar like currently `Response` wrapping `HttpResponse` and `Request` wrapping `HttpRequest`), so changing variable names in advance.