### PR TITLE
Fix slow test

### DIFF
--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
@@ -218,7 +218,7 @@ public class RegistryAuthenticatorTest {
   @Test
   public void testSourceImage_differentSourceRepository()
       throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException {
-    try (TestWebServer server = new TestWebServer(false)) {
+    try (TestWebServer server = new TestWebServer(false, 2)) {
       try {
         RegistryEndpointRequestProperties registryEndpointRequestProperties =
             new RegistryEndpointRequestProperties("someserver", "someimage", "anotherimage");
@@ -235,7 +235,7 @@ public class RegistryAuthenticatorTest {
       Assert.assertThat(
           server.getInputRead(),
           CoreMatchers.containsString(
-              "scope=repository:someimage:pull,push&scope=repository:anotherimage:pull"));
+              "scope=repository:someimage:pull,push&scope=repository:anotherimage:pull "));
     }
   }
 


### PR DESCRIPTION
This test makes two HTTP calls, but the server could only respond once. The test succeeds only after the second call times out, which is 20 seconds on my machine.

And adding a space makes the test more robust.