### PR TITLE
Upgrade idea-ext to 0.7, removes deprecated gradle api usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
   id 'io.freefair.maven-plugin' version '3.8.1' apply false
 
   // apply so we can correctly configure the test runner to be gradle at the project level
-  id "org.jetbrains.gradle.plugin.idea-ext" version "0.5"
+  id 'org.jetbrains.gradle.plugin.idea-ext' version '0.7'
 }
 
 // run tests in intellij using gradle test runner


### PR DESCRIPTION
see: https://github.com/JetBrains/gradle-idea-ext-plugin/pull/89
