### PR TITLE
Improve authentication when pulling base image

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -175,7 +175,7 @@ class PullBaseImageStep implements Callable<ImageAndAuthorization> {
         }
 
         // Last resort. Access "<registry URL>/v2/" and hope the registry will return
-        // "WWW-Authenticate: Bearer ...".
+        // "WWW-Authenticate: Bearer ...". Perhaps it's rare to reach here.
         RegistryAuthenticator registryAuthenticator =
             registryClient.getRegistryAuthenticator().orElseThrow(() -> ex);
         Authorization authorization = registryAuthenticator.authenticatePull(credentials);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.builder.steps;
 
-import com.google.api.client.http.HttpResponseException;
 import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.ImageReference;
@@ -329,22 +328,5 @@ class PullBaseImageStep implements Callable<ImageAndAuthorization> {
     return Optional.of(
         JsonToImageTranslator.toImage(
             (BuildableManifestTemplate) manifestTemplate, configurationTemplate));
-  }
-
-  private Optional<RegistryAuthenticator> getRegistryAuthenticator(
-      HttpResponseException httpResponseException) throws RegistryException, IOException {
-    RegistryClient registryClient =
-        buildContext.newBaseImageRegistryClientFactory().newRegistryClient();
-    String wwwAuthenticate = httpResponseException.getHeaders().getAuthenticate();
-    if (wwwAuthenticate != null) {
-      // The registry requires us to authenticate using the Docker Token Authentication.
-      // See https://docs.docker.com/registry/spec/auth/token
-      return registryClient.getRegistryAuthenticator(wwwAuthenticate);
-    } else {
-      // It's unexpected to reach here; the registry should have returned WWW-Authenticate on
-      // the first manifest request. However, for one last attempt, let's try <server url>/v2/
-      // and hope the registry will return the header.
-      return registryClient.getRegistryAuthenticator();
-    }
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.api.client.util.Base64;
 import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
+import com.google.cloud.tools.jib.api.RegistryAuthenticationFailedException;
 import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
@@ -282,6 +283,12 @@ public class RegistryClient {
     return callRegistryEndpoint(
         new AuthenticationMethodRetriever(
             registryEndpointRequestProperties, getUserAgent(), httpClient));
+  }
+
+  public Optional<RegistryAuthenticator> getRegistryAuthenticator(String wwwAuthenticate)
+      throws RegistryAuthenticationFailedException {
+    return RegistryAuthenticator.fromAuthenticationMethod(
+        wwwAuthenticate, registryEndpointRequestProperties, userAgent, httpClient);
   }
 
   /**


### PR DESCRIPTION
Closes #2134.

I think this is still not an ideal sequence for auth and we can actually simplify this a lot. But as mentioned in the issue, I don't want to change the basic flow of the current behavior even if it is inefficient. This PR will basically add a new shortcut that in practice I expect Jib will take for most registries, so I think this helps a lot. The shortcut is to take and use `WWW-Authenticate` from the first failure. It will cut down 2 HTTP round trips.
