### PR TITLE
Replace assemble task dependency with runtimeClasspath

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -51,6 +51,7 @@ public class JibPlugin implements Plugin<Project> {
   public static final String BUILD_IMAGE_TASK_NAME = "jib";
   public static final String BUILD_TAR_TASK_NAME = "jibBuildTar";
   public static final String BUILD_DOCKER_TASK_NAME = "jibDockerBuild";
+  public static final String DEPENDENCIES_TASK_NAME = "jibDependencies";
   public static final String SKAFFOLD_FILES_TASK_V2_NAME = "_jibSkaffoldFilesV2";
   public static final String SKAFFOLD_INIT_TASK_NAME = "_jibSkaffoldInit";
   public static final String SKAFFOLD_SYNC_MAP_TASK_NAME = "_jibSkaffoldSyncMap";
@@ -177,7 +178,7 @@ public class JibPlugin implements Plugin<Project> {
           TaskProvider<Task> warTask = TaskCommon.getWarTaskProvider(projectAfterEvaluation);
           TaskProvider<Task> bootWarTask =
               TaskCommon.getBootWarTaskProvider(projectAfterEvaluation);
-          TaskProvider<Task> jibDependenciesTask = tasks.register("jibDependencies");
+          TaskProvider<Task> jibDependenciesTask = tasks.register(DEPENDENCIES_TASK_NAME);
           if (warTask != null || bootWarTask != null) {
             // Have all tasks depend on the 'war' and/or 'bootWar' task.
             if (warTask != null) {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -165,7 +165,8 @@ public class JibPlugin implements Plugin<Project> {
             SyncMapTask.class,
             task -> task.setJibExtension(jibExtension));
 
-    Set<TaskProvider<?>> jibTaskProviders = ImmutableSet.of(buildImageTask, buildDockerTask, buildTarTask, syncMapTask);
+    Set<TaskProvider<?>> jibTaskProviders =
+        ImmutableSet.of(buildImageTask, buildDockerTask, buildTarTask, syncMapTask);
 
     // A check to catch older versions of Jib.  This can be removed once we are certain people
     // are using Jib 1.3.1 or later.
@@ -197,10 +198,16 @@ public class JibPlugin implements Plugin<Project> {
             }
           }
 
-          SourceSet mainSourceSet = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName(MAIN_SOURCE_SET_NAME);
+          SourceSet mainSourceSet =
+              project
+                  .getConvention()
+                  .getPlugin(JavaPluginConvention.class)
+                  .getSourceSets()
+                  .getByName(MAIN_SOURCE_SET_NAME);
           jibDependenciesTask.configure(it -> it.dependsOn(mainSourceSet.getRuntimeClasspath()));
 
-          jibTaskProviders.forEach(provider -> provider.configure(task -> task.dependsOn(jibDependenciesTask)));
+          jibTaskProviders.forEach(
+              provider -> provider.configure(task -> task.dependsOn(jibDependenciesTask)));
         });
   }
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.jib.gradle;
 
+import static org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME;
+
 import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.cloud.tools.jib.gradle.skaffold.CheckJibVersionTask;
 import com.google.cloud.tools.jib.gradle.skaffold.FilesTaskV2;
@@ -23,18 +25,19 @@ import com.google.cloud.tools.jib.gradle.skaffold.InitTask;
 import com.google.cloud.tools.jib.gradle.skaffold.SyncMapTask;
 import com.google.cloud.tools.jib.plugins.common.VersionChecker;
 import com.google.common.annotations.VisibleForTesting;
-import java.util.ArrayList;
+import com.google.common.collect.ImmutableSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.UnknownTaskException;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.DependencySet;
 import org.gradle.api.artifacts.ProjectDependency;
-import org.gradle.api.plugins.BasePlugin;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.tasks.Jar;
@@ -162,68 +165,42 @@ public class JibPlugin implements Plugin<Project> {
             SyncMapTask.class,
             task -> task.setJibExtension(jibExtension));
 
