### PR TITLE
Allow pushing local base image layers immediately after compressing

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Each local base image layer is pushed immediately after being compressed, rather than waiting for all layers to finish compressing before starting to push. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))
+
 ### Fixed
 
 - `Containerizer#setAllowInsecureRegistries(boolean)` and the `sendCredentialsOverHttp` system property are now effective for authentication service server connections. ([#2074](https://github.com/GoogleContainerTools/jib/pull/2074)

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -233,13 +233,13 @@ public class LocalBaseImageSteps {
             progressEventDispatcherFactory.create(
                 "processing base image layers", layerFiles.size())) {
           // Start compressing layers in parallel
-          List<Future<PreparedLayer>> cachedLayers = new ArrayList<>();
+          List<Future<PreparedLayer>> preparedLayers = new ArrayList<>();
           for (int index = 0; index < layerFiles.size(); index++) {
             Path layerFile = destination.resolve(layerFiles.get(index));
             DescriptorDigest diffId = configurationTemplate.getLayerDiffId(index);
             ProgressEventDispatcher.Factory layerProgressDispatcherFactory =
                 progressEventDispatcher.newChildProducer();
-            cachedLayers.add(
+            preparedLayers.add(
                 executorService.submit(
                     () ->
                         compressAndCacheTarLayer(
@@ -249,7 +249,7 @@ public class LocalBaseImageSteps {
                             layersAreCompressed,
                             layerProgressDispatcherFactory)));
           }
-          return new LocalImage(cachedLayers, configurationTemplate);
+          return new LocalImage(preparedLayers, configurationTemplate);
         }
       }
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -142,13 +142,13 @@ public class LocalBaseImageSteps {
             buildContext, tarPath, progressEventDispatcherFactory, tempDirectoryProvider);
   }
 
-  static Callable<ImageAndAuthorization> retrieveImageAndAuthorizationStep(
+  static Callable<ImageAndAuthorization> returnImageAndAuthorizationStep(
       List<PreparedLayer> layers, ContainerConfigurationTemplate configurationTemplate) {
     return () -> {
       // Collect compressed layers and add to manifest
       V22ManifestTemplate v22Manifest = new V22ManifestTemplate();
-      for (PreparedLayer layerFuture : layers) {
-        BlobDescriptor descriptor = layerFuture.getBlobDescriptor();
+      for (PreparedLayer layer : layers) {
+        BlobDescriptor descriptor = layer.getBlobDescriptor();
         v22Manifest.addLayer(descriptor.getSize(), descriptor.getDigest());
       }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -136,7 +136,7 @@ public class LocalBaseImageSteps {
     return () -> cacheDockerImageTar(buildConfiguration, tarPath, progressEventDispatcherFactory);
   }
 
-  static Callable<ImageAndAuthorization> retrieveLocalImageStep(
+  static Callable<ImageAndAuthorization> retrieveImageAndAuthorizationStep(
       Future<LocalImage> localImageFuture) {
     return () -> {
       // Collect compressed layers and add to manifest

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.blob.Blobs;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
+import com.google.cloud.tools.jib.builder.steps.PullBaseImageStep.ImageAndAuthorization;
 import com.google.cloud.tools.jib.cache.Cache;
 import com.google.cloud.tools.jib.cache.CacheCorruptedException;
 import com.google.cloud.tools.jib.cache.CachedLayer;
@@ -34,11 +35,9 @@ import com.google.cloud.tools.jib.docker.DockerClient.DockerImageDetails;
 import com.google.cloud.tools.jib.docker.json.DockerManifestEntryTemplate;
 import com.google.cloud.tools.jib.event.progress.ThrottledAccumulatingConsumer;
 import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
-import com.google.cloud.tools.jib.hash.Digests;
 import com.google.cloud.tools.jib.http.NotifyingOutputStream;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.LayerCountMismatchException;
-import com.google.cloud.tools.jib.image.json.BadContainerConfigurationFormatException;
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
 import com.google.cloud.tools.jib.image.json.JsonToImageTranslator;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
@@ -46,6 +45,7 @@ import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.cloud.tools.jib.tar.TarExtractor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.ByteStreams;
+import com.google.common.util.concurrent.Futures;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -55,7 +55,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.zip.GZIPInputStream;
@@ -66,12 +65,13 @@ public class LocalBaseImageSteps {
 
   /** Contains an {@link Image} and its layers. * */
   static class LocalImage {
-    final Image baseImage;
-    final List<PreparedLayer> layers;
+    final List<Future<PreparedLayer>> layers;
+    final ContainerConfigurationTemplate configurationTemplate;
 
-    LocalImage(Image baseImage, List<PreparedLayer> layers) {
-      this.baseImage = baseImage;
+    LocalImage(
+        List<Future<PreparedLayer>> layers, ContainerConfigurationTemplate configurationTemplate) {
       this.layers = layers;
+      this.configurationTemplate = configurationTemplate;
     }
   }
 
@@ -92,7 +92,7 @@ public class LocalBaseImageSteps {
     }
   }
 
-  static Callable<LocalImage> retrieveDockerDaemonImageStep(
+  static Callable<LocalImage> retrieveDockerDaemonLayersStep(
       BuildConfiguration buildConfiguration,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
       DockerClient dockerClient) {
@@ -129,21 +129,37 @@ public class LocalBaseImageSteps {
     };
   }
 
-  static Callable<LocalImage> retrieveTarImageStep(
+  static Callable<LocalImage> retrieveTarLayersStep(
       BuildConfiguration buildConfiguration,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
       Path tarPath) {
     return () -> cacheDockerImageTar(buildConfiguration, tarPath, progressEventDispatcherFactory);
   }
 
+  static Callable<ImageAndAuthorization> retrieveLocalImageStep(
+      Future<LocalImage> localImageFuture) {
+    return () -> {
+      // Collect compressed layers and add to manifest
+      LocalImage localImage = localImageFuture.get();
+      V22ManifestTemplate v22Manifest = new V22ManifestTemplate();
+      for (Future<PreparedLayer> layerFuture : localImage.layers) {
+        BlobDescriptor descriptor = layerFuture.get().getBlobDescriptor();
+        v22Manifest.addLayer(descriptor.getSize(), descriptor.getDigest());
+      }
+
+      BlobDescriptor configDescriptor =
+          Blobs.from(localImage.configurationTemplate).writeTo(ByteStreams.nullOutputStream());
+      v22Manifest.setContainerConfiguration(
+          configDescriptor.getSize(), configDescriptor.getDigest());
+      return new ImageAndAuthorization(
+          JsonToImageTranslator.toImage(v22Manifest, localImage.configurationTemplate), null);
+    };
+  }
+
   @VisibleForTesting
   static Optional<LocalImage> getCachedDockerImage(
       Cache cache, DockerImageDetails dockerImageDetails)
-      throws DigestException, IOException, CacheCorruptedException, LayerCountMismatchException,
-          BadContainerConfigurationFormatException {
-    V22ManifestTemplate v22Manifest = new V22ManifestTemplate();
-    List<PreparedLayer> cachedLayers = new ArrayList<>();
-
+      throws DigestException, IOException, CacheCorruptedException {
     // Get config
     Optional<ContainerConfigurationTemplate> cachedConfig =
         cache.retrieveLocalConfig(dockerImageDetails.getImageId());
@@ -152,21 +168,17 @@ public class LocalBaseImageSteps {
     }
 
     // Get layers
+    List<Future<PreparedLayer>> cachedLayers = new ArrayList<>();
     for (DescriptorDigest diffId : dockerImageDetails.getDiffIds()) {
       Optional<CachedLayer> cachedLayer = cache.retrieveTarLayer(diffId);
       if (!cachedLayer.isPresent()) {
         return Optional.empty();
       }
       CachedLayer layer = cachedLayer.get();
-      cachedLayers.add(new PreparedLayer.Builder(layer).build());
-      v22Manifest.addLayer(layer.getSize(), layer.getDigest());
+      cachedLayers.add(Futures.immediateFuture(new PreparedLayer.Builder(layer).build()));
     }
 
-    // Create manifest
-    BlobDescriptor configDescriptor = Digests.computeDigest(cachedConfig.get());
-    v22Manifest.setContainerConfiguration(configDescriptor.getSize(), configDescriptor.getDigest());
-    Image image = JsonToImageTranslator.toImage(v22Manifest, cachedConfig.get());
-    return Optional.of(new LocalImage(image, cachedLayers));
+    return Optional.of(new LocalImage(cachedLayers, cachedConfig.get()));
   }
 
   @VisibleForTesting
@@ -174,93 +186,73 @@ public class LocalBaseImageSteps {
       BuildConfiguration buildConfiguration,
       Path tarPath,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory)
-      throws IOException, LayerCountMismatchException, BadContainerConfigurationFormatException,
-          ExecutionException, InterruptedException {
+      throws IOException, LayerCountMismatchException {
     ExecutorService executorService = buildConfiguration.getExecutorService();
-    try (TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider()) {
+    try (TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider();
+        TimerEventDispatcher ignored =
+            new TimerEventDispatcher(
+                buildConfiguration.getEventHandlers(), "Extracting tar " + tarPath)) {
       Path destination = tempDirectoryProvider.newDirectory();
+      TarExtractor.extract(tarPath, destination);
 
-      try (TimerEventDispatcher ignored =
-          new TimerEventDispatcher(
-              buildConfiguration.getEventHandlers(),
-              "Extracting tar " + tarPath + " into " + destination)) {
-        TarExtractor.extract(tarPath, destination);
+      InputStream manifestStream = Files.newInputStream(destination.resolve("manifest.json"));
+      DockerManifestEntryTemplate loadManifest =
+          new ObjectMapper()
+              .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+              .readValue(manifestStream, DockerManifestEntryTemplate[].class)[0];
+      manifestStream.close();
 
-        InputStream manifestStream = Files.newInputStream(destination.resolve("manifest.json"));
-        DockerManifestEntryTemplate loadManifest =
-            new ObjectMapper()
-                .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
-                .readValue(manifestStream, DockerManifestEntryTemplate[].class)[0];
-        manifestStream.close();
+      Path configPath = destination.resolve(loadManifest.getConfig());
+      ContainerConfigurationTemplate configurationTemplate =
+          JsonTemplateMapper.readJsonFromFile(configPath, ContainerConfigurationTemplate.class);
+      BlobDescriptor originalConfigDescriptor =
+          Blobs.from(configPath).writeTo(ByteStreams.nullOutputStream());
 
-        Path configPath = destination.resolve(loadManifest.getConfig());
-        ContainerConfigurationTemplate configurationTemplate =
-            JsonTemplateMapper.readJsonFromFile(configPath, ContainerConfigurationTemplate.class);
-        BlobDescriptor originalConfigDescriptor =
-            Blobs.from(configPath).writeTo(ByteStreams.nullOutputStream());
+      List<String> layerFiles = loadManifest.getLayerFiles();
+      if (configurationTemplate.getLayerCount() != layerFiles.size()) {
+        throw new LayerCountMismatchException(
+            "Invalid base image format: manifest contains "
+                + layerFiles.size()
+                + " layers, but container configuration contains "
+                + configurationTemplate.getLayerCount()
+                + " layers");
+      }
+      buildConfiguration
+          .getBaseImageLayersCache()
+          .writeLocalConfig(originalConfigDescriptor.getDigest(), configurationTemplate);
 
-        List<String> layerFiles = loadManifest.getLayerFiles();
-        if (configurationTemplate.getLayerCount() != layerFiles.size()) {
-          throw new LayerCountMismatchException(
-              "Invalid base image format: manifest contains "
-                  + layerFiles.size()
-                  + " layers, but container configuration contains "
-                  + configurationTemplate.getLayerCount()
-                  + " layers");
+      // Check the first layer to see if the layers are compressed already. 'docker save' output
+      // is uncompressed, but a jib-built tar has compressed layers.
+      boolean layersAreCompressed =
+          layerFiles.size() > 0 && isGzipped(destination.resolve(layerFiles.get(0)));
+
+      // Process layer blobs
+      try (ProgressEventDispatcher progressEventDispatcher =
+          progressEventDispatcherFactory.create(
+              "processing base image layers", layerFiles.size())) {
+        // Start compressing layers in parallel
+        List<Future<PreparedLayer>> cachedLayers = new ArrayList<>();
+        for (int index = 0; index < layerFiles.size(); index++) {
+          Path layerFile = destination.resolve(layerFiles.get(index));
+          DescriptorDigest diffId = configurationTemplate.getLayerDiffId(index);
+          ProgressEventDispatcher.Factory layerProgressDispatcherFactory =
+              progressEventDispatcher.newChildProducer();
+          cachedLayers.add(
+              executorService.submit(
+                  () ->
+                      compressAndCacheTarLayer(
+                          buildConfiguration.getBaseImageLayersCache(),
+                          diffId,
+                          layerFile,
+                          layersAreCompressed,
+                          layerProgressDispatcherFactory)));
         }
-        buildConfiguration
-            .getBaseImageLayersCache()
-            .writeLocalConfig(originalConfigDescriptor.getDigest(), configurationTemplate);
-
-        // Check the first layer to see if the layers are compressed already. 'docker save' output
-        // is uncompressed, but a jib-built tar has compressed layers.
-        boolean layersAreCompressed =
-            layerFiles.size() > 0 && isGzipped(destination.resolve(layerFiles.get(0)));
-
-        // Process layer blobs
-        try (ProgressEventDispatcher progressEventDispatcher =
-            progressEventDispatcherFactory.create(
-                "processing base image layers", layerFiles.size())) {
-          List<PreparedLayer> layers = new ArrayList<>(layerFiles.size());
-          V22ManifestTemplate v22Manifest = new V22ManifestTemplate();
-
-          // Start compressing layers in parallel
-          List<Future<CachedLayer>> cachedLayers = new ArrayList<>();
-          for (int index = 0; index < layerFiles.size(); index++) {
-            Path layerFile = destination.resolve(layerFiles.get(index));
-            DescriptorDigest diffId = configurationTemplate.getLayerDiffId(index);
-            ProgressEventDispatcher.Factory layerProgressDispatcherFactory =
-                progressEventDispatcher.newChildProducer();
-            cachedLayers.add(
-                executorService.submit(
-                    () ->
-                        compressAndCacheTarLayer(
-                            buildConfiguration.getBaseImageLayersCache(),
-                            diffId,
-                            layerFile,
-                            layersAreCompressed,
-                            layerProgressDispatcherFactory)));
-          }
-
-          // Collect compressed layers and add to manifest
-          for (Future<CachedLayer> layerFuture : cachedLayers) {
-            CachedLayer layer = layerFuture.get();
-            layers.add(new PreparedLayer.Builder(layer).build());
-            v22Manifest.addLayer(layer.getSize(), layer.getDigest());
-          }
-
-          BlobDescriptor configDescriptor =
-              Blobs.from(configurationTemplate).writeTo(ByteStreams.nullOutputStream());
-          v22Manifest.setContainerConfiguration(
-              configDescriptor.getSize(), configDescriptor.getDigest());
-          Image image = JsonToImageTranslator.toImage(v22Manifest, configurationTemplate);
-          return new LocalImage(image, layers);
-        }
+        return new LocalImage(cachedLayers, configurationTemplate);
       }
     }
   }
 
-  private static CachedLayer compressAndCacheTarLayer(
+  private static PreparedLayer compressAndCacheTarLayer(
       Cache cache,
       DescriptorDigest diffId,
       Path layerFile,
@@ -275,12 +267,13 @@ public class LocalBaseImageSteps {
       // Retrieve pre-compressed layer from cache
       Optional<CachedLayer> optionalLayer = cache.retrieveTarLayer(diffId);
       if (optionalLayer.isPresent()) {
-        return optionalLayer.get();
+        return new PreparedLayer.Builder(optionalLayer.get()).build();
       }
 
       // Just write layers that are already compressed
       if (layersAreCompressed) {
-        return cache.writeTarLayer(diffId, Blobs.from(layerFile));
+        return new PreparedLayer.Builder(cache.writeTarLayer(diffId, Blobs.from(layerFile)))
+            .build();
       }
 
       // Compress uncompressed layers while writing
@@ -293,7 +286,7 @@ public class LocalBaseImageSteps {
                   Blobs.from(layerFile).writeTo(notifyingOutputStream);
                 }
               });
-      return cache.writeTarLayer(diffId, compressedBlob);
+      return new PreparedLayer.Builder(cache.writeTarLayer(diffId, compressedBlob)).build();
     }
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -143,22 +143,21 @@ public class LocalBaseImageSteps {
   }
 
   static Callable<ImageAndAuthorization> retrieveImageAndAuthorizationStep(
-      Future<LocalImage> localImageFuture) {
+      List<PreparedLayer> layers, ContainerConfigurationTemplate configurationTemplate) {
     return () -> {
       // Collect compressed layers and add to manifest
-      LocalImage localImage = localImageFuture.get();
       V22ManifestTemplate v22Manifest = new V22ManifestTemplate();
-      for (Future<PreparedLayer> layerFuture : localImage.layers) {
-        BlobDescriptor descriptor = layerFuture.get().getBlobDescriptor();
+      for (PreparedLayer layerFuture : layers) {
+        BlobDescriptor descriptor = layerFuture.getBlobDescriptor();
         v22Manifest.addLayer(descriptor.getSize(), descriptor.getDigest());
       }
 
       BlobDescriptor configDescriptor =
-          Blobs.from(localImage.configurationTemplate).writeTo(ByteStreams.nullOutputStream());
+          Blobs.from(configurationTemplate).writeTo(ByteStreams.nullOutputStream());
       v22Manifest.setContainerConfiguration(
           configDescriptor.getSize(), configDescriptor.getDigest());
       return new ImageAndAuthorization(
-          JsonToImageTranslator.toImage(v22Manifest, localImage.configurationTemplate), null);
+          JsonToImageTranslator.toImage(v22Manifest, configurationTemplate), null);
     };
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushLayerStep.java
@@ -64,7 +64,7 @@ class PushLayerStep implements Callable<BlobDescriptor> {
   @Nullable private final Authorization pushAuthorization;
   private final Future<PreparedLayer> preparedLayer;
 
-  PushLayerStep(
+  private PushLayerStep(
       BuildConfiguration buildConfiguration,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
       @Nullable Authorization pushAuthorization,

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -242,7 +242,7 @@ public class StepsRunner {
                 buildConfiguration, childProgressDispatcherFactory, dockerClient.get()));
     results.baseImageLayers = executorService.submit(() -> localImage.get().layers);
     results.baseImageAndAuth =
-        executorService.submit(LocalBaseImageSteps.retrieveLocalImageStep(localImage));
+        executorService.submit(LocalBaseImageSteps.retrieveImageAndAuthorizationStep(localImage));
   }
 
   private void extractTar() {
@@ -256,7 +256,7 @@ public class StepsRunner {
                 buildConfiguration, childProgressDispatcherFactory, tarPath.get()));
     results.baseImageLayers = executorService.submit(() -> localImage.get().layers);
     results.baseImageAndAuth =
-        executorService.submit(LocalBaseImageSteps.retrieveLocalImageStep(localImage));
+        executorService.submit(LocalBaseImageSteps.retrieveImageAndAuthorizationStep(localImage));
   }
 
   private void pullBaseImage() {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -239,7 +239,10 @@ public class StepsRunner {
     Future<LocalImage> localImage =
         executorService.submit(
             LocalBaseImageSteps.retrieveDockerDaemonLayersStep(
-                buildConfiguration, childProgressDispatcherFactory, dockerClient.get()));
+                buildConfiguration,
+                childProgressDispatcherFactory,
+                dockerClient.get(),
+                tempDirectoryProvider));
     results.baseImageLayers = executorService.submit(() -> localImage.get().layers);
     results.baseImageAndAuth =
         executorService.submit(LocalBaseImageSteps.retrieveImageAndAuthorizationStep(localImage));
@@ -253,7 +256,10 @@ public class StepsRunner {
     Future<LocalImage> localImage =
         executorService.submit(
             LocalBaseImageSteps.retrieveTarLayersStep(
-                buildConfiguration, childProgressDispatcherFactory, tarPath.get()));
+                buildConfiguration,
+                childProgressDispatcherFactory,
+                tarPath.get(),
+                tempDirectoryProvider));
     results.baseImageLayers = executorService.submit(() -> localImage.get().layers);
     results.baseImageAndAuth =
         executorService.submit(LocalBaseImageSteps.retrieveImageAndAuthorizationStep(localImage));

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -263,7 +263,7 @@ public class StepsRunner {
     results.baseImageAndAuth =
         executorService.submit(
             () ->
-                LocalBaseImageSteps.retrieveImageAndAuthorizationStep(
+                LocalBaseImageSteps.returnImageAndAuthorizationStep(
                         realizeFutures(results.baseImageLayers.get()),
                         localImage.get().configurationTemplate)
                     .call());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageStepsTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageStepsTest.java
@@ -23,10 +23,7 @@ import com.google.cloud.tools.jib.cache.CacheCorruptedException;
 import com.google.cloud.tools.jib.configuration.BuildConfiguration;
 import com.google.cloud.tools.jib.docker.DockerClient.DockerImageDetails;
 import com.google.cloud.tools.jib.event.EventHandlers;
-import com.google.cloud.tools.jib.image.LayerCountMismatchException;
-import com.google.cloud.tools.jib.image.json.BadContainerConfigurationFormatException;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
@@ -87,17 +84,17 @@ public class LocalBaseImageStepsTest {
     Assert.assertEquals(2, result.layers.size());
     Assert.assertEquals(
         "5e701122d3347fae0758cd5b7f0692c686fcd07b0e7fd9c4a125fbdbbedc04dd",
-        result.layers.get(0).getDiffId().getHash());
+        result.layers.get(0).get().getDiffId().getHash());
     Assert.assertEquals(
         "0011328ac5dfe3dde40c7c5e0e00c98d1833a3aeae2bfb668cf9eb965c229c7f",
-        result.layers.get(0).getBlobDescriptor().getDigest().getHash());
+        result.layers.get(0).get().getBlobDescriptor().getDigest().getHash());
     Assert.assertEquals(
         "f1ac3015bcbf0ada4750d728626eb10f0f585199e2b667dcd79e49f0e926178e",
-        result.layers.get(1).getDiffId().getHash());
+        result.layers.get(1).get().getDiffId().getHash());
     Assert.assertEquals(
         "c10ef24a5cef5092bbcb5a5666721cff7b86ce978c203a958d1fc86ee6c19f94",
-        result.layers.get(1).getBlobDescriptor().getDigest().getHash());
-    Assert.assertEquals("value1", result.baseImage.getLabels().get("label1"));
+        result.layers.get(1).get().getBlobDescriptor().getDigest().getHash());
+    Assert.assertEquals(2, result.configurationTemplate.getLayerCount());
   }
 
   @Test
@@ -111,23 +108,22 @@ public class LocalBaseImageStepsTest {
     Assert.assertEquals(2, result.layers.size());
     Assert.assertEquals(
         "5e701122d3347fae0758cd5b7f0692c686fcd07b0e7fd9c4a125fbdbbedc04dd",
-        result.layers.get(0).getDiffId().getHash());
+        result.layers.get(0).get().getDiffId().getHash());
     Assert.assertEquals(
         "0011328ac5dfe3dde40c7c5e0e00c98d1833a3aeae2bfb668cf9eb965c229c7f",
-        result.layers.get(0).getBlobDescriptor().getDigest().getHash());
+        result.layers.get(0).get().getBlobDescriptor().getDigest().getHash());
     Assert.assertEquals(
         "f1ac3015bcbf0ada4750d728626eb10f0f585199e2b667dcd79e49f0e926178e",
-        result.layers.get(1).getDiffId().getHash());
+        result.layers.get(1).get().getDiffId().getHash());
     Assert.assertEquals(
         "c10ef24a5cef5092bbcb5a5666721cff7b86ce978c203a958d1fc86ee6c19f94",
-        result.layers.get(1).getBlobDescriptor().getDigest().getHash());
-    Assert.assertEquals("value1", result.baseImage.getLabels().get("label1"));
+        result.layers.get(1).get().getBlobDescriptor().getDigest().getHash());
+    Assert.assertEquals(2, result.configurationTemplate.getLayerCount());
   }
 
   @Test
   public void testGetCachedDockerImage()
-      throws IOException, DigestException, BadContainerConfigurationFormatException,
-          CacheCorruptedException, LayerCountMismatchException, URISyntaxException {
+      throws IOException, DigestException, CacheCorruptedException, URISyntaxException {
     DockerImageDetails dockerImageDetails =
         new DockerImageDetails(
             0,
@@ -172,8 +168,7 @@ public class LocalBaseImageStepsTest {
     localImage = LocalBaseImageSteps.getCachedDockerImage(cache, dockerImageDetails);
     Assert.assertTrue(localImage.isPresent());
     LocalImage image = localImage.get();
-    Assert.assertEquals(
-        ImmutableMap.of("label1", "value1", "label2", "value2"), image.baseImage.getLabels());
+    Assert.assertEquals(2, image.configurationTemplate.getLayerCount());
     Assert.assertEquals(2, image.layers.size());
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageStepsTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageStepsTest.java
@@ -78,7 +78,7 @@ public class LocalBaseImageStepsTest {
   }
 
   @After
-  public void cleanup() {
+  public void tearDown() {
     tempDirectoryProvider.close();
   }
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Each local base image layer is pushed immediately after being compressed, rather than waiting for all layers to finish compressing before starting to push. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))
+
 ### Fixed
 
 - Fixed reporting parent build file when `skaffold init` is run on multi-module projects. ([#2091](https://github.com/GoogleContainerTools/jib/pull/2091))

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Each local base image layer is pushed immediately after being compressed, rather than waiting for all layers to finish compressing before starting to push. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))
+- Optimized building to a registry with local base images. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))
 
 ### Fixed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Each local base image layer is pushed immediately after being compressed, rather than waiting for all layers to finish compressing before starting to push. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))
+
 ### Fixed
 
 - Fixed reporting wrong module name when `skaffold init` is run on multi-module projects ([#2088](https://github.com/GoogleContainerTools/jib/issues/2088)).

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Each local base image layer is pushed immediately after being compressed, rather than waiting for all layers to finish compressing before starting to push. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))
+- Optimized building to a registry with local base images. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))
 
 ### Fixed
 


### PR DESCRIPTION
Fixes #1913.

This PR splits up the local base image steps so that the base image layer futures are returned before the layers are actually processed. This means later steps with dependencies on the base image layers can start as soon as each layer finishes being compressed, rather than waiting for all layers to be compressed before continuing.

Amount of time save varies depending on the base image, but it seems to save 4 seconds for uncached distroless (15s -> 11s).