### PR TITLE
Do not overwrite Gradle task dependencies

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -208,7 +208,7 @@ public class JibPlugin implements Plugin<Project> {
           jibDependencies.add(mainSourceSet.getRuntimeClasspath());
 
           jibTaskProviders.forEach(
-              provider -> provider.configure(task -> task.setDependsOn(jibDependencies)));
+              provider -> provider.configure(task -> jibDependencies.forEach(task::dependsOn)));
         });
   }
 }


### PR DESCRIPTION
This fixes a bug where user-configured task dependencies (`tasks.jib.dependsOn '...'` immediately after `jib {}` section) are overwritten by the plugin.