### PR TITLE
remove deprecation warnings

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
@@ -51,7 +51,6 @@ public class ContainerParameters {
   private String creationTime = "EPOCH";
 
   @Input
-  @Optional
   public boolean getUseCurrentTimestamp() {
     if (System.getProperty(PropertyNames.CONTAINER_USE_CURRENT_TIMESTAMP) != null) {
       return Boolean.getBoolean(PropertyNames.CONTAINER_USE_CURRENT_TIMESTAMP);

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -192,7 +192,6 @@ public class JibExtension {
   }
 
   @Input
-  @Optional
   boolean getAllowInsecureRegistries() {
     if (System.getProperty(PropertyNames.ALLOW_INSECURE_REGISTRIES) != null) {
       return Boolean.getBoolean(PropertyNames.ALLOW_INSECURE_REGISTRIES);


### PR DESCRIPTION
<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->
close #2086 by removing deprecated `@org.gradle.api.tasks.Optional` annotation