### PR TITLE
Push out project version setting to tool

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/ProjectInfo.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/ProjectInfo.java
@@ -16,8 +16,6 @@
 
 package com.google.cloud.tools.jib;
 
-import javax.annotation.Nullable;
-
 /** Constants relating to the Jib project. */
 public class ProjectInfo {
 
@@ -26,10 +24,6 @@ public class ProjectInfo {
 
   /** Link to file an issue against the GitHub repository. */
   public static final String GITHUB_NEW_ISSUE_URL = GITHUB_URL + "/issues/new";
-
-  /** The project version. May be {@code null} if the version cannot be determined. */
-  @Nullable
-  public static final String VERSION = ProjectInfo.class.getPackage().getImplementationVersion();
 
   private ProjectInfo() {}
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/Containerizer.java
@@ -47,6 +47,8 @@ public class Containerizer {
   public static final Path DEFAULT_BASE_CACHE_DIRECTORY = XdgDirectories.getCacheHome();
 
   private static final String DEFAULT_TOOL_NAME = "jib-core";
+  private static final String DEFAULT_TOOL_VERSION =
+      Containerizer.class.getPackage().getImplementationVersion();
 
   private static final String DESCRIPTION_FOR_DOCKER_REGISTRY = "Building and pushing image";
   private static final String DESCRIPTION_FOR_DOCKER_DAEMON = "Building image to Docker daemon";
@@ -128,6 +130,7 @@ public class Containerizer {
   private boolean allowInsecureRegistries = false;
   private boolean offline = false;
   private String toolName = DEFAULT_TOOL_NAME;
+  @Nullable private String toolVersion = DEFAULT_TOOL_VERSION;
   private boolean alwaysCacheBaseImage = false;
 
   /** Instantiate with {@link #to}. */
@@ -270,6 +273,19 @@ public class Containerizer {
   }
 
   /**
+   * Sets the version of the tool that is using Jib Core. The tool version is sent as part of the
+   * {@code User-Agent} in registry requests and set as the {@code created_by} in the container
+   * layer history. Defaults to the current version of jib-core.
+   *
+   * @param toolVersion the name of the tool using this library
+   * @return this
+   */
+  public Containerizer setToolVersion(@Nullable String toolVersion) {
+    this.toolVersion = toolVersion;
+    return this;
+  }
+
+  /**
    * Controls the optimization which skips downloading base image layers that exist in a target
    * registry. If the user does not set this property, then read as false.
    *
@@ -323,6 +339,11 @@ public class Containerizer {
 
   String getToolName() {
     return toolName;
+  }
+
+  @Nullable
+  String getToolVersion() {
+    return toolVersion;
   }
 
   boolean getAlwaysCacheBaseImage() {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -565,6 +565,7 @@ public class JibContainerBuilder {
         .setAllowInsecureRegistries(containerizer.getAllowInsecureRegistries())
         .setOffline(containerizer.isOfflineMode())
         .setToolName(containerizer.getToolName())
+        .setToolVersion(containerizer.getToolVersion())
         .setExecutorService(containerizer.getExecutorService().orElse(null))
         .setEventHandlers(containerizer.buildEventHandlers())
         .setAlwaysCacheBaseImage(containerizer.getAlwaysCacheBaseImage())

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.builder.steps;
 
-import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
@@ -107,7 +106,7 @@ class BuildImageStep implements Callable<Image> {
                 HistoryEntry.builder()
                     .setCreationTimestamp(layerCreationTime)
                     .setAuthor("Jib")
-                    .setCreatedBy(buildContext.getToolName() + ":" + ProjectInfo.VERSION)
+                    .setCreatedBy(buildContext.getToolName() + ":" + buildContext.getToolVersion())
                     .setComment(applicationLayer.getName())
                     .build());
       }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
@@ -74,6 +74,7 @@ public class BuildContext implements Closeable {
     private ImmutableList<FileEntriesLayer> layerConfigurations = ImmutableList.of();
     private Class<? extends BuildableManifestTemplate> targetFormat = DEFAULT_TARGET_FORMAT;
     private String toolName = DEFAULT_TOOL_NAME;
+    @Nullable private String toolVersion;
     private EventHandlers eventHandlers = EventHandlers.NONE;
     @Nullable private ExecutorService executorService;
     private boolean alwaysCacheBaseImage = false;
@@ -220,6 +221,17 @@ public class BuildContext implements Closeable {
     }
 
     /**
+     * Sets the version of the tool that is executing the build.
+     *
+     * @param toolVersion the tool version
+     * @return this
+     */
+    public Builder setToolVersion(@Nullable String toolVersion) {
+      this.toolVersion = toolVersion;
+      return this;
+    }
+
+    /**
      * Sets the {@link EventHandlers} to dispatch events with.
      *
      * @param eventHandlers the {@link EventHandlers}
@@ -287,6 +299,7 @@ public class BuildContext implements Closeable {
               offline,
               layerConfigurations,
               toolName,
+              toolVersion,
               eventHandlers,
               // TODO: try setting global User-Agent: here
               new FailoverHttpClient(
@@ -346,6 +359,7 @@ public class BuildContext implements Closeable {
   private final boolean offline;
   private final ImmutableList<FileEntriesLayer> layerConfigurations;
   private final String toolName;
+  @Nullable private final String toolVersion;
   private final EventHandlers eventHandlers;
   private final FailoverHttpClient httpClient;
   private final ExecutorService executorService;
@@ -364,6 +378,7 @@ public class BuildContext implements Closeable {
       boolean offline,
       ImmutableList<FileEntriesLayer> layerConfigurations,
       String toolName,
+      @Nullable String toolVersion,
       EventHandlers eventHandlers,
       FailoverHttpClient httpClient,
       ExecutorService executorService,
@@ -379,6 +394,7 @@ public class BuildContext implements Closeable {
     this.offline = offline;
     this.layerConfigurations = layerConfigurations;
     this.toolName = toolName;
+    this.toolVersion = toolVersion;
     this.eventHandlers = eventHandlers;
     this.httpClient = httpClient;
     this.executorService = executorService;
@@ -418,6 +434,11 @@ public class BuildContext implements Closeable {
 
   public String getToolName() {
     return toolName;
+  }
+
+  @Nullable
+  public String getToolVersion() {
+    return toolVersion;
   }
 
   public EventHandlers getEventHandlers() {
@@ -500,7 +521,7 @@ public class BuildContext implements Closeable {
               targetImageConfiguration.getImageRepository(),
               baseImageConfiguration.getImageRepository(),
               httpClient)
-          .setUserAgentSuffix(getToolName());
+          .setUserAgentSuffix(getToolVersion() + " " + getToolName());
     }
     return newRegistryClientFactory(targetImageConfiguration);
   }
@@ -511,7 +532,7 @@ public class BuildContext implements Closeable {
             imageConfiguration.getImageRegistry(),
             imageConfiguration.getImageRepository(),
             httpClient)
-        .setUserAgentSuffix(getToolName());
+        .setUserAgentSuffix(getToolVersion() + " " + getToolName());
   }
 
   @Override

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
@@ -545,8 +545,8 @@ public class BuildContext implements Closeable {
   }
 
   /**
-   * The {@code User-Agent} is in the form of {@code jib <version> <type>}. For example: {@code jib
-   * 0.9.0 jib-maven-plugin}.
+   * The {@code User-Agent} is in the form of {@code jib <toolVersion> <toolName>}. For example:
+   * {@code jib 0.9.0 jib-maven-plugin}.
    *
    * @return the {@code User-Agent} header to send. The {@code User-Agent} can be disabled by
    *     setting the system property variable {@code _JIB_DISABLE_USER_AGENT} to any non-empty

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.jib.registry;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.api.client.http.HttpStatusCodes;
 import com.google.api.client.util.Base64;
-import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.LogEvent;
@@ -90,7 +89,7 @@ public class RegistryClient {
     }
 
     /**
-     * Sets a suffix to append to {@code User-Agent} headers.
+     * Sets a suffix to append to {@code User-Agent} headers. See {@link #makeUserAgent()}.
      *
      * @param userAgentSuffix the suffix to append
      * @return this
@@ -127,7 +126,7 @@ public class RegistryClient {
         return "";
       }
 
-      StringBuilder userAgentBuilder = new StringBuilder("jib ").append(ProjectInfo.VERSION);
+      StringBuilder userAgentBuilder = new StringBuilder("jib");
       if (userAgentSuffix != null) {
         userAgentBuilder.append(" ").append(userAgentSuffix);
       }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -40,7 +40,6 @@ import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
@@ -65,7 +64,7 @@ public class RegistryClient {
     private final RegistryEndpointRequestProperties registryEndpointRequestProperties;
     private final FailoverHttpClient httpClient;
 
-    @Nullable private String userAgentSuffix;
+    private String userAgent = "";
     @Nullable private Credential credential;
 
     private Factory(
@@ -89,13 +88,13 @@ public class RegistryClient {
     }
 
     /**
-     * Sets a suffix to append to {@code User-Agent} headers. See {@link #makeUserAgent()}.
+     * Sets a the value of {@code User-Agent} in headers for registry requests.
      *
-     * @param userAgentSuffix the suffix to append
+     * @param userAgent non-null user agent string, can be empty
      * @return this
      */
-    public Factory setUserAgentSuffix(@Nullable String userAgentSuffix) {
-      this.userAgentSuffix = userAgentSuffix;
+    public Factory setUserAgent(String userAgent) {
+      this.userAgent = userAgent;
       return this;
     }
 
@@ -106,36 +105,7 @@ public class RegistryClient {
      */
     public RegistryClient newRegistryClient() {
       return new RegistryClient(
-          eventHandlers,
-          credential,
-          registryEndpointRequestProperties,
-          makeUserAgent(),
-          httpClient);
-    }
-
-    /**
-     * The {@code User-Agent} is in the form of {@code jib <version> <type>}. For example: {@code
-     * jib 0.9.0 jib-maven-plugin}.
-     *
-     * @return the {@code User-Agent} header to send. The {@code User-Agent} can be disabled by
-     *     setting the system property variable {@code _JIB_DISABLE_USER_AGENT} to any non-empty
-     *     string.
-     */
-    private String makeUserAgent() {
-      if (!JibSystemProperties.isUserAgentEnabled()) {
-        return "";
-      }
-
-      StringBuilder userAgentBuilder = new StringBuilder("jib");
-      if (userAgentSuffix != null) {
-        userAgentBuilder.append(" ").append(userAgentSuffix);
-      }
-      if (!Strings.isNullOrEmpty(System.getProperty(JibSystemProperties.UPSTREAM_CLIENT))) {
-        userAgentBuilder
-            .append(" ")
-            .append(System.getProperty(JibSystemProperties.UPSTREAM_CLIENT));
-      }
-      return userAgentBuilder.toString();
+          eventHandlers, credential, registryEndpointRequestProperties, userAgent, httpClient);
     }
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -64,7 +64,7 @@ public class RegistryClient {
     private final RegistryEndpointRequestProperties registryEndpointRequestProperties;
     private final FailoverHttpClient httpClient;
 
-    private String userAgent = "";
+    @Nullable private String userAgent;
     @Nullable private Credential credential;
 
     private Factory(
@@ -88,12 +88,12 @@ public class RegistryClient {
     }
 
     /**
-     * Sets a the value of {@code User-Agent} in headers for registry requests.
+     * Sets the value of {@code User-Agent} in headers for registry requests.
      *
-     * @param userAgent non-null user agent string, can be empty
+     * @param userAgent user agent string
      * @return this
      */
-    public Factory setUserAgent(String userAgent) {
+    public Factory setUserAgent(@Nullable String userAgent) {
       this.userAgent = userAgent;
       return this;
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -64,7 +64,7 @@ public class RegistryClient {
     private final RegistryEndpointRequestProperties registryEndpointRequestProperties;
     private final FailoverHttpClient httpClient;
 
-    @Nullable private String userAgent;
+    private String userAgent = "";
     @Nullable private Credential credential;
 
     private Factory(
@@ -90,10 +90,10 @@ public class RegistryClient {
     /**
      * Sets the value of {@code User-Agent} in headers for registry requests.
      *
-     * @param userAgent user agent string
+     * @param userAgent non-null user agent string, can be empty
      * @return this
      */
-    public Factory setUserAgent(@Nullable String userAgent) {
+    public Factory setUserAgent(String userAgent) {
       this.userAgent = userAgent;
       return this;
     }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
@@ -23,7 +23,6 @@ import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.api.RegistryUnauthorizedException;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.event.EventHandlers;
-import com.google.cloud.tools.jib.global.JibSystemProperties;
 import com.google.cloud.tools.jib.http.TestWebServer;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -39,9 +38,7 @@ import org.hamcrest.CoreMatchers;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
 import org.mockito.ArgumentMatchers;
@@ -54,8 +51,6 @@ import org.mockito.junit.MockitoJUnitRunner;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class RegistryClientTest {
-
-  @Rule public final RestoreSystemProperties systemPropertyRestorer = new RestoreSystemProperties();
 
   @Mock private EventHandlers eventHandlers;
 
@@ -82,38 +77,6 @@ public class RegistryClientTest {
     if (authServer != null) {
       authServer.close();
     }
-  }
-
-  @Test
-  public void testGetUserAgent_null() {
-    Assert.assertTrue(
-        testRegistryClientFactory.newRegistryClient().getUserAgent().startsWith("jib"));
-
-    Assert.assertTrue(
-        testRegistryClientFactory
-            .setUserAgentSuffix(null)
-            .newRegistryClient()
-            .getUserAgent()
-            .startsWith("jib"));
-  }
-
-  @Test
-  public void testGetUserAgent() {
-    RegistryClient registryClient =
-        testRegistryClientFactory.setUserAgentSuffix("some user agent suffix").newRegistryClient();
-
-    Assert.assertTrue(registryClient.getUserAgent().startsWith("jib "));
-    Assert.assertTrue(registryClient.getUserAgent().endsWith(" some user agent suffix"));
-  }
-
-  @Test
-  public void testGetUserAgentWithUpstreamClient() {
-    System.setProperty(JibSystemProperties.UPSTREAM_CLIENT, "skaffold/0.34.0");
-
-    RegistryClient registryClient =
-        testRegistryClientFactory.setUserAgentSuffix("foo").newRegistryClient();
-    Assert.assertTrue(registryClient.getUserAgent().startsWith("jib "));
-    Assert.assertTrue(registryClient.getUserAgent().endsWith(" skaffold/0.34.0"));
   }
 
   @Test

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -69,6 +69,10 @@ public class GradleProjectProperties implements ProjectProperties {
   /** Used to generate the User-Agent header and history metadata. */
   private static final String TOOL_NAME = "jib-gradle-plugin";
 
+  /** Used to generate the User-Agent header and history metadata and verify versions. */
+  static final String TOOL_VERSION =
+      GradleProjectProperties.class.getPackage().getImplementationVersion();
+
   /** Used for logging during main class inference. */
   private static final String PLUGIN_NAME = "jib";
 
@@ -296,6 +300,11 @@ public class GradleProjectProperties implements ProjectProperties {
   @Override
   public String getToolName() {
     return TOOL_NAME;
+  }
+
+  @Override
+  public String getToolVersion() {
+    return TOOL_VERSION;
   }
 
   @Override

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.jib.gradle;
 
 import static org.gradle.api.tasks.SourceSet.MAIN_SOURCE_SET_NAME;
 
-import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.cloud.tools.jib.gradle.skaffold.CheckJibVersionTask;
 import com.google.cloud.tools.jib.gradle.skaffold.FilesTaskV2;
 import com.google.cloud.tools.jib.gradle.skaffold.InitTask;
@@ -102,7 +101,7 @@ public class JibPlugin implements Plugin<Project> {
     if (requiredVersion == null) {
       return;
     }
-    String actualVersion = ProjectInfo.VERSION;
+    String actualVersion = GradleProjectProperties.TOOL_VERSION;
     if (actualVersion == null) {
       throw new GradleException("Could not determine Jib plugin version");
     }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -55,7 +55,11 @@ class TaskCommon {
     ExecutorService executorService = Executors.newSingleThreadExecutor();
     try {
       return UpdateChecker.checkForUpdate(
-          executorService, projectProperties::log, VERSION_URL, projectProperties.getToolName());
+          executorService,
+          projectProperties::log,
+          VERSION_URL,
+          projectProperties.getToolName(),
+          projectProperties.getToolVersion());
     } finally {
       executorService.shutdown();
     }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -74,7 +74,7 @@ public class BuildDockerMojo extends JibPluginConfiguration {
     TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider();
     MavenProjectProperties projectProperties =
         MavenProjectProperties.getForProject(
-            getProject(), getSession(), getLog(), tempDirectoryProvider);
+            descriptor, getProject(), getSession(), getLog(), tempDirectoryProvider);
     Future<Optional<String>> updateCheckFuture =
         MojoCommon.newUpdateChecker(projectProperties, getLog());
     try {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildDockerMojo.java
@@ -32,6 +32,7 @@ import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryExceptio
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -74,7 +75,11 @@ public class BuildDockerMojo extends JibPluginConfiguration {
     TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider();
     MavenProjectProperties projectProperties =
         MavenProjectProperties.getForProject(
-            descriptor, getProject(), getSession(), getLog(), tempDirectoryProvider);
+            Preconditions.checkNotNull(descriptor),
+            getProject(),
+            getSession(),
+            getLog(),
+            tempDirectoryProvider);
     Future<Optional<String>> updateCheckFuture =
         MojoCommon.newUpdateChecker(projectProperties, getLog());
     try {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -32,6 +32,7 @@ import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryExceptio
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import java.io.IOException;
 import java.util.Arrays;
@@ -88,7 +89,11 @@ public class BuildImageMojo extends JibPluginConfiguration {
     TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider();
     MavenProjectProperties projectProperties =
         MavenProjectProperties.getForProject(
-            descriptor, getProject(), getSession(), getLog(), tempDirectoryProvider);
+            Preconditions.checkNotNull(descriptor),
+            getProject(),
+            getSession(),
+            getLog(),
+            tempDirectoryProvider);
     Future<Optional<String>> updateCheckFuture =
         MojoCommon.newUpdateChecker(projectProperties, getLog());
     try {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildImageMojo.java
@@ -88,7 +88,7 @@ public class BuildImageMojo extends JibPluginConfiguration {
     TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider();
     MavenProjectProperties projectProperties =
         MavenProjectProperties.getForProject(
-            getProject(), getSession(), getLog(), tempDirectoryProvider);
+            descriptor, getProject(), getSession(), getLog(), tempDirectoryProvider);
     Future<Optional<String>> updateCheckFuture =
         MojoCommon.newUpdateChecker(projectProperties, getLog());
     try {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -66,7 +66,7 @@ public class BuildTarMojo extends JibPluginConfiguration {
     TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider();
     MavenProjectProperties projectProperties =
         MavenProjectProperties.getForProject(
-            getProject(), getSession(), getLog(), tempDirectoryProvider);
+            descriptor, getProject(), getSession(), getLog(), tempDirectoryProvider);
     Future<Optional<String>> updateCheckFuture =
         MojoCommon.newUpdateChecker(projectProperties, getLog());
     try {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/BuildTarMojo.java
@@ -31,6 +31,7 @@ import com.google.cloud.tools.jib.plugins.common.InvalidWorkingDirectoryExceptio
 import com.google.cloud.tools.jib.plugins.common.MainClassInferenceException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.Future;
@@ -66,7 +67,11 @@ public class BuildTarMojo extends JibPluginConfiguration {
     TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider();
     MavenProjectProperties projectProperties =
         MavenProjectProperties.getForProject(
-            descriptor, getProject(), getSession(), getLog(), tempDirectoryProvider);
+            Preconditions.checkNotNull(descriptor),
+            getProject(),
+            getSession(),
+            getLog(),
+            tempDirectoryProvider);
     Future<Optional<String>> updateCheckFuture =
         MojoCommon.newUpdateChecker(projectProperties, getLog());
     try {

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -57,6 +57,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.shared.utils.Os;
@@ -82,6 +83,7 @@ public class MavenProjectProperties implements ProjectProperties {
   /**
    * Static factory method for {@link MavenProjectProperties}.
    *
+   * @param jibPluginDescriptor the jib-maven-plugin plugin descriptor
    * @param project the {@link MavenProject} for the plugin.
    * @param session the {@link MavenSession} for the plugin.
    * @param log the Maven {@link Log} to log messages during Jib execution
@@ -89,11 +91,14 @@ public class MavenProjectProperties implements ProjectProperties {
    * @return a MavenProjectProperties from the given project and logger.
    */
   public static MavenProjectProperties getForProject(
+      @Nullable PluginDescriptor jibPluginDescriptor,
       MavenProject project,
       MavenSession session,
       Log log,
       TempDirectoryProvider tempDirectoryProvider) {
-    return new MavenProjectProperties(project, session, log, tempDirectoryProvider);
+    Preconditions.checkNotNull(jibPluginDescriptor);
+    return new MavenProjectProperties(
+        jibPluginDescriptor, project, session, log, tempDirectoryProvider);
   }
 
   /**
@@ -181,6 +186,7 @@ public class MavenProjectProperties implements ProjectProperties {
     return Optional.ofNullable(node.getValue());
   }
 
+  private final PluginDescriptor jibPluginDescriptor;
   private final MavenProject project;
   private final MavenSession session;
   private final SingleThreadedExecutor singleThreadedExecutor = new SingleThreadedExecutor();
@@ -189,10 +195,12 @@ public class MavenProjectProperties implements ProjectProperties {
 
   @VisibleForTesting
   MavenProjectProperties(
+      PluginDescriptor jibPluginDescriptor,
       MavenProject project,
       MavenSession session,
       Log log,
       TempDirectoryProvider tempDirectoryProvider) {
+    this.jibPluginDescriptor = jibPluginDescriptor;
     this.project = project;
     this.session = session;
     this.tempDirectoryProvider = tempDirectoryProvider;
@@ -334,6 +342,11 @@ public class MavenProjectProperties implements ProjectProperties {
   @Override
   public String getToolName() {
     return TOOL_NAME;
+  }
+
+  @Override
+  public String getToolVersion() {
+    return jibPluginDescriptor.getVersion();
   }
 
   @Override

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -91,7 +91,7 @@ public class MavenProjectProperties implements ProjectProperties {
    * @return a MavenProjectProperties from the given project and logger.
    */
   public static MavenProjectProperties getForProject(
-      @Nullable PluginDescriptor jibPluginDescriptor,
+      PluginDescriptor jibPluginDescriptor,
       MavenProject project,
       MavenSession session,
       Log log,

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
@@ -59,7 +59,11 @@ public class MojoCommon {
     ExecutorService executorService = Executors.newSingleThreadExecutor();
     try {
       return UpdateChecker.checkForUpdate(
-          executorService, projectProperties::log, VERSION_URL, projectProperties.getToolName());
+          executorService,
+          projectProperties::log,
+          VERSION_URL,
+          projectProperties.getToolName(),
+          projectProperties.getToolVersion());
     } finally {
       executorService.shutdown();
     }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojo.java
@@ -76,7 +76,7 @@ public class SyncMapMojo extends JibPluginConfiguration {
     try (TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider()) {
       MavenProjectProperties projectProperties =
           MavenProjectProperties.getForProject(
-              getProject(), getSession(), getLog(), tempDirectoryProvider);
+              descriptor, getProject(), getSession(), getLog(), tempDirectoryProvider);
 
       MavenRawConfiguration configuration = new MavenRawConfiguration(this);
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojo.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojo.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.jib.plugins.common.ContainerizingMode;
 import com.google.cloud.tools.jib.plugins.common.InvalidContainerizingModeException;
 import com.google.cloud.tools.jib.plugins.common.PluginConfigurationProcessor;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
@@ -76,7 +77,11 @@ public class SyncMapMojo extends JibPluginConfiguration {
     try (TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider()) {
       MavenProjectProperties projectProperties =
           MavenProjectProperties.getForProject(
-              descriptor, getProject(), getSession(), getLog(), tempDirectoryProvider);
+              Preconditions.checkNotNull(descriptor),
+              getProject(),
+              getSession(),
+              getLog(),
+              tempDirectoryProvider);
 
       MavenRawConfiguration configuration = new MavenRawConfiguration(this);
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -60,6 +60,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.model.Build;
 import org.apache.maven.model.Plugin;
 import org.apache.maven.model.PluginExecution;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.archiver.zip.ZipEntry;
@@ -229,6 +230,7 @@ public class MavenProjectPropertiesTest {
   private final Xpp3Dom pluginConfiguration = new Xpp3Dom("configuration");
 
   @Mock private Build mockBuild;
+  @Mock private PluginDescriptor mockJibPluginDescriptor;
   @Mock private MavenProject mockMavenProject;
   @Mock private MavenSession mockMavenSession;
   @Mock private MavenExecutionRequest mockMavenRequest;
@@ -249,7 +251,11 @@ public class MavenProjectPropertiesTest {
     Mockito.when(mockMavenSession.getRequest()).thenReturn(mockMavenRequest);
     mavenProjectProperties =
         new MavenProjectProperties(
-            mockMavenProject, mockMavenSession, mockLog, mockTempDirectoryProvider);
+            mockJibPluginDescriptor,
+            mockMavenProject,
+            mockMavenSession,
+            mockLog,
+            mockTempDirectoryProvider);
 
     Path outputPath = getResource("maven/application/output");
     Path dependenciesPath = getResource("maven/application/dependencies");
@@ -669,7 +675,11 @@ public class MavenProjectPropertiesTest {
 
     Map<LayerType, List<Path>> classifyDependencies =
         new MavenProjectProperties(
-                mockMavenProject, mockMavenSession, mockLog, mockTempDirectoryProvider)
+                mockJibPluginDescriptor,
+                mockMavenProject,
+                mockMavenSession,
+                mockLog,
+                mockTempDirectoryProvider)
             .classifyDependencies(artifacts, projectArtifacts);
 
     Assert.assertEquals(
@@ -1006,7 +1016,11 @@ public class MavenProjectPropertiesTest {
             .setModificationTimeProvider((ignored1, ignored2) -> SAMPLE_FILE_MODIFICATION_TIME);
     JibContainerBuilder jibContainerBuilder =
         new MavenProjectProperties(
-                mockMavenProject, mockMavenSession, mockLog, mockTempDirectoryProvider)
+                mockJibPluginDescriptor,
+                mockMavenProject,
+                mockMavenSession,
+                mockLog,
+                mockTempDirectoryProvider)
             .createJibContainerBuilder(javaContainerBuilder, containerizingMode);
     return JibContainerBuilderTestHelper.toBuildContext(
         jibContainerBuilder, Containerizer.to(RegistryImage.named("to")));

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -816,6 +816,7 @@ public class PluginConfigurationProcessor {
     containerizer
         .setOfflineMode(projectProperties.isOffline())
         .setToolName(projectProperties.getToolName())
+        .setToolVersion(projectProperties.getToolVersion())
         .setAllowInsecureRegistries(rawConfiguration.getAllowInsecureRegistries())
         .setBaseImageLayersCache(
             getCheckedCacheDirectory(

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
@@ -46,6 +46,8 @@ public interface ProjectProperties {
 
   String getToolName();
 
+  String getToolVersion();
+
   String getPluginName();
 
   /**

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.jib.plugins.common;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.filesystem.XdgDirectories;
 import com.google.cloud.tools.jib.http.FailoverHttpClient;
@@ -27,7 +26,6 @@ import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
-import com.google.common.base.Verify;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
@@ -75,18 +73,17 @@ public class UpdateChecker {
    * @param log {@link Consumer} used to log messages
    * @param versionUrl the location to check for the latest version
    * @param toolName the tool name
+   * @param toolVersion the tool version
    * @return a new {@link UpdateChecker}
    */
   public static Future<Optional<String>> checkForUpdate(
-      ExecutorService executorService, Consumer<LogEvent> log, String versionUrl, String toolName) {
+      ExecutorService executorService,
+      Consumer<LogEvent> log,
+      String versionUrl,
+      String toolName,
+      String toolVersion) {
     return executorService.submit(
-        () ->
-            performUpdateCheck(
-                log,
-                Verify.verifyNotNull(ProjectInfo.VERSION),
-                versionUrl,
-                getConfigDir(),
-                toolName));
+        () -> performUpdateCheck(log, toolVersion, versionUrl, getConfigDir(), toolName));
   }
 
   @VisibleForTesting

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -111,8 +111,8 @@ public class PluginConfigurationProcessorTest {
     Mockito.when(rawConfiguration.getExtraDirectories())
         .thenReturn(Arrays.asList(Paths.get("nonexistent/path")));
     Mockito.when(rawConfiguration.getContainerizingMode()).thenReturn("exploded");
-
     Mockito.when(projectProperties.getToolName()).thenReturn("tool");
+    Mockito.when(projectProperties.getToolVersion()).thenReturn("tool-version");
     Mockito.when(projectProperties.getMainClassFromJar()).thenReturn("java.lang.Object");
     Mockito.when(projectProperties.getDefaultCacheDirectory()).thenReturn(Paths.get("cache"));
     Mockito.when(
@@ -124,6 +124,7 @@ public class PluginConfigurationProcessorTest {
     Mockito.when(inferredAuthProvider.inferAuth(Mockito.any())).thenReturn(Optional.empty());
 
     Mockito.when(containerizer.setToolName(Mockito.anyString())).thenReturn(containerizer);
+    Mockito.when(containerizer.setToolVersion(Mockito.anyString())).thenReturn(containerizer);
     Mockito.when(containerizer.setAllowInsecureRegistries(Mockito.anyBoolean()))
         .thenReturn(containerizer);
     Mockito.when(containerizer.setBaseImageLayersCache(Mockito.any(Path.class)))


### PR DESCRIPTION
fixes #1716

I think I also need this for #2350 (`XYZ.class.getPackage()` can return weird results if two jars use the same packaging [like `com.google.cloud.tools.jib`]) -- this is the source of the integration test error in that pr.