### PR TITLE
Use a different marker so we don't clash with other jib json outputs

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/SyncMapTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/SyncMapTask.java
@@ -80,7 +80,7 @@ public class SyncMapTask extends DefaultTask {
             PluginConfigurationProcessor.getSkaffoldSyncMap(configuration, projectProperties);
 
         System.out.println();
-        System.out.println("BEGIN JIB SYNCMAP JSON");
+        System.out.println("BEGIN JIB JSON: SYNCMAP/1");
         System.out.println(syncMapJson);
 
       } catch (Exception ex) {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/SyncMapTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/SyncMapTask.java
@@ -80,7 +80,7 @@ public class SyncMapTask extends DefaultTask {
             PluginConfigurationProcessor.getSkaffoldSyncMap(configuration, projectProperties);
 
         System.out.println();
-        System.out.println("BEGIN JIB JSON");
+        System.out.println("BEGIN JIB SYNCMAP JSON");
         System.out.println(syncMapJson);
 
       } catch (Exception ex) {

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/skaffold/SyncMapTaskTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/skaffold/SyncMapTaskTest.java
@@ -72,7 +72,7 @@ public class SyncMapTaskTest {
     List<String> outputLines =
         Splitter.on(System.lineSeparator()).omitEmptyStrings().splitToList(buildResult.getOutput());
     Assert.assertEquals(2, outputLines.size());
-    Assert.assertEquals("BEGIN JIB JSON", outputLines.get(0));
+    Assert.assertEquals("BEGIN JIB SYNCMAP JSON", outputLines.get(0));
     return SkaffoldSyncMapTemplate.from(outputLines.get(1));
   }
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/skaffold/SyncMapTaskTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/skaffold/SyncMapTaskTest.java
@@ -72,7 +72,7 @@ public class SyncMapTaskTest {
     List<String> outputLines =
         Splitter.on(System.lineSeparator()).omitEmptyStrings().splitToList(buildResult.getOutput());
     Assert.assertEquals(2, outputLines.size());
-    Assert.assertEquals("BEGIN JIB SYNCMAP JSON", outputLines.get(0));
+    Assert.assertEquals("BEGIN JIB JSON: SYNCMAP/1", outputLines.get(0));
     return SkaffoldSyncMapTemplate.from(outputLines.get(1));
   }
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojo.java
@@ -79,7 +79,7 @@ public class SyncMapMojo extends JibPluginConfiguration {
             PluginConfigurationProcessor.getSkaffoldSyncMap(configuration, projectProperties);
 
         System.out.println();
-        System.out.println("BEGIN JIB SYNCMAP JSON");
+        System.out.println("BEGIN JIB JSON: SYNCMAP/1");
         System.out.println(syncMapJson);
 
       } catch (Exception ex) {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojo.java
@@ -79,7 +79,7 @@ public class SyncMapMojo extends JibPluginConfiguration {
             PluginConfigurationProcessor.getSkaffoldSyncMap(configuration, projectProperties);
 
         System.out.println();
-        System.out.println("BEGIN JIB JSON");
+        System.out.println("BEGIN JIB SYNCMAP JSON");
         System.out.println(syncMapJson);
 
       } catch (Exception ex) {

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojoTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojoTest.java
@@ -66,7 +66,7 @@ public class SyncMapMojoTest {
     Path logFile = runBuild(projectRoot, module, null);
     List<String> outputLines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
     Assert.assertEquals(3, outputLines.size()); // we expect ["\n", "<marker>", "<sync-json>"]
-    Assert.assertEquals("BEGIN JIB SYNCMAP JSON", outputLines.get(1));
+    Assert.assertEquals("BEGIN JIB JSON: SYNCMAP/1", outputLines.get(1));
     return outputLines.get(2); // this is the JSON output
   }
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojoTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojoTest.java
@@ -65,7 +65,8 @@ public class SyncMapMojoTest {
       throws VerificationException, IOException {
     Path logFile = runBuild(projectRoot, module, null);
     List<String> outputLines = Files.readAllLines(logFile, StandardCharsets.UTF_8);
-    Assert.assertEquals(3, outputLines.size()); // we expect ["\n", "BEGIN JIB JSON", "<sync-json>"]
+    Assert.assertEquals(3, outputLines.size()); // we expect ["\n", "<marker>", "<sync-json>"]
+    Assert.assertEquals("BEGIN JIB SYNCMAP JSON", outputLines.get(1));
     return outputLines.get(2); // this is the JSON output
   }
 


### PR DESCRIPTION
This is to potentially protect us from the case where we run sync and files tasks together.