### PR TITLE
only depend on assemble on java-library projects

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -35,6 +35,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ProjectDependency;
 import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.tasks.Jar;
@@ -200,15 +201,14 @@ public class JibPlugin implements Plugin<Project> {
             buildTarTask.configure(task -> task.dependsOn(dependsOnTask));
             syncMapTask.configure(task -> task.dependsOn(dependsOnTask));
 
-            // Find project dependencies and add a dependency to their assemble task. We make sure
-            // to only add the dependency after BasePlugin is evaluated as otherwise the assemble
-            // task may not be available yet.
+            // for project dependencies that use 'java-library' we need to do something special
+            // since 'classes' will not automatically depend on 'jar' or 'war' or whatever
             List<Project> computedDependencies = getProjectDependencies(projectAfterEvaluation);
             for (Project dependencyProject : computedDependencies) {
               dependencyProject
                   .getPlugins()
                   .withType(
-                      BasePlugin.class,
+                      JavaLibraryPlugin.class,
                       unused -> {
                         TaskProvider<Task> assembleTask =
                             dependencyProject.getTasks().named(BasePlugin.ASSEMBLE_TASK_NAME);


### PR DESCRIPTION
limits the scope of: https://github.com/GoogleContainerTools/jib/issues/2184

I tried everything and accessing the builtBy is actually pretty hard. This limits the scope of depending on "assemble" to only subprojects that use the `java-library` plugin.

It is *a* solution, but there are probably others, this should solve the problem for most people right now, except those using `java-library` and want the reduced task dependencies.