### PR TITLE
Corrected dropwizard-jib-example pom to use jvmFlag rather than jmxFlag.

### DIFF
--- a/examples/dropwizard/pom.xml
+++ b/examples/dropwizard/pom.xml
@@ -72,14 +72,14 @@
 
                         <!-- good defaults intended for Java 8 (>= 8u191) containers -->
                         <jvmFlags>
-                            <jmxFlag>-server</jmxFlag>
-                            <jmxFlag>-Djava.awt.headless=true</jmxFlag>
-                            <jmxFlag>-XX:InitialRAMFraction=2</jmxFlag>
-                            <jmxFlag>-XX:MinRAMFraction=2</jmxFlag>
-                            <jmxFlag>-XX:MaxRAMFraction=2</jmxFlag>
-                            <jmxFlag>-XX:+UseG1GC</jmxFlag>
-                            <jmxFlag>-XX:MaxGCPauseMillis=100</jmxFlag>
-                            <jmxFlag>-XX:+UseStringDeduplication</jmxFlag>
+                            <jvmFlag>-server</jvmFlag>
+                            <jvmFlag>-Djava.awt.headless=true</jvmFlag>
+                            <jvmFlag>-XX:InitialRAMFraction=2</jvmFlag>
+                            <jvmFlag>-XX:MinRAMFraction=2</jvmFlag>
+                            <jvmFlag>-XX:MaxRAMFraction=2</jvmFlag>
+                            <jvmFlag>-XX:+UseG1GC</jvmFlag>
+                            <jvmFlag>-XX:MaxGCPauseMillis=100</jvmFlag>
+                            <jvmFlag>-XX:+UseStringDeduplication</jvmFlag>
                         </jvmFlags>
                     </container>
                 </configuration>


### PR DESCRIPTION
This PR simply corrects one of the examples, we happened to notice it was wrong because it was the one we copied.  It would appear that the use of jmxFlag instead of jvmFlag does not cause any problems but it is confusing and might cause issues in the future.