### PR TITLE
Don't use bootWar if disabled

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,7 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed reporting parent build file when `skaffold init` is run on multi-module projects.
+- Fixed reporting parent build file when `skaffold init` is run on multi-module projects. ([#2091](https://github.com/GoogleContainerTools/jib/pull/2091))
+- Now correctly uses the `war` task if it is enabled and the `bootWar` task is disabled for Spring WAR projects. ([#2096](https://github.com/GoogleContainerTools/jib/issues/2096))
 
 ## 1.7.0
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -87,6 +87,11 @@ class GradleProjectProperties implements ProjectProperties {
   }
 
   String getWarFilePath() {
+    TaskProvider<Task> bootWarTask = TaskCommon.getBootWarTaskProvider(project);
+    if (bootWarTask != null && bootWarTask.get().getEnabled()) {
+      return bootWarTask.get().getOutputs().getFiles().getAsPath();
+    }
+
     TaskProvider<Task> warTask = TaskCommon.getWarTaskProvider(project);
     return Verify.verifyNotNull(warTask).get().getOutputs().getFiles().getAsPath();
   }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -108,17 +108,6 @@ public class JibPlugin implements Plugin<Project> {
     }
   }
 
-  private static TaskProvider<?> getTaskProvider(
-      Project project, String pluginName, String taskName) {
-    try {
-      if (project.getPlugins().hasPlugin(pluginName)) {
-        return project.getTasks().named(taskName);
-      }
-    } catch (UnknownTaskException ignored) { // fall through
-    }
-    return null;
-  }
-
   @Override
   public void apply(Project project) {
     checkGradleVersion();

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -40,10 +40,10 @@ class TaskCommon {
 
   @Nullable
   static TaskProvider<Task> getWarTaskProvider(Project project) {
-    if (!project.getPlugins().hasPlugin(WarPlugin.class)) {
-      return null;
+    if (project.getPlugins().hasPlugin(WarPlugin.class)) {
+      return project.getTasks().named(WarPlugin.WAR_TASK_NAME);
     }
-    return project.getTasks().named(WarPlugin.WAR_TASK_NAME);
+    return null;
   }
 
   @Nullable

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -43,15 +43,18 @@ class TaskCommon {
     if (!project.getPlugins().hasPlugin(WarPlugin.class)) {
       return null;
     }
+    return project.getTasks().named(WarPlugin.WAR_TASK_NAME);
+  }
 
+  @Nullable
+  static TaskProvider<Task> getBootWarTaskProvider(Project project) {
     if (project.getPlugins().hasPlugin("org.springframework.boot")) {
       try {
         return project.getTasks().named("bootWar");
       } catch (UnknownTaskException ignored) { // fall through
       }
     }
-
-    return project.getTasks().named(WarPlugin.WAR_TASK_NAME);
+    return null;
   }
 
   /** Disables annoying Apache HTTP client logging. */

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -56,29 +56,22 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-import org.gradle.StartParameter;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.file.AbstractFileCollection;
 import org.gradle.api.internal.file.FileResolver;
-import org.gradle.api.invocation.Gradle;
 import org.gradle.api.java.archives.Manifest;
 import org.gradle.api.java.archives.internal.DefaultManifest;
 import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.configuration.ConsoleOutput;
-import org.gradle.api.plugins.Convention;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
-import org.gradle.api.plugins.PluginContainer;
 import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.SourceSetOutput;
-import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.tasks.Jar;
@@ -191,21 +184,20 @@ public class GradleProjectPropertiesTest {
 
   @Mock private TempDirectoryProvider mockTempDirectoryProvider;
   @Mock private FileResolver mockFileResolver;
-  @Mock private Jar mockJar;
-  @Mock private Project mockProject;
-  @Mock private Convention mockConvention;
-  @Mock private TaskContainer mockTaskContainer;
-  @Mock private PluginContainer mockPluginContainer;
   @Mock private Logger mockLogger;
-  @Mock private Gradle mockGradle;
-  @Mock private StartParameter mockStartParameter;
   @Mock private JavaPluginConvention mockJavaPluginConvention;
   @Mock private SourceSetContainer mockSourceSetContainer;
   @Mock private SourceSet mockMainSourceSet;
   @Mock private SourceSetOutput mockMainSourceSetOutput;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  private TaskProvider<Task> mockWarTaskProvider;
+  private Project mockProject;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private TaskProvider<Task> mockTaskProvider1;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private TaskProvider<Task> mockTaskProvider2;
 
   private Manifest manifest;
   private GradleProjectProperties gradleProjectProperties;
@@ -213,20 +205,11 @@ public class GradleProjectPropertiesTest {
   @Before
   public void setup() throws URISyntaxException, IOException {
     manifest = new DefaultManifest(mockFileResolver);
-    Mockito.when(mockProject.getConvention()).thenReturn(mockConvention);
-    Mockito.when(mockConvention.getPlugin(JavaPluginConvention.class))
+    Mockito.when(mockProject.getConvention().getPlugin(JavaPluginConvention.class))
         .thenReturn(mockJavaPluginConvention);
     Mockito.when(mockJavaPluginConvention.getSourceSets()).thenReturn(mockSourceSetContainer);
-    Mockito.when(mockProject.getTasks()).thenReturn(mockTaskContainer);
-    Mockito.when(mockProject.getPlugins()).thenReturn(mockPluginContainer);
-    Mockito.when(mockJar.getManifest()).thenReturn(manifest);
-    Mockito.when(mockProject.getGradle()).thenReturn(mockGradle);
-    Mockito.when(mockGradle.getStartParameter()).thenReturn(mockStartParameter);
-    Mockito.when(mockStartParameter.getConsoleOutput()).thenReturn(ConsoleOutput.Auto);
 
     // mocking to complete ignore project dependency resolution
-    Mockito.when(mockProject.getConfigurations())
-        .thenReturn(Mockito.mock(ConfigurationContainer.class, Mockito.RETURNS_DEEP_STUBS));
     Mockito.when(
             mockProject
                 .getConfigurations()
@@ -270,38 +253,22 @@ public class GradleProjectPropertiesTest {
   @Test
   public void testGetMainClassFromJar_success() {
     manifest.attributes(ImmutableMap.of("Main-Class", "some.main.class"));
-    Mockito.when(mockTaskContainer.findByName("jar")).thenReturn(mockJar);
+    Jar mockJar = Mockito.mock(Jar.class);
+    Mockito.when(mockJar.getManifest()).thenReturn(manifest);
+    Mockito.when(mockProject.getTasks().findByName("jar")).thenReturn(mockJar);
     Assert.assertEquals("some.main.class", gradleProjectProperties.getMainClassFromJar());
   }
 
   @Test
   public void testGetMainClassFromJar_missing() {
-    Mockito.when(mockTaskContainer.findByName("jar")).thenReturn(null);
+    Mockito.when(mockProject.getTasks().findByName("jar")).thenReturn(null);
     Assert.assertNull(gradleProjectProperties.getMainClassFromJar());
   }
 
   @Test
   public void testIsWarProject() {
-    Mockito.when(mockPluginContainer.hasPlugin(WarPlugin.class)).thenReturn(true);
+    Mockito.when(mockProject.getPlugins().hasPlugin(WarPlugin.class)).thenReturn(true);
     Assert.assertTrue(gradleProjectProperties.isWarProject());
-  }
-
-  @Test
-  public void testGetWar_warProject() {
-    Mockito.when(mockPluginContainer.hasPlugin(WarPlugin.class)).thenReturn(true);
-    Mockito.when(mockTaskContainer.named("war")).thenReturn(mockWarTaskProvider);
-    Assert.assertNotNull(TaskCommon.getWarTaskProvider(mockProject));
-  }
-
-  @Test
-  public void testGetWar_noWarPlugin() {
-    Mockito.when(mockPluginContainer.hasPlugin(WarPlugin.class)).thenReturn(false);
-    Assert.assertNull(TaskCommon.getWarTaskProvider(mockProject));
-  }
-
-  @Test
-  public void testGetWar_noWarTask() {
-    Assert.assertNull(TaskCommon.getWarTaskProvider(mockProject));
   }
 
   @Test
@@ -325,7 +292,7 @@ public class GradleProjectPropertiesTest {
 
   @Test
   public void testGetMajorJavaVersion() {
-    Mockito.when(mockConvention.findPlugin(JavaPluginConvention.class))
+    Mockito.when(mockProject.getConvention().findPlugin(JavaPluginConvention.class))
         .thenReturn(mockJavaPluginConvention);
 
     Mockito.when(mockJavaPluginConvention.getTargetCompatibility())
@@ -587,6 +554,41 @@ public class GradleProjectPropertiesTest {
     setupBuildConfiguration("/anything", DEFAULT_CONTAINERIZING_MODE); // should pass
   }
 
+  @Test
+  public void testGetWarFilePath() {
+    Mockito.when(mockProject.getPlugins().hasPlugin(WarPlugin.class)).thenReturn(true);
+    Mockito.when(mockProject.getTasks().named("war")).thenReturn(mockTaskProvider1);
+    Mockito.when(mockTaskProvider1.get().getOutputs().getFiles().getAsPath())
+        .thenReturn("/war/file/here.war");
+
+    Assert.assertEquals("/war/file/here.war", gradleProjectProperties.getWarFilePath());
+  }
+
+  @Test
+  public void testGetWarFilePath_bootWar() {
+    Mockito.when(mockProject.getPlugins().hasPlugin("org.springframework.boot")).thenReturn(true);
+    Mockito.when(mockProject.getTasks().named("bootWar")).thenReturn(mockTaskProvider1);
+    Mockito.when(mockTaskProvider1.get().getEnabled()).thenReturn(true);
+    Mockito.when(mockTaskProvider1.get().getOutputs().getFiles().getAsPath())
+        .thenReturn("/boot/war/file.war");
+
+    Assert.assertEquals("/boot/war/file.war", gradleProjectProperties.getWarFilePath());
+  }
+
+  @Test
+  public void testGetWarFilePath_bootWarDisabled() {
+    Mockito.when(mockProject.getPlugins().hasPlugin("org.springframework.boot")).thenReturn(true);
+    Mockito.when(mockProject.getTasks().named("bootWar")).thenReturn(mockTaskProvider1);
+    Mockito.when(mockTaskProvider1.get().getOutputs().getFiles().getAsPath())
+        .thenReturn("boot.war");
+
+    Mockito.when(mockProject.getPlugins().hasPlugin(WarPlugin.class)).thenReturn(true);
+    Mockito.when(mockProject.getTasks().named("war")).thenReturn(mockTaskProvider2);
+    Mockito.when(mockTaskProvider2.get().getOutputs().getFiles().getAsPath()).thenReturn("war.war");
+
+    Assert.assertEquals("war.war", gradleProjectProperties.getWarFilePath());
+  }
+
   private BuildConfiguration setupBuildConfiguration(
       String appRoot, ContainerizingMode containerizingMode)
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException {
@@ -607,11 +609,10 @@ public class GradleProjectPropertiesTest {
     Path targetZip =
         zipUpDirectory(webAppDirectory, temporaryFolder.getRoot().toPath().resolve("my-app.war"));
 
-    Mockito.when(mockPluginContainer.hasPlugin(WarPlugin.class)).thenReturn(true);
-    Mockito.when(mockTaskContainer.named("war")).thenReturn(mockWarTaskProvider);
-    Mockito.when(mockWarTaskProvider.get().getOutputs().getFiles().getAsPath())
+    Mockito.when(mockProject.getPlugins().hasPlugin(WarPlugin.class)).thenReturn(true);
+    Mockito.when(mockProject.getTasks().named("war")).thenReturn(mockTaskProvider1);
+    Mockito.when(mockTaskProvider1.get().getOutputs().getFiles().getAsPath())
         .thenReturn(targetZip.toString());
-    Mockito.when(gradleProjectProperties.getWarFilePath()).thenReturn(targetZip.toString());
 
     // Make "GradleProjectProperties" use this folder to explode the WAR into.
     Path unzipTarget = temporaryFolder.newFolder("exploded").toPath();

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -199,10 +199,10 @@ public class GradleProjectPropertiesTest {
   private Project mockProject;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  private TaskProvider<Task> mockTaskProvider1;
+  private TaskProvider<Task> mockWarTaskProvider;
 
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
-  private TaskProvider<Task> mockTaskProvider2;
+  private TaskProvider<Task> mockBootWarTaskProvider;
 
   private Manifest manifest;
   private GradleProjectProperties gradleProjectProperties;
@@ -566,8 +566,8 @@ public class GradleProjectPropertiesTest {
   @Test
   public void testGetWarFilePath() {
     Mockito.when(mockProject.getPlugins().hasPlugin(WarPlugin.class)).thenReturn(true);
-    Mockito.when(mockTaskContainer.named("war")).thenReturn(mockTaskProvider1);
-    Mockito.when(mockTaskProvider1.get().getOutputs().getFiles().getAsPath())
+    Mockito.when(mockTaskContainer.named("war")).thenReturn(mockWarTaskProvider);
+    Mockito.when(mockWarTaskProvider.get().getOutputs().getFiles().getAsPath())
         .thenReturn("/war/file/here.war");
 
     Assert.assertEquals("/war/file/here.war", gradleProjectProperties.getWarFilePath());
@@ -576,9 +576,9 @@ public class GradleProjectPropertiesTest {
   @Test
   public void testGetWarFilePath_bootWar() {
     Mockito.when(mockProject.getPlugins().hasPlugin("org.springframework.boot")).thenReturn(true);
-    Mockito.when(mockTaskContainer.named("bootWar")).thenReturn(mockTaskProvider1);
-    Mockito.when(mockTaskProvider1.get().getEnabled()).thenReturn(true);
-    Mockito.when(mockTaskProvider1.get().getOutputs().getFiles().getAsPath())
+    Mockito.when(mockTaskContainer.named("bootWar")).thenReturn(mockBootWarTaskProvider);
+    Mockito.when(mockBootWarTaskProvider.get().getEnabled()).thenReturn(true);
+    Mockito.when(mockBootWarTaskProvider.get().getOutputs().getFiles().getAsPath())
         .thenReturn("/boot/war/file.war");
 
     Assert.assertEquals("/boot/war/file.war", gradleProjectProperties.getWarFilePath());
@@ -587,13 +587,14 @@ public class GradleProjectPropertiesTest {
   @Test
   public void testGetWarFilePath_bootWarDisabled() {
     Mockito.when(mockProject.getPlugins().hasPlugin("org.springframework.boot")).thenReturn(true);
-    Mockito.when(mockTaskContainer.named("bootWar")).thenReturn(mockTaskProvider1);
-    Mockito.when(mockTaskProvider1.get().getOutputs().getFiles().getAsPath())
+    Mockito.when(mockTaskContainer.named("bootWar")).thenReturn(mockBootWarTaskProvider);
+    Mockito.when(mockBootWarTaskProvider.get().getOutputs().getFiles().getAsPath())
         .thenReturn("boot.war");
 
     Mockito.when(mockProject.getPlugins().hasPlugin(WarPlugin.class)).thenReturn(true);
-    Mockito.when(mockTaskContainer.named("war")).thenReturn(mockTaskProvider2);
-    Mockito.when(mockTaskProvider2.get().getOutputs().getFiles().getAsPath()).thenReturn("war.war");
+    Mockito.when(mockTaskContainer.named("war")).thenReturn(mockWarTaskProvider);
+    Mockito.when(mockWarTaskProvider.get().getOutputs().getFiles().getAsPath())
+        .thenReturn("war.war");
 
     Assert.assertEquals("war.war", gradleProjectProperties.getWarFilePath());
   }
@@ -619,8 +620,8 @@ public class GradleProjectPropertiesTest {
         zipUpDirectory(webAppDirectory, temporaryFolder.getRoot().toPath().resolve("my-app.war"));
 
     Mockito.when(mockProject.getPlugins().hasPlugin(WarPlugin.class)).thenReturn(true);
-    Mockito.when(mockTaskContainer.named("war")).thenReturn(mockTaskProvider1);
-    Mockito.when(mockTaskProvider1.get().getOutputs().getFiles().getAsPath())
+    Mockito.when(mockTaskContainer.named("war")).thenReturn(mockWarTaskProvider);
+    Mockito.when(mockWarTaskProvider.get().getOutputs().getFiles().getAsPath())
         .thenReturn(targetZip.toString());
 
     // Make "GradleProjectProperties" use this folder to explode the WAR into.

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/TaskCommonTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/TaskCommonTest.java
@@ -22,6 +22,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.WarPlugin;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.api.tasks.bundling.War;
 import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Assert;
 import org.junit.Before;
@@ -161,19 +162,7 @@ public class TaskCommonTest {
     project.getPlugins().apply(JavaPlugin.class);
 
     TaskProvider<Task> warProviderTask = TaskCommon.getWarTaskProvider(project);
-
     Assert.assertNull(warProviderTask);
-  }
-
-  @Test
-  public void testGetWarTask_bootJavaProject() {
-    Project project = ProjectBuilder.builder().build();
-    project.getPlugins().apply(JavaPlugin.class);
-    project.getPlugins().apply(SpringBootPlugin.class);
-
-    TaskProvider<Task> warTask = TaskCommon.getWarTaskProvider(project);
-
-    Assert.assertNull(warTask);
   }
 
   @Test
@@ -182,19 +171,18 @@ public class TaskCommonTest {
     project.getPlugins().apply(WarPlugin.class);
 
     TaskProvider<Task> warTask = TaskCommon.getWarTaskProvider(project);
-
     Assert.assertNotNull(warTask);
+    Assert.assertNotNull(warTask instanceof War);
   }
 
   @Test
-  public void testGetWarTask_bootWarProject() {
+  public void testGetBootWarTask_bootWarProject() {
     Project project = ProjectBuilder.builder().build();
     project.getPlugins().apply(WarPlugin.class);
     project.getPlugins().apply(SpringBootPlugin.class);
 
-    TaskProvider<Task> warTask = TaskCommon.getWarTaskProvider(project);
-
-    Assert.assertNotNull(warTask);
-    Assert.assertTrue(warTask.get() instanceof BootWar);
+    TaskProvider<Task> bootWarTask = TaskCommon.getBootWarTaskProvider(project);
+    Assert.assertNotNull(bootWarTask);
+    Assert.assertNotNull(bootWarTask instanceof BootWar);
   }
 }


### PR DESCRIPTION
Fixes #2096.

~~The only thing that may matter is that now `task.dependsOn(Object...)` takes a `List`, so I'll do some actual tests to see this works as desired.~~ Works fine.