### PR TITLE
Ignore registry port when inferring auth from maven settings

### DIFF
--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentials.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentials.java
@@ -114,12 +114,12 @@ class MavenSettingsServerCredentials implements InferredAuthProvider {
   @Nullable
   @VisibleForTesting
   Server getServerFromMavenSettings(String registry) {
-    // Find and remove port (if present)
     Server server = settings.getServer(registry);
     if (server != null) {
       return server;
     }
 
+    // try without port
     int index = registry.lastIndexOf(':');
     if (index != -1) {
       return settings.getServer(registry.substring(0, index));

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentials.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentials.java
@@ -19,7 +19,9 @@ package com.google.cloud.tools.jib.maven;
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
 import com.google.cloud.tools.jib.plugins.common.InferredAuthException;
 import com.google.cloud.tools.jib.plugins.common.InferredAuthProvider;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Optional;
+import javax.annotation.Nullable;
 import org.apache.maven.settings.Server;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.building.SettingsProblem;
@@ -58,7 +60,7 @@ class MavenSettingsServerCredentials implements InferredAuthProvider {
   @Override
   public Optional<AuthProperty> inferAuth(String registry) throws InferredAuthException {
 
-    Server server = settings.getServer(registry);
+    Server server = getServerFromMavenSettings(registry);
     if (server == null) {
       return Optional.empty();
     }
@@ -107,5 +109,21 @@ class MavenSettingsServerCredentials implements InferredAuthProvider {
             return CREDENTIAL_SOURCE;
           }
         });
+  }
+
+  @Nullable
+  @VisibleForTesting
+  Server getServerFromMavenSettings(String registry) {
+    // Find and remove port (if present)
+    Server server = settings.getServer(registry);
+    if (server != null) {
+      return server;
+    }
+
+    int index = registry.lastIndexOf(':');
+    if (index != -1) {
+      return settings.getServer(registry.substring(0, index));
+    }
+    return null;
   }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentialsTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenSettingsServerCredentialsTest.java
@@ -87,6 +87,34 @@ public class MavenSettingsServerCredentialsTest {
   }
 
   @Test
+  public void testInferredAuth_registryWithHostAndPort() throws InferredAuthException {
+    Optional<AuthProperty> auth =
+        mavenSettingsServerCredentialsNoMasterPassword.inferAuth("docker.example.com:8080");
+    Assert.assertTrue(auth.isPresent());
+    Assert.assertEquals("registryUser", auth.get().getUsername());
+    Assert.assertEquals("registryPassword", auth.get().getPassword());
+  }
+
+  @Test
+  public void testInferredAuth_registryWithHostWithoutPort() throws InferredAuthException {
+    Optional<AuthProperty> auth =
+        mavenSettingsServerCredentialsNoMasterPassword.inferAuth("docker.example.com");
+    Assert.assertTrue(auth.isPresent());
+    Assert.assertEquals("registryUser", auth.get().getUsername());
+    Assert.assertEquals("registryPassword", auth.get().getPassword());
+  }
+
+  @Test
+  public void testInferredAuth_registrySettingsWithPort() throws InferredAuthException {
+    // Attempt to resolve WITHOUT the port. Should work as well.
+    Optional<AuthProperty> auth =
+        mavenSettingsServerCredentialsNoMasterPassword.inferAuth("docker.example.com:5432");
+    Assert.assertTrue(auth.isPresent());
+    Assert.assertEquals("registryUser", auth.get().getUsername());
+    Assert.assertEquals("registryPassword", auth.get().getPassword());
+  }
+
+  @Test
   public void testInferredAuth_notFound() throws InferredAuthException {
     Assert.assertFalse(mavenSettingsServerCredentials.inferAuth("serverUnknown").isPresent());
   }

--- a/jib-maven-plugin/src/test/resources/maven/settings/settings.xml
+++ b/jib-maven-plugin/src/test/resources/maven/settings/settings.xml
@@ -15,5 +15,10 @@
       <username>badUser</username>
       <password>{i-made-this-up=}</password>
     </server>
+    <server>
+      <id>docker.example.com</id>
+      <username>registryUser</username>
+      <password>registryPassword</password>
+    </server>
   </servers>
 </settings>


### PR DESCRIPTION
This PR is a suggestion to fix #2135 

It changes the lookup of the server information from the Maven settings to ignore the port information from the registry.

It splits the registry information at the (last) colon and extracts the substring before it:
`docker.example.com:12345` would match with the server id `docker.example.com`

I've tried to run as many integration tests as possible (but those working with the docker daemon didn't run on my Fedora 31 with podman).