### PR TITLE
Build plan adapter methods for JibContainerBuilder

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.api;
 
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.api.buildplan.ContainerBuildPlan;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.FileEntry;
 import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
@@ -69,10 +70,17 @@ public class JibContainerBuilder {
     return Character.toUpperCase(string.charAt(0)) + string.substring(1);
   }
 
+  private final ContainerBuildPlan.Builder containerBuildPlanBuilder =
+      ContainerBuildPlan.builder().setArchitectureHint("amd64").setOsHint("linux");
+  // TODO(chanseok): remove and use containerBuildPlanBuilder instead. Note that
+  // ContainerConfiguation implements equals() and hashCode(), so need to verify
+  // if they are required.
   private final ContainerConfiguration.Builder containerConfigurationBuilder =
       ContainerConfiguration.builder();
   private final BuildContext.Builder buildContextBuilder;
 
+  private ImageConfiguration baseImageConfiguration;
+  // TODO(chanseok): remove and use containerBuildPlanBuilder instead.
   private List<FileEntriesLayer> layerConfigurations = new ArrayList<>();
 
   /** Instantiate with {@link Jib#from}. */
@@ -108,6 +116,8 @@ public class JibContainerBuilder {
   JibContainerBuilder(
       ImageConfiguration imageConfiguration, BuildContext.Builder buildContextBuilder) {
     this.buildContextBuilder = buildContextBuilder.setBaseImageConfiguration(imageConfiguration);
+    baseImageConfiguration = imageConfiguration;
+    containerBuildPlanBuilder.setBaseImage(imageConfiguration.getImage().toString());
   }
 
   /**
@@ -170,7 +180,7 @@ public class JibContainerBuilder {
   /**
    * Adds a layer (defined by a {@link LayerConfiguration}).
    *
-   * @deprecated Use {@link #addFileEntriesLayer(FileEntriesLayer)}.
+   * @deprecated use {@link #addFileEntriesLayer(FileEntriesLayer)}.
    * @param layerConfiguration the {@link LayerConfiguration}
    * @return this
    */
@@ -186,6 +196,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder addFileEntriesLayer(FileEntriesLayer layer) {
+    containerBuildPlanBuilder.addLayer(layer);
     layerConfigurations.add(layer);
     return this;
   }
@@ -194,7 +205,7 @@ public class JibContainerBuilder {
    * Sets the layers (defined by a list of {@link LayerConfiguration}s). This replaces any
    * previously-added layers.
    *
-   * @deprecated Use {@link #setFileEntriesLayers(List)}.
+   * @deprecated use {@link #setFileEntriesLayers(List)}.
    * @param layerConfigurations the list of {@link LayerConfiguration}s
    * @return this
    */
@@ -215,6 +226,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setFileEntriesLayers(List<FileEntriesLayer> layers) {
+    containerBuildPlanBuilder.setLayers(layers);
     layerConfigurations = new ArrayList<>(layers);
     return this;
   }
@@ -222,7 +234,7 @@ public class JibContainerBuilder {
   /**
    * Sets the layers. This replaces any previously-added layers.
    *
-   * @deprecated Use {@link #setFileEntriesLayers(FileEntriesLayer...)}.
+   * @deprecated use {@link #setFileEntriesLayers(FileEntriesLayer...)}.
    * @param layerConfigurations the {@link LayerConfiguration}s
    * @return this
    */
@@ -255,6 +267,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setEntrypoint(@Nullable List<String> entrypoint) {
+    containerBuildPlanBuilder.setEntrypoint(entrypoint);
     containerConfigurationBuilder.setEntrypoint(entrypoint);
     return this;
   }
@@ -287,6 +300,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setProgramArguments(@Nullable List<String> programArguments) {
+    containerBuildPlanBuilder.setCmd(programArguments);
     containerConfigurationBuilder.setProgramArguments(programArguments);
     return this;
   }
@@ -316,6 +330,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setEnvironment(Map<String, String> environmentMap) {
+    containerBuildPlanBuilder.setEnvironment(environmentMap);
     containerConfigurationBuilder.setEnvironment(environmentMap);
     return this;
   }
@@ -329,6 +344,7 @@ public class JibContainerBuilder {
    * @see #setEnvironment
    */
   public JibContainerBuilder addEnvironmentVariable(String name, String value) {
+    containerBuildPlanBuilder.addEnvironmentVariable(name, value);
     containerConfigurationBuilder.addEnvironment(name, value);
     return this;
   }
@@ -343,6 +359,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setVolumes(Set<AbsoluteUnixPath> volumes) {
+    containerBuildPlanBuilder.setVolumes(volumes);
     containerConfigurationBuilder.setVolumes(volumes);
     return this;
   }
@@ -366,6 +383,7 @@ public class JibContainerBuilder {
    * @see #setVolumes(Set)
    */
   public JibContainerBuilder addVolume(AbsoluteUnixPath volume) {
+    containerBuildPlanBuilder.addVolume(volume);
     containerConfigurationBuilder.addVolume(volume);
     return this;
   }
@@ -386,6 +404,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setExposedPorts(Set<Port> ports) {
+    containerBuildPlanBuilder.setExposedPorts(ports);
     containerConfigurationBuilder.setExposedPorts(ports);
     return this;
   }
@@ -409,6 +428,7 @@ public class JibContainerBuilder {
    * @see #setExposedPorts(Set)
    */
   public JibContainerBuilder addExposedPort(Port port) {
+    containerBuildPlanBuilder.addExposedPort(port);
     containerConfigurationBuilder.addExposedPort(port);
     return this;
   }
@@ -423,6 +443,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setLabels(Map<String, String> labelMap) {
+    containerBuildPlanBuilder.setLabels(labelMap);
     containerConfigurationBuilder.setLabels(labelMap);
     return this;
   }
@@ -435,6 +456,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder addLabel(String key, String value) {
+    containerBuildPlanBuilder.addLabel(key, value);
     containerConfigurationBuilder.addLabel(key, value);
     return this;
   }
@@ -447,6 +469,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setFormat(ImageFormat imageFormat) {
+    containerBuildPlanBuilder.setFormat(imageFormat);
     buildContextBuilder.setTargetFormat(imageFormat);
     return this;
   }
@@ -458,6 +481,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setCreationTime(Instant creationTime) {
+    containerBuildPlanBuilder.setCreationTime(creationTime);
     containerConfigurationBuilder.setCreationTime(creationTime);
     return this;
   }
@@ -483,6 +507,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setUser(@Nullable String user) {
+    containerBuildPlanBuilder.setUser(user);
     containerConfigurationBuilder.setUser(user);
     return this;
   }
@@ -494,6 +519,7 @@ public class JibContainerBuilder {
    * @return this
    */
   public JibContainerBuilder setWorkingDirectory(@Nullable AbsoluteUnixPath workingDirectory) {
+    containerBuildPlanBuilder.setWorkingDirectory(workingDirectory);
     containerConfigurationBuilder.setWorkingDirectory(workingDirectory);
     return this;
   }
@@ -542,10 +568,85 @@ public class JibContainerBuilder {
    * Describes the container contents and configuration without actually physically building a
    * container.
    *
+   * @deprecated use {@link #toContainerBuildPlan}.
    * @return a description of the container being built
    */
+  @Deprecated
   public JibContainerDescription describeContainer() {
     return new JibContainerDescription(layerConfigurations);
+  }
+
+  /**
+   * Internal method. API end users should not use it.
+   *
+   * <p>Converts to {@link ContainerBuildPlan}. Note that not all values that this class holds can
+   * be described by a build plan, such as {@link CredentialRetriever}s for {@link RegistryImage},
+   * {@link DockerClient} for {@link DockerDaemonImage}, and output path for {@link TarImage}.
+   *
+   * @return {@link ContainerBuildPlan}
+   */
+  public ContainerBuildPlan toContainerBuildPlan() {
+    return containerBuildPlanBuilder.build();
+  }
+
+  /**
+   * Internal method. API end users should not use it.
+   *
+   * <p>Reconfigures {@link JibContainerBuilder} from the given {@code buildPlan}. Every value
+   * configurable using "setters" in this class is overwritten by the value in {@code buildPlan};
+   * only retained are some base image properties inherent in {@link JibContainerBuilder} but absent
+   * in {@link ContainerBuildPlan}, such as {@link CredentialRetriever}s for {@link RegistryImage},
+   * {@link DockerClient} for {@link DockerDaemonImage}, and output path for {@link TarImage}.
+   *
+   * @param buildPlan build plan to apply
+   * @return {@link JibContainerBuilder} reconfigured from {@code buildPlan}
+   * @throws InvalidImageReferenceException if the base image value in {@code buildPlan} is an
+   *     invalid reference
+   */
+  @SuppressWarnings("unchecked")
+  public JibContainerBuilder applyContainerBuildPlan(ContainerBuildPlan buildPlan)
+      throws InvalidImageReferenceException {
+    containerBuildPlanBuilder
+        .setBaseImage(buildPlan.getBaseImage())
+        .setArchitectureHint(buildPlan.getArchitectureHint())
+        .setOsHint(buildPlan.getOsHint())
+        .setCreationTime(buildPlan.getCreationTime())
+        .setFormat(buildPlan.getFormat())
+        .setEnvironment(buildPlan.getEnvironment())
+        .setLabels(buildPlan.getLabels())
+        .setVolumes(buildPlan.getVolumes())
+        .setExposedPorts(buildPlan.getExposedPorts())
+        .setUser(buildPlan.getUser())
+        .setWorkingDirectory(buildPlan.getWorkingDirectory())
+        .setEntrypoint(buildPlan.getEntrypoint())
+        .setCmd(buildPlan.getCmd())
+        .setLayers(buildPlan.getLayers());
+
+    containerConfigurationBuilder
+        .setCreationTime(buildPlan.getCreationTime())
+        .setEnvironment(buildPlan.getEnvironment())
+        .setLabels(buildPlan.getLabels())
+        .setVolumes(buildPlan.getVolumes())
+        .setExposedPorts(buildPlan.getExposedPorts())
+        .setUser(buildPlan.getUser())
+        .setWorkingDirectory(buildPlan.getWorkingDirectory())
+        .setEntrypoint(buildPlan.getEntrypoint())
+        .setProgramArguments(buildPlan.getCmd());
+
+    ImageConfiguration.Builder builder =
+        ImageConfiguration.builder(ImageReference.parse(buildPlan.getBaseImage()))
+            .setCredentialRetrievers(baseImageConfiguration.getCredentialRetrievers());
+    baseImageConfiguration.getDockerClient().ifPresent(builder::setDockerClient);
+    baseImageConfiguration.getTarPath().ifPresent(builder::setTarPath);
+    baseImageConfiguration = builder.build();
+
+    // For now, only FileEntriesLayer is supported in jib-core.
+    layerConfigurations = (List<FileEntriesLayer>) buildPlan.getLayers();
+
+    buildContextBuilder
+        .setBaseImageConfiguration(baseImageConfiguration)
+        .setLayerConfigurations(layerConfigurations);
+    return this;
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -644,6 +644,7 @@ public class JibContainerBuilder {
     layerConfigurations = (List<FileEntriesLayer>) buildPlan.getLayers();
 
     buildContextBuilder
+        .setTargetFormat(buildPlan.getFormat())
         .setBaseImageConfiguration(baseImageConfiguration)
         .setLayerConfigurations(layerConfigurations);
     return this;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
@@ -322,7 +322,7 @@ public class JibContainerBuilderTest {
         containerBuilder.toBuildContext(Containerizer.to(RegistryImage.named("target/image")));
     Assert.assertEquals(
         "some/base", buildContext.getBaseImageConfiguration().getImage().toString());
-    Assert.assertEquals(V22ManifestTemplate.class, buildContext.getTargetFormat());
+    Assert.assertEquals(OciManifestTemplate.class, buildContext.getTargetFormat());
     Assert.assertEquals(1, buildContext.getLayerConfigurations().size());
     Assert.assertEquals(1, buildContext.getLayerConfigurations().get(0).getEntries().size());
     Assert.assertEquals(


### PR DESCRIPTION
Adds internal methods for conversion between `JibContainerBuilder` <--> `ContainerBuildPlan`. I can't think of other ways to enable this conversion while not adding public methods to `JibContainerBuilder`.

As we currently build a `JibContainerBuilder` instance (which is the front-end public API) in our plugins code, the idea for the extension framework is basically like this:

1. Construct `JibContainerBuilder` (current behavior).
1. Convert `JibContainerBuilder` to `ContainerBuildPlan` and pass it to extensions.
1. Extensions modify the `ContainerBuildPlan`.
1. Convert `ContainerBuildPlan` back to `JibContainerBuilder`.
1. Plugins code proceeds with `JibContainerBuilder` to build an image (current behavior)

Another approach would be to revamp everything around `BuildContext` and `ContainerConfiguration` in jib-core. However, I think the amount of refactoring work to do so is prohibitively enormous, and this is not practical.