### PR TITLE
Use @deprecated javadoc

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -170,8 +170,7 @@ public class JibContainerBuilder {
   /**
    * Adds a layer (defined by a {@link LayerConfiguration}).
    *
-   * <p>Deprecated. Use {@link #addFileEntriesLayer(FileEntriesLayer)}.
-   *
+   * @deprecated Use {@link #addFileEntriesLayer(FileEntriesLayer)}.
    * @param layerConfiguration the {@link LayerConfiguration}
    * @return this
    */
@@ -195,8 +194,7 @@ public class JibContainerBuilder {
    * Sets the layers (defined by a list of {@link LayerConfiguration}s). This replaces any
    * previously-added layers.
    *
-   * <p>Deprecated. Use {@link #setFileEntriesLayers(List)}.
-   *
+   * @deprecated Use {@link #setFileEntriesLayers(List)}.
    * @param layerConfigurations the list of {@link LayerConfiguration}s
    * @return this
    */
@@ -224,8 +222,7 @@ public class JibContainerBuilder {
   /**
    * Sets the layers. This replaces any previously-added layers.
    *
-   * <p>Deprecated. Use {@link #setFileEntriesLayers(FileEntriesLayer...)}.
-   *
+   * @deprecated Use {@link #setFileEntriesLayers(FileEntriesLayer...)}.
    * @param layerConfigurations the {@link LayerConfiguration}s
    * @return this
    */

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/LayerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/LayerConfiguration.java
@@ -32,7 +32,7 @@ import javax.annotation.concurrent.Immutable;
 /**
  * Configures how to build a layer in the container image. Instantiate with {@link #builder}.
  *
- * <p>Deprecated. Use {@link FileEntriesLayer}.
+ * @deprecated Use {@link FileEntriesLayer}.
  */
 @Deprecated
 @Immutable

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/LayerEntry.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/LayerEntry.java
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>This class is immutable and thread-safe.
  *
- * <p>Deprecated. Use {@link FileEntry}.
+ * @deprecated Use {@link FileEntry}.
  */
 @Deprecated
 @Immutable


### PR DESCRIPTION
The `@deprecated` javadoc annotation allows surfacing recommendations to be use by tools.