### PR TITLE
Move skip execution logic to MojoCommon

### DIFF
--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -31,7 +31,6 @@ import com.google.cloud.tools.jib.plugins.common.InvalidFilesModificationTimeExc
 import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
-import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -53,19 +52,7 @@ public class BuildDockerMojo extends JibPluginConfiguration {
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     checkJibVersion();
-    if (isSkipped()) {
-      getLog().info("Skipping containerization because jib-maven-plugin: skip = true");
-      return;
-    } else if (!isContainerizable()) {
-      getLog()
-          .info(
-              "Skipping containerization of this module (not specified in "
-                  + PropertyNames.CONTAINERIZE
-                  + ")");
-      return;
-    }
-    if ("pom".equals(getProject().getPackaging())) {
-      getLog().info("Skipping containerization because packaging is 'pom'...");
+    if (MojoCommon.shouldSkipJibExecution(this)) {
       return;
     }
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -31,7 +31,6 @@ import com.google.cloud.tools.jib.plugins.common.InvalidFilesModificationTimeExc
 import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
-import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import java.io.IOException;
@@ -55,19 +54,7 @@ public class BuildImageMojo extends JibPluginConfiguration {
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     checkJibVersion();
-    if (isSkipped()) {
-      getLog().info("Skipping containerization because jib-maven-plugin: skip = true");
-      return;
-    } else if (!isContainerizable()) {
-      getLog()
-          .info(
-              "Skipping containerization of this module (not specified in "
-                  + PropertyNames.CONTAINERIZE
-                  + ")");
-      return;
-    }
-    if ("pom".equals(getProject().getPackaging())) {
-      getLog().info("Skipping containerization because packaging is 'pom'...");
+    if (MojoCommon.shouldSkipJibExecution(this)) {
       return;
     }
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -30,7 +30,6 @@ import com.google.cloud.tools.jib.plugins.common.InvalidFilesModificationTimeExc
 import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryException;
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
-import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -55,19 +54,7 @@ public class BuildTarMojo extends JibPluginConfiguration {
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     checkJibVersion();
-    if (isSkipped()) {
-      getLog().info("Skipping containerization because jib-maven-plugin: skip = true");
-      return;
-    } else if (!isContainerizable()) {
-      getLog()
-          .info(
-              "Skipping containerization of this module (not specified in "
-                  + PropertyNames.CONTAINERIZE
-                  + ")");
-      return;
-    }
-    if ("pom".equals(getProject().getPackaging())) {
-      getLog().info("Skipping containerization because packaging is 'pom'...");
+    if (MojoCommon.shouldSkipJibExecution(this)) {
       return;
     }
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
@@ -124,12 +124,20 @@ public class MojoCommon {
     }
   }
 
+  /**
+   * Determines if Jib goal execution on this project/module should be skipped due to configuration.
+   *
+   * @param jibPluginConfiguration usually {@code this}, the Mojo this check is applied in.
+   * @return {@code true} if Jib should be skipped (should not execute goal), or {@code false} if it
+   *     should continue with execution.
+   */
   public static boolean shouldSkipJibExecution(JibPluginConfiguration jibPluginConfiguration) {
     Log log = jibPluginConfiguration.getLog();
     if (jibPluginConfiguration.isSkipped()) {
       log.info("Skipping containerization because jib-maven-plugin: skip = true");
       return true;
-    } else if (!jibPluginConfiguration.isContainerizable()) {
+    }
+    if (!jibPluginConfiguration.isContainerizable()) {
       log.info(
           "Skipping containerization of this module (not specified in "
               + PropertyNames.CONTAINERIZE


### PR DESCRIPTION
Reuse some skip logic across maven mojos, so I can resuse in the skaffold sync map goal.

part of #2097 