### PR TITLE
Do not recurse into java-platform dependencies in Skaffold task

### DIFF
--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/TestProject.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/TestProject.java
@@ -55,6 +55,7 @@ public class TestProject extends TemporaryFolder implements Closeable {
   }
 
   private final String testProjectName;
+  private String gradleVersion = JibPlugin.GRADLE_MIN_VERSION.getVersion();
   private GradleRunner gradleRunner;
 
   private Path projectRoot;
@@ -78,9 +79,14 @@ public class TestProject extends TemporaryFolder implements Closeable {
 
     gradleRunner =
         GradleRunner.create()
-            .withGradleVersion(JibPlugin.GRADLE_MIN_VERSION.getVersion())
+            .withGradleVersion(gradleVersion)
             .withProjectDir(projectRoot.toFile())
             .withPluginClasspath();
+  }
+
+  public TestProject withGradleVersion(String version) {
+    gradleVersion = version;
+    return this;
   }
 
   public BuildResult build(String... gradleArguments) {

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2Test.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2Test.java
@@ -40,6 +40,10 @@ public class FilesTaskV2Test {
 
   @ClassRule public static final TestProject multiTestProject = new TestProject("multi-service");
 
+  @ClassRule
+  public static final TestProject platformProject =
+      new TestProject("platform").withGradleVersion("5.2");
+
   /**
    * Verifies that the files task succeeded and returns the list of paths it prints out.
    *
@@ -138,6 +142,25 @@ public class FilesTaskV2Test {
             complexServiceRoot.resolve(
                 "local-m2-repo/com/google/cloud/tools/tiny-test-lib/0.0.1-SNAPSHOT/tiny-test-lib-0.0.1-SNAPSHOT.jar")),
         result.getInputs());
+    Assert.assertEquals(result.getIgnore().size(), 0);
+  }
+
+  @Test
+  public void testFilesTask_platformProject() throws IOException {
+    Path projectRoot = platformProject.getProjectRoot();
+    Path platformRoot = projectRoot.resolve("platform");
+    Path serviceRoot = projectRoot.resolve("service");
+    SkaffoldFilesOutput result =
+        new SkaffoldFilesOutput(verifyTaskSuccess(platformProject, "service"));
+    assertPathListsAreEqual(
+        ImmutableList.of(
+            projectRoot.resolve("build.gradle"),
+            projectRoot.resolve("settings.gradle"),
+            serviceRoot.resolve("build.gradle"),
+            platformRoot.resolve("build.gradle")),
+        result.getBuild());
+    assertPathListsAreEqual(
+        ImmutableList.of(serviceRoot.resolve("src/main/java")), result.getInputs());
     Assert.assertEquals(result.getIgnore().size(), 0);
   }
 }

--- a/jib-gradle-plugin/src/test/resources/gradle/projects/platform/build.gradle
+++ b/jib-gradle-plugin/src/test/resources/gradle/projects/platform/build.gradle
@@ -1,0 +1,5 @@
+subprojects {
+  repositories {
+    mavenCentral()
+  }
+}

--- a/jib-gradle-plugin/src/test/resources/gradle/projects/platform/platform/build.gradle
+++ b/jib-gradle-plugin/src/test/resources/gradle/projects/platform/platform/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+  id 'java-platform'
+}
+
+dependencies {
+  constraints {
+    api 'org.apache.commons:commons-io:1.3.2'
+  }
+}

--- a/jib-gradle-plugin/src/test/resources/gradle/projects/platform/service/build.gradle
+++ b/jib-gradle-plugin/src/test/resources/gradle/projects/platform/service/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+  id 'java'
+  id 'com.google.cloud.tools.jib'
+}
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+dependencies {
+  implementation platform(project(':platform'))
+
+  implementation 'org.apache.commons:commons-io'
+}
+
+jib {
+  to {
+    image = System.getProperty("_TARGET_IMAGE")
+  }
+}

--- a/jib-gradle-plugin/src/test/resources/gradle/projects/platform/service/src/main/java/com/test/HelloWorld.java
+++ b/jib-gradle-plugin/src/test/resources/gradle/projects/platform/service/src/main/java/com/test/HelloWorld.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.test;
+
+public class HelloWorld {
+  public static void main(String[] args) {
+    System.out.println("Hello world");
+  }
+}

--- a/jib-gradle-plugin/src/test/resources/gradle/projects/platform/settings.gradle
+++ b/jib-gradle-plugin/src/test/resources/gradle/projects/platform/settings.gradle
@@ -1,0 +1,2 @@
+include ':platform'
+include ':service'


### PR DESCRIPTION
Fixes #2269

java-platform modules cause existing implementation to fail in two ways:
- they don't have runtimeClasspath configuration and for a good reason, you don't always want to pick up ALL platform dependencies
- they don't have a source set nor `JavaPluginConvention` plugin

I've tested the patch on my project and "skaffold build" is working correctly now.