### PR TITLE
Back at it again with the checkstyle

### DIFF
--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -9,12 +9,13 @@
   <suppress files=".*\.java" checks="RightCurly"/>
   <suppress files=".*\.java" checks="LineLength"/>
 
+  <!-- class with jib repo style: although maybe these should be eventually fixed -->
+  <suppress files=".*\.java" checks="OverloadMethodsDeclarationOrder"/>
+
   <!-- temporary suppressions as we work through them -->
   <suppress files=".*\.java" checks="VariableDeclarationUsageDistance"/>
   <suppress files=".*\.java" checks="MissingJavadocMethod"/>
   <suppress files=".*\.java" checks="SummaryJavadoc"/>
-  <suppress files=".*\.java" checks="MemberName"/>
-  <suppress files=".*\.java" checks="OverloadMethodsDeclarationOrder"/>
 
   <!-- leniency for json templates -->
   <suppress files=".*/jib-core/.*Template\.java" checks="MemberName"/>

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -18,10 +18,10 @@
   <suppress files=".*\.java" checks="SummaryJavadoc"/>
 
   <!-- leniency for json templates -->
-  <suppress files=".*/jib-core/.*Template\.java" checks="MemberName"/>
+  <suppress files=".*[\\/]jib-core[\\/].*Template\.java" checks="MemberName"/>
 
   <!-- leniency for test files -->
-  <suppress files=".*/integration-test/.*\.java" checks="MissingJavadocMethod"/>
-  <suppress files=".*/integration-test/.*\.java" checks="VariableDeclarationUsageDistance"/>
+  <suppress files=".*[\\/]integration-test[\\/].*\.java" checks="MissingJavadocMethod"/>
+  <suppress files=".*[\\/]integration-test[\\/].*\.java" checks="VariableDeclarationUsageDistance"/>
 
 </suppressions>

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
@@ -117,8 +117,8 @@ public class RegistryAuthenticator {
   }
 
   /** Template for the authentication response JSON. */
-  @JsonIgnoreProperties(ignoreUnknown = true)
   @VisibleForTesting
+  @JsonIgnoreProperties(ignoreUnknown = true)
   static class AuthenticationResponseTemplate implements JsonTemplate {
 
     @Nullable private String token;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.registry;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.cloud.tools.jib.api.Credential;
@@ -117,7 +118,8 @@ public class RegistryAuthenticator {
 
   /** Template for the authentication response JSON. */
   @JsonIgnoreProperties(ignoreUnknown = true)
-  private static class AuthenticationResponseTemplate implements JsonTemplate {
+  @VisibleForTesting
+  static class AuthenticationResponseTemplate implements JsonTemplate {
 
     @Nullable private String token;
 
@@ -127,15 +129,18 @@ public class RegistryAuthenticator {
      * @see <a
      *     href="https://docs.docker.com/registry/spec/auth/token/#token-response-fields">https://docs.docker.com/registry/spec/auth/token/#token-response-fields</a>
      */
-    @Nullable private String access_token;
-
-    /** @return {@link #token} if not null, or {@link #access_token} */
     @Nullable
-    private String getToken() {
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    /** @return {@link #token} if not null, or {@link #accessToken} */
+    @Nullable
+    @VisibleForTesting
+    String getToken() {
       if (token != null) {
         return token;
       }
-      return access_token;
+      return accessToken;
     }
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.registry.credentials;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.json.JsonTemplate;
@@ -43,11 +44,19 @@ public class DockerCredentialHelper {
   private final Path credentialHelper;
 
   /** Template for a Docker credential helper output. */
+  @VisibleForTesting
   @JsonIgnoreProperties(ignoreUnknown = true)
-  private static class DockerCredentialsTemplate implements JsonTemplate {
+  static class DockerCredentialsTemplate implements JsonTemplate {
 
-    @Nullable private String Username;
-    @Nullable private String Secret;
+    @Nullable
+    @VisibleForTesting
+    @JsonProperty("Username")
+    String username;
+
+    @Nullable
+    @VisibleForTesting
+    @JsonProperty("Secret")
+    String secret;
   }
 
   /**
@@ -106,13 +115,13 @@ public class DockerCredentialHelper {
         try {
           DockerCredentialsTemplate dockerCredentials =
               JsonTemplateMapper.readJson(output, DockerCredentialsTemplate.class);
-          if (Strings.isNullOrEmpty(dockerCredentials.Username)
-              || Strings.isNullOrEmpty(dockerCredentials.Secret)) {
+          if (Strings.isNullOrEmpty(dockerCredentials.username)
+              || Strings.isNullOrEmpty(dockerCredentials.secret)) {
             throw new CredentialHelperUnhandledServerUrlException(
                 credentialHelper, serverUrl, output);
           }
 
-          return Credential.from(dockerCredentials.Username, dockerCredentials.Secret);
+          return Credential.from(dockerCredentials.username, dockerCredentials.secret);
 
         } catch (JsonProcessingException ex) {
           throw new CredentialHelperUnhandledServerUrlException(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
@@ -22,6 +22,7 @@ import com.google.cloud.tools.jib.http.FailoverHttpClient;
 import com.google.cloud.tools.jib.http.Response;
 import com.google.cloud.tools.jib.http.ResponseException;
 import com.google.cloud.tools.jib.http.TestWebServer;
+import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -301,5 +302,41 @@ public class RegistryAuthenticatorTest {
               + "over HTTP",
           ex.getMessage());
     }
+  }
+
+  @Test
+  public void testAuthenticationResponseTemplate_readsToken() throws IOException {
+    String input = "{\"token\":\"test_value\"}";
+    RegistryAuthenticator.AuthenticationResponseTemplate template =
+        JsonTemplateMapper.readJson(
+            input, RegistryAuthenticator.AuthenticationResponseTemplate.class);
+    Assert.assertEquals("test_value", template.getToken());
+  }
+
+  @Test
+  public void testAuthenticationResponseTemplate_readsAccessToken() throws IOException {
+    String input = "{\"access_token\":\"test_value\"}";
+    RegistryAuthenticator.AuthenticationResponseTemplate template =
+        JsonTemplateMapper.readJson(
+            input, RegistryAuthenticator.AuthenticationResponseTemplate.class);
+    Assert.assertEquals("test_value", template.getToken());
+  }
+
+  @Test
+  public void testAuthenticationResponseTemplate_prefersToken() throws IOException {
+    String input = "{\"token\":\"test_value\",\"access_token\":\"wrong_value\"}";
+    RegistryAuthenticator.AuthenticationResponseTemplate template =
+        JsonTemplateMapper.readJson(
+            input, RegistryAuthenticator.AuthenticationResponseTemplate.class);
+    Assert.assertEquals("test_value", template.getToken());
+  }
+
+  @Test
+  public void testAuthenticationResponseTemplate_acceptsNull() throws IOException {
+    String input = "{}";
+    RegistryAuthenticator.AuthenticationResponseTemplate template =
+        JsonTemplateMapper.readJson(
+            input, RegistryAuthenticator.AuthenticationResponseTemplate.class);
+    Assert.assertNull(template.getToken());
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.registry.credentials;
+
+import com.google.cloud.tools.jib.json.JsonTemplateMapper;
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DockerCredentialHelperTest {
+
+  @Test
+  public void testDockerCredentialsTemplate_read() throws IOException {
+    String input = "{\"Username\":\"myusername\",\"Secret\":\"mysecret\"}";
+    DockerCredentialHelper.DockerCredentialsTemplate template =
+        JsonTemplateMapper.readJson(input, DockerCredentialHelper.DockerCredentialsTemplate.class);
+    Assert.assertEquals("myusername", template.username);
+    Assert.assertEquals("mysecret", template.secret);
+  }
+
+  @Test
+  public void testDockerCredentialsTemplate_canReadNull() throws IOException {
+    String input = "{}";
+    DockerCredentialHelper.DockerCredentialsTemplate template =
+        JsonTemplateMapper.readJson(input, DockerCredentialHelper.DockerCredentialsTemplate.class);
+    Assert.assertNull(template.username);
+    Assert.assertNull(template.secret);
+  }
+}


### PR DESCRIPTION
- MemberName
- OverloadedMethodDeclarationOrder to "ignore" as it conflicts with
  historic Jib style

Parts of #2272 