### PR TITLE
Fix test source compile warnings in jib-maven-plugin

### DIFF
--- a/jib-maven-plugin/build.gradle
+++ b/jib-maven-plugin/build.gradle
@@ -16,6 +16,8 @@ dependencies {
 
   // equivalent to "provided"
   compileOnly 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.5'
+  // needed to suppress "unknown enum constant" warnings
+  testImplementation 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.5'
 
   // maven-plugin-testing-harness pulls in conflicting implementations of DefaultPlexusContainer
   // (sisu (correct) vs default-plexus-container (wrong)) so ensure this is first in the test classpath


### PR DESCRIPTION
Sorry, I removed this in #2323, but turns out it suppresses some warnings.

```
> Task :jib-maven-plugin:compileTestJava                                                                                                                                                                           
warning: unknown enum constant ResolutionScope.COMPILE_PLUS_RUNTIME                                                                                                                                                
  reason: class file for org.apache.maven.plugins.annotations.ResolutionScope not found                  
warning: unknown enum constant ResolutionScope.NONE                                                      
warning: unknown enum constant ResolutionScope.NONE                                                                                                                                                                
warning: unknown enum constant LifecyclePhase.INITIALIZE                                                 
  reason: class file for org.apache.maven.plugins.annotations.LifecyclePhase not found                   
warning: unknown enum constant ResolutionScope.COMPILE_PLUS_RUNTIME                                                                                                                                                
warning: unknown enum constant ResolutionScope.COMPILE_PLUS_RUNTIME                                                                                                                                                
6 warnings                                                                                                                                                                                                         
                                                                                                                                                                                                                   
> Task :jib-maven-plugin:compileIntegrationTestJava                                                                                                                                                                
warning: unknown enum constant ResolutionScope.RUNTIME_PLUS_SYSTEM                                                                                                                                                 
  reason: class file for org.apache.maven.plugins.annotations.ResolutionScope not found                  
warning: unknown enum constant ResolutionScope.RUNTIME_PLUS_SYSTEM                                       
warning: unknown enum constant ResolutionScope.RUNTIME_PLUS_SYSTEM                                       
3 warnings                                                                                                                                                                                                         
```