### PR TITLE
remove env check for integTest so intellij sync works

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,6 +212,7 @@ subprojects {
     classpath = sourceSets.integrationTest.runtimeClasspath
     systemProperty '_JIB_DISABLE_USER_AGENT', true
   }
+
   integrationTest.dependsOn test
 
   task integrationTestJar(type: Jar) {
@@ -390,13 +391,6 @@ tasks.register("dev") {
 }
 
 tasks.register("devFull") {
-  if (!System.getenv('JIB_INTEGRATION_TESTING_PROJECT')
-      && !System.getenv('JIB_INTEGRATION_TESTING_LOCATION')) {
-    throw new GradleException(
-        "Must set environment variable JIB_INTEGRATION_TESTING_PROJECT to the "
-        + "GCP project to use for integration testing or "
-        + "JIB_INTEGRATION_TESTING_LOCATION to a suitable registry/repository location.");
-  }
   dependsOn tasks.dev
   subprojects.each { subproject ->
     dependsOn subproject.tasks.integrationTest


### PR DESCRIPTION
Turns out intellij doesn't care that you're using register, the sync mechanism will resolve and configure all tasks during sync.

We can't put this check with the integrationTest (`doFirst {}`) because jib-core doesn't actually need it to run integration tests (as seen in kokoro/presubmit.sh)