### PR TITLE
Set Gradle version to run in integration tests

### DIFF
--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/TestProject.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/TestProject.java
@@ -75,7 +75,11 @@ class TestProject extends TemporaryFolder implements Closeable {
     projectRoot = newFolder().toPath();
     copyProject(testProjectName, projectRoot);
 
-    gradleRunner = GradleRunner.create().withProjectDir(projectRoot.toFile()).withPluginClasspath();
+    gradleRunner =
+        GradleRunner.create()
+            .withGradleVersion(JibPlugin.GRADLE_MIN_VERSION.getVersion())
+            .withProjectDir(projectRoot.toFile())
+            .withPluginClasspath();
   }
 
   BuildResult build(String... gradleArguments) {

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -599,7 +599,7 @@ public class BuildImageMojoIntegrationTest {
 
   @Test
   public void testExecute_timestampCustom()
-      throws IOException, InterruptedException, VerificationException, DigestException {
+      throws IOException, InterruptedException, VerificationException {
     String targetImage = "localhost:6000/simpleimage:maven" + System.nanoTime();
     String pom = "pom-timestamps-custom.xml";
     Assert.assertEquals(
@@ -642,7 +642,7 @@ public class BuildImageMojoIntegrationTest {
 
   @Test
   public void testExecute_complex_sameFromAndToRegistry()
-      throws IOException, InterruptedException, VerificationException, DigestException {
+      throws IOException, InterruptedException, VerificationException {
     String targetImage = "localhost:5000/compleximage:maven" + System.nanoTime();
     Assert.assertEquals(
         "Hello, world. An argument.\n1970-01-01T00:00:01Z\nrwxr-xr-x\nrwxrwxrwx\nfoo\ncat\n"
@@ -655,7 +655,7 @@ public class BuildImageMojoIntegrationTest {
 
   @Test
   public void testExecute_complexProperties()
-      throws InterruptedException, DigestException, VerificationException, IOException {
+      throws InterruptedException, VerificationException, IOException {
     String targetImage = "localhost:6000/compleximage:maven" + System.nanoTime();
     Assert.assertEquals(
         "Hello, world. An argument.\n1970-01-01T00:00:01Z\nrwxr-xr-x\nrwxrwxrwx\nfoo\ncat\n"

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -219,7 +219,7 @@ public class BuildImageMojoIntegrationTest {
       String password,
       LocalRegistry targetRegistry,
       String pomFile)
-      throws VerificationException, IOException, InterruptedException, DigestException {
+      throws VerificationException, IOException, InterruptedException {
     Verifier verifier = new Verifier(simpleTestProject.getProjectRoot().toString());
     verifier.setSystemProperty("jib.useOnlyProjectCache", "true");
     verifier.setSystemProperty("_TARGET_IMAGE", imageReference);


### PR DESCRIPTION
`GRADLE_MIN_VERSION` is 4.9.

Verified one of the tests fails if Gradle 5 API is used.