+    Set<TaskProvider<?>> jibTaskProviders = ImmutableSet.of(buildImageTask, buildDockerTask, buildTarTask, syncMapTask);
+
     // A check to catch older versions of Jib.  This can be removed once we are certain people
     // are using Jib 1.3.1 or later.
     tasks.register(SKAFFOLD_CHECK_REQUIRED_VERSION_TASK_NAME, CheckJibVersionTask.class);
 
     project.afterEvaluate(
         projectAfterEvaluation -> {
-          try {
-            TaskProvider<Task> warTask = TaskCommon.getWarTaskProvider(projectAfterEvaluation);
-            TaskProvider<Task> bootWarTask =
-                TaskCommon.getBootWarTaskProvider(projectAfterEvaluation);
-            List<TaskProvider<?>> dependsOnTask = new ArrayList<>();
-            if (warTask != null || bootWarTask != null) {
-              // Have all tasks depend on the 'war' and/or 'bootWar' task.
-              if (warTask != null) {
-                dependsOnTask.add(warTask);
-              }
-              if (bootWarTask != null) {
-                dependsOnTask.add(bootWarTask);
-              }
-            } else if ("packaged".equals(jibExtension.getContainerizingMode())) {
-              // Have all tasks depend on the 'jar' task.
-              TaskProvider<Task> jarTask = projectAfterEvaluation.getTasks().named("jar");
-              dependsOnTask.add(jarTask);
-
-              if (projectAfterEvaluation.getPlugins().hasPlugin("org.springframework.boot")) {
-                Jar jar = (Jar) jarTask.get();
-                jar.setEnabled(true);
-                jar.getArchiveClassifier().set("original");
-              }
-            } else {
-              // Have all tasks depend on the 'classes' task.
-              dependsOnTask.add(projectAfterEvaluation.getTasks().named("classes"));
+          TaskProvider<Task> warTask = TaskCommon.getWarTaskProvider(projectAfterEvaluation);
+          TaskProvider<Task> bootWarTask =
+              TaskCommon.getBootWarTaskProvider(projectAfterEvaluation);
+          TaskProvider<Task> jibDependenciesTask = tasks.register("jibDependencies");
+          if (warTask != null || bootWarTask != null) {
+            // Have all tasks depend on the 'war' and/or 'bootWar' task.
+            if (warTask != null) {
+              jibDependenciesTask.configure(it -> it.dependsOn(warTask));
             }
-            buildImageTask.configure(task -> task.dependsOn(dependsOnTask));
-            buildDockerTask.configure(task -> task.dependsOn(dependsOnTask));
-            buildTarTask.configure(task -> task.dependsOn(dependsOnTask));
-            syncMapTask.configure(task -> task.dependsOn(dependsOnTask));
-
-            // Find project dependencies and add a dependency to their assemble task. We make sure
-            // to only add the dependency after BasePlugin is evaluated as otherwise the assemble
-            // task may not be available yet.
-            List<Project> computedDependencies = getProjectDependencies(projectAfterEvaluation);
-            for (Project dependencyProject : computedDependencies) {
-              dependencyProject
-                  .getPlugins()
-                  .withType(
-                      BasePlugin.class,
-                      unused -> {
-                        TaskProvider<Task> assembleTask =
-                            dependencyProject.getTasks().named(BasePlugin.ASSEMBLE_TASK_NAME);
-                        buildImageTask.configure(task -> task.dependsOn(assembleTask));
-                        buildDockerTask.configure(task -> task.dependsOn(assembleTask));
-                        buildTarTask.configure(task -> task.dependsOn(assembleTask));
-                      });
+            if (bootWarTask != null) {
+              jibDependenciesTask.configure(it -> it.dependsOn(bootWarTask));
             }
-          } catch (UnknownTaskException ex) {
-            throw new GradleException(
-                "Could not find task 'classes' on project "
-                    + projectAfterEvaluation.getDisplayName()
-                    + " - perhaps you did not apply the 'java' plugin?",
-                ex);
+          } else if ("packaged".equals(jibExtension.getContainerizingMode())) {
+            // Have all tasks depend on the 'jar' task.
+            TaskProvider<Task> jarTask = projectAfterEvaluation.getTasks().named("jar");
+            jibDependenciesTask.configure(it -> it.dependsOn(jarTask));
+
+            if (projectAfterEvaluation.getPlugins().hasPlugin("org.springframework.boot")) {
+              Jar jar = (Jar) jarTask.get();
+              jar.setEnabled(true);
+              jar.getArchiveClassifier().set("original");
+            }
           }
+
+          SourceSet mainSourceSet = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName(MAIN_SOURCE_SET_NAME);
+          jibDependenciesTask.configure(it -> it.dependsOn(mainSourceSet.getRuntimeClasspath()));
+
+          jibTaskProviders.forEach(provider -> provider.configure(task -> task.dependsOn(jibDependenciesTask)));
         });
   }
 }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -17,17 +17,12 @@
 package com.google.cloud.tools.jib.gradle;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import java.util.Set;
-import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import org.gradle.api.GradleException;
 import org.gradle.api.Project;
@@ -137,75 +132,7 @@ public class JibPluginTest {
       Assert.assertEquals("Could not determine Jib plugin version", ex.getCause().getMessage());
     }
   }
-
-  /*
-  @SuppressWarnings("unchecked")
-  @Test
-  public void testProjectDependencyAssembleTasksAreRun() {
-    // root project is our jib packaged service
-    Project rootProject = createProject("java");
-
-    // our service DOES depend on this, and jib should trigger an assemble from this project
-    Project subProject =
-        ProjectBuilder.builder()
-            .withParent(rootProject)
-            .withProjectDir(testProjectRoot.getRoot())
-            .withName("sub")
-            .build();
-    subProject.getPluginManager().apply("java");
-
-    // our service doesn't depend on this, and jib should NOT trigger an assemble from this project
-    Project unrelatedSubProject =
-        ProjectBuilder.builder()
-            .withParent(rootProject)
-            .withProjectDir(testProjectRoot.getRoot())
-            .withName("unrelated")
-            .build();
-    unrelatedSubProject.getPluginManager().apply("java");
-
-    // equivalent of "compile project(':sub')" on the root(jib) project
-    rootProject
-        .getConfigurations()
-        .getByName("compile")
-        .getDependencies()
-        .add(rootProject.getDependencies().project(ImmutableMap.of("path", subProject.getPath())));
-
-    // programmatic check
-    Assert.assertEquals(
-        Collections.singletonList(":sub"),
-        JibPlugin.getProjectDependencies(rootProject)
-            .stream()
-            .map(Project::getPath)
-            .collect(Collectors.toList()));
-
-    // check by applying the jib plugin and inspect the task dependencies
-    rootProject.getPluginManager().apply("com.google.cloud.tools.jib");
-
-    TaskContainer tasks = rootProject.getTasks();
-    // add a custom task that our jib tasks depend on to ensure we do not overwrite this dependsOn
-    TaskProvider<Task> dependencyTask = rootProject.getTasks().register("myCustomTask", task -> {});
-    KNOWN_JIB_TASKS.forEach(taskName -> tasks.getByPath(taskName).dependsOn(dependencyTask));
-
-    ((ProjectInternal) rootProject).evaluate();
-
-    KNOWN_JIB_TASKS.forEach(
-        taskName ->
-            Assert.assertEquals(
-                ImmutableSet.of(":sub:assemble", ":classes", ":myCustomTask"),
-                tasks
-                    .getByPath(taskName)
-                    .getDependsOn()
-                    .stream()
-                    .map(
-                        object ->
-                            object instanceof List ? object : Collections.singletonList(object))
-                    .map(List.class::cast)
-                    .flatMap(List::stream)
-                    .map(object -> ((TaskProvider<Task>) object).get().getPath())
-                    .collect(Collectors.toSet())));
-  }
-  */
-
+  
   @SuppressWarnings("unchecked")
   @Test
   public void testWebAppProject() {

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -143,21 +143,16 @@ public class JibPluginTest {
     Task warTask = tasks.getByPath(":war");
     Assert.assertNotNull(warTask);
 
-    Task jibDependenciesTask = tasks.getByPath(":" + JibPlugin.DEPENDENCIES_TASK_NAME);
-    Set<Task> taskDependencies =
-        jibDependenciesTask
-            .getDependsOn()
-            .stream()
-            .filter(TaskProvider.class::isInstance)
-            .map(it -> ((TaskProvider<?>) it).get())
-            .collect(Collectors.toSet());
-
-    Assert.assertTrue(taskDependencies.contains(warTask));
-
     for (String taskName : KNOWN_JIB_TASKS) {
-      TaskProvider<?> jibDependenciesTaskProvider =
-          (TaskProvider<?>) tasks.getByPath(taskName).getDependsOn().iterator().next();
-      Assert.assertEquals(jibDependenciesTaskProvider.get(), jibDependenciesTask);
+      Set<Task> taskDependencies =
+          tasks.getByPath(taskName)
+              .getDependsOn()
+              .stream()
+              .filter(TaskProvider.class::isInstance)
+              .map(it -> ((TaskProvider<?>) it).get())
+              .collect(Collectors.toSet());
+
+      Assert.assertTrue(taskDependencies.contains(warTask));
     }
   }
 
@@ -171,24 +166,19 @@ public class JibPluginTest {
     TaskContainer tasks = project.getTasks();
     Task warTask = tasks.getByPath(":war");
     Task bootWarTask = tasks.getByPath(":bootWar");
-    Task jibDependenciesTask = tasks.getByPath(":" + JibPlugin.DEPENDENCIES_TASK_NAME);
     Assert.assertNotNull(warTask);
     Assert.assertNotNull(bootWarTask);
 
-    Set<Task> taskDependencies =
-        jibDependenciesTask
-            .getDependsOn()
-            .stream()
-            .filter(TaskProvider.class::isInstance)
-            .map(it -> ((TaskProvider<?>) it).get())
-            .collect(Collectors.toSet());
-
-    Assert.assertTrue(taskDependencies.containsAll(Arrays.asList(warTask, bootWarTask)));
-
     for (String taskName : KNOWN_JIB_TASKS) {
-      TaskProvider<?> jibTaskProvider =
-          (TaskProvider<?>) tasks.getByPath(taskName).getDependsOn().iterator().next();
-      Assert.assertEquals(jibTaskProvider.get(), jibDependenciesTask);
+      Set<Task> taskDependencies =
+          tasks.getByPath(taskName)
+              .getDependsOn()
+              .stream()
+              .filter(TaskProvider.class::isInstance)
+              .map(it -> ((TaskProvider<?>) it).get())
+              .collect(Collectors.toSet());
+
+      Assert.assertTrue(taskDependencies.containsAll(Arrays.asList(warTask, bootWarTask)));
     }
   }
 
@@ -202,25 +192,23 @@ public class JibPluginTest {
     TaskContainer tasks = project.getTasks();
     Task warTask = tasks.getByPath(":war");
     Task bootWarTask = tasks.getByPath(":bootWar");
-    Task jibDependenciesTask = tasks.getByPath(":" + JibPlugin.DEPENDENCIES_TASK_NAME);
     Assert.assertNotNull(warTask);
     Assert.assertNotNull(bootWarTask);
     bootWarTask.setEnabled(false); // should depend on bootWar even if disabled
 
-    Set<Task> taskDependencies =
-        jibDependenciesTask
-            .getDependsOn()
-            .stream()
-            .filter(TaskProvider.class::isInstance)
-            .map(it -> ((TaskProvider<?>) it).get())
-            .collect(Collectors.toSet());
 
-    Assert.assertTrue(taskDependencies.containsAll(Arrays.asList(warTask, bootWarTask)));
+
 
     for (String taskName : KNOWN_JIB_TASKS) {
-      TaskProvider<?> jibTaskProvider =
-          (TaskProvider<?>) tasks.getByPath(taskName).getDependsOn().iterator().next();
-      Assert.assertEquals(jibTaskProvider.get(), jibDependenciesTask);
+      Set<Task> taskDependencies =
+          tasks.getByPath(taskName)
+              .getDependsOn()
+              .stream()
+              .filter(TaskProvider.class::isInstance)
+              .map(it -> ((TaskProvider<?>) it).get())
+              .collect(Collectors.toSet());
+
+      Assert.assertTrue(taskDependencies.containsAll(Arrays.asList(warTask, bootWarTask)));
     }
   }
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -148,7 +148,7 @@ public class JibPluginTest {
         jibDependenciesTask
             .getDependsOn()
             .stream()
-            .filter(it -> it instanceof TaskProvider)
+            .filter(TaskProvider.class::isInstance)
             .map(it -> ((TaskProvider<?>) it).get())
             .collect(Collectors.toSet());
 
@@ -179,7 +179,7 @@ public class JibPluginTest {
         jibDependenciesTask
             .getDependsOn()
             .stream()
-            .filter(it -> it instanceof TaskProvider)
+            .filter(TaskProvider.class::isInstance)
             .map(it -> ((TaskProvider<?>) it).get())
             .collect(Collectors.toSet());
 
@@ -211,7 +211,7 @@ public class JibPluginTest {
         jibDependenciesTask
             .getDependsOn()
             .stream()
-            .filter(it -> it instanceof TaskProvider)
+            .filter(TaskProvider.class::isInstance)
             .map(it -> ((TaskProvider<?>) it).get())
             .collect(Collectors.toSet());
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -143,7 +143,7 @@ public class JibPluginTest {
     Task warTask = tasks.getByPath(":war");
     Assert.assertNotNull(warTask);
 
-    Task jibDependenciesTask = tasks.getByPath(":jibDependencies");
+    Task jibDependenciesTask = tasks.getByPath(":" + JibPlugin.DEPENDENCIES_TASK_NAME);
     Set<Task> taskDependencies =
         jibDependenciesTask
             .getDependsOn()
@@ -171,7 +171,7 @@ public class JibPluginTest {
     TaskContainer tasks = project.getTasks();
     Task warTask = tasks.getByPath(":war");
     Task bootWarTask = tasks.getByPath(":bootWar");
-    Task jibDependenciesTask = tasks.getByPath(":jibDependencies");
+    Task jibDependenciesTask = tasks.getByPath(":" + JibPlugin.DEPENDENCIES_TASK_NAME);
     Assert.assertNotNull(warTask);
     Assert.assertNotNull(bootWarTask);
 
@@ -202,7 +202,7 @@ public class JibPluginTest {
     TaskContainer tasks = project.getTasks();
     Task warTask = tasks.getByPath(":war");
     Task bootWarTask = tasks.getByPath(":bootWar");
-    Task jibDependenciesTask = tasks.getByPath(":jibDependencies");
+    Task jibDependenciesTask = tasks.getByPath(":" + JibPlugin.DEPENDENCIES_TASK_NAME);
     Assert.assertNotNull(warTask);
     Assert.assertNotNull(bootWarTask);
     bootWarTask.setEnabled(false); // should depend on bootWar even if disabled

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -132,7 +132,7 @@ public class JibPluginTest {
       Assert.assertEquals("Could not determine Jib plugin version", ex.getCause().getMessage());
     }
   }
-  
+
   @SuppressWarnings("unchecked")
   @Test
   public void testWebAppProject() {
@@ -144,11 +144,13 @@ public class JibPluginTest {
     Assert.assertNotNull(warTask);
 
     Task jibDependenciesTask = tasks.getByPath(":jibDependencies");
-    Set<Task> taskDependencies = jibDependenciesTask.getDependsOn()
-        .stream()
-        .filter(it -> it instanceof TaskProvider)
-        .map(it -> ((TaskProvider<?>) it).get())
-        .collect(Collectors.toSet());
+    Set<Task> taskDependencies =
+        jibDependenciesTask
+            .getDependsOn()
+            .stream()
+            .filter(it -> it instanceof TaskProvider)
+            .map(it -> ((TaskProvider<?>) it).get())
+            .collect(Collectors.toSet());
 
     Assert.assertTrue(taskDependencies.contains(warTask));
 
@@ -173,11 +175,13 @@ public class JibPluginTest {
     Assert.assertNotNull(warTask);
     Assert.assertNotNull(bootWarTask);
 
-    Set<Task> taskDependencies = jibDependenciesTask.getDependsOn()
-        .stream()
-        .filter(it -> it instanceof TaskProvider)
-        .map(it -> ((TaskProvider<?>) it).get())
-        .collect(Collectors.toSet());
+    Set<Task> taskDependencies =
+        jibDependenciesTask
+            .getDependsOn()
+            .stream()
+            .filter(it -> it instanceof TaskProvider)
+            .map(it -> ((TaskProvider<?>) it).get())
+            .collect(Collectors.toSet());
 
     Assert.assertTrue(taskDependencies.containsAll(Arrays.asList(warTask, bootWarTask)));
 
@@ -203,11 +207,13 @@ public class JibPluginTest {
     Assert.assertNotNull(bootWarTask);
     bootWarTask.setEnabled(false); // should depend on bootWar even if disabled
 
-    Set<Task> taskDependencies = jibDependenciesTask.getDependsOn()
-        .stream()
-        .filter(it -> it instanceof TaskProvider)
-        .map(it -> ((TaskProvider<?>) it).get())
-        .collect(Collectors.toSet());
+    Set<Task> taskDependencies =
+        jibDependenciesTask
+            .getDependsOn()
+            .stream()
+            .filter(it -> it instanceof TaskProvider)
+            .map(it -> ((TaskProvider<?>) it).get())
+            .collect(Collectors.toSet());
 
     Assert.assertTrue(taskDependencies.containsAll(Arrays.asList(warTask, bootWarTask)));
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -145,7 +145,8 @@ public class JibPluginTest {
 
     for (String taskName : KNOWN_JIB_TASKS) {
       Set<Task> taskDependencies =
-          tasks.getByPath(taskName)
+          tasks
+              .getByPath(taskName)
               .getDependsOn()
               .stream()
               .filter(TaskProvider.class::isInstance)
@@ -171,7 +172,8 @@ public class JibPluginTest {
 
     for (String taskName : KNOWN_JIB_TASKS) {
       Set<Task> taskDependencies =
-          tasks.getByPath(taskName)
+          tasks
+              .getByPath(taskName)
               .getDependsOn()
               .stream()
               .filter(TaskProvider.class::isInstance)
@@ -196,12 +198,10 @@ public class JibPluginTest {
     Assert.assertNotNull(bootWarTask);
     bootWarTask.setEnabled(false); // should depend on bootWar even if disabled
 
-
-
-
     for (String taskName : KNOWN_JIB_TASKS) {
       Set<Task> taskDependencies =
-          tasks.getByPath(taskName)
+          tasks
+              .getByPath(taskName)
               .getDependsOn()
               .stream()
               .filter(TaskProvider.class::isInstance)


### PR DESCRIPTION
This introduces a new lifecycle task called `jibDependencies` (the name can really be anything, that was just what I came up with) that all the jib tasks depend on and it in turn depends on any requisite tasks / configurations. Being a lifecycle task, it doesn't have any task action itself and essentially exists as a convenient hook for other dependencies. In particular, `jibDependencies` will depend on the `war`/`bootWar` tasks  when applicable, the `jar` task when applicable, and always depends on the projects `runtimeClasspath` configuration.

Gradle allows tasks to depend on `FileCollection`s (rather than just tasks). When doing so Gradle expands the task graph expands to include all the necessary tasks to produce the files listed in the `FileCollection`. Doing so with the `runtimeClasspath` configuration means Gradle will run all the tasks to get all the artifacts necessary to run this project, making it more efficient than using the `assemble` task which will often run slow, and unnecessary tasks. In particular, the main source set's `runtimeClasspath`'s property includes the source set output appended to the project's `runtimeClasspath` configuration so depending on that obviates the need to run even manually run the `classes` task. (See https://docs.gradle.org/current/userguide/java_plugin.html#sec:source_set_properties)

 If we only want to conditionally depend on the runtime classpath I'm happy to make that change though I assume it's never really going to be a bad thing even in the case of the `war` based projects.

Also, for what it's worth — jib itself uses the `runtimeClasspath` to get the list of files to add to the container so it makes sense to use that same collection to set up the task dependencies.
https://github.com/GoogleContainerTools/jib/blob/d3615a6df6f0f7e2654466128e685ea7ee73958a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java#L174 

There are a few different potential approaches here so I'm happy to make changes to go with a different approach. For example, we don't _have_ to introduce the `jibDependencies` task but it made the implementation a little cleaner and also made it so that the changes to tests were minimal (some of them make assumptions about the contents of `task.getDependsOn()` which are no longer true when tasks depend on configurations for example). It might also be useful in the future if there are new dependencies since they can all hook into `jibDependencies`.


This should resolve #2184 