### PR TITLE
Fix Kokoro Ubuntu

### DIFF
--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -14,6 +14,7 @@ gcloud components install docker-credential-gcr
 
 # docker-credential-gcr uses GOOGLE_APPLICATION_CREDENTIALS as the credentials key file
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_KEYSTORE_DIR}/72743_jib_integration_testing_key
+docker-credential-gcr configure-docker
 
 # Stops any left-over containers.
 docker stop $(docker ps --all --quiet) || true


### PR DESCRIPTION
I removed this in #2186, since it worked on macOS without it. Turns out, this is still required on Ubuntu. I confirm this works.