### PR TITLE
Deserialize entire "docker inspect" JSON output

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed authentication failure with error `server did not return 'WWW-Authenticate: Bearer' header` in certain cases (for example, on OpenShift). ([#2258](https://github.com/GoogleContainerTools/jib/issues/2258))
+- Fixed an issue where using local Docker images (by `docker://...`) on Windows caused an error. ([#2270](https://github.com/GoogleContainerTools/jib/issues/2270))
 
 ## 0.13.0
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageStepsTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageStepsTest.java
@@ -24,7 +24,7 @@ import com.google.cloud.tools.jib.configuration.BuildContext;
 import com.google.cloud.tools.jib.docker.DockerClient.DockerImageDetails;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
-import com.google.common.collect.ImmutableList;
+import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
@@ -133,13 +133,14 @@ public class LocalBaseImageStepsTest {
   @Test
   public void testGetCachedDockerImage()
       throws IOException, DigestException, CacheCorruptedException, URISyntaxException {
+    String dockerInspectJson =
+        "{\"Size\": 0,"
+            + "\"Id\": \"sha256:066872f17ae819f846a6d5abcfc3165abe13fb0a157640fa8cb7af81077670c0\","
+            + "\"RootFS\": { \"Layers\": ["
+            + "  \"sha256:5e701122d3347fae0758cd5b7f0692c686fcd07b0e7fd9c4a125fbdbbedc04dd\","
+            + "  \"sha256:f1ac3015bcbf0ada4750d728626eb10f0f585199e2b667dcd79e49f0e926178e\" ] } }";
     DockerImageDetails dockerImageDetails =
-        new DockerImageDetails(
-            0,
-            "sha256:066872f17ae819f846a6d5abcfc3165abe13fb0a157640fa8cb7af81077670c0",
-            ImmutableList.of(
-                "sha256:5e701122d3347fae0758cd5b7f0692c686fcd07b0e7fd9c4a125fbdbbedc04dd",
-                "sha256:f1ac3015bcbf0ada4750d728626eb10f0f585199e2b667dcd79e49f0e926178e"));
+        JsonTemplateMapper.readJson(dockerInspectJson, DockerImageDetails.class);
     Path cachePath = temporaryFolder.newFolder("cache").toPath();
     Files.createDirectories(cachePath.resolve("local/config"));
     Cache cache = Cache.withDirectory(cachePath);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/DockerClientTest.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.docker.DockerClient.DockerImageDetails;
 import com.google.cloud.tools.jib.image.ImageTarball;
+import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 import java.io.ByteArrayInputStream;
@@ -257,14 +258,15 @@ public class DockerClientTest {
   }
 
   @Test
-  public void testParseInspectResults() throws DigestException, IOException {
-    String output =
-        "{\"size\":488118507,"
-            + "\"imageId\":\"sha256:e8d00769c8a805a0656dbfd49d4f91cbc2e36d0199f10343d1beba36ecdcb3fd\","
-            + "\"diffIds\":[\"sha256:55e6b89812f369277290d098c1e44c9e85a5ab0286c649f37e66e11074f8ebd1\","
-            + "\"sha256:26b1991f37bd5b798e1523f65d7f6aa6961b75515f465cf44123fa0ad3b8961b\","
-            + "\"sha256:8bacec4e34468110538ebf108ca8ec0d880a37018a55be91b9670b8e900c593a\"]}\n";
-    DockerImageDetails results = DockerClient.parseInspectResults(output);
+  public void testDockerImageDetails() throws DigestException, IOException {
+    String json =
+        "{\"Size\":488118507,"
+            + "\"Id\":\"sha256:e8d00769c8a805a0656dbfd49d4f91cbc2e36d0199f10343d1beba36ecdcb3fd\","
+            + "\"RootFS\": { \"Layers\" : ["
+            + "  \"sha256:55e6b89812f369277290d098c1e44c9e85a5ab0286c649f37e66e11074f8ebd1\","
+            + "  \"sha256:26b1991f37bd5b798e1523f65d7f6aa6961b75515f465cf44123fa0ad3b8961b\","
+            + "  \"sha256:8bacec4e34468110538ebf108ca8ec0d880a37018a55be91b9670b8e900c593a\"]}}\n";
+    DockerImageDetails results = JsonTemplateMapper.readJson(json, DockerImageDetails.class);
     Assert.assertEquals(488118507, results.getSize());
     Assert.assertEquals(
         DescriptorDigest.fromHash(
@@ -279,6 +281,39 @@ public class DockerClientTest {
             DescriptorDigest.fromHash(
                 "8bacec4e34468110538ebf108ca8ec0d880a37018a55be91b9670b8e900c593a")),
         results.getDiffIds());
+  }
+
+  @Test
+  public void testDockerImageDetails_unknownProperties() throws IOException, DigestException {
+    String json =
+        "{\"Unknown\": [ ], \"Structure\": [ { \"Test\": 0 } ], \"Size\": 1234,"
+            + "\"Id\": \"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\","
+            + "\"RootFS\": { \"Someting\": \"unrelated\", \"Layers\": ["
+            + "  \"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc\" ] } }";
+    DockerImageDetails results = JsonTemplateMapper.readJson(json, DockerImageDetails.class);
+    Assert.assertEquals(1234, results.getSize());
+    Assert.assertEquals(
+        DescriptorDigest.fromHash(
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+        results.getImageId());
+    Assert.assertEquals(
+        Arrays.asList(
+            DescriptorDigest.fromHash(
+                "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc")),
+        results.getDiffIds());
+  }
+
+  @Test
+  public void testDockerImageDetails_emptyJson() throws IOException, DigestException {
+    DockerImageDetails details = JsonTemplateMapper.readJson("{}", DockerImageDetails.class);
+    Assert.assertEquals(0, details.getSize());
+    Assert.assertEquals(Collections.emptyList(), details.getDiffIds());
+    try {
+      details.getImageId();
+      Assert.fail();
+    } catch (DigestException ex) {
+      Assert.assertEquals("Invalid digest: ", ex.getMessage());
+    }
   }
 
   private DockerClient makeDockerSaveClient() {

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed authentication failure with error `server did not return 'WWW-Authenticate: Bearer' header` in certain cases (for example, on OpenShift). ([#2258](https://github.com/GoogleContainerTools/jib/issues/2258))
+- Fixed an issue where using local Docker images (by `docker://...`) on Windows caused an error. ([#2270](https://github.com/GoogleContainerTools/jib/issues/2270))
 
 ## 2.0.0
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed authentication failure with error `server did not return 'WWW-Authenticate: Bearer' header` in certain cases (for example, on OpenShift). ([#2258](https://github.com/GoogleContainerTools/jib/issues/2258))
+- Fixed an issue where using local Docker images (by `docker://...`) on Windows caused an error. ([#2270](https://github.com/GoogleContainerTools/jib/issues/2270))
 
 ## 2.0.0
 


### PR DESCRIPTION
Fixes #2270.

`docker inspect` returns an array, so I had to do `docker inspect -f {{json .}}` at least.

Actual command output looks like this and capitalization in JSON properties matters.
```
{                                                                                                      
  "Id": "sha256:ccc6e87d482b79dd1645affd958479139486e47191dfe7a997c862d89cd8b4c0",
  ...
  "Size": 64194748,
  ...
  "RootFS": {
    "Type": "layers",
    "Layers": [
      "sha256:43c67172d1d182ca5460fc962f8f053f33028e0a3a1d423e05d91b532429e73d",
      ...
    ]
  },
  ...
}
```