### PR TITLE
Fix release script text

### DIFF
--- a/jib-gradle-plugin/scripts/prepare_release.sh
+++ b/jib-gradle-plugin/scripts/prepare_release.sh
@@ -59,4 +59,4 @@ echo https://github.com/GoogleContainerTools/jib/pull/new/${BRANCH}
 
 EchoGreen "Once approved, checkout the 'v${VERSION}-gradle' tag and run './gradlew jib-gradle-plugin:publishPlugins'."
 EchoGreen "Merge the PR after the plugin is released."
-EchoGreen "Run './scripts/update_gcs_latest.sh ${VERSION}' when the release is complete to update the latest version string on GCS."
+EchoGreen "Run './jib-gradle-plugin/scripts/update_gcs_latest.sh ${VERSION}' when the release is complete to update the latest version string on GCS."

--- a/jib-gradle-plugin/scripts/prepare_release.sh
+++ b/jib-gradle-plugin/scripts/prepare_release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -
-# Usage: ./scripts/prepare_release.sh <release version> [<post-release version>]
+# Usage: ./jib-gradle-plugin/scripts/prepare_release.sh <release version> [<post-release version>]
 
 set -e
 

--- a/jib-gradle-plugin/scripts/update_gcs_latest.sh
+++ b/jib-gradle-plugin/scripts/update_gcs_latest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -
-# Usage: ./scripts/update_gcs_latest.sh <release version>
+# Usage: ./jib-gradle-plugin/scripts/update_gcs_latest.sh <release version>
 
 set -e
 

--- a/jib-gradle-plugin/scripts/update_gcs_latest.sh
+++ b/jib-gradle-plugin/scripts/update_gcs_latest.sh
@@ -20,7 +20,7 @@ CheckVersion() {
     [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+)?$ ]] || Die "Version: $1 not in ###.###.###[-XXX] format."
 }
 
-[ $# -ne 1 ] && Die "Usage: ./scripts/update_gcs_latest.sh <release version>"
+[ $# -ne 1 ] && Die "Usage: ./jib-gradle-plugin/scripts/update_gcs_latest.sh <release version>"
 
 CheckVersion $1
 

--- a/jib-maven-plugin/scripts/prepare_release.sh
+++ b/jib-maven-plugin/scripts/prepare_release.sh
@@ -58,4 +58,4 @@ EchoGreen 'File a PR for the new release branch:'
 echo https://github.com/GoogleContainerTools/jib/pull/new/${BRANCH}
 
 EchoGreen "Merge the PR after the plugin is released."
-EchoGreen "Run './scripts/update_gcs_latest.sh ${VERSION}' when the release is complete to update the latest version string on GCS."
+EchoGreen "Run './jib-maven-plugin/scripts/update_gcs_latest.sh ${VERSION}' when the release is complete to update the latest version string on GCS."

--- a/jib-maven-plugin/scripts/update_gcs_latest.sh
+++ b/jib-maven-plugin/scripts/update_gcs_latest.sh
@@ -20,7 +20,7 @@ CheckVersion() {
     [[ $1 =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z]+)?$ ]] || Die "Version: $1 not in ###.###.###[-XXX] format."
 }
 
-[ $# -ne 1 ] && Die "Usage: ./scripts/update_gcs_latest.sh <release version>"
+[ $# -ne 1 ] && Die "Usage: ./jib-maven-plugin/scripts/update_gcs_latest.sh <release version>"
 
 CheckVersion $1
 

--- a/jib-maven-plugin/scripts/update_gcs_latest.sh
+++ b/jib-maven-plugin/scripts/update_gcs_latest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -
-# Usage: ./scripts/update_gcs_latest.sh <release version>
+# Usage: ./jib-maven-plugin/scripts/update_gcs_latest.sh <release version>
 
 set -e
 


### PR DESCRIPTION
Corrects the relative paths for the GCS update scripts, since the release scripts are run from the root project directory.