### PR TITLE
Use ConsoleLogger instead of native Gradle logger

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.api.Containerizer;
 import com.google.cloud.tools.jib.api.JavaContainerBuilder;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.api.LogEvent.Level;
 import com.google.cloud.tools.jib.event.events.ProgressEvent;
 import com.google.cloud.tools.jib.event.events.TimerEvent;
 import com.google.cloud.tools.jib.event.progress.ProgressEventHandler;
@@ -123,7 +124,6 @@ public class GradleProjectProperties implements ProjectProperties {
 
   private final Project project;
   private final SingleThreadedExecutor singleThreadedExecutor = new SingleThreadedExecutor();
-  private final Logger logger;
   private final ConsoleLogger consoleLogger;
   private final TempDirectoryProvider tempDirectoryProvider;
 
@@ -131,7 +131,6 @@ public class GradleProjectProperties implements ProjectProperties {
   GradleProjectProperties(
       Project project, Logger logger, TempDirectoryProvider tempDirectoryProvider) {
     this.project = project;
-    this.logger = logger;
     this.tempDirectoryProvider = tempDirectoryProvider;
     ConsoleLoggerBuilder consoleLoggerBuilder =
         (isProgressFooterEnabled(project)
@@ -159,7 +158,8 @@ public class GradleProjectProperties implements ProjectProperties {
     try {
       if (isWarProject()) {
         String warFilePath = getWarFilePath();
-        logger.info("WAR project identified, creating WAR image from: " + warFilePath);
+        consoleLogger.log(
+            Level.INFO, "WAR project identified, creating WAR image from: " + warFilePath);
         Path explodedWarPath = tempDirectoryProvider.newDirectory();
         ZipUtil.unzip(Paths.get(warFilePath), explodedWarPath);
         return JavaContainerBuilderHelper.fromExplodedWar(javaContainerBuilder, explodedWarPath);
@@ -229,7 +229,8 @@ public class GradleProjectProperties implements ProjectProperties {
             javaContainerBuilder.addClasses(classesOutputDirectory.toPath());
           }
           if (classesOutputDirectories.isEmpty()) {
-            logger.warn("No classes files were found - did you compile your project?");
+            consoleLogger.log(
+                Level.WARN, "No classes files were found - did you compile your project?");
           }
           break;
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -206,7 +206,6 @@ public class GradleProjectPropertiesTest {
 
   @Before
   public void setup() throws URISyntaxException, IOException {
-    Mockito.when(mockLogger.isLifecycleEnabled()).thenReturn(true);
     Mockito.when(mockLogger.isDebugEnabled()).thenReturn(true);
     Mockito.when(mockLogger.isInfoEnabled()).thenReturn(true);
     Mockito.when(mockLogger.isWarnEnabled()).thenReturn(true);

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -205,7 +205,7 @@ public class GradleProjectPropertiesTest {
   private GradleProjectProperties gradleProjectProperties;
 
   @Before
-  public void setup() throws URISyntaxException, IOException {
+  public void setUp() throws URISyntaxException, IOException {
     Mockito.when(mockLogger.isDebugEnabled()).thenReturn(true);
     Mockito.when(mockLogger.isInfoEnabled()).thenReturn(true);
     Mockito.when(mockLogger.isWarnEnabled()).thenReturn(true);
@@ -379,6 +379,7 @@ public class GradleProjectPropertiesTest {
         .thenReturn(new TestFileCollection(ImmutableSet.of(nonexistentFile)));
     gradleProjectProperties.createJibContainerBuilder(
         JavaContainerBuilder.from(RegistryImage.named("base")), ContainerizingMode.EXPLODED);
+    gradleProjectProperties.waitForLoggingThread();
     Mockito.verify(mockLogger).warn("No classes files were found - did you compile your project?");
   }
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -206,6 +206,12 @@ public class GradleProjectPropertiesTest {
 
   @Before
   public void setup() throws URISyntaxException, IOException {
+    Mockito.when(mockLogger.isLifecycleEnabled()).thenReturn(true);
+    Mockito.when(mockLogger.isDebugEnabled()).thenReturn(true);
+    Mockito.when(mockLogger.isInfoEnabled()).thenReturn(true);
+    Mockito.when(mockLogger.isWarnEnabled()).thenReturn(true);
+    Mockito.when(mockLogger.isErrorEnabled()).thenReturn(true);
+
     manifest = new DefaultManifest(mockFileResolver);
     Mockito.when(mockProject.getConvention()).thenReturn(mockConvention);
     Mockito.when(mockConvention.getPlugin(JavaPluginConvention.class))

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -223,7 +223,6 @@ public class MavenProjectPropertiesTest {
   @Before
   public void setUp() throws IOException, URISyntaxException {
     Mockito.when(mockLog.isDebugEnabled()).thenReturn(true);
-    Mockito.when(mockLog.isInfoEnabled()).thenReturn(true);
     Mockito.when(mockLog.isWarnEnabled()).thenReturn(true);
     Mockito.when(mockLog.isErrorEnabled()).thenReturn(true);
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -222,6 +222,11 @@ public class MavenProjectPropertiesTest {
 
   @Before
   public void setUp() throws IOException, URISyntaxException {
+    Mockito.when(mockLog.isDebugEnabled()).thenReturn(true);
+    Mockito.when(mockLog.isInfoEnabled()).thenReturn(true);
+    Mockito.when(mockLog.isWarnEnabled()).thenReturn(true);
+    Mockito.when(mockLog.isErrorEnabled()).thenReturn(true);
+
     Mockito.when(mockMavenSession.getRequest()).thenReturn(mockMavenRequest);
     mavenProjectProperties =
         new MavenProjectProperties(


### PR DESCRIPTION
See #2175.

However, I can never figure out why the test doesn't pass on the Travis Java 11 build. Doesn't make sense to me. Still looking into it.