### PR TITLE
Do not fail when "urls" field is present in manifest JSON

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.image.json;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
 import java.util.Map;
@@ -45,6 +46,7 @@ public interface BuildableManifestTemplate extends ManifestTemplate {
     @Nullable private String mediaType;
     @Nullable private DescriptorDigest digest;
     private long size;
+    @Nullable private List<String> urls;
     @Nullable private Map<String, String> annotations;
 
     ContentDescriptorTemplate(String mediaType, long size, DescriptorDigest digest) {
@@ -73,6 +75,16 @@ public interface BuildableManifestTemplate extends ManifestTemplate {
 
     void setDigest(DescriptorDigest digest) {
       this.digest = digest;
+    }
+
+    @VisibleForTesting
+    @Nullable
+    public List<String> getUrls() {
+      return urls;
+    }
+
+    void setUrls(List<String> urls) {
+      this.urls = ImmutableList.copyOf(urls);
     }
 
     @VisibleForTesting

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/V22ManifestTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/V22ManifestTemplateTest.java
@@ -17,7 +17,9 @@
 package com.google.cloud.tools.jib.image.json;
 
 import com.google.cloud.tools.jib.api.DescriptorDigest;
+import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate.ContentDescriptorTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -26,6 +28,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.DigestException;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -77,5 +81,29 @@ public class V22ManifestTemplateTest {
         manifestJson.getLayers().get(0).getDigest());
 
     Assert.assertEquals(1000_000, manifestJson.getLayers().get(0).getSize());
+  }
+
+  @Test
+  public void testFromJson_optionalProperties() throws IOException, URISyntaxException {
+    Path jsonFile =
+        Paths.get(Resources.getResource("core/json/v22manifest_optional_properties.json").toURI());
+
+    V22ManifestTemplate manifestJson =
+        JsonTemplateMapper.readJsonFromFile(jsonFile, V22ManifestTemplate.class);
+
+    List<ContentDescriptorTemplate> layers = manifestJson.getLayers();
+    Assert.assertEquals(4, layers.size());
+    Assert.assertNull(layers.get(0).getUrls());
+    Assert.assertNull(layers.get(0).getAnnotations());
+
+    Assert.assertEquals(Arrays.asList("url-foo", "url-bar"), layers.get(1).getUrls());
+    Assert.assertNull(layers.get(1).getAnnotations());
+
+    Assert.assertNull(layers.get(2).getUrls());
+    Assert.assertEquals(ImmutableMap.of("key-foo", "value-foo"), layers.get(2).getAnnotations());
+
+    Assert.assertEquals(Arrays.asList("cool-url"), layers.get(3).getUrls());
+    Assert.assertEquals(
+        ImmutableMap.of("key1", "value1", "key2", "value2"), layers.get(3).getAnnotations());
   }
 }

--- a/jib-core/src/test/resources/core/json/v22manifest_optional_properties.json
+++ b/jib-core/src/test/resources/core/json/v22manifest_optional_properties.json
@@ -1,0 +1,35 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "type",
+  "config":{
+    "mediaType": "type",
+    "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "size": 10
+  },
+  "layers":[
+    {
+      "mediaType": "type",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "size": 1
+    },
+    {
+      "mediaType": "type",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "size": 2,
+      "urls": ["url-foo", "url-bar"]
+    },
+    {
+      "mediaType": "type",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "size": 3,
+      "annotations": {"key-foo":"value-foo"}
+    },
+    {
+      "mediaType": "type",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "size": 4,
+      "urls": ["cool-url"],
+      "annotations": {"key1":"value1", "key2":"value2"}
+    }
+  ]
+}


### PR DESCRIPTION
See #2215. This prevents Jib from crashing when `urls` is given.

`annotations` was already being retrieved. Added `urls` in the same way.