### PR TITLE
No need to pass around ExecutorService

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -93,7 +93,6 @@ public class LocalBaseImageSteps {
   }
 
   static Callable<LocalImage> retrieveDockerDaemonImageStep(
-      ExecutorService executorService,
       BuildConfiguration buildConfiguration,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
       DockerClient dockerClient) {
@@ -125,22 +124,16 @@ public class LocalBaseImageSteps {
         }
 
         return cacheDockerImageTar(
-            buildConfiguration,
-            executorService,
-            tarPath,
-            progressEventDispatcher.newChildProducer());
+            buildConfiguration, tarPath, progressEventDispatcher.newChildProducer());
       }
     };
   }
 
   static Callable<LocalImage> retrieveTarImageStep(
-      ExecutorService executorService,
       BuildConfiguration buildConfiguration,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
       Path tarPath) {
-    return () ->
-        cacheDockerImageTar(
-            buildConfiguration, executorService, tarPath, progressEventDispatcherFactory);
+    return () -> cacheDockerImageTar(buildConfiguration, tarPath, progressEventDispatcherFactory);
   }
 
   @VisibleForTesting
@@ -179,11 +172,11 @@ public class LocalBaseImageSteps {
   @VisibleForTesting
   static LocalImage cacheDockerImageTar(
       BuildConfiguration buildConfiguration,
-      ExecutorService executorService,
       Path tarPath,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory)
       throws IOException, LayerCountMismatchException, BadContainerConfigurationFormatException,
           ExecutionException, InterruptedException {
+    ExecutorService executorService = buildConfiguration.getExecutorService();
     try (TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider()) {
       Path destination = tempDirectoryProvider.newDirectory();
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -239,10 +239,7 @@ public class StepsRunner {
     assignLocalImageResult(
         executorService.submit(
             LocalBaseImageSteps.retrieveDockerDaemonImageStep(
-                executorService,
-                buildConfiguration,
-                childProgressDispatcherFactory,
-                dockerClient.get())));
+                buildConfiguration, childProgressDispatcherFactory, dockerClient.get())));
   }
 
   private void extractTar() {
@@ -253,10 +250,7 @@ public class StepsRunner {
     assignLocalImageResult(
         executorService.submit(
             LocalBaseImageSteps.retrieveTarImageStep(
-                executorService,
-                buildConfiguration,
-                childProgressDispatcherFactory,
-                tarPath.get())));
+                buildConfiguration, childProgressDispatcherFactory, tarPath.get())));
   }
 
   private void assignLocalImageResult(Future<LocalImage> localImageFuture) {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageStepsTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageStepsTest.java
@@ -64,6 +64,8 @@ public class LocalBaseImageStepsTest {
 
   @Before
   public void setup() throws IOException {
+    Mockito.when(buildConfiguration.getExecutorService())
+        .thenReturn(MoreExecutors.newDirectExecutorService());
     Mockito.when(buildConfiguration.getBaseImageLayersCache())
         .thenReturn(Cache.withDirectory(temporaryFolder.newFolder().toPath()));
     Mockito.when(buildConfiguration.getEventHandlers()).thenReturn(eventHandlers);
@@ -79,10 +81,7 @@ public class LocalBaseImageStepsTest {
     Path dockerBuild = getResource("core/extraction/docker-save.tar");
     LocalImage result =
         LocalBaseImageSteps.cacheDockerImageTar(
-            buildConfiguration,
-            MoreExecutors.newDirectExecutorService(),
-            dockerBuild,
-            progressEventDispatcherFactory);
+            buildConfiguration, dockerBuild, progressEventDispatcherFactory);
 
     Mockito.verify(progressEventDispatcher, Mockito.times(2)).newChildProducer();
     Assert.assertEquals(2, result.layers.size());
@@ -106,10 +105,7 @@ public class LocalBaseImageStepsTest {
     Path tarBuild = getResource("core/extraction/jib-image.tar");
     LocalImage result =
         LocalBaseImageSteps.cacheDockerImageTar(
-            buildConfiguration,
-            MoreExecutors.newDirectExecutorService(),
-            tarBuild,
-            progressEventDispatcherFactory);
+            buildConfiguration, tarBuild, progressEventDispatcherFactory);
 
     Mockito.verify(progressEventDispatcher, Mockito.times(2)).newChildProducer();
     Assert.assertEquals(2, result.layers.size());


### PR DESCRIPTION
We should eventually make the step clear of `ExecutorService`, as that's the business of `StepsRunner` which will also increase concurrency (#1913), but until then, we can apply this cleanup.

But at the same time, I said I am not sure I like having `ExecutorService` in `BuildConfiguration`: https://github.com/GoogleContainerTools/jib/pull/2125#issue-337469649