### PR TITLE
Fix wrong hashCode() in ContainerConfiguration

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -373,6 +373,13 @@ public class ContainerConfiguration {
   @VisibleForTesting
   public int hashCode() {
     return Objects.hash(
-        creationTime, entrypoint, programArguments, environmentMap, exposedPorts, labels, user);
+        creationTime,
+        entrypoint,
+        programArguments,
+        environmentMap,
+        exposedPorts,
+        labels,
+        user,
+        workingDirectory);
   }
 }


### PR DESCRIPTION
`workingDirectory` missing