### PR TITLE
Add glob support for extra file permissions

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Glob pattern support for `jib.extraDirectories.permissions`. ([#1200](https://github.com/GoogleContainerTools/jib/issues/1200))
+
 ### Changed
 
 - `jib.container.creationTime` now accepts more timezone formats:`+HHmm`. This allows for easier configuration of creationTime by external systems. ([#2320](https://github.com/GoogleContainerTools/jib/issues/2320))

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.gradle;
 
-import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FilePermissions;
 import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
@@ -162,7 +161,7 @@ public class GradleRawConfiguration implements RawConfiguration {
   }
 
   @Override
-  public Map<AbsoluteUnixPath, FilePermissions> getExtraDirectoryPermissions() {
+  public Map<String, FilePermissions> getExtraDirectoryPermissions() {
     return TaskCommon.convertPermissionsMap(jibExtension.getExtraDirectories().getPermissions());
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -23,7 +23,7 @@ import com.google.cloud.tools.jib.api.buildplan.FilePermissions;
 import com.google.cloud.tools.jib.plugins.common.ProjectProperties;
 import com.google.cloud.tools.jib.plugins.common.UpdateChecker;
 import com.google.common.util.concurrent.Futures;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
@@ -120,7 +120,8 @@ class TaskCommon {
    * @return the converted map
    */
   static Map<String, FilePermissions> convertPermissionsMap(Map<String, String> stringMap) {
-    Map<String, FilePermissions> permissionsMap = new HashMap<>();
+    // Order is important, so use a LinkedHashMap
+    Map<String, FilePermissions> permissionsMap = new LinkedHashMap<>();
     for (Map.Entry<String, String> entry : stringMap.entrySet()) {
       permissionsMap.put(entry.getKey(), FilePermissions.fromOctalString(entry.getValue()));
     }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.jib.gradle;
 import com.google.api.client.http.HttpTransport;
 import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.cloud.tools.jib.api.LogEvent;
-import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FilePermissions;
 import com.google.cloud.tools.jib.plugins.common.ProjectProperties;
 import com.google.cloud.tools.jib.plugins.common.UpdateChecker;
@@ -114,19 +113,16 @@ class TaskCommon {
   }
 
   /**
-   * Validates and converts a {@code String->String} file-path-to-file-permissions map to an
-   * equivalent {@code AbsoluteUnixPath->FilePermission} map.
+   * Converts a {@code String->String} file-path-to-file-permissions map to an equivalent {@code
+   * String->FilePermission} map.
    *
    * @param stringMap the map to convert (example entry: {@code "/path/on/container" -> "755"})
    * @return the converted map
    */
-  static Map<AbsoluteUnixPath, FilePermissions> convertPermissionsMap(
-      Map<String, String> stringMap) {
-    Map<AbsoluteUnixPath, FilePermissions> permissionsMap = new HashMap<>();
+  static Map<String, FilePermissions> convertPermissionsMap(Map<String, String> stringMap) {
+    Map<String, FilePermissions> permissionsMap = new HashMap<>();
     for (Map.Entry<String, String> entry : stringMap.entrySet()) {
-      AbsoluteUnixPath key = AbsoluteUnixPath.get(entry.getKey());
-      FilePermissions value = FilePermissions.fromOctalString(entry.getValue());
-      permissionsMap.put(key, value);
+      permissionsMap.put(entry.getKey(), FilePermissions.fromOctalString(entry.getValue()));
     }
     return permissionsMap;
   }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -286,9 +286,9 @@ public class GradleProjectPropertiesTest {
   public void testConvertPermissionsMap() {
     Assert.assertEquals(
         ImmutableMap.of(
-            AbsoluteUnixPath.get("/test/folder/file1"),
+            "/test/folder/file1",
             FilePermissions.fromOctalString("123"),
-            AbsoluteUnixPath.get("/test/file2"),
+            "/test/file2",
             FilePermissions.fromOctalString("456")),
         TaskCommon.convertPermissionsMap(
             ImmutableMap.of("/test/folder/file1", "123", "/test/file2", "456")));

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Glob pattern support for `<extraDirectories><permissions>`. ([#1200](https://github.com/GoogleContainerTools/jib/issues/1200))
+
 ### Changed
 
 - `<container><creationTime>` now accepts more timezone formats:`+HHmm`. This allows for easier configuration of creationTime by external systems. ([#2320](https://github.com/GoogleContainerTools/jib/issues/2320))

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.maven;
 
-import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FilePermissions;
 import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
@@ -167,7 +166,7 @@ public class MavenRawConfiguration implements RawConfiguration {
   }
 
   @Override
-  public Map<AbsoluteUnixPath, FilePermissions> getExtraDirectoryPermissions() {
+  public Map<String, FilePermissions> getExtraDirectoryPermissions() {
     return MojoCommon.convertPermissionsList(jibPluginConfiguration.getExtraDirectoryPermissions());
   }
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
@@ -29,7 +29,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -107,7 +107,8 @@ public class MojoCommon {
    */
   static Map<String, FilePermissions> convertPermissionsList(
       List<PermissionConfiguration> permissionList) {
-    Map<String, FilePermissions> permissionsMap = new HashMap<>();
+    // Order is important, so use a LinkedHashMap
+    Map<String, FilePermissions> permissionsMap = new LinkedHashMap<>();
     for (PermissionConfiguration permission : permissionList) {
       if (!permission.getFile().isPresent() || !permission.getMode().isPresent()) {
         throw new IllegalArgumentException(

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.jib.maven;
 
 import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.cloud.tools.jib.api.LogEvent;
-import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FilePermissions;
 import com.google.cloud.tools.jib.maven.JibPluginConfiguration.PermissionConfiguration;
 import com.google.cloud.tools.jib.plugins.common.ProjectProperties;
@@ -100,24 +99,22 @@ public class MojoCommon {
   }
 
   /**
-   * Validates and converts a list of {@link PermissionConfiguration} to an equivalent {@code
-   * AbsoluteUnixPath->FilePermission} map.
+   * Converts a list of {@link PermissionConfiguration} to an equivalent {@code
+   * String->FilePermission} map.
    *
    * @param permissionList the list to convert
    * @return the resulting map
    */
-  @VisibleForTesting
-  static Map<AbsoluteUnixPath, FilePermissions> convertPermissionsList(
+  static Map<String, FilePermissions> convertPermissionsList(
       List<PermissionConfiguration> permissionList) {
-    Map<AbsoluteUnixPath, FilePermissions> permissionsMap = new HashMap<>();
+    Map<String, FilePermissions> permissionsMap = new HashMap<>();
     for (PermissionConfiguration permission : permissionList) {
       if (!permission.getFile().isPresent() || !permission.getMode().isPresent()) {
         throw new IllegalArgumentException(
             "Incomplete <permission> configuration; requires <file> and <mode> fields to be set");
       }
-      AbsoluteUnixPath key = AbsoluteUnixPath.get(permission.getFile().get());
-      FilePermissions value = FilePermissions.fromOctalString(permission.getMode().get());
-      permissionsMap.put(key, value);
+      permissionsMap.put(
+          permission.getFile().get(), FilePermissions.fromOctalString(permission.getMode().get()));
     }
     return permissionsMap;
   }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelper.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelper.java
@@ -40,8 +40,7 @@ import java.util.function.Predicate;
 public class JavaContainerBuilderHelper {
 
   /**
-   * Validates and returns a {@link FileEntriesLayer} for adding the extra directory to the
-   * container.
+   * Returns a {@link FileEntriesLayer} for adding the extra directory to the container.
    *
    * @param extraDirectory the source extra directory path
    * @param extraDirectoryPermissions map from path on container to file permissions

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelper.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelper.java
@@ -31,7 +31,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.function.Predicate;
@@ -56,9 +56,10 @@ public class JavaContainerBuilderHelper {
       throws IOException {
     FileEntriesLayer.Builder builder =
         FileEntriesLayer.builder().setName(LayerType.EXTRA_FILES.getName());
-    Map<PathMatcher, FilePermissions> pathMatchers = new HashMap<>();
-    for (Map.Entry<String, FilePermissions> glob : extraDirectoryPermissions.entrySet()) {
-      pathMatchers.put(FileSystems.getDefault().getPathMatcher("glob:" + glob), glob.getValue());
+    Map<PathMatcher, FilePermissions> pathMatchers = new LinkedHashMap<>();
+    for (Map.Entry<String, FilePermissions> entry : extraDirectoryPermissions.entrySet()) {
+      pathMatchers.put(
+          FileSystems.getDefault().getPathMatcher("glob:" + entry.getKey()), entry.getValue());
     }
 
     new DirectoryWalker(extraDirectory)

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.plugins.common;
 
-import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FilePermissions;
 import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
 import java.nio.file.Path;
@@ -81,7 +80,7 @@ public interface RawConfiguration {
 
   List<Path> getExtraDirectories();
 
-  Map<AbsoluteUnixPath, FilePermissions> getExtraDirectoryPermissions();
+  Map<String, FilePermissions> getExtraDirectoryPermissions();
 
   Optional<Path> getDockerExecutable();
 

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelperTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelperTest.java
@@ -27,9 +27,11 @@ import com.google.cloud.tools.jib.api.LayerConfiguration;
 import com.google.cloud.tools.jib.api.LayerEntry;
 import com.google.cloud.tools.jib.api.RegistryImage;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.api.buildplan.FilePermissions;
 import com.google.cloud.tools.jib.configuration.BuildContext;
 import com.google.cloud.tools.jib.filesystem.FileOperations;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.google.common.util.concurrent.MoreExecutors;
 import java.io.IOException;
@@ -41,6 +43,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.junit.Assert;
@@ -95,6 +98,72 @@ public class JavaContainerBuilderHelperTest {
             extraFilesDirectory.resolve("c/cat"),
             extraFilesDirectory.resolve("foo")),
         layerConfiguration.getLayerEntries());
+  }
+
+  @Test
+  public void testExtraDirectoryLayerConfiguration_globPermissions()
+      throws URISyntaxException, IOException {
+    Path extraFilesDirectory = Paths.get(Resources.getResource("core/layer").toURI());
+    Map<String, FilePermissions> permissionsMap =
+        ImmutableMap.of(
+            "/a",
+            FilePermissions.fromOctalString("123"),
+            "/a/*",
+            FilePermissions.fromOctalString("456"),
+            "**/bar",
+            FilePermissions.fromOctalString("765"));
+    LayerConfiguration layerConfiguration =
+        JavaContainerBuilderHelper.extraDirectoryLayerConfiguration(
+            extraFilesDirectory, permissionsMap, (ignored1, ignored2) -> Instant.EPOCH);
+    assertExtractionPathsUnordered(
+        Arrays.asList("/a", "/a/b", "/a/b/bar", "/c", "/c/cat", "/foo"),
+        layerConfiguration.getLayerEntries());
+
+    Map<AbsoluteUnixPath, FilePermissions> expectedPermissions =
+        ImmutableMap.<AbsoluteUnixPath, FilePermissions>builder()
+            .put(AbsoluteUnixPath.get("/a"), FilePermissions.fromOctalString("123"))
+            .put(AbsoluteUnixPath.get("/a/b"), FilePermissions.fromOctalString("456"))
+            .put(AbsoluteUnixPath.get("/a/b/bar"), FilePermissions.fromOctalString("765"))
+            .put(AbsoluteUnixPath.get("/c"), FilePermissions.DEFAULT_FOLDER_PERMISSIONS)
+            .put(AbsoluteUnixPath.get("/c/cat"), FilePermissions.DEFAULT_FILE_PERMISSIONS)
+            .put(AbsoluteUnixPath.get("/foo"), FilePermissions.DEFAULT_FILE_PERMISSIONS)
+            .build();
+    for (LayerEntry entry : layerConfiguration.getLayerEntries()) {
+      Assert.assertEquals(
+          expectedPermissions.get(entry.getExtractionPath()), entry.getPermissions());
+    }
+  }
+
+  @Test
+  public void testExtraDirectoryLayerConfiguration_overlappingPermissions()
+      throws URISyntaxException, IOException {
+    Path extraFilesDirectory = Paths.get(Resources.getResource("core/layer").toURI());
+    Map<String, FilePermissions> permissionsMap =
+        ImmutableMap.of(
+            "/a**",
+            FilePermissions.fromOctalString("123"),
+            "/a/b/bar",
+            FilePermissions.fromOctalString("765"));
+    LayerConfiguration layerConfiguration =
+        JavaContainerBuilderHelper.extraDirectoryLayerConfiguration(
+            extraFilesDirectory, permissionsMap, (ignored1, ignored2) -> Instant.EPOCH);
+    assertExtractionPathsUnordered(
+        Arrays.asList("/a", "/a/b", "/a/b/bar", "/c", "/c/cat", "/foo"),
+        layerConfiguration.getLayerEntries());
+
+    Map<AbsoluteUnixPath, FilePermissions> expectedPermissions =
+        ImmutableMap.<AbsoluteUnixPath, FilePermissions>builder()
+            .put(AbsoluteUnixPath.get("/a"), FilePermissions.fromOctalString("123"))
+            .put(AbsoluteUnixPath.get("/a/b"), FilePermissions.fromOctalString("123"))
+            .put(AbsoluteUnixPath.get("/a/b/bar"), FilePermissions.fromOctalString("765"))
+            .put(AbsoluteUnixPath.get("/c"), FilePermissions.DEFAULT_FOLDER_PERMISSIONS)
+            .put(AbsoluteUnixPath.get("/c/cat"), FilePermissions.DEFAULT_FILE_PERMISSIONS)
+            .put(AbsoluteUnixPath.get("/foo"), FilePermissions.DEFAULT_FILE_PERMISSIONS)
+            .build();
+    for (LayerEntry entry : layerConfiguration.getLayerEntries()) {
+      Assert.assertEquals(
+          expectedPermissions.get(entry.getExtractionPath()), entry.getPermissions());
+    }
   }
 
   @Test

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelperTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelperTest.java
@@ -142,6 +142,10 @@ public class JavaContainerBuilderHelperTest {
         ImmutableMap.of(
             "/a**",
             FilePermissions.fromOctalString("123"),
+            // Should be ignored, since first match takes priority
+            "/a/b**",
+            FilePermissions.fromOctalString("000"),
+            // Should override first match since explicit path is used instead of glob
             "/a/b/bar",
             FilePermissions.fromOctalString("765"));
     FileEntriesLayer fileEntriesLayer =

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -166,8 +166,7 @@ public class PluginConfigurationProcessorTest {
     Path extraDirectory = Paths.get(Resources.getResource("core/layer").toURI());
     Mockito.when(rawConfiguration.getExtraDirectories()).thenReturn(Arrays.asList(extraDirectory));
     Mockito.when(rawConfiguration.getExtraDirectoryPermissions())
-        .thenReturn(
-            ImmutableMap.of(AbsoluteUnixPath.get("/foo"), FilePermissions.fromOctalString("123")));
+        .thenReturn(ImmutableMap.of("/foo", FilePermissions.fromOctalString("123")));
 
     BuildContext buildContext = getBuildContext(processCommonConfiguration());
     List<LayerEntry> extraFiles =


### PR DESCRIPTION
Fixes #1200.

Can now use glob patterns when setting extra files permissions. Permissions configured with explicit paths will take priority over globs (e.g. if both `'/a/b/file': '777'` and `'**/file': '444'` are configured, `/a/b/file` will have `777` permissions, and all other files named `file` will have `444` permissions).

If a file matches multiple globs (e.g. if there's a file `/a/b/file`, and permissions are configured for both `/a/b/*` and `**/file`), ~~behavior is undefined at the moment~~ first configured match wins.