### PR TITLE
Put skaffold classes in skaffold package

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -17,6 +17,10 @@
 package com.google.cloud.tools.jib.gradle;
 
 import com.google.cloud.tools.jib.ProjectInfo;
+import com.google.cloud.tools.jib.gradle.skaffold.CheckJibVersionTask;
+import com.google.cloud.tools.jib.gradle.skaffold.FilesTask;
+import com.google.cloud.tools.jib.gradle.skaffold.FilesTaskV2;
+import com.google.cloud.tools.jib.gradle.skaffold.InitTask;
 import com.google.cloud.tools.jib.plugins.common.VersionChecker;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
@@ -39,19 +43,17 @@ public class JibPlugin implements Plugin<Project> {
 
   @VisibleForTesting static final GradleVersion GRADLE_MIN_VERSION = GradleVersion.version("4.9");
 
-  @VisibleForTesting static final String JIB_EXTENSION_NAME = "jib";
-  @VisibleForTesting static final String BUILD_IMAGE_TASK_NAME = "jib";
-  @VisibleForTesting static final String BUILD_TAR_TASK_NAME = "jibBuildTar";
-  @VisibleForTesting static final String BUILD_DOCKER_TASK_NAME = "jibDockerBuild";
-  @VisibleForTesting static final String FILES_TASK_NAME = "_jibSkaffoldFiles";
-  @VisibleForTesting static final String FILES_TASK_V2_NAME = "_jibSkaffoldFilesV2";
-  @VisibleForTesting static final String INIT_TASK_NAME = "_jibSkaffoldInit";
+  public static final String JIB_EXTENSION_NAME = "jib";
+  public static final String BUILD_IMAGE_TASK_NAME = "jib";
+  public static final String BUILD_TAR_TASK_NAME = "jibBuildTar";
+  public static final String BUILD_DOCKER_TASK_NAME = "jibDockerBuild";
+  public static final String SKAFFOLD_FILES_TASK_NAME = "_jibSkaffoldFiles";
+  public static final String SKAFFOLD_FILES_TASK_V2_NAME = "_jibSkaffoldFilesV2";
+  public static final String SKAFFOLD_INIT_TASK_NAME = "_jibSkaffoldInit";
+  public static final String SKAFFOLD_CHECK_REQUIRED_VERSION_TASK_NAME =
+      "_skaffoldFailIfJibOutOfDate";
 
-  @VisibleForTesting static final String EXPLODED_WAR_TASK_NAME = "jibExplodedWar";
-
-  static final String CHECK_REQUIRED_VERSION_TASK_NAME = "_skaffoldFailIfJibOutOfDate";
-
-  static final String REQUIRED_VERSION_PROPERTY_NAME = "jib.requiredVersion";
+  public static final String REQUIRED_VERSION_PROPERTY_NAME = "jib.requiredVersion";
 
   /**
    * Collects all project dependencies of the style "compile project(':mylib')" for any kind of
@@ -148,18 +150,18 @@ public class JibPlugin implements Plugin<Project> {
             });
 
     tasks
-        .register(FILES_TASK_NAME, FilesTask.class)
+        .register(SKAFFOLD_FILES_TASK_NAME, FilesTask.class)
         .configure(task -> task.setJibExtension(jibExtension));
     tasks
-        .register(FILES_TASK_V2_NAME, FilesTaskV2.class)
+        .register(SKAFFOLD_FILES_TASK_V2_NAME, FilesTaskV2.class)
         .configure(task -> task.setJibExtension(jibExtension));
     tasks
-        .register(INIT_TASK_NAME, SkaffoldInitTask.class)
+        .register(SKAFFOLD_INIT_TASK_NAME, InitTask.class)
         .configure(task -> task.setJibExtension(jibExtension));
 
     // A check to catch older versions of Jib.  This can be removed once we are certain people
     // are using Jib 1.3.1 or later.
-    tasks.register(CHECK_REQUIRED_VERSION_TASK_NAME, CheckJibVersionTask.class);
+    tasks.register(SKAFFOLD_CHECK_REQUIRED_VERSION_TASK_NAME, CheckJibVersionTask.class);
 
     project.afterEvaluate(
         projectAfterEvaluation -> {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/CheckJibVersionTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/CheckJibVersionTask.java
@@ -14,8 +14,9 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.gradle;
+package com.google.cloud.tools.jib.gradle.skaffold;
 
+import com.google.cloud.tools.jib.gradle.JibPlugin;
 import com.google.common.base.Strings;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -36,7 +37,7 @@ public class CheckJibVersionTask extends DefaultTask {
   public void checkVersion() {
     if (Strings.isNullOrEmpty(System.getProperty(JibPlugin.REQUIRED_VERSION_PROPERTY_NAME))) {
       throw new GradleException(
-          JibPlugin.CHECK_REQUIRED_VERSION_TASK_NAME
+          JibPlugin.SKAFFOLD_CHECK_REQUIRED_VERSION_TASK_NAME
               + " requires "
               + JibPlugin.REQUIRED_VERSION_PROPERTY_NAME
               + " to be set");

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTask.java
@@ -14,8 +14,9 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.gradle;
+package com.google.cloud.tools.jib.gradle.skaffold;
 
+import com.google.cloud.tools.jib.gradle.JibExtension;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.nio.file.Files;

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2.java
@@ -14,8 +14,9 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.gradle;
+package com.google.cloud.tools.jib.gradle.skaffold;
 
+import com.google.cloud.tools.jib.gradle.JibExtension;
 import com.google.cloud.tools.jib.plugins.common.SkaffoldFilesOutput;
 import com.google.common.base.Preconditions;
 import java.io.File;

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/InitTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/InitTask.java
@@ -14,8 +14,9 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.gradle;
+package com.google.cloud.tools.jib.gradle.skaffold;
 
+import com.google.cloud.tools.jib.gradle.JibExtension;
 import com.google.cloud.tools.jib.plugins.common.SkaffoldInitOutput;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
@@ -29,11 +30,11 @@ import org.gradle.api.tasks.TaskAction;
  *
  * <p>Expected use: {@code ./gradlew _jibSkaffoldInit -q}
  */
-public class SkaffoldInitTask extends DefaultTask {
+public class InitTask extends DefaultTask {
 
   @Nullable private JibExtension jibExtension;
 
-  public SkaffoldInitTask setJibExtension(JibExtension jibExtension) {
+  public InitTask setJibExtension(JibExtension jibExtension) {
     this.jibExtension = jibExtension;
     return this;
   }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -116,7 +116,8 @@ public class JibPluginTest {
   public void testCheckJibVersionNames() {
     // These identifiers will be baked into Skaffold and should not be changed
     Assert.assertEquals(JibPlugin.REQUIRED_VERSION_PROPERTY_NAME, "jib.requiredVersion");
-    Assert.assertEquals(JibPlugin.CHECK_REQUIRED_VERSION_TASK_NAME, "_skaffoldFailIfJibOutOfDate");
+    Assert.assertEquals(
+        JibPlugin.SKAFFOLD_CHECK_REQUIRED_VERSION_TASK_NAME, "_skaffoldFailIfJibOutOfDate");
   }
 
   @Test

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/TestProject.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/TestProject.java
@@ -30,7 +30,7 @@ import org.junit.rules.TemporaryFolder;
 
 // TODO: Consolidate with TestProject in jib-maven-plugin.
 /** Works with the test Gradle projects in the {@code resources/projects} directory. */
-class TestProject extends TemporaryFolder implements Closeable {
+public class TestProject extends TemporaryFolder implements Closeable {
 
   private static final String PROJECTS_PATH_IN_RESOURCES = "gradle/projects/";
 
@@ -59,7 +59,7 @@ class TestProject extends TemporaryFolder implements Closeable {
   private Path projectRoot;
 
   /** Initialize with a specific project directory. */
-  TestProject(String testProjectName) {
+  public TestProject(String testProjectName) {
     this.testProjectName = testProjectName;
   }
 
@@ -78,11 +78,11 @@ class TestProject extends TemporaryFolder implements Closeable {
     gradleRunner = GradleRunner.create().withProjectDir(projectRoot.toFile()).withPluginClasspath();
   }
 
-  BuildResult build(String... gradleArguments) {
+  public BuildResult build(String... gradleArguments) {
     return gradleRunner.withArguments(gradleArguments).build();
   }
 
-  Path getProjectRoot() {
+  public Path getProjectRoot() {
     return projectRoot;
   }
 }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/skaffold/InitTaskTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/skaffold/InitTaskTest.java
@@ -14,8 +14,10 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.gradle;
+package com.google.cloud.tools.jib.gradle.skaffold;
 
+import com.google.cloud.tools.jib.gradle.JibPlugin;
+import com.google.cloud.tools.jib.gradle.TestProject;
 import com.google.cloud.tools.jib.plugins.common.SkaffoldInitOutput;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,8 +32,8 @@ import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 
-/** Tests for {@link SkaffoldInitTask}. */
-public class SkaffoldInitTaskTest {
+/** Tests for {@link InitTask}. */
+public class InitTaskTest {
 
   @ClassRule public static final TestProject simpleTestProject = new TestProject("simple");
 
@@ -46,8 +48,8 @@ public class SkaffoldInitTaskTest {
    */
   private static List<String> getJsons(TestProject project) {
     BuildResult buildResult =
-        project.build(JibPlugin.INIT_TASK_NAME, "-q", "-D_TARGET_IMAGE=testimage");
-    BuildTask jibTask = buildResult.task(":" + JibPlugin.INIT_TASK_NAME);
+        project.build(JibPlugin.SKAFFOLD_INIT_TASK_NAME, "-q", "-D_TARGET_IMAGE=testimage");
+    BuildTask jibTask = buildResult.task(":" + JibPlugin.SKAFFOLD_INIT_TASK_NAME);
     Assert.assertNotNull(jibTask);
     Assert.assertEquals(TaskOutcome.SUCCESS, jibTask.getOutcome());
     String output = buildResult.getOutput().trim();


### PR DESCRIPTION
This is a reorganization of skaffold related classes into a skaffold package (similar to how the maven plugin is organized), makes some task names public (which I think is okay, for users that want to directly reference those names).