### PR TITLE
Set classifier of jar task for Gradle Spring Boot projects only when safe and needed

### DIFF
--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   integrationTestImplementation project(path:':jib-core', configuration:'integrationTests')
 
   // only for testing a concrete Spring Boot example in a test (not for test infrastructure)
-  testRuntime 'org.springframework.boot:spring-boot-gradle-plugin:2.1.6.RELEASE'
+  testImplementation 'org.springframework.boot:spring-boot-gradle-plugin:2.1.6.RELEASE'
 }
 
 /* RELEASE */

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -26,7 +26,7 @@ dependencies {
   integrationTestImplementation project(path:':jib-core', configuration:'integrationTests')
 
   // only for testing a concrete Spring Boot example in a test (not for test infrastructure)
-  testImplementation 'org.springframework.boot:spring-boot-gradle-plugin:2.1.6.RELEASE'
+  testRuntime 'org.springframework.boot:spring-boot-gradle-plugin:2.1.6.RELEASE'
 }
 
 /* RELEASE */

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -193,7 +193,7 @@ public class JibPlugin implements Plugin<Project> {
             jibDependencies.add(jarTask);
 
             if (projectAfterEvaluation.getPlugins().hasPlugin("org.springframework.boot")) {
-              Task bootJarTask = projectAfterEvaluation.getTasks().getAt("bootJar");
+              Task bootJarTask = projectAfterEvaluation.getTasks().getByName("bootJar");
 
               if (bootJarTask.getEnabled()) {
                 String bootJarPath = bootJarTask.getOutputs().getFiles().getAsPath();
@@ -203,8 +203,8 @@ public class JibPlugin implements Plugin<Project> {
                     ((Jar) jarTask.get()).getArchiveClassifier().set("original");
                   } else {
                     throw new GradleException(
-                        "Both 'bootJar' and 'jar' tasks are enabled, but they write their own jar "
-                            + "file into the same location at "
+                        "Both 'bootJar' and 'jar' tasks are enabled, but they write their jar file "
+                            + "into the same location at "
                             + jarPath
                             + ". Did you forget to set 'archiveClassifier' on either task?");
                   }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -276,8 +276,8 @@ public class JibPluginTest {
       Assert.assertThat(
           ex.getCause().getMessage(),
           CoreMatchers.startsWith(
-              "Both 'bootJar' and 'jar' tasks are enabled, but they write their own jar file into "
-                  + "the same location at "));
+              "Both 'bootJar' and 'jar' tasks are enabled, but they write their jar file into the "
+                  + "same location at "));
       Assert.assertThat(
           ex.getCause().getMessage(),
           CoreMatchers.endsWith(

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -271,6 +271,7 @@ public class JibPluginTest {
     TaskContainer tasks = project.getTasks();
     try {
       tasks.getByPath(":jar");
+      Assert.fail();
     } catch (GradleException ex) {
       Assert.assertThat(
           ex.getCause().getMessage(),


### PR DESCRIPTION
Fixes #2278.

See https://github.com/GoogleContainerTools/jib/issues/2278#issuecomment-584404686.