### PR TITLE
Treat empty update check config as non-existent

### DIFF
--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
@@ -102,7 +102,7 @@ public class UpdateChecker {
 
     try {
       // Check global config
-      if (Files.exists(configFile)) {
+      if (Files.exists(configFile) && Files.size(configFile) > 0) {
         // Abort if update checks are disabled
         try {
           ConfigJsonTemplate config =
@@ -113,11 +113,10 @@ public class UpdateChecker {
         } catch (IOException ex) {
           log.accept(
               LogEvent.warn(
-                  "Failed to read global Jib config: "
-                      + ex.getMessage()
-                      + "; you may need to fix or delete "
+                  "Failed to read global Jib config; you may need to fix or delete "
                       + configFile
-                      + "; "));
+                      + ": "
+                      + ex.getMessage()));
           return Optional.empty();
         }
       } else {
@@ -134,7 +133,7 @@ public class UpdateChecker {
       }
 
       // Check time of last update check
-      if (Files.exists(lastUpdateCheck)) {
+      if (Files.exists(lastUpdateCheck) && Files.size(lastUpdateCheck) > 0) {
         try {
           String fileContents =
               new String(Files.readAllBytes(lastUpdateCheck), StandardCharsets.UTF_8);

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
@@ -133,7 +133,7 @@ public class UpdateChecker {
       }
 
       // Check time of last update check
-      if (Files.exists(lastUpdateCheck) && Files.size(lastUpdateCheck) > 0) {
+      if (Files.exists(lastUpdateCheck)) {
         try {
           String fileContents =
               new String(Files.readAllBytes(lastUpdateCheck), StandardCharsets.UTF_8);

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/UpdateCheckerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/UpdateCheckerTest.java
@@ -141,6 +141,25 @@ public class UpdateCheckerTest {
   }
 
   @Test
+  public void testPerformUpdateCheck_emptyConfigAndLastUpdateCheck() throws IOException {
+    Files.createFile(configDir.resolve("config.json"));
+    Files.createFile(configDir.resolve("lastUpdateCheck"));
+    Instant before = Instant.now();
+    Optional<String> message =
+        UpdateChecker.performUpdateCheck(
+            ignored -> {}, "1.0.2", testWebServer.getEndpoint(), configDir, "tool name");
+    Assert.assertTrue(message.isPresent());
+    Assert.assertEquals(
+        "A new version of Jib (2.0.0) is available (currently using 1.0.2). Update your build "
+            + "configuration to use the latest features and fixes!",
+        message.get());
+    String modifiedTime =
+        new String(
+            Files.readAllBytes(configDir.resolve("lastUpdateCheck")), StandardCharsets.UTF_8);
+    Assert.assertTrue(Instant.parse(modifiedTime).isAfter(before));
+  }
+
+  @Test
   public void testPerformUpdateCheck_lastUpdateCheckTooSoon() throws IOException {
     FileTime modifiedTime = FileTime.from(Instant.now().minusSeconds(12));
     setupConfigAndLastUpdateCheck();


### PR DESCRIPTION
I may keep looking into #2294 to see if I can somehow reproduce the error without intentionally creating an empty config file, but this should avoid the warning message in the meantime. Empty config files are now treated as empty, meaning they will be regenerated with defaults.