### PR TITLE
Remove Guava dependency from certain core API classes

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/FilePermissions.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/FilePermissions.java
@@ -58,7 +58,7 @@ public class FilePermissions {
     map.put(PosixFilePermission.OTHERS_WRITE, 02);
     map.put(PosixFilePermission.OTHERS_EXECUTE, 01);
     PERMISSION_MAP = Collections.unmodifiableMap(map);
-  };
+  }
 
   /**
    * Creates a new {@link FilePermissions} from an octal string representation (e.g. "123", "644",

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/FilePermissions.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/FilePermissions.java
@@ -16,17 +16,19 @@
 
 package com.google.cloud.tools.jib.api;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableMap;
 import java.nio.file.attribute.PosixFilePermission;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import javax.annotation.concurrent.Immutable;
 
 /**
  * Represents read/write/execute file permissions for owner, group, and others.
  *
  * <p>This class is immutable and thread-safe.
  */
+@Immutable
 public class FilePermissions {
 
   /** Default permissions for files added to the container. */
@@ -42,18 +44,21 @@ public class FilePermissions {
   private static final String OCTAL_PATTERN = "[0-7][0-7][0-7]";
 
   /** Maps from a {@link PosixFilePermission} to its corresponding file permission bit. */
-  private static final ImmutableMap<PosixFilePermission, Integer> PERMISSION_MAP =
-      ImmutableMap.<PosixFilePermission, Integer>builder()
-          .put(PosixFilePermission.OWNER_READ, 0400)
-          .put(PosixFilePermission.OWNER_WRITE, 0200)
-          .put(PosixFilePermission.OWNER_EXECUTE, 0100)
-          .put(PosixFilePermission.GROUP_READ, 040)
-          .put(PosixFilePermission.GROUP_WRITE, 020)
-          .put(PosixFilePermission.GROUP_EXECUTE, 010)
-          .put(PosixFilePermission.OTHERS_READ, 04)
-          .put(PosixFilePermission.OTHERS_WRITE, 02)
-          .put(PosixFilePermission.OTHERS_EXECUTE, 01)
-          .build();
+  private static final Map<PosixFilePermission, Integer> PERMISSION_MAP;
+
+  static {
+    Map<PosixFilePermission, Integer> map = new HashMap<>(9);
+    map.put(PosixFilePermission.OWNER_READ, 0400);
+    map.put(PosixFilePermission.OWNER_WRITE, 0200);
+    map.put(PosixFilePermission.OWNER_EXECUTE, 0100);
+    map.put(PosixFilePermission.GROUP_READ, 040);
+    map.put(PosixFilePermission.GROUP_WRITE, 020);
+    map.put(PosixFilePermission.GROUP_EXECUTE, 010);
+    map.put(PosixFilePermission.OTHERS_READ, 04);
+    map.put(PosixFilePermission.OTHERS_WRITE, 02);
+    map.put(PosixFilePermission.OTHERS_EXECUTE, 01);
+    PERMISSION_MAP = Collections.unmodifiableMap(map);
+  };
 
   /**
    * Creates a new {@link FilePermissions} from an octal string representation (e.g. "123", "644",
@@ -63,9 +68,10 @@ public class FilePermissions {
    * @return a new {@link FilePermissions} with the given permissions
    */
   public static FilePermissions fromOctalString(String octalPermissions) {
-    Preconditions.checkArgument(
-        octalPermissions.matches(OCTAL_PATTERN),
-        "octalPermissions must be a 3-digit octal number (000-777)");
+    if (!octalPermissions.matches(OCTAL_PATTERN)) {
+      throw new IllegalArgumentException(
+          "octalPermissions must be a 3-digit octal number (000-777)");
+    }
     return new FilePermissions(Integer.parseInt(octalPermissions, 8));
   }
 
@@ -79,14 +85,18 @@ public class FilePermissions {
       Set<PosixFilePermission> posixFilePermissions) {
     int permissionBits = 0;
     for (PosixFilePermission permission : posixFilePermissions) {
-      permissionBits |= Preconditions.checkNotNull(PERMISSION_MAP.get(permission));
+      Integer bit = PERMISSION_MAP.get(permission);
+      if (bit == null) {
+        throw new RuntimeException("BUG: PERMISSION_MAP is not initialized");
+      }
+      permissionBits |= bit;
     }
     return new FilePermissions(permissionBits);
   }
 
   private final int permissionBits;
 
-  @VisibleForTesting
+  // VisibleForTesting
   FilePermissions(int permissionBits) {
     this.permissionBits = permissionBits;
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/LayerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/LayerConfiguration.java
@@ -282,7 +282,7 @@ public class LayerConfiguration {
    * Use {@link #builder} to instantiate.
    *
    * @param name an optional name for the layer
-   * @param layerEntries the list of {@link LayerEntry}s
+   * @param entries the list of {@link LayerEntry}s
    */
   private LayerConfiguration(String name, List<LayerEntry> entries) {
     this.name = name;
@@ -299,9 +299,9 @@ public class LayerConfiguration {
   }
 
   /**
-   * Gets the list of layer entries.
+   * Gets the list of entries.
    *
-   * @return the list of layer entries
+   * @return the list of entries
    */
   public ImmutableList<LayerEntry> getLayerEntries() {
     return ImmutableList.copyOf(entries);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/LayerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/LayerConfiguration.java
@@ -21,18 +21,22 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.concurrent.Immutable;
 
 /** Configures how to build a layer in the container image. Instantiate with {@link #builder}. */
+@Immutable
 public class LayerConfiguration {
 
   /** Builds a {@link LayerConfiguration}. */
   public static class Builder {
 
-    private final ImmutableList.Builder<LayerEntry> layerEntries = ImmutableList.builder();
     private String name = "";
+    private List<LayerEntry> entries = new ArrayList<>();
 
     private Builder() {}
 
@@ -48,13 +52,24 @@ public class LayerConfiguration {
     }
 
     /**
+     * Sets entries for the layer.
+     *
+     * @param entries file entries in the layer
+     * @return this
+     */
+    public Builder setEntries(List<LayerEntry> entries) {
+      this.entries = new ArrayList<>(entries);
+      return this;
+    }
+
+    /**
      * Adds an entry to the layer.
      *
      * @param entry the layer entry to add
      * @return this
      */
     public Builder addEntry(LayerEntry entry) {
-      layerEntries.add(entry);
+      entries.add(entry);
       return this;
     }
 
@@ -231,7 +246,7 @@ public class LayerConfiguration {
      * @return the built {@link LayerConfiguration}
      */
     public LayerConfiguration build() {
-      return new LayerConfiguration(name, layerEntries.build());
+      return new LayerConfiguration(name, entries);
     }
   }
 
@@ -260,8 +275,8 @@ public class LayerConfiguration {
     return new Builder();
   }
 
-  private final ImmutableList<LayerEntry> layerEntries;
   private final String name;
+  private final List<LayerEntry> entries;
 
   /**
    * Use {@link #builder} to instantiate.
@@ -269,9 +284,9 @@ public class LayerConfiguration {
    * @param name an optional name for the layer
    * @param layerEntries the list of {@link LayerEntry}s
    */
-  private LayerConfiguration(String name, ImmutableList<LayerEntry> layerEntries) {
+  private LayerConfiguration(String name, List<LayerEntry> entries) {
     this.name = name;
-    this.layerEntries = layerEntries;
+    this.entries = entries;
   }
 
   /**
@@ -289,6 +304,10 @@ public class LayerConfiguration {
    * @return the list of layer entries
    */
   public ImmutableList<LayerEntry> getLayerEntries() {
-    return layerEntries;
+    return ImmutableList.copyOf(entries);
+  }
+
+  public Builder toBuilder() {
+    return builder().setName(name).setEntries(entries);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/LayerEntry.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/LayerEntry.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.api;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Objects;
+import javax.annotation.concurrent.Immutable;
 
 /**
  * Represents an entry in the layer. A layer consists of many entries that can be converted into tar
@@ -26,6 +27,7 @@ import java.util.Objects;
  *
  * <p>This class is immutable and thread-safe.
  */
+@Immutable
 public class LayerEntry {
 
   private final Path sourceFile;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/Port.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/Port.java
@@ -17,8 +17,10 @@
 package com.google.cloud.tools.jib.api;
 
 import java.util.Objects;
+import javax.annotation.concurrent.Immutable;
 
 /** Represents a port number with a protocol (TCP or UDP). */
+@Immutable
 public class Port {
 
   private static final String TCP_PROTOCOL = "tcp";

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/RelativeUnixPath.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/RelativeUnixPath.java
@@ -17,8 +17,8 @@
 package com.google.cloud.tools.jib.api;
 
 import com.google.cloud.tools.jib.filesystem.UnixPathParser;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -37,16 +37,17 @@ public class RelativeUnixPath {
    * @return a new {@link RelativeUnixPath}
    */
   public static RelativeUnixPath get(String relativePath) {
-    Preconditions.checkArgument(
-        !relativePath.startsWith("/"), "Path starts with forward slash (/): " + relativePath);
+    if (relativePath.startsWith("/")) {
+      throw new IllegalArgumentException("Path starts with forward slash (/): " + relativePath);
+    }
 
     return new RelativeUnixPath(UnixPathParser.parse(relativePath));
   }
 
-  private final ImmutableList<String> pathComponents;
+  private final List<String> pathComponents;
 
   /** Instantiate with {@link #get}. */
-  private RelativeUnixPath(ImmutableList<String> pathComponents) {
+  private RelativeUnixPath(List<String> pathComponents) {
     this.pathComponents = pathComponents;
   }
 
@@ -55,7 +56,7 @@ public class RelativeUnixPath {
    *
    * @return the relative path this represents, in a list of components
    */
-  ImmutableList<String> getRelativePathComponents() {
-    return pathComponents;
+  List<String> getRelativePathComponents() {
+    return new ArrayList<>(pathComponents);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/UnixPathParser.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/UnixPathParser.java
@@ -16,8 +16,8 @@
 
 package com.google.cloud.tools.jib.filesystem;
 
-import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
 
 /** Parses Unix-style paths. */
 public class UnixPathParser {
@@ -28,16 +28,15 @@ public class UnixPathParser {
    * @param unixPath the Unix-style path
    * @return a list of path components
    */
-  public static ImmutableList<String> parse(String unixPath) {
-    ImmutableList.Builder<String> pathComponents = ImmutableList.builder();
-    for (String pathComponent : Splitter.on('/').split(unixPath)) {
-      if (pathComponent.isEmpty()) {
-        // Skips empty components.
-        continue;
+  public static List<String> parse(String unixPath) {
+    List<String> pathComponents = new ArrayList<>();
+    // -1 limit for Guava Splitter behavior: https://errorprone.info/bugpattern/StringSplitter
+    for (String component : unixPath.split("/", -1)) {
+      if (!component.isEmpty()) {
+        pathComponents.add(component);
       }
-      pathComponents.add(pathComponent);
     }
-    return pathComponents.build();
+    return pathComponents;
   }
 
   private UnixPathParser() {}


### PR DESCRIPTION
I plan to copy these classes into the jib-build-plan project, where we won't depend on Guava.