### PR TITLE
More checkstyle fixes

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -16,11 +16,8 @@
   <suppress files=".*\.java" checks="JavadocParagraph"/>
   <suppress files=".*\.java" checks="MemberName"/>
   <suppress files=".*\.java" checks="OverloadMethodsDeclarationOrder"/>
-  <suppress files=".*\.java" checks="AbbreviationAsWordInName"/>
-  <suppress files=".*\.java" checks="WhitespaceAround"/>
   <suppress files=".*\.java" checks="EmptyCatchBlock"/>
   <suppress files=".*\.java" checks="MissingSwitchDefault"/>
-  <suppress files=".*\.java" checks="NonEmptyAtclauseDescription"/>
   <suppress files=".*\.java" checks="MethodName"/>
 
   <!-- leniency for json templates -->

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperIntegrationTest.java
@@ -35,7 +35,7 @@ public class DockerCredentialHelperIntegrationTest {
 
   /** Tests retrieval via {@code docker-credential-gcr} CLI. */
   @Test
-  public void testRetrieveGCR()
+  public void testRetrieveGcr()
       throws IOException, CredentialHelperUnhandledServerUrlException,
           CredentialHelperNotFoundException, URISyntaxException, InterruptedException {
     new Command(GCR_CREDENTIAL_HELPER, "store")

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/hash/CountingDigestOutputStreamTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/hash/CountingDigestOutputStreamTest.java
@@ -34,7 +34,7 @@ import org.junit.Test;
 /** Tests for {@link CountingDigestOutputStream}. */
 public class CountingDigestOutputStreamTest {
 
-  private final Map<String, String> KNOWN_SHA256_HASHES =
+  private static final ImmutableMap<String, String> KNOWN_SHA256_HASHES =
       ImmutableMap.of(
           "crepecake",
           "52a9e4d4ba4333ce593707f98564fee1e6d898db0d3602408c0b2a6a424d357c",

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
@@ -197,39 +197,39 @@ public class ReproducibleLayerBuilderTest {
     Path testRoot = temporaryFolder.getRoot().toPath();
 
     // the path doesn't really matter on source files, but these are structured
-    Path parent = Files.createDirectories(testRoot.resolve("aaa"));
+    Path parent = Files.createDirectories(testRoot.resolve("dirA"));
     Path fileA = Files.createFile(parent.resolve("fileA"));
-    Path ignoredParent = Files.createDirectories(testRoot.resolve("bbb-ignored"));
+    Path ignoredParent = Files.createDirectories(testRoot.resolve("dirB-ignored"));
     Path fileB = Files.createFile(ignoredParent.resolve("fileB"));
     Path fileC =
-        Files.createFile(Files.createDirectories(testRoot.resolve("ccc-absent")).resolve("fileC"));
+        Files.createFile(Files.createDirectories(testRoot.resolve("dirC-absent")).resolve("fileC"));
 
     Blob layer =
         new ReproducibleLayerBuilder(
                 ImmutableList.of(
                     new LayerEntry(
                         parent,
-                        AbsoluteUnixPath.get("/root/aaa"),
+                        AbsoluteUnixPath.get("/root/dirA"),
                         FilePermissions.fromOctalString("111"),
                         Instant.ofEpochSecond(10)),
                     new LayerEntry(
                         fileA,
-                        AbsoluteUnixPath.get("/root/aaa/fileA"),
+                        AbsoluteUnixPath.get("/root/dirA/fileA"),
                         FilePermissions.fromOctalString("222"),
                         Instant.ofEpochSecond(20)),
                     new LayerEntry(
                         fileB,
-                        AbsoluteUnixPath.get("/root/bbb-ignored/fileB"),
+                        AbsoluteUnixPath.get("/root/dirB-ignored/fileB"),
                         FilePermissions.fromOctalString("333"),
                         Instant.ofEpochSecond(30)),
                     new LayerEntry(
                         ignoredParent,
-                        AbsoluteUnixPath.get("/root/bbb-ignored"),
+                        AbsoluteUnixPath.get("/root/dirB-ignored"),
                         FilePermissions.fromOctalString("444"),
                         Instant.ofEpochSecond(40)),
                     new LayerEntry(
                         fileC,
-                        AbsoluteUnixPath.get("/root/ccc-absent/file3"),
+                        AbsoluteUnixPath.get("/root/dirC-absent/file3"),
                         FilePermissions.fromOctalString("555"),
                         Instant.ofEpochSecond(50))))
             .build();
@@ -246,17 +246,17 @@ public class ReproducibleLayerBuilderTest {
       Assert.assertEquals(Instant.ofEpochSecond(1), root.getModTime().toInstant());
 
       // parentAAA (custom permissions, custom timestamp)
-      TarArchiveEntry rootParentAaa = in.getNextTarEntry();
-      Assert.assertEquals(040111, rootParentAaa.getMode());
-      Assert.assertEquals(Instant.ofEpochSecond(10), rootParentAaa.getModTime().toInstant());
+      TarArchiveEntry rootParentA = in.getNextTarEntry();
+      Assert.assertEquals(040111, rootParentA.getMode());
+      Assert.assertEquals(Instant.ofEpochSecond(10), rootParentA.getModTime().toInstant());
 
       // skip over fileA
       in.getNextTarEntry();
 
       // parentBBB (default permissions - ignored custom permissions, since fileB added first)
-      TarArchiveEntry rootParentBbb = in.getNextTarEntry();
+      TarArchiveEntry rootParentB = in.getNextTarEntry();
       // TODO (#1650): we want 040444 here.
-      Assert.assertEquals(040755, rootParentBbb.getMode());
+      Assert.assertEquals(040755, rootParentB.getMode());
       // TODO (#1650): we want Instant.ofEpochSecond(40) here.
       Assert.assertEquals(Instant.ofEpochSecond(1), root.getModTime().toInstant());
 
@@ -264,8 +264,8 @@ public class ReproducibleLayerBuilderTest {
       in.getNextTarEntry();
 
       // parentCCC (default permissions - no entry provided)
-      TarArchiveEntry rootParentCcc = in.getNextTarEntry();
-      Assert.assertEquals(040755, rootParentCcc.getMode());
+      TarArchiveEntry rootParentC = in.getNextTarEntry();
+      Assert.assertEquals(040755, rootParentC.getMode());
       Assert.assertEquals(Instant.ofEpochSecond(1), root.getModTime().toInstant());
 
       // we don't care about fileC

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
@@ -246,17 +246,17 @@ public class ReproducibleLayerBuilderTest {
       Assert.assertEquals(Instant.ofEpochSecond(1), root.getModTime().toInstant());
 
       // parentAAA (custom permissions, custom timestamp)
-      TarArchiveEntry rootParentAAA = in.getNextTarEntry();
-      Assert.assertEquals(040111, rootParentAAA.getMode());
-      Assert.assertEquals(Instant.ofEpochSecond(10), rootParentAAA.getModTime().toInstant());
+      TarArchiveEntry rootParentAaa = in.getNextTarEntry();
+      Assert.assertEquals(040111, rootParentAaa.getMode());
+      Assert.assertEquals(Instant.ofEpochSecond(10), rootParentAaa.getModTime().toInstant());
 
       // skip over fileA
       in.getNextTarEntry();
 
       // parentBBB (default permissions - ignored custom permissions, since fileB added first)
-      TarArchiveEntry rootParentBBB = in.getNextTarEntry();
+      TarArchiveEntry rootParentBbb = in.getNextTarEntry();
       // TODO (#1650): we want 040444 here.
-      Assert.assertEquals(040755, rootParentBBB.getMode());
+      Assert.assertEquals(040755, rootParentBbb.getMode());
       // TODO (#1650): we want Instant.ofEpochSecond(40) here.
       Assert.assertEquals(Instant.ofEpochSecond(1), root.getModTime().toInstant());
 
@@ -264,8 +264,8 @@ public class ReproducibleLayerBuilderTest {
       in.getNextTarEntry();
 
       // parentCCC (default permissions - no entry provided)
-      TarArchiveEntry rootParentCCC = in.getNextTarEntry();
-      Assert.assertEquals(040755, rootParentCCC.getMode());
+      TarArchiveEntry rootParentCcc = in.getNextTarEntry();
+      Assert.assertEquals(040755, rootParentCcc.getMode());
       Assert.assertEquals(Instant.ofEpochSecond(1), root.getModTime().toInstant());
 
       // we don't care about fileC

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/V22ManifestListTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/V22ManifestListTemplateTest.java
@@ -40,20 +40,20 @@ public class V22ManifestListTemplateTest {
     List<ManifestDescriptorTemplate> manifests = manifestListJson.getManifests();
     Assert.assertEquals(3, manifests.size());
 
-    List<String> validPlatformPPC = manifestListJson.getDigestsForPlatform("ppc64le", "linux");
-    Assert.assertEquals(1, validPlatformPPC.size());
+    List<String> validPlatformPpc = manifestListJson.getDigestsForPlatform("ppc64le", "linux");
+    Assert.assertEquals(1, validPlatformPpc.size());
     Assert.assertEquals(
         "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
-        validPlatformPPC.get(0));
+        validPlatformPpc.get(0));
 
-    List<String> validPlatformAMD = manifestListJson.getDigestsForPlatform("amd64", "linux");
-    Assert.assertEquals(2, validPlatformAMD.size());
+    List<String> validPlatformAmd = manifestListJson.getDigestsForPlatform("amd64", "linux");
+    Assert.assertEquals(2, validPlatformAmd.size());
     Assert.assertEquals(
         "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
-        validPlatformAMD.get(0));
+        validPlatformAmd.get(0));
     Assert.assertEquals(
         "sha256:cccbcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501999",
-        validPlatformAMD.get(1));
+        validPlatformAmd.get(1));
 
     List<String> invalidArch = manifestListJson.getDigestsForPlatform("amd72", "linux");
     Assert.assertEquals(0, invalidArch.size());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobPusherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobPusherTest.java
@@ -48,7 +48,7 @@ public class BlobPusherTest {
   private static final String TEST_BLOB_CONTENT = "some BLOB content";
   private static final Blob TEST_BLOB = Blobs.from(TEST_BLOB_CONTENT);
 
-  @Mock private URL mockURL;
+  @Mock private URL mockUrl;
   @Mock private Response mockResponse;
 
   private DescriptorDigest fakeDescriptorDigest;
@@ -164,7 +164,7 @@ public class BlobPusherTest {
   @Test
   public void testWriter_getContent() throws IOException {
     LongAdder byteCount = new LongAdder();
-    BlobHttpContent body = testBlobPusher.writer(mockURL, byteCount::add).getContent();
+    BlobHttpContent body = testBlobPusher.writer(mockUrl, byteCount::add).getContent();
 
     Assert.assertNotNull(body);
     Assert.assertEquals("application/octet-stream", body.getType());
@@ -179,7 +179,7 @@ public class BlobPusherTest {
 
   @Test
   public void testWriter_GetAccept() {
-    Assert.assertEquals(0, testBlobPusher.writer(mockURL, ignored -> {}).getAccept().size());
+    Assert.assertEquals(0, testBlobPusher.writer(mockUrl, ignored -> {}).getAccept().size());
   }
 
   @Test
@@ -190,7 +190,7 @@ public class BlobPusherTest {
     Mockito.when(mockResponse.getRequestUrl()).thenReturn(requestUrl);
     Assert.assertEquals(
         new URL("https://somenewurl/location"),
-        testBlobPusher.writer(mockURL, ignored -> {}).handleResponse(mockResponse));
+        testBlobPusher.writer(mockUrl, ignored -> {}).handleResponse(mockResponse));
   }
 
   @Test
@@ -201,30 +201,30 @@ public class BlobPusherTest {
 
   @Test
   public void testWriter_getHttpMethod() {
-    Assert.assertEquals("PATCH", testBlobPusher.writer(mockURL, ignored -> {}).getHttpMethod());
+    Assert.assertEquals("PATCH", testBlobPusher.writer(mockUrl, ignored -> {}).getHttpMethod());
   }
 
   @Test
   public void testWriter_getActionDescription() {
     Assert.assertEquals(
         "push BLOB for someServerUrl/someImageName with digest " + fakeDescriptorDigest,
-        testBlobPusher.writer(mockURL, ignored -> {}).getActionDescription());
+        testBlobPusher.writer(mockUrl, ignored -> {}).getActionDescription());
   }
 
   @Test
   public void testCommitter_getContent() {
-    Assert.assertNull(testBlobPusher.committer(mockURL).getContent());
+    Assert.assertNull(testBlobPusher.committer(mockUrl).getContent());
   }
 
   @Test
   public void testCommitter_GetAccept() {
-    Assert.assertEquals(0, testBlobPusher.committer(mockURL).getAccept().size());
+    Assert.assertEquals(0, testBlobPusher.committer(mockUrl).getAccept().size());
   }
 
   @Test
   public void testCommitter_handleResponse() throws IOException, RegistryException {
     Assert.assertNull(
-        testBlobPusher.committer(mockURL).handleResponse(Mockito.mock(Response.class)));
+        testBlobPusher.committer(mockUrl).handleResponse(Mockito.mock(Response.class)));
   }
 
   @Test
@@ -236,13 +236,13 @@ public class BlobPusherTest {
 
   @Test
   public void testCommitter_getHttpMethod() {
-    Assert.assertEquals("PUT", testBlobPusher.committer(mockURL).getHttpMethod());
+    Assert.assertEquals("PUT", testBlobPusher.committer(mockUrl).getHttpMethod());
   }
 
   @Test
   public void testCommitter_getActionDescription() {
     Assert.assertEquals(
         "push BLOB for someServerUrl/someImageName with digest " + fakeDescriptorDigest,
-        testBlobPusher.committer(mockURL).getActionDescription());
+        testBlobPusher.committer(mockUrl).getActionDescription());
   }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -437,13 +437,15 @@ public class MavenProjectProperties implements ProjectProperties {
   }
 
   /**
-   * Gets the path of the JAR that the Maven JAR Plugin generates.
+   * Gets the path of the JAR that the Maven JAR Plugin generates. Will also make copies of jar
+   * files with non-conforming names like those produced by springboot -- myjar.jar.original ->
+   * myjar.original.jar.
    *
    * <p>https://maven.apache.org/plugins/maven-jar-plugin/jar-mojo.html
    * https://github.com/apache/maven-jar-plugin/blob/80f58a84aacff6e671f5a601d62a3a3800b507dc/src/main/java/org/apache/maven/plugins/jar/AbstractJarMojo.java#L177
    *
    * @return the path of the JAR
-   * @throws IOException
+   * @throws IOException if copying jars with non-conforming names fails
    */
   @VisibleForTesting
   Path getJarArtifact() throws IOException {

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/TimerEventHandlerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/TimerEventHandlerTest.java
@@ -30,7 +30,7 @@ public class TimerEventHandlerTest {
 
   private final Deque<String> logMessageQueue = new ArrayDeque<>();
 
-  private final TimerEvent.Timer ROOT_TIMER = Optional::empty;
+  private static final TimerEvent.Timer ROOT_TIMER = Optional::empty;
 
   @Test
   public void testAccept() {


### PR DESCRIPTION
- AbbreviationAsWordInName
- WhitespaceAround
- NonEmptyAtclauseDescription

part of #2272 