### PR TITLE
Do not swallow insecure server exception

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/AuthenticatePushStep.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.api.Credential;
-import com.google.cloud.tools.jib.api.InsecureRegistryException;
 import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
@@ -68,8 +67,6 @@ class AuthenticatePushStep implements Callable<Optional<Authorization>> {
       if (registryAuthenticator.isPresent()) {
         return Optional.of(registryAuthenticator.get().authenticatePush(registryCredential));
       }
-    } catch (InsecureRegistryException ex) {
-      // Cannot skip certificate validation or use HTTP; fall through.
     }
 
     return (registryCredential == null || registryCredential.isOAuth2RefreshToken())

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.jib.builder.steps;
 import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.ImageReference;
-import com.google.cloud.tools.jib.api.InsecureRegistryException;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.api.RegistryUnauthorizedException;
@@ -123,12 +122,12 @@ class PullBaseImageStep implements Callable<ImageAndAuthorization> {
 
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create("pulling base image manifest", 2);
-        TimerEventDispatcher ignored = new TimerEventDispatcher(eventHandlers, DESCRIPTION)) {
+        TimerEventDispatcher ignored1 = new TimerEventDispatcher(eventHandlers, DESCRIPTION)) {
       // First, try with no credentials.
       try {
         return new ImageAndAuthorization(pullBaseImage(null, progressEventDispatcher), null);
 
-      } catch (RegistryUnauthorizedException ex) {
+      } catch (RegistryUnauthorizedException ignored2) {
         eventHandlers.dispatch(
             LogEvent.lifecycle(
                 "The base image requires auth. Trying again for " + imageReference + "..."));
@@ -155,26 +154,22 @@ class PullBaseImageStep implements Callable<ImageAndAuthorization> {
         } catch (RegistryUnauthorizedException registryUnauthorizedException) {
           // The registry requires us to authenticate using the Docker Token Authentication.
           // See https://docs.docker.com/registry/spec/auth/token
-          try {
-            Optional<RegistryAuthenticator> registryAuthenticator =
-                buildConfiguration
-                    .newBaseImageRegistryClientFactory()
-                    .newRegistryClient()
-                    .getRegistryAuthenticator();
-            if (registryAuthenticator.isPresent()) {
-              Authorization pullAuthorization =
-                  registryAuthenticator.get().authenticatePull(registryCredential);
+          Optional<RegistryAuthenticator> registryAuthenticator =
+              buildConfiguration
+                  .newBaseImageRegistryClientFactory()
+                  .newRegistryClient()
+                  .getRegistryAuthenticator();
+          if (registryAuthenticator.isPresent()) {
+            Authorization pullAuthorization =
+                registryAuthenticator.get().authenticatePull(registryCredential);
 
-              return new ImageAndAuthorization(
-                  pullBaseImage(pullAuthorization, progressEventDispatcher), pullAuthorization);
-            }
-
-          } catch (InsecureRegistryException insecureRegistryException) {
-            // Cannot skip certificate validation or use HTTP; fall through.
+            return new ImageAndAuthorization(
+                pullBaseImage(pullAuthorization, progressEventDispatcher), pullAuthorization);
           }
           eventHandlers.dispatch(
               LogEvent.error(
-                  "Failed to retrieve authentication challenge for registry that required token authentication"));
+                  "Failed to retrieve authentication challenge for registry that required token "
+                      + "authentication"));
           throw registryUnauthorizedException;
         }
       }


### PR DESCRIPTION
We've been swallowing `InsecureRegistryException` when trying to auth with the registry through `RegistryAuthenticator`. I've been mulling over why we are doing this, and I think it is rather good to surface the error. For `AuthenticatePushStep`, the intention might have been to fall back and return null or basic credentials, but I still think there's no point of doing that if we get `InsecureRegistryException`. I think it's an unrecoverable situation.

I'll give it a second look later, but for now, I think it's good to surface this.