### PR TITLE
Add slf4j implementation to tests

### DIFF
--- a/jib-maven-plugin/build.gradle
+++ b/jib-maven-plugin/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 
   testImplementation 'org.apache.maven.shared:maven-verifier:1.6'
   testImplementation 'org.apache.maven:maven-compat:3.5.4'
+  testImplementation 'org.slf4j:slf4j-api:1.7.30'
+  testImplementation 'org.slf4j:slf4j-simple:1.7.30'
 
   testImplementation project(path:':jib-plugins-common', configuration:'tests')
   integrationTestImplementation project(path:':jib-core', configuration:'integrationTests')


### PR DESCRIPTION
Originally manifests in:
[com.google.cloud.tools.jib.maven.TestRepository:51](https://github.com/GoogleContainerTools/jib/blob/master/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/TestRepository.java#L51-L52)

Something in the plexus libraries is loading the slf4j logger,
this just cleans up the error message from not having an actual
binding.

```
com.google.cloud.tools.jib.maven.MavenProjectPropertiesTest > testGetJarArtifact STANDARD_ERROR
    SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
    SLF4J: Defaulting to no-operation (NOP) logger implementation
    SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```

I figured using a simple logger (vs nop-logger) was better so
we could get some log feedback if it happened to pop up.