### PR TITLE
Detect Spring Boot fat-JAR repackaging and use original thin JAR

### DIFF
--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -13,10 +13,12 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed `<extraDirectories><permissions>` being ignored if `<paths>` are not explicitly defined. ([#2106](https://github.com/GoogleContainerTools/jib/issues/2160))
+- Now `<containerizingMode>packaged` works as intended with Spring Boot projects that generate a fat JAR. ([]())
+- Now `<containerizingMode>packaged` correctly identifies the packaged JAR generated at a non-default location when configured with the Maven Jar Plugin's `<classifier>` and `<outputDirectory>`. ([]())
 
 ## 1.8.0
 
-## Changed
+### Changed
 
 - Optimized building to a registry with local base images. ([#1913](https://github.com/GoogleContainerTools/jib/issues/1913))
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -13,8 +13,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed `<extraDirectories><permissions>` being ignored if `<paths>` are not explicitly defined. ([#2106](https://github.com/GoogleContainerTools/jib/issues/2160))
-- Now `<containerizingMode>packaged` works as intended with Spring Boot projects that generate a fat JAR. ([]())
-- Now `<containerizingMode>packaged` correctly identifies the packaged JAR generated at a non-default location when configured with the Maven Jar Plugin's `<classifier>` and `<outputDirectory>`. ([]())
+- Now `<containerizingMode>packaged` works as intended with Spring Boot projects that generate a fat JAR. ([#2170](https://github.com/GoogleContainerTools/jib/issues/2170))
+- Now `<containerizingMode>packaged` correctly identifies the packaged JAR generated at a non-default location when configured with the Maven Jar Plugin's `<classifier>` and `<outputDirectory>`. ([#2170](https://github.com/GoogleContainerTools/jib/issues/2170))
 
 ## 1.8.0
 

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -69,6 +69,8 @@ public class BuildImageMojoIntegrationTest {
 
   @ClassRule public static final TestProject servlet25Project = new TestProject("war_servlet25");
 
+  @ClassRule public static final TestProject springBootProject = new TestProject("spring-boot");
+
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   private static String getTestImageReference(String label) {
@@ -667,22 +669,41 @@ public class BuildImageMojoIntegrationTest {
   @Test
   public void testExecute_jettyServlet25()
       throws VerificationException, IOException, InterruptedException {
-    buildAndRunWar("jetty-servlet25:maven", "pom.xml");
+    buildAndRunWebApp(servlet25Project, "jetty-servlet25:maven", "pom.xml");
     HttpGetVerifier.verifyBody("Hello world", new URL("http://localhost:8080/hello"));
   }
 
   @Test
   public void testExecute_tomcatServlet25()
       throws VerificationException, IOException, InterruptedException {
-    buildAndRunWar("tomcat-servlet25:maven", "pom-tomcat.xml");
+    buildAndRunWebApp(servlet25Project, "tomcat-servlet25:maven", "pom-tomcat.xml");
     HttpGetVerifier.verifyBody("Hello world", new URL("http://localhost:8080/hello"));
   }
 
-  private void buildAndRunWar(String label, String pomXml)
+  @Test
+  public void testExecute_springBootPackaged()
+      throws VerificationException, IOException, InterruptedException {
+    buildAndRunWebApp(springBootProject, "spring-boot:maven", "pom.xml");
+
+    String sizeOutput =
+        new Command(
+                "docker",
+                "exec",
+                detachedContainerName,
+                "/busybox/wc",
+                "-c",
+                "/app/classpath/spring-boot-0.1.0.jar")
+            .run();
+    Assert.assertEquals("2749 /app/classpath/spring-boot-0.1.0.jar\n", sizeOutput);
+
+    HttpGetVerifier.verifyBody("Hello world", new URL("http://localhost:8080"));
+  }
+
+  private void buildAndRunWebApp(TestProject project, String label, String pomXml)
       throws VerificationException, IOException, InterruptedException {
     String targetImage = getTestImageReference(label);
 
-    Verifier verifier = new Verifier(servlet25Project.getProjectRoot().toString());
+    Verifier verifier = new Verifier(project.getProjectRoot().toString());
     verifier.setSystemProperty("jib.useOnlyProjectCache", "true");
     verifier.setSystemProperty("_TARGET_IMAGE", targetImage);
     if (targetImage.startsWith("localhost")) {

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -692,9 +692,9 @@ public class BuildImageMojoIntegrationTest {
                 detachedContainerName,
                 "/busybox/wc",
                 "-c",
-                "/app/classpath/spring-boot-0.1.0.jar")
+                "/app/classpath/spring-boot-0.1.0.original.jar")
             .run();
-    Assert.assertEquals("2749 /app/classpath/spring-boot-0.1.0.jar\n", sizeOutput);
+    Assert.assertEquals("2749 /app/classpath/spring-boot-0.1.0.original.jar\n", sizeOutput);
 
     HttpGetVerifier.verifyBody("Hello world", new URL("http://localhost:8080"));
   }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -444,10 +444,7 @@ public class MavenProjectProperties implements ProjectProperties {
           Optional<String> directoryString = getChildValue(configuration, "outputDirectory");
 
           if (directoryString.isPresent()) {
-            outputDirectory = Paths.get(directoryString.get());
-            if (!outputDirectory.isAbsolute()) {
-              outputDirectory = project.getBasedir().toPath().resolve(outputDirectory);
-            }
+            outputDirectory = project.getBasedir().toPath().resolve(directoryString.get());
           }
         }
       }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -461,7 +461,7 @@ public class MavenProjectProperties implements ProjectProperties {
 
     String jarName =
         project.getBuild().getFinalName() + (classifier == null ? "" : '-' + classifier) + suffix;
-    consoleLogger.log(Level.LIFECYCLE, "Using JAR: " + outputDirectory.resolve(jarName));
+    consoleLogger.log(Level.DEBUG, "Using JAR: " + outputDirectory.resolve(jarName));
     return outputDirectory.resolve(jarName);
   }
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -427,7 +427,7 @@ public class MavenProjectPropertiesTest {
   public void testCreateContainerBuilder_correctFiles()
       throws URISyntaxException, IOException, InvalidImageReferenceException,
           CacheDirectoryCreationException {
-    BuildContext buildContext = setupBuildContext("/app", DEFAULT_CONTAINERIZING_MODE);
+    BuildContext buildContext = setUpBuildContext("/app", DEFAULT_CONTAINERIZING_MODE);
     ContainerBuilderLayers layers = new ContainerBuilderLayers(buildContext);
 
     Path dependenciesPath = getResource("maven/application/dependencies");
@@ -472,7 +472,7 @@ public class MavenProjectPropertiesTest {
   @Test
   public void testCreateContainerBuilder_nonDefaultAppRoot()
       throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
-    BuildContext buildContext = setupBuildContext("/my/app", DEFAULT_CONTAINERIZING_MODE);
+    BuildContext buildContext = setUpBuildContext("/my/app", DEFAULT_CONTAINERIZING_MODE);
     assertNonDefaultAppRoot(buildContext);
   }
 
@@ -484,7 +484,7 @@ public class MavenProjectPropertiesTest {
     Mockito.when(mockBuild.getDirectory()).thenReturn(temporaryFolder.getRoot().toString());
     Mockito.when(mockBuild.getFinalName()).thenReturn("final-name");
 
-    BuildContext buildContext = setupBuildContext("/app-root", ContainerizingMode.PACKAGED);
+    BuildContext buildContext = setUpBuildContext("/app-root", ContainerizingMode.PACKAGED);
 
     ContainerBuilderLayers layers = new ContainerBuilderLayers(buildContext);
     Assert.assertEquals(1, layers.dependenciesLayers.size());
@@ -533,7 +533,7 @@ public class MavenProjectPropertiesTest {
           CacheDirectoryCreationException {
     Path unzipTarget = setUpWar(getResource("maven/webapp/final-name"));
 
-    BuildContext buildContext = setupBuildContext("/my/app", DEFAULT_CONTAINERIZING_MODE);
+    BuildContext buildContext = setUpBuildContext("/my/app", DEFAULT_CONTAINERIZING_MODE);
     ContainerBuilderLayers layers = new ContainerBuilderLayers(buildContext);
     assertSourcePathsUnordered(
         ImmutableList.of(unzipTarget.resolve("WEB-INF/lib/dependency-1.0.0.jar")),
@@ -595,7 +595,7 @@ public class MavenProjectPropertiesTest {
       throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
     // Test when the default packaging is set
     Mockito.when(mockMavenProject.getPackaging()).thenReturn("jar");
-    BuildContext buildContext = setupBuildContext("/my/app", DEFAULT_CONTAINERIZING_MODE);
+    BuildContext buildContext = setUpBuildContext("/my/app", DEFAULT_CONTAINERIZING_MODE);
     assertNonDefaultAppRoot(buildContext);
   }
 
@@ -604,7 +604,7 @@ public class MavenProjectPropertiesTest {
       throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
     setUpWar(temporaryFolder.newFolder("final-name").toPath());
 
-    setupBuildContext("/anything", DEFAULT_CONTAINERIZING_MODE); // should pass
+    setUpBuildContext("/anything", DEFAULT_CONTAINERIZING_MODE); // should pass
   }
 
   @Test
@@ -613,7 +613,7 @@ public class MavenProjectPropertiesTest {
     temporaryFolder.newFolder("final-name", "WEB-INF", "classes");
     setUpWar(temporaryFolder.getRoot().toPath());
 
-    setupBuildContext("/anything", DEFAULT_CONTAINERIZING_MODE); // should pass
+    setUpBuildContext("/anything", DEFAULT_CONTAINERIZING_MODE); // should pass
   }
 
   @Test
@@ -622,7 +622,7 @@ public class MavenProjectPropertiesTest {
     temporaryFolder.newFolder("final-name", "WEB-INF", "lib");
     setUpWar(temporaryFolder.getRoot().toPath());
 
-    setupBuildContext("/anything", DEFAULT_CONTAINERIZING_MODE); // should pass
+    setUpBuildContext("/anything", DEFAULT_CONTAINERIZING_MODE); // should pass
   }
 
   @Test
@@ -780,7 +780,7 @@ public class MavenProjectPropertiesTest {
     Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
         .thenReturn(mockPlugin);
     Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
-    Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("goal", "repackage"));
+    Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("repackage"));
     Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
     addXpp3DomChild(pluginConfiguration, "skip", "true");
     Assert.assertFalse(mavenProjectProperties.jarRepackagedBySpringBoot());
@@ -791,7 +791,7 @@ public class MavenProjectPropertiesTest {
     Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
         .thenReturn(mockPlugin);
     Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
-    Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("goal", "repackage"));
+    Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("repackage"));
     Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
     addXpp3DomChild(pluginConfiguration, "skip", null);
     Assert.assertTrue(mavenProjectProperties.jarRepackagedBySpringBoot());
@@ -816,10 +816,10 @@ public class MavenProjectPropertiesTest {
     Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
     Mockito.when(mockPluginExecution.getId()).thenReturn("default-jar");
     Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
-    addXpp3DomChild(pluginConfiguration, "outputDirectory", Paths.get("/jar/outDir").toString());
+    addXpp3DomChild(pluginConfiguration, "outputDirectory", Paths.get("/jar/out").toString());
 
     Assert.assertEquals(
-        Paths.get("/jar/outDir/helloworld-1.jar"), mavenProjectProperties.getJarArtifact());
+        Paths.get("/jar/out/helloworld-1.jar"), mavenProjectProperties.getJarArtifact());
   }
 
   @Test
@@ -833,11 +833,10 @@ public class MavenProjectPropertiesTest {
     Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
     Mockito.when(mockPluginExecution.getId()).thenReturn("default-jar");
     Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
-    addXpp3DomChild(pluginConfiguration, "outputDirectory", Paths.get("target/jar").toString());
+    addXpp3DomChild(pluginConfiguration, "outputDirectory", Paths.get("relative").toString());
 
     Assert.assertEquals(
-        Paths.get("/base/dir/target/jar/helloworld-1.jar"),
-        mavenProjectProperties.getJarArtifact());
+        Paths.get("/base/dir/relative/helloworld-1.jar"), mavenProjectProperties.getJarArtifact());
   }
 
   @Test
@@ -878,10 +877,7 @@ public class MavenProjectPropertiesTest {
     Mockito.when(mockBuild.getDirectory()).thenReturn(Paths.get("/foo/bar").toString());
     Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
 
-    Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
-        .thenReturn(mockPlugin);
-    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
-    Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("repackage"));
+    setUpSpringBootFatJar();
 
     Assert.assertEquals(
         Paths.get("/foo/bar/helloworld-1.jar.original"), mavenProjectProperties.getJarArtifact());
@@ -892,7 +888,7 @@ public class MavenProjectPropertiesTest {
   }
 
   @Test
-  public void testGetJarArtifact_originalJarAndSpringBootJarInDifferentDirectories() {
+  public void testGetJarArtifact_originalJarIfSpringBoot_differentDirectories() {
     Mockito.when(mockBuild.getDirectory()).thenReturn("/should/ignore");
     Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
 
@@ -901,25 +897,44 @@ public class MavenProjectPropertiesTest {
     Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
     Mockito.when(mockPluginExecution.getId()).thenReturn("default-jar");
     Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
-    addXpp3DomChild(pluginConfiguration, "outputDirectory", Paths.get("/tmp/jarOutDir").toString());
+    addXpp3DomChild(pluginConfiguration, "outputDirectory", Paths.get("/jar/out").toString());
 
-    PluginExecution mockSpringBootExecution = Mockito.mock(PluginExecution.class);
-    Plugin mockSpringBootPlugin = Mockito.mock(Plugin.class);
-    Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
-        .thenReturn(mockSpringBootPlugin);
-    Mockito.when(mockSpringBootPlugin.getExecutions())
-        .thenReturn(Arrays.asList(mockSpringBootExecution));
-    Mockito.when(mockSpringBootExecution.getGoals()).thenReturn(Arrays.asList("repackage"));
+    setUpSpringBootFatJar();
 
     Assert.assertEquals(
-        Paths.get("/tmp/jarOutDir/helloworld-1.jar"), mavenProjectProperties.getJarArtifact());
+        Paths.get("/jar/out/helloworld-1.jar"), mavenProjectProperties.getJarArtifact());
 
     mavenProjectProperties.waitForLoggingThread();
     Mockito.verify(mockLog)
         .info("Spring Boot repackaging (fat JAR) detected; using the original JAR");
   }
 
-  private BuildContext setupBuildContext(String appRoot, ContainerizingMode containerizingMode)
+  @Test
+  public void testGetJarArtifact_originalJarIfSpringBoot_sameDirectory() {
+    Path baseDir = Paths.get("/project");
+    Mockito.when(mockMavenProject.getBasedir()).thenReturn(baseDir.toFile());
+    Mockito.when(mockBuild.getDirectory()).thenReturn(baseDir.resolve("target").toString());
+    Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
+
+    Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
+    Mockito.when(mockPluginExecution.getId()).thenReturn("default-jar");
+    Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
+    addXpp3DomChild(pluginConfiguration, "outputDirectory", "target");
+
+    setUpSpringBootFatJar();
+
+    Assert.assertEquals(
+        Paths.get("/project/target/helloworld-1.jar.original"),
+        mavenProjectProperties.getJarArtifact());
+
+    mavenProjectProperties.waitForLoggingThread();
+    Mockito.verify(mockLog)
+        .info("Spring Boot repackaging (fat JAR) detected; using the original JAR");
+  }
+
+  private BuildContext setUpBuildContext(String appRoot, ContainerizingMode containerizingMode)
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException {
     JavaContainerBuilder javaContainerBuilder =
         JavaContainerBuilder.from(RegistryImage.named("base"))
@@ -945,5 +960,14 @@ public class MavenProjectPropertiesTest {
     Path unzipTarget = temporaryFolder.newFolder("exploded").toPath();
     Mockito.when(mockTempDirectoryProvider.newDirectory()).thenReturn(unzipTarget);
     return unzipTarget;
+  }
+
+  private void setUpSpringBootFatJar() {
+    PluginExecution execution = Mockito.mock(PluginExecution.class);
+    Plugin plugin = Mockito.mock(Plugin.class);
+    Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
+        .thenReturn(plugin);
+    Mockito.when(plugin.getExecutions()).thenReturn(Arrays.asList(execution));
+    Mockito.when(execution.getGoals()).thenReturn(Arrays.asList("repackage"));
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -226,6 +226,8 @@ public class MavenProjectPropertiesTest {
   @Rule public final TestRepository testRepository = new TestRepository();
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
+  private final Xpp3Dom pluginConfiguration = new Xpp3Dom("configuration");
+
   @Mock private Build mockBuild;
   @Mock private MavenProject mockMavenProject;
   @Mock private MavenSession mockMavenSession;
@@ -235,8 +237,6 @@ public class MavenProjectPropertiesTest {
   @Mock private PluginExecution mockPluginExecution;
   @Mock private Log mockLog;
   @Mock private TempDirectoryProvider mockTempDirectoryProvider;
-
-  private Xpp3Dom pluginConfiguration = new Xpp3Dom("configuration");
 
   private MavenProjectProperties mavenProjectProperties;
 
@@ -275,29 +275,26 @@ public class MavenProjectPropertiesTest {
 
   @Test
   public void testGetMainClassFromJar_success() {
-    Xpp3Dom archive = new Xpp3Dom("archive");
-    Xpp3Dom manifest = new Xpp3Dom("manifest");
-
-    pluginConfiguration.addChild(archive);
-    archive.addChild(manifest);
-    manifest.addChild(newXpp3Dom("mainClass", "some.main.class"));
-
     Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
         .thenReturn(mockPlugin);
     Mockito.when(mockPlugin.getConfiguration()).thenReturn(pluginConfiguration);
+    Xpp3Dom archive = new Xpp3Dom("archive");
+    Xpp3Dom manifest = new Xpp3Dom("manifest");
+    pluginConfiguration.addChild(archive);
+    archive.addChild(manifest);
+    manifest.addChild(newXpp3Dom("mainClass", "some.main.class"));
 
     Assert.assertEquals("some.main.class", mavenProjectProperties.getMainClassFromJar());
   }
 
   @Test
   public void testGetMainClassFromJar_missingMainClass() {
-    Xpp3Dom archive = new Xpp3Dom("archive");
-    archive.addChild(new Xpp3Dom("manifest"));
-    pluginConfiguration.addChild(archive);
-
     Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
         .thenReturn(mockPlugin);
     Mockito.when(mockPlugin.getConfiguration()).thenReturn(pluginConfiguration);
+    Xpp3Dom archive = new Xpp3Dom("archive");
+    archive.addChild(new Xpp3Dom("manifest"));
+    pluginConfiguration.addChild(archive);
 
     Assert.assertNull(mavenProjectProperties.getMainClassFromJar());
   }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -805,6 +805,7 @@ public class MavenProjectPropertiesTest {
 
   @Test
   public void testGetJarArtifact_outputDirectoryFromJarPlugin() {
+    Mockito.when(mockMavenProject.getBasedir()).thenReturn(new File("/should/ignore"));
     Mockito.when(mockBuild.getDirectory()).thenReturn("/should/ignore");
     Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
 
@@ -886,6 +887,7 @@ public class MavenProjectPropertiesTest {
 
   @Test
   public void testGetJarArtifact_originalJarIfSpringBoot_differentDirectories() {
+    Mockito.when(mockMavenProject.getBasedir()).thenReturn(new File("/should/ignore"));
     Mockito.when(mockBuild.getDirectory()).thenReturn("/should/ignore");
     Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -58,6 +59,7 @@ import org.apache.maven.execution.MavenExecutionRequest;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Plugin;
+import org.apache.maven.model.PluginExecution;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.archiver.zip.ZipEntry;
@@ -196,6 +198,31 @@ public class MavenProjectPropertiesTest {
     return targetZip;
   }
 
+  private static Artifact newArtifact(Path sourceJar) {
+    Artifact artifact = Mockito.mock(Artifact.class);
+    Mockito.when(artifact.getFile()).thenReturn(sourceJar.toFile());
+    return artifact;
+  }
+
+  private static Artifact newArtifact(String group, String artifactId, String version) {
+    Artifact artifact = new DefaultArtifact(group, artifactId, version, null, "jar", "", null);
+    artifact.setFile(new File("/tmp/" + group + artifactId + version));
+    return artifact;
+  }
+
+  private static Xpp3Dom newXpp3Dom(String name, String value) {
+    Xpp3Dom node = new Xpp3Dom(name);
+    node.setValue(value);
+    return node;
+  }
+
+  private static Xpp3Dom addXpp3DomChild(Xpp3Dom parent, String name, String value) {
+    Xpp3Dom node = new Xpp3Dom(name);
+    node.setValue(value);
+    parent.addChild(node);
+    return node;
+  }
+
   @Rule public final TestRepository testRepository = new TestRepository();
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -204,19 +231,12 @@ public class MavenProjectPropertiesTest {
   @Mock private MavenSession mockMavenSession;
   @Mock private MavenExecutionRequest mockMavenRequest;
   @Mock private Properties mockMavenProperties;
-  @Mock private Plugin mockJarPlugin;
-  @Mock private Plugin mockCompilerPlugin;
+  @Mock private Plugin mockPlugin;
+  @Mock private PluginExecution mockPluginExecution;
   @Mock private Log mockLog;
   @Mock private TempDirectoryProvider mockTempDirectoryProvider;
 
-  private Xpp3Dom jarPluginConfiguration;
-  private Xpp3Dom archive;
-  private Xpp3Dom manifest;
-  private Xpp3Dom jarPluginMainClass;
-
-  @Mock private Xpp3Dom compilerPluginConfiguration;
-  @Mock private Xpp3Dom compilerTarget;
-  @Mock private Xpp3Dom compilerRelease;
+  private Xpp3Dom pluginConfiguration = new Xpp3Dom("configuration");
 
   private MavenProjectProperties mavenProjectProperties;
 
@@ -226,10 +246,6 @@ public class MavenProjectPropertiesTest {
     mavenProjectProperties =
         new MavenProjectProperties(
             mockMavenProject, mockMavenSession, mockLog, mockTempDirectoryProvider);
-    jarPluginConfiguration = new Xpp3Dom("");
-    archive = new Xpp3Dom("archive");
-    manifest = new Xpp3Dom("manifest");
-    jarPluginMainClass = new Xpp3Dom("mainClass");
 
     Path outputPath = getResource("maven/application/output");
     Path dependenciesPath = getResource("maven/application/dependencies");
@@ -259,24 +275,29 @@ public class MavenProjectPropertiesTest {
 
   @Test
   public void testGetMainClassFromJar_success() {
-    Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
-        .thenReturn(mockJarPlugin);
-    Mockito.when(mockJarPlugin.getConfiguration()).thenReturn(jarPluginConfiguration);
-    jarPluginConfiguration.addChild(archive);
+    Xpp3Dom archive = new Xpp3Dom("archive");
+    Xpp3Dom manifest = new Xpp3Dom("manifest");
+
+    pluginConfiguration.addChild(archive);
     archive.addChild(manifest);
-    manifest.addChild(jarPluginMainClass);
-    jarPluginMainClass.setValue("some.main.class");
+    manifest.addChild(newXpp3Dom("mainClass", "some.main.class"));
+
+    Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getConfiguration()).thenReturn(pluginConfiguration);
 
     Assert.assertEquals("some.main.class", mavenProjectProperties.getMainClassFromJar());
   }
 
   @Test
   public void testGetMainClassFromJar_missingMainClass() {
+    Xpp3Dom archive = new Xpp3Dom("archive");
+    archive.addChild(new Xpp3Dom("manifest"));
+    pluginConfiguration.addChild(archive);
+
     Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
-        .thenReturn(mockJarPlugin);
-    Mockito.when(mockJarPlugin.getConfiguration()).thenReturn(jarPluginConfiguration);
-    jarPluginConfiguration.addChild(archive);
-    archive.addChild(manifest);
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getConfiguration()).thenReturn(pluginConfiguration);
 
     Assert.assertNull(mavenProjectProperties.getMainClassFromJar());
   }
@@ -284,9 +305,9 @@ public class MavenProjectPropertiesTest {
   @Test
   public void testGetMainClassFromJar_missingManifest() {
     Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
-        .thenReturn(mockJarPlugin);
-    Mockito.when(mockJarPlugin.getConfiguration()).thenReturn(jarPluginConfiguration);
-    jarPluginConfiguration.addChild(archive);
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getConfiguration()).thenReturn(pluginConfiguration);
+    pluginConfiguration.addChild(new Xpp3Dom("archive"));
 
     Assert.assertNull(mavenProjectProperties.getMainClassFromJar());
   }
@@ -294,8 +315,8 @@ public class MavenProjectPropertiesTest {
   @Test
   public void testGetMainClassFromJar_missingArchive() {
     Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
-        .thenReturn(mockJarPlugin);
-    Mockito.when(mockJarPlugin.getConfiguration()).thenReturn(jarPluginConfiguration);
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getConfiguration()).thenReturn(pluginConfiguration);
 
     Assert.assertNull(mavenProjectProperties.getMainClassFromJar());
   }
@@ -303,7 +324,7 @@ public class MavenProjectPropertiesTest {
   @Test
   public void testGetMainClassFromJar_missingConfiguration() {
     Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
-        .thenReturn(mockJarPlugin);
+        .thenReturn(mockPlugin);
 
     Assert.assertNull(mavenProjectProperties.getMainClassFromJar());
   }
@@ -363,34 +384,36 @@ public class MavenProjectPropertiesTest {
   @Test
   public void testValidateBaseImageVersion_compilerPluginTarget() {
     Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-compiler-plugin"))
-        .thenReturn(mockCompilerPlugin);
-    Mockito.when(mockCompilerPlugin.getConfiguration()).thenReturn(compilerPluginConfiguration);
-    Mockito.when(compilerPluginConfiguration.getChild("target")).thenReturn(compilerTarget);
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getConfiguration()).thenReturn(pluginConfiguration);
+    Xpp3Dom compilerTarget = new Xpp3Dom("target");
+    pluginConfiguration.addChild(compilerTarget);
 
-    Mockito.when(compilerTarget.getValue()).thenReturn("1.8");
+    compilerTarget.setValue("1.8");
     Assert.assertEquals(8, mavenProjectProperties.getMajorJavaVersion());
 
-    Mockito.when(compilerTarget.getValue()).thenReturn("1.6");
+    compilerTarget.setValue("1.6");
     Assert.assertEquals(6, mavenProjectProperties.getMajorJavaVersion());
 
-    Mockito.when(compilerTarget.getValue()).thenReturn("13");
+    compilerTarget.setValue("13");
     Assert.assertEquals(13, mavenProjectProperties.getMajorJavaVersion());
   }
 
   @Test
   public void testValidateBaseImageVersion_compilerPluginRelease() {
     Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-compiler-plugin"))
-        .thenReturn(mockCompilerPlugin);
-    Mockito.when(mockCompilerPlugin.getConfiguration()).thenReturn(compilerPluginConfiguration);
-    Mockito.when(compilerPluginConfiguration.getChild("release")).thenReturn(compilerRelease);
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getConfiguration()).thenReturn(pluginConfiguration);
+    Xpp3Dom compilerRelease = new Xpp3Dom("release");
+    pluginConfiguration.addChild(compilerRelease);
 
-    Mockito.when(compilerRelease.getValue()).thenReturn("1.8");
+    compilerRelease.setValue("1.8");
     Assert.assertEquals(8, mavenProjectProperties.getMajorJavaVersion());
 
-    Mockito.when(compilerRelease.getValue()).thenReturn("10");
+    compilerRelease.setValue("10");
     Assert.assertEquals(10, mavenProjectProperties.getMajorJavaVersion());
 
-    Mockito.when(compilerRelease.getValue()).thenReturn("13");
+    compilerRelease.setValue("13");
     Assert.assertEquals(13, mavenProjectProperties.getMajorJavaVersion());
   }
 
@@ -603,16 +626,6 @@ public class MavenProjectPropertiesTest {
   }
 
   @Test
-  public void testGetJarArtifact() {
-    Mockito.when(mockBuild.getDirectory()).thenReturn(temporaryFolder.getRoot().toString());
-    Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
-
-    Assert.assertEquals(
-        temporaryFolder.getRoot().toPath().resolve("helloworld-1.jar"),
-        mavenProjectProperties.getJarArtifact());
-  }
-
-  @Test
   public void testIsWarProject_WarPackagingIsWar() {
     Mockito.when(mockMavenProject.getPackaging()).thenReturn("war");
     Assert.assertTrue(mavenProjectProperties.isWarProject());
@@ -679,6 +692,233 @@ public class MavenProjectPropertiesTest {
             newArtifact("com.test", "projectC", "3.0").getFile().toPath()));
   }
 
+  @Test
+  public void testGetChildValue_null() {
+    Assert.assertFalse(MavenProjectProperties.getChildValue(null).isPresent());
+    Assert.assertFalse(MavenProjectProperties.getChildValue(null, "foo", "bar").isPresent());
+  }
+
+  @Test
+  public void testGetChildValue_noPathGiven() {
+    Xpp3Dom root = newXpp3Dom("root", "value");
+
+    Assert.assertEquals(Optional.of("value"), MavenProjectProperties.getChildValue(root));
+  }
+
+  @Test
+  public void testGetChildValue_noChild() {
+    Xpp3Dom root = newXpp3Dom("root", "value");
+
+    Assert.assertFalse(MavenProjectProperties.getChildValue(root, "foo").isPresent());
+    Assert.assertFalse(MavenProjectProperties.getChildValue(root, "foo", "bar").isPresent());
+  }
+
+  @Test
+  public void testGetChildValue_childPathMatched() {
+    Xpp3Dom root = newXpp3Dom("root", "value");
+    Xpp3Dom foo = addXpp3DomChild(root, "foo", "foo");
+    addXpp3DomChild(foo, "bar", "bar");
+
+    Assert.assertEquals(Optional.of("foo"), MavenProjectProperties.getChildValue(root, "foo"));
+    Assert.assertEquals(
+        Optional.of("bar"), MavenProjectProperties.getChildValue(root, "foo", "bar"));
+    Assert.assertEquals(Optional.of("bar"), MavenProjectProperties.getChildValue(foo, "bar"));
+  }
+
+  @Test
+  public void testGetChildValue_notFullyMatched() {
+    Xpp3Dom root = newXpp3Dom("root", "value");
+    Xpp3Dom foo = addXpp3DomChild(root, "foo", "foo");
+
+    addXpp3DomChild(foo, "bar", "bar");
+    Assert.assertFalse(MavenProjectProperties.getChildValue(root, "baz").isPresent());
+    Assert.assertFalse(MavenProjectProperties.getChildValue(root, "foo", "baz").isPresent());
+  }
+
+  @Test
+  public void testGetChildValue_nullValue() {
+    Xpp3Dom root = new Xpp3Dom("root");
+    addXpp3DomChild(root, "foo", null);
+
+    Assert.assertFalse(MavenProjectProperties.getChildValue(root).isPresent());
+    Assert.assertFalse(MavenProjectProperties.getChildValue(root, "foo").isPresent());
+  }
+
+  @Test
+  public void testJarRepackagedBySpringBoot_pluginNotApplied() {
+    Assert.assertFalse(mavenProjectProperties.jarRepackagedBySpringBoot());
+  }
+
+  @Test
+  public void testJarRepackagedBySpringBoot_noExecutions() {
+    Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Collections.emptyList());
+    Assert.assertFalse(mavenProjectProperties.jarRepackagedBySpringBoot());
+  }
+
+  @Test
+  public void testJarRepackagedBySpringBoot_noRepackageGoal() {
+    Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
+    Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("goal", "foo", "bar"));
+    Assert.assertFalse(mavenProjectProperties.jarRepackagedBySpringBoot());
+  }
+
+  @Test
+  public void testJarRepackagedBySpringBoot_repackageGoal() {
+    Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
+    Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("goal", "repackage"));
+    Assert.assertTrue(mavenProjectProperties.jarRepackagedBySpringBoot());
+  }
+
+  @Test
+  public void testJarRepackagedBySpringBoot_skipped() {
+    Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
+    Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("goal", "repackage"));
+    Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
+    addXpp3DomChild(pluginConfiguration, "skip", "true");
+    Assert.assertFalse(mavenProjectProperties.jarRepackagedBySpringBoot());
+  }
+
+  @Test
+  public void testJarRepackagedBySpringBoot_skipNotTrue() {
+    Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
+    Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("goal", "repackage"));
+    Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
+    addXpp3DomChild(pluginConfiguration, "skip", null);
+    Assert.assertTrue(mavenProjectProperties.jarRepackagedBySpringBoot());
+  }
+
+  @Test
+  public void testGetJarArtifact() {
+    Mockito.when(mockBuild.getDirectory()).thenReturn(Paths.get("/foo/bar").toString());
+    Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
+
+    Assert.assertEquals(
+        Paths.get("/foo/bar/helloworld-1.jar"), mavenProjectProperties.getJarArtifact());
+  }
+
+  @Test
+  public void testGetJarArtifact_outputDirectoryFromJarPlugin() {
+    Mockito.when(mockBuild.getDirectory()).thenReturn("/should/ignore");
+    Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
+
+    Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
+    Mockito.when(mockPluginExecution.getId()).thenReturn("default-jar");
+    Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
+    addXpp3DomChild(pluginConfiguration, "outputDirectory", Paths.get("/jar/outDir").toString());
+
+    Assert.assertEquals(
+        Paths.get("/jar/outDir/helloworld-1.jar"), mavenProjectProperties.getJarArtifact());
+  }
+
+  @Test
+  public void testGetJarArtifact_relativeOutputDirectoryFromJarPlugin() {
+    Mockito.when(mockMavenProject.getBasedir()).thenReturn(new File("/base/dir"));
+    Mockito.when(mockBuild.getDirectory()).thenReturn(temporaryFolder.getRoot().toString());
+    Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
+
+    Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
+    Mockito.when(mockPluginExecution.getId()).thenReturn("default-jar");
+    Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
+    addXpp3DomChild(pluginConfiguration, "outputDirectory", Paths.get("target/jar").toString());
+
+    Assert.assertEquals(
+        Paths.get("/base/dir/target/jar/helloworld-1.jar"),
+        mavenProjectProperties.getJarArtifact());
+  }
+
+  @Test
+  public void testGetJarArtifact_classifier() {
+    Mockito.when(mockBuild.getDirectory()).thenReturn(Paths.get("/foo/bar").toString());
+    Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
+
+    Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
+    Mockito.when(mockPluginExecution.getId()).thenReturn("default-jar");
+    Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
+    addXpp3DomChild(pluginConfiguration, "classifier", "a-class");
+
+    Assert.assertEquals(
+        Paths.get("/foo/bar/helloworld-1-a-class.jar"), mavenProjectProperties.getJarArtifact());
+  }
+
+  @Test
+  public void testGetJarArtifact_executionIdNotMatched() {
+    Mockito.when(mockBuild.getDirectory()).thenReturn(Paths.get("/foo/bar").toString());
+    Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
+
+    Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
+    Mockito.when(mockPluginExecution.getId()).thenReturn("no-id-match");
+    Mockito.lenient().when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
+    addXpp3DomChild(pluginConfiguration, "outputDirectory", "/should/ignore");
+    addXpp3DomChild(pluginConfiguration, "classifier", "a-class");
+
+    Assert.assertEquals(
+        Paths.get("/foo/bar/helloworld-1.jar"), mavenProjectProperties.getJarArtifact());
+  }
+
+  @Test
+  public void testGetJarArtifact_originalJarIfSpringBoot() {
+    Mockito.when(mockBuild.getDirectory()).thenReturn(Paths.get("/foo/bar").toString());
+    Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
+
+    Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
+    Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("repackage"));
+
+    Assert.assertEquals(
+        Paths.get("/foo/bar/helloworld-1.jar.original"), mavenProjectProperties.getJarArtifact());
+
+    mavenProjectProperties.waitForLoggingThread();
+    Mockito.verify(mockLog)
+        .info("Spring Boot repackaging (fat JAR) detected; using the original JAR");
+  }
+
+  @Test
+  public void testGetJarArtifact_originalJarAndSpringBootJarInDifferentDirectories() {
+    Mockito.when(mockBuild.getDirectory()).thenReturn("/should/ignore");
+    Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
+
+    Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
+    Mockito.when(mockPluginExecution.getId()).thenReturn("default-jar");
+    Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
+    addXpp3DomChild(pluginConfiguration, "outputDirectory", Paths.get("/tmp/jarOutDir").toString());
+
+    PluginExecution mockSpringBootExecution = Mockito.mock(PluginExecution.class);
+    Plugin mockSpringBootPlugin = Mockito.mock(Plugin.class);
+    Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
+        .thenReturn(mockSpringBootPlugin);
+    Mockito.when(mockSpringBootPlugin.getExecutions())
+        .thenReturn(Arrays.asList(mockSpringBootExecution));
+    Mockito.when(mockSpringBootExecution.getGoals()).thenReturn(Arrays.asList("repackage"));
+
+    Assert.assertEquals(
+        Paths.get("/tmp/jarOutDir/helloworld-1.jar"), mavenProjectProperties.getJarArtifact());
+
+    mavenProjectProperties.waitForLoggingThread();
+    Mockito.verify(mockLog)
+        .info("Spring Boot repackaging (fat JAR) detected; using the original JAR");
+  }
+
   private BuildContext setupBuildContext(String appRoot, ContainerizingMode containerizingMode)
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException {
     JavaContainerBuilder javaContainerBuilder =
@@ -705,17 +945,5 @@ public class MavenProjectPropertiesTest {
     Path unzipTarget = temporaryFolder.newFolder("exploded").toPath();
     Mockito.when(mockTempDirectoryProvider.newDirectory()).thenReturn(unzipTarget);
     return unzipTarget;
-  }
-
-  private Artifact newArtifact(Path sourceJar) {
-    Artifact artifact = Mockito.mock(Artifact.class);
-    Mockito.when(artifact.getFile()).thenReturn(sourceJar.toFile());
-    return artifact;
-  }
-
-  private Artifact newArtifact(String group, String artifactId, String version) {
-    Artifact artifact = new DefaultArtifact(group, artifactId, version, null, "jar", "", null);
-    artifact.setFile(new File("/tmp/" + group + artifactId + version));
-    return artifact;
   }
 }

--- a/jib-maven-plugin/src/test/resources/maven/projects/spring-boot/pom.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/spring-boot/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>example</groupId>
+    <artifactId>spring-boot</artifactId>
+    <version>0.1.0</version>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.1.6.RELEASE</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <java.version>1.8</java.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>2.1.6.RELEASE</version>
+            </plugin>
+            <plugin>
+                <groupId>com.google.cloud.tools</groupId>
+                <artifactId>jib-maven-plugin</artifactId>
+                <version>1.8.1-SNAPSHOT</version>
+                <configuration>
+                  <from><image>gcr.io/distroless/java:debug</image></from>
+                  <to><image>${_TARGET_IMAGE}</image></to>
+                  <containerizingMode>packaged</containerizingMode>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jib-maven-plugin/src/test/resources/maven/projects/spring-boot/src/main/java/hello/Application.java
+++ b/jib-maven-plugin/src/test/resources/maven/projects/spring-boot/src/main/java/hello/Application.java
@@ -1,0 +1,13 @@
+package hello;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class Application {
+    
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+}

--- a/jib-maven-plugin/src/test/resources/maven/projects/spring-boot/src/main/java/hello/Application.java
+++ b/jib-maven-plugin/src/test/resources/maven/projects/spring-boot/src/main/java/hello/Application.java
@@ -5,9 +5,8 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class Application {
-    
-    public static void main(String[] args) {
-        SpringApplication.run(Application.class, args);
-    }
 
+  public static void main(String[] args) {
+    SpringApplication.run(Application.class, args);
+  }
 }

--- a/jib-maven-plugin/src/test/resources/maven/projects/spring-boot/src/main/java/hello/HelloController.java
+++ b/jib-maven-plugin/src/test/resources/maven/projects/spring-boot/src/main/java/hello/HelloController.java
@@ -1,13 +1,13 @@
 package hello;
 
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 public class HelloController {
-    
-    @RequestMapping("/")
-    public String index() {
-        return "Hello world";
-    }
+
+  @RequestMapping("/")
+  public String index() {
+    return "Hello world";
+  }
 }

--- a/jib-maven-plugin/src/test/resources/maven/projects/spring-boot/src/main/java/hello/HelloController.java
+++ b/jib-maven-plugin/src/test/resources/maven/projects/spring-boot/src/main/java/hello/HelloController.java
@@ -1,0 +1,13 @@
+package hello;
+
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RestController
+public class HelloController {
+    
+    @RequestMapping("/")
+    public String index() {
+        return "Hello world";
+    }
+}


### PR DESCRIPTION
Implements https://github.com/GoogleContainerTools/jib/issues/1852#issuecomment-557275771 for Maven. That is, auto-detect Spring Boot fat-JAR repackaging and use the original thin JAR.

Additionally takes care of the corner cases with `<classifier>` and `<outputDirectory>` from `maven-jar-plugin`. This is basically irrelevant of the Spring Boot fat JAR stuff, but I decided to fix them for correctness.