### PR TITLE
Fix sourceProject helper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -332,10 +332,10 @@ subprojects {
   project.ext.sourceProjects = []
   // sourceProject(Project) accepts a project and adds it as a dependency in a special manner:
   // 1. force evaluation of the project first
-  // 1. add the project classes as "compileOnly" and make it available to tests in "testImplementation"
-  // 2. add the project's depedencies as "implementation"
-  // 3. remove any transitive reference of any sourceProject depenency that may have appeared
-  // 4. add the project's classes to the final jar
+  // 2. add the project classes as "compileOnly" and make it available to tests in "testImplementation"
+  // 3. add the project's depedencies as "implementation"
+  // 4. remove any transitive reference of any sourceProject depenency that may have appeared
+  // 5. add the project's classes to the final jar
   // Other nice effects (vs shadowJar)
   // 1. Generated poms will be correct
   // 2. Configuration is isolated to this single "sourceProject" call

--- a/build.gradle
+++ b/build.gradle
@@ -355,12 +355,12 @@ subprojects {
         implementation dependencyProject.configurations.api.dependencies
       }
     }
-    // if we find any project dependencies that were brought in transitively, go remove them
-    project.configurations.implementation.dependencies.removeAll {
-      d -> d instanceof ProjectDependency && sourceProjects.contains(d.dependencyProject)
-    }
-    // keep track of all dependencyProjects for later removal
+    // keep track of all dependencyProjects for removal
     sourceProjects += dependencyProject
+    // if we find any project dependencies that were brought in transitively, go remove them
+    project.configurations.implementation.dependencies.removeAll { d ->
+      return d instanceof ProjectDependency && sourceProjects.contains(d.dependencyProject)
+    }
     // adds dependencyProject's classes to jar (fat jar-esque)
     jar {
       from dependencyProjectClasses

--- a/build.gradle
+++ b/build.gradle
@@ -331,6 +331,7 @@ subprojects {
   // to keep track of all source projects
   project.ext.sourceProjects = []
   // sourceProject(Project) accepts a project and adds it as a dependency in a special manner:
+  // 1. force evaluation of the project first
   // 1. add the project classes as "compileOnly" and make it available to tests in "testImplementation"
   // 2. add the project's depedencies as "implementation"
   // 3. remove any transitive reference of any sourceProject depenency that may have appeared
@@ -340,6 +341,9 @@ subprojects {
   // 2. Configuration is isolated to this single "sourceProject" call
   // 3. These configurations are compliant with IDEs
   project.ext.sourceProject = { Project dependencyProject ->
+    // make sure those projects are evaluated first so we know their dependencies
+    project.evaluationDependsOn dependencyProject.path
+    // add the sourceProjecect dependency
     def dependencyProjectClasses = dependencyProject.sourceSets.main.output
     dependencies {
       // add the dependencyProject classes as compileOnly, make it available to tests
@@ -350,10 +354,10 @@ subprojects {
       if (dependencyProject.configurations.hasProperty('api')) {
         implementation dependencyProject.configurations.api.dependencies
       }
-      // if we find any project dependencies that are brought in transitively, go remove them
-      project.sourceProjects.each { projectToRemove ->
-        project.configurations.implementation.dependencies.remove projectToRemove
-      }
+    }
+    // if we find any project dependencies that were brought in transitively, go remove them
+    project.configurations.implementation.dependencies.removeAll {
+      d -> d instanceof ProjectDependency && sourceProjects.contains(d.dependencyProject)
     }
     // keep track of all dependencyProjects for later removal
     sourceProjects += dependencyProject


### PR DESCRIPTION
- force evaluation of dependencyProject
- actually do the right kind of removal (perhaps this changed with gradle update?)
  this will be caught by forcing evaluation now.
