### PR TITLE
make googleJavaFormat run earlier in 'dev' mode

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -377,7 +377,7 @@ subprojects {
 /* LOCAL DEVELOPMENT HELPER TASKS */
 tasks.register('dev') {
   subprojects.each { subproject ->
-    subproject.tasks.check.dependsOn subproject.tasks.googleJavaFormat
+    subproject.tasks.classes.dependsOn subproject.tasks.googleJavaFormat
     dependsOn subproject.tasks.check
     dependsOn subproject.tasks.javadoc
   }


### PR DESCRIPTION
goJF was running after checkstyle which is dumb. This should make auto formatting run before checkstyle so it does break for no good reason.
