### PR TITLE
Use POSIX long file mode to support enormous files

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -46,6 +46,7 @@ public class TarStreamBuilder {
         new TarArchiveOutputStream(out, StandardCharsets.UTF_8.name())) {
       // Enables PAX extended headers to support long file names.
       tarArchiveOutputStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+      tarArchiveOutputStream.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
       for (Map.Entry<TarArchiveEntry, Blob> entry : archiveMap.entrySet()) {
         tarArchiveOutputStream.putArchiveEntry(entry.getKey());
         entry.getValue().writeTo(tarArchiveOutputStream);


### PR DESCRIPTION
Enable POSIX big-file records to support packaging arbitrarily large large files.  This setting is used by the [Spotify docker-client library](https://github.com/spotify/docker-client/blob/14b4464fb7acec25073c8c9c564136188f94562c/src/main/java/com/spotify/docker/client/CompressedDirectory.java#L114).