### PR TITLE
Make BuildContext builder throw CacheDirectoryCreationException

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
@@ -45,7 +45,8 @@ public class Cache {
    *
    * @param cacheDirectory the directory for the cache. Creates the directory if it does not exist.
    * @return a new {@link Cache}
-   * @throws IOException if an I/O exception occurs
+   * @throws CacheDirectoryCreationException if an I/O exception occurs when creating cache
+   *     directory
    */
   public static Cache withDirectory(Path cacheDirectory) throws CacheDirectoryCreationException {
     try {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.cache;
 
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.buildplan.FileEntry;
@@ -46,8 +47,12 @@ public class Cache {
    * @return a new {@link Cache}
    * @throws IOException if an I/O exception occurs
    */
-  public static Cache withDirectory(Path cacheDirectory) throws IOException {
-    Files.createDirectories(cacheDirectory);
+  public static Cache withDirectory(Path cacheDirectory) throws CacheDirectoryCreationException {
+    try {
+      Files.createDirectories(cacheDirectory);
+    } catch (IOException ex) {
+      throw new CacheDirectoryCreationException(ex);
+    }
     return new Cache(new CacheStorageFiles(cacheDirectory));
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.configuration;
 
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
@@ -245,9 +246,9 @@ public class BuildContext implements Closeable {
      * Builds a new {@link BuildContext} using the parameters passed into the builder.
      *
      * @return the corresponding build context
-     * @throws IOException if an I/O exception occurs
+     * @throws CacheDirectoryCreationException if I/O exception occurs when creating cache directory
      */
-    public BuildContext build() throws IOException {
+    public BuildContext build() throws CacheDirectoryCreationException {
       // Validates the parameters.
       List<String> missingFields = new ArrayList<>();
       if (baseImageConfiguration == null) {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStepTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.builder.steps;
 
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.FileEntry;
@@ -95,7 +96,7 @@ public class BuildAndCacheApplicationLayerStepTest {
   private FileEntriesLayer emptyLayerConfiguration;
 
   @Before
-  public void setUp() throws IOException, URISyntaxException {
+  public void setUp() throws IOException, URISyntaxException, CacheDirectoryCreationException {
     fakeDependenciesLayerConfiguration =
         makeLayerConfiguration(
             "core/application/dependencies", EXTRACTION_PATH_ROOT.resolve("libs"));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageStepsTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageStepsTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.builder.steps;
 
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.steps.LocalBaseImageSteps.LocalImage;
 import com.google.cloud.tools.jib.cache.Cache;
@@ -64,7 +65,7 @@ public class LocalBaseImageStepsTest {
   }
 
   @Before
-  public void setup() throws IOException {
+  public void setup() throws IOException, CacheDirectoryCreationException {
     Mockito.when(buildContext.getExecutorService())
         .thenReturn(MoreExecutors.newDirectExecutorService());
     Mockito.when(buildContext.getBaseImageLayersCache())
@@ -132,7 +133,8 @@ public class LocalBaseImageStepsTest {
 
   @Test
   public void testGetCachedDockerImage()
-      throws IOException, DigestException, CacheCorruptedException, URISyntaxException {
+      throws IOException, DigestException, CacheDirectoryCreationException, CacheCorruptedException,
+          URISyntaxException {
     String dockerInspectJson =
         "{\"Size\": 0,"
             + "\"Id\": \"sha256:066872f17ae819f846a6d5abcfc3165abe13fb0a157640fa8cb7af81077670c0\","

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RegistryCredentialRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RegistryCredentialRetrieverTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.builder.steps;
 
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.api.CredentialRetriever;
 import com.google.cloud.tools.jib.api.ImageReference;
@@ -25,7 +26,6 @@ import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.registry.credentials.CredentialRetrievalException;
 import com.google.common.util.concurrent.MoreExecutors;
-import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,7 +45,8 @@ public class RegistryCredentialRetrieverTest {
   @Mock private EventHandlers mockEventHandlers;
 
   @Test
-  public void testCall_retrieved() throws CredentialRetrievalException, IOException {
+  public void testCall_retrieved()
+      throws CredentialRetrievalException, CacheDirectoryCreationException {
     BuildContext buildContext =
         makeFakeBuildContext(
             Arrays.asList(
@@ -64,7 +65,7 @@ public class RegistryCredentialRetrieverTest {
   }
 
   @Test
-  public void testCall_none() throws CredentialRetrievalException, IOException {
+  public void testCall_none() throws CredentialRetrievalException, CacheDirectoryCreationException {
     BuildContext buildContext =
         makeFakeBuildContext(
             Arrays.asList(Optional::empty, Optional::empty), Collections.emptyList());
@@ -82,7 +83,7 @@ public class RegistryCredentialRetrieverTest {
   }
 
   @Test
-  public void testCall_exception() throws IOException {
+  public void testCall_exception() throws CacheDirectoryCreationException {
     CredentialRetrievalException credentialRetrievalException =
         Mockito.mock(CredentialRetrievalException.class);
     BuildContext buildContext =
@@ -104,7 +105,7 @@ public class RegistryCredentialRetrieverTest {
   private BuildContext makeFakeBuildContext(
       List<CredentialRetriever> baseCredentialRetrievers,
       List<CredentialRetriever> targetCredentialRetrievers)
-      throws IOException {
+      throws CacheDirectoryCreationException {
     ImageReference baseImage = ImageReference.of("baseregistry", "baserepo", null);
     ImageReference targetImage = ImageReference.of("targetregistry", "targetrepo", null);
     return BuildContext.builder()

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.tools.jib.cache;
 
-import static org.junit.Assert.assertThat;
-
 import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
@@ -153,7 +151,7 @@ public class CacheTest {
       Assert.fail();
 
     } catch (CacheDirectoryCreationException ex) {
-      assertThat(ex.getCause(), CoreMatchers.instanceOf(FileAlreadyExistsException.class));
+      Assert.assertThat(ex.getCause(), CoreMatchers.instanceOf(FileAlreadyExistsException.class));
     }
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
@@ -16,6 +16,9 @@
 
 package com.google.cloud.tools.jib.cache;
 
+import static org.junit.Assert.assertThat;
+
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
@@ -33,6 +36,7 @@ import java.nio.file.attribute.FileTime;
 import java.time.Instant;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -148,14 +152,14 @@ public class CacheTest {
       Cache.withDirectory(file);
       Assert.fail();
 
-    } catch (FileAlreadyExistsException ex) {
-      // pass
+    } catch (CacheDirectoryCreationException ex) {
+      assertThat(ex.getCause(), CoreMatchers.instanceOf(FileAlreadyExistsException.class));
     }
   }
 
   @Test
   public void testWriteCompressed_retrieveByLayerDigest()
-      throws IOException, CacheCorruptedException {
+      throws IOException, CacheDirectoryCreationException, CacheCorruptedException {
     Cache cache = Cache.withDirectory(temporaryFolder.newFolder().toPath());
 
     verifyIsLayer1(cache.writeCompressedLayer(compress(layerBlob1)));
@@ -165,7 +169,7 @@ public class CacheTest {
 
   @Test
   public void testWriteUncompressedWithLayerEntries_retrieveByLayerDigest()
-      throws IOException, CacheCorruptedException {
+      throws IOException, CacheDirectoryCreationException, CacheCorruptedException {
     Cache cache = Cache.withDirectory(temporaryFolder.newFolder().toPath());
 
     verifyIsLayer1(cache.writeUncompressedLayer(layerBlob1, layerEntries1));
@@ -175,7 +179,7 @@ public class CacheTest {
 
   @Test
   public void testWriteUncompressedWithLayerEntries_retrieveByLayerEntries()
-      throws IOException, CacheCorruptedException {
+      throws IOException, CacheDirectoryCreationException, CacheCorruptedException {
     Cache cache = Cache.withDirectory(temporaryFolder.newFolder().toPath());
 
     verifyIsLayer1(cache.writeUncompressedLayer(layerBlob1, layerEntries1));
@@ -189,7 +193,8 @@ public class CacheTest {
   }
 
   @Test
-  public void testRetrieveWithTwoEntriesInCache() throws IOException, CacheCorruptedException {
+  public void testRetrieveWithTwoEntriesInCache()
+      throws IOException, CacheDirectoryCreationException, CacheCorruptedException {
     Cache cache = Cache.withDirectory(temporaryFolder.newFolder().toPath());
 
     verifyIsLayer1(cache.writeUncompressedLayer(layerBlob1, layerEntries1));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildContextTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildContextTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.configuration;
 
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.api.CredentialRetriever;
 import com.google.cloud.tools.jib.api.ImageReference;
@@ -158,7 +159,7 @@ public class BuildContextTest {
   }
 
   @Test
-  public void testBuilder_default() throws IOException {
+  public void testBuilder_default() throws CacheDirectoryCreationException {
     // These are required and don't have defaults.
     String expectedBaseImageServerUrl = "someserver";
     String expectedBaseImageName = "baseimage";
@@ -199,7 +200,7 @@ public class BuildContextTest {
   }
 
   @Test
-  public void testBuilder_missingValues() throws IOException {
+  public void testBuilder_missingValues() throws CacheDirectoryCreationException {
     // Target image is missing
     try {
       BuildContext.builder()
@@ -242,7 +243,8 @@ public class BuildContextTest {
   }
 
   @Test
-  public void testBuilder_digestWarning() throws IOException, InvalidImageReferenceException {
+  public void testBuilder_digestWarning()
+      throws CacheDirectoryCreationException, InvalidImageReferenceException {
     EventHandlers mockEventHandlers = Mockito.mock(EventHandlers.class);
     BuildContext.Builder builder =
         BuildContext.builder()
@@ -272,7 +274,8 @@ public class BuildContextTest {
   }
 
   @Test
-  public void testClose_shutDownInternalExecutorService() throws IOException {
+  public void testClose_shutDownInternalExecutorService()
+      throws IOException, CacheDirectoryCreationException {
     BuildContext buildContext =
         BuildContext.builder()
             .setBaseImageConfiguration(
@@ -288,7 +291,8 @@ public class BuildContextTest {
   }
 
   @Test
-  public void testClose_doNotShutDownProvidedExecutorService() throws IOException {
+  public void testClose_doNotShutDownProvidedExecutorService()
+      throws IOException, CacheDirectoryCreationException {
     ExecutorService executorService = MoreExecutors.newDirectExecutorService();
     BuildContext buildContext =
         BuildContext.builder()


### PR DESCRIPTION
No public API is affected.

`JibContainerBuilder.toBuildContext()` is already throwing `CacheDirectoryCreationException`, coming from `Containerizer.getApplicationLayersCacheDirectory()` and `Containerizer.getBaseImageLayersCacheDirectory()`.

I noticed the `IOException` from `BuildContextBuilder.build()` is only from creating cache directories, so I figured it is reasonable to make them align.