### PR TITLE
Display where Jib got credentials for base and target images

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStep.java
@@ -84,10 +84,8 @@ class RetrieveRegistryCredentialsStep implements Callable<Optional<Credential>> 
         }
       }
 
-      // If no credentials found, give an info (not warning because in most cases, the base image is
-      // public and does not need extra credentials) and return empty.
       eventHandlers.dispatch(
-          LogEvent.info("No credentials could be retrieved for registry " + registry));
+          LogEvent.lifecycle("No credentials could be retrieved for registry " + registry));
       return Optional.empty();
     }
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStep.java
@@ -85,7 +85,7 @@ class RetrieveRegistryCredentialsStep implements Callable<Optional<Credential>> 
       }
 
       eventHandlers.dispatch(
-          LogEvent.lifecycle("No credentials could be retrieved for registry " + registry));
+          LogEvent.info("No credentials could be retrieved for registry " + registry));
       return Optional.empty();
     }
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactory.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactory.java
@@ -255,15 +255,16 @@ public class CredentialRetrieverFactory {
   CredentialRetriever dockerConfig(
       DockerConfigCredentialRetriever dockerConfigCredentialRetriever) {
     return () -> {
+      Path configFile = dockerConfigCredentialRetriever.getDockerConfigFile();
       try {
         Optional<Credential> credentials = dockerConfigCredentialRetriever.retrieve(logger);
         if (credentials.isPresent()) {
-          logGotCredentialsFrom("credentials from Docker config file");
+          logGotCredentialsFrom("credentials from Docker config (" + configFile + ")");
           return credentials;
         }
 
       } catch (IOException ex) {
-        logger.accept(LogEvent.info("Unable to parse Docker config file"));
+        logger.accept(LogEvent.info("Unable to parse Docker config file: " + configFile));
       }
       return Optional.empty();
     };

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactory.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactory.java
@@ -110,7 +110,7 @@ public class CredentialRetrieverFactory {
    */
   public CredentialRetriever known(Credential credential, String credentialSource) {
     return () -> {
-      logGotCredentialsFrom(credentialSource);
+      logGotCredentialsFrom("credentials from " + credentialSource);
       return Optional.of(credential);
     };
   }
@@ -258,12 +258,12 @@ public class CredentialRetrieverFactory {
       try {
         Optional<Credential> credentials = dockerConfigCredentialRetriever.retrieve(logger);
         if (credentials.isPresent()) {
-          logGotCredentialsFrom("credentials from Docker config");
+          logGotCredentialsFrom("credentials from Docker config file");
           return credentials;
         }
 
       } catch (IOException ex) {
-        logger.accept(LogEvent.info("Unable to parse Docker config"));
+        logger.accept(LogEvent.info("Unable to parse Docker config file"));
       }
       return Optional.empty();
     };
@@ -276,12 +276,11 @@ public class CredentialRetrieverFactory {
         dockerCredentialHelperFactory
             .create(imageReference.getRegistry(), credentialHelper)
             .retrieve();
-    logGotCredentialsFrom("credentials from " + credentialHelper.getFileName().toString());
+    logGotCredentialsFrom("credential helper " + credentialHelper.getFileName().toString());
     return credentials;
   }
 
   private void logGotCredentialsFrom(String credentialSource) {
-    logger.accept(
-        LogEvent.info("Using " + credentialSource + " for " + imageReference.getRegistry()));
+    logger.accept(LogEvent.lifecycle("Using " + credentialSource + " for " + imageReference));
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
@@ -66,6 +66,10 @@ public class DockerConfigCredentialRetriever {
     this.dockerConfigFile = dockerConfigFile;
   }
 
+  public Path getDockerConfigFile() {
+    return dockerConfigFile;
+  }
+
   /**
    * Retrieves credentials for a registry. Tries all possible known aliases.
    *
@@ -99,7 +103,7 @@ public class DockerConfigCredentialRetriever {
       if (dockerCredentialHelper != null) {
         try {
           Path helperPath = dockerCredentialHelper.getCredentialHelper();
-          logger.accept(LogEvent.debug("trying " + helperPath + " for " + registryAlias));
+          logger.accept(LogEvent.info("trying " + helperPath + " for " + registryAlias));
           // Tries with the given registry alias (may be the original registry).
           return Optional.of(dockerCredentialHelper.retrieve());
 
@@ -125,7 +129,7 @@ public class DockerConfigCredentialRetriever {
         String username = usernameColonPassword.substring(0, usernameColonPassword.indexOf(":"));
         String password = usernameColonPassword.substring(usernameColonPassword.indexOf(":") + 1);
         logger.accept(
-            LogEvent.debug("Docker config auths section defines credentials for " + registryAlias));
+            LogEvent.info("Docker config auths section defines credentials for " + registryAlias));
         return Optional.of(Credential.from(username, password));
       }
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
@@ -98,6 +98,8 @@ public class DockerConfigCredentialRetriever {
           dockerConfig.getCredentialHelperFor(registryAlias);
       if (dockerCredentialHelper != null) {
         try {
+          Path helperPath = dockerCredentialHelper.getCredentialHelper();
+          logger.accept(LogEvent.debug("trying " + helperPath + " for " + registryAlias));
           // Tries with the given registry alias (may be the original registry).
           return Optional.of(dockerCredentialHelper.retrieve());
 
@@ -122,6 +124,8 @@ public class DockerConfigCredentialRetriever {
             new String(Base64.decodeBase64(auth), StandardCharsets.UTF_8);
         String username = usernameColonPassword.substring(0, usernameColonPassword.indexOf(":"));
         String password = usernameColonPassword.substring(usernameColonPassword.indexOf(":") + 1);
+        logger.accept(
+            LogEvent.debug("Docker config auths section defines credentials for " + registryAlias));
         return Optional.of(Credential.from(username, password));
       }
     }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
@@ -86,8 +86,7 @@ public class RetrieveRegistryCredentialsStepTest {
     Mockito.verify(mockEventHandlers, Mockito.atLeastOnce())
         .dispatch(Mockito.any(ProgressEvent.class));
     Mockito.verify(mockEventHandlers)
-        .dispatch(
-            LogEvent.lifecycle("No credentials could be retrieved for registry baseregistry"));
+        .dispatch(LogEvent.info("No credentials could be retrieved for registry baseregistry"));
 
     Assert.assertFalse(
         RetrieveRegistryCredentialsStep.forTargetImage(
@@ -97,8 +96,7 @@ public class RetrieveRegistryCredentialsStepTest {
             .isPresent());
 
     Mockito.verify(mockEventHandlers)
-        .dispatch(
-            LogEvent.lifecycle("No credentials could be retrieved for registry baseregistry"));
+        .dispatch(LogEvent.info("No credentials could be retrieved for registry baseregistry"));
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RetrieveRegistryCredentialsStepTest.java
@@ -86,7 +86,8 @@ public class RetrieveRegistryCredentialsStepTest {
     Mockito.verify(mockEventHandlers, Mockito.atLeastOnce())
         .dispatch(Mockito.any(ProgressEvent.class));
     Mockito.verify(mockEventHandlers)
-        .dispatch(LogEvent.info("No credentials could be retrieved for registry baseregistry"));
+        .dispatch(
+            LogEvent.lifecycle("No credentials could be retrieved for registry baseregistry"));
 
     Assert.assertFalse(
         RetrieveRegistryCredentialsStep.forTargetImage(
@@ -96,7 +97,8 @@ public class RetrieveRegistryCredentialsStepTest {
             .isPresent());
 
     Mockito.verify(mockEventHandlers)
-        .dispatch(LogEvent.info("No credentials could be retrieved for registry baseregistry"));
+        .dispatch(
+            LogEvent.lifecycle("No credentials could be retrieved for registry baseregistry"));
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactoryTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactoryTest.java
@@ -129,13 +129,17 @@ public class CredentialRetrieverFactoryTest {
         Mockito.mock(DockerConfigCredentialRetriever.class);
     Mockito.when(dockerConfigCredentialRetriever.retrieve(mockLogger))
         .thenReturn(Optional.of(FAKE_CREDENTIALS));
+    Mockito.when(dockerConfigCredentialRetriever.getDockerConfigFile())
+        .thenReturn(Paths.get("/foo/config.json"));
 
     Assert.assertEquals(
         Optional.of(FAKE_CREDENTIALS),
         credentialRetrieverFactory.dockerConfig(dockerConfigCredentialRetriever).retrieve());
 
     Mockito.verify(mockLogger)
-        .accept(LogEvent.lifecycle("Using credentials from Docker config file for registry/repo"));
+        .accept(
+            LogEvent.lifecycle(
+                "Using credentials from Docker config (/foo/config.json) for registry/repo"));
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactoryTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactoryTest.java
@@ -125,12 +125,12 @@ public class CredentialRetrieverFactoryTest {
     CredentialRetrieverFactory credentialRetrieverFactory =
         createCredentialRetrieverFactory("registry", "repo");
 
+    Path dockerConfig = Paths.get("/foo/config.json");
     DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
         Mockito.mock(DockerConfigCredentialRetriever.class);
     Mockito.when(dockerConfigCredentialRetriever.retrieve(mockLogger))
         .thenReturn(Optional.of(FAKE_CREDENTIALS));
-    Mockito.when(dockerConfigCredentialRetriever.getDockerConfigFile())
-        .thenReturn(Paths.get("/foo/config.json"));
+    Mockito.when(dockerConfigCredentialRetriever.getDockerConfigFile()).thenReturn(dockerConfig);
 
     Assert.assertEquals(
         Optional.of(FAKE_CREDENTIALS),
@@ -139,7 +139,7 @@ public class CredentialRetrieverFactoryTest {
     Mockito.verify(mockLogger)
         .accept(
             LogEvent.lifecycle(
-                "Using credentials from Docker config (/foo/config.json) for registry/repo"));
+                "Using credentials from Docker config (" + dockerConfig + ") for registry/repo"));
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactoryTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/frontend/CredentialRetrieverFactoryTest.java
@@ -67,24 +67,25 @@ public class CredentialRetrieverFactoryTest {
   @Test
   public void testDockerCredentialHelper() throws CredentialRetrievalException {
     CredentialRetrieverFactory credentialRetrieverFactory =
-        createCredentialRetrieverFactory("registry", "repository");
+        createCredentialRetrieverFactory("registry", "repo");
 
     Assert.assertEquals(
         Optional.of(FAKE_CREDENTIALS),
         credentialRetrieverFactory
-            .dockerCredentialHelper(Paths.get("docker-credential-helper"))
+            .dockerCredentialHelper(Paths.get("docker-credential-foo"))
             .retrieve());
 
     Mockito.verify(mockDockerCredentialHelperFactory)
-        .create("registry", Paths.get("docker-credential-helper"));
+        .create("registry", Paths.get("docker-credential-foo"));
     Mockito.verify(mockLogger)
-        .accept(LogEvent.info("Using credentials from docker-credential-helper for registry"));
+        .accept(
+            LogEvent.lifecycle("Using credential helper docker-credential-foo for registry/repo"));
   }
 
   @Test
   public void testWellKnownCredentialHelpers() throws CredentialRetrievalException {
     CredentialRetrieverFactory credentialRetrieverFactory =
-        createCredentialRetrieverFactory("something.gcr.io", "repository");
+        createCredentialRetrieverFactory("something.gcr.io", "repo");
 
     Assert.assertEquals(
         Optional.of(FAKE_CREDENTIALS),
@@ -93,7 +94,9 @@ public class CredentialRetrieverFactoryTest {
     Mockito.verify(mockDockerCredentialHelperFactory)
         .create("something.gcr.io", Paths.get("docker-credential-gcr"));
     Mockito.verify(mockLogger)
-        .accept(LogEvent.info("Using credentials from docker-credential-gcr for something.gcr.io"));
+        .accept(
+            LogEvent.lifecycle(
+                "Using credential helper docker-credential-gcr for something.gcr.io/repo"));
   }
 
   @Test
@@ -106,7 +109,7 @@ public class CredentialRetrieverFactoryTest {
     Mockito.when(mockDockerCredentialHelper.retrieve()).thenThrow(notFoundException);
 
     CredentialRetrieverFactory credentialRetrieverFactory =
-        createCredentialRetrieverFactory("something.amazonaws.com", "repository");
+        createCredentialRetrieverFactory("something.amazonaws.com", "repo");
 
     Assert.assertFalse(
         credentialRetrieverFactory.wellKnownCredentialHelpers().retrieve().isPresent());
@@ -120,7 +123,7 @@ public class CredentialRetrieverFactoryTest {
   @Test
   public void testDockerConfig() throws IOException, CredentialRetrievalException {
     CredentialRetrieverFactory credentialRetrieverFactory =
-        createCredentialRetrieverFactory("registry", "repository");
+        createCredentialRetrieverFactory("registry", "repo");
 
     DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
         Mockito.mock(DockerConfigCredentialRetriever.class);
@@ -132,7 +135,7 @@ public class CredentialRetrieverFactoryTest {
         credentialRetrieverFactory.dockerConfig(dockerConfigCredentialRetriever).retrieve());
 
     Mockito.verify(mockLogger)
-        .accept(LogEvent.info("Using credentials from Docker config for registry"));
+        .accept(LogEvent.lifecycle("Using credentials from Docker config file for registry/repo"));
   }
 
   @Test
@@ -189,7 +192,7 @@ public class CredentialRetrieverFactoryTest {
   public void testGoogleApplicationDefaultCredentials_endUserCredentials()
       throws CredentialRetrievalException {
     CredentialRetrieverFactory credentialRetrieverFactory =
-        createCredentialRetrieverFactory("awesome.gcr.io", "repository");
+        createCredentialRetrieverFactory("awesome.gcr.io", "repo");
 
     Credential credential =
         credentialRetrieverFactory.googleApplicationDefaultCredentials().retrieve().get();
@@ -200,7 +203,9 @@ public class CredentialRetrieverFactoryTest {
 
     Mockito.verify(mockLogger).accept(LogEvent.info("Google ADC found"));
     Mockito.verify(mockLogger)
-        .accept(LogEvent.info("Using Google Application Default Credentials for awesome.gcr.io"));
+        .accept(
+            LogEvent.lifecycle(
+                "Using Google Application Default Credentials for awesome.gcr.io/repo"));
     Mockito.verifyNoMoreInteractions(mockLogger);
   }
 
@@ -212,7 +217,7 @@ public class CredentialRetrieverFactoryTest {
         .thenReturn(mockGoogleCredentials);
 
     CredentialRetrieverFactory credentialRetrieverFactory =
-        createCredentialRetrieverFactory("gcr.io", "repository");
+        createCredentialRetrieverFactory("gcr.io", "repo");
 
     Credential credential =
         credentialRetrieverFactory.googleApplicationDefaultCredentials().retrieve().get();
@@ -227,7 +232,7 @@ public class CredentialRetrieverFactoryTest {
     Mockito.verify(mockLogger)
         .accept(LogEvent.info("ADC is a service account. Setting GCS read-write scope"));
     Mockito.verify(mockLogger)
-        .accept(LogEvent.info("Using Google Application Default Credentials for gcr.io"));
+        .accept(LogEvent.lifecycle("Using Google Application Default Credentials for gcr.io/repo"));
     Mockito.verifyNoMoreInteractions(mockLogger);
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
@@ -70,20 +70,26 @@ public class DockerConfigCredentialRetrieverTest {
     Assert.assertTrue(credentials.isPresent());
     Assert.assertEquals("some", credentials.get().getUsername());
     Assert.assertEquals("other:auth", credentials.get().getPassword());
+    Mockito.verify(mockLogger)
+        .accept(
+            LogEvent.info(
+                "Docker config auths section defines credentials for some other registry"));
   }
 
   @Test
   public void testRetrieve_credentialHelperTakesPrecedenceOverAuth() {
     Mockito.when(mockDockerConfig.getCredentialHelperFor("some registry"))
         .thenReturn(mockDockerCredentialHelper);
+    Mockito.when(mockDockerCredentialHelper.getCredentialHelper())
+        .thenReturn(Paths.get("docker-credential-foo"));
     DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
         new DockerConfigCredentialRetriever("some registry", dockerConfigFile);
-
-    dockerConfigCredentialRetriever.retrieve(mockDockerConfig, mockLogger);
 
     Assert.assertEquals(
         Optional.of(FAKE_CREDENTIAL),
         dockerConfigCredentialRetriever.retrieve(mockDockerConfig, mockLogger));
+    Mockito.verify(mockLogger)
+        .accept(LogEvent.info("trying docker-credential-foo for some registry"));
   }
 
   @Test

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentials.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentials.java
@@ -34,7 +34,7 @@ import org.apache.maven.settings.crypto.SettingsDecryptionResult;
  */
 class MavenSettingsServerCredentials implements InferredAuthProvider {
 
-  static final String CREDENTIAL_SOURCE = "Maven settings";
+  static final String CREDENTIAL_SOURCE = "Maven settings file";
 
   private final Settings settings;
   private final SettingsDecrypter decrypter;


### PR DESCRIPTION
Fixes #2056.

```
[INFO] Using credentials from Docker config (/usr/local/home/guest/.docker/config.json) for francium25/test
```
```
[INFO] Using credential helper docker-credential-gcr for gcr.io/project/repo
```
```
[INFO] Using credentials from Maven settings file for gcr.io/project/repo
```
```
[INFO] Using credentials from <from><auth> for gcr.io/project/repo
```
```
[INFO] Using credentials from from.auth for gcr.io/project/repo
```

Overall, it will look like
```
[INFO] Containerizing application to francium25/test...
[WARNING] Base image 'gcr.io/chanseok-playground-new/test' does not use a specific image digest - build may not be reproducible
[INFO] Using credentials from Docker config (/usr/local/home/guest/.docker/config.json) for francium25/test
[INFO] The base image requires auth. Trying again for gcr.io/<redacted>...
[INFO] Using credentials from <from><auth> for gcr.io/<redacted>
[INFO] Executing tasks:
[INFO] [===============               ] 50.0% complete
[INFO] > building image to registry
```