### PR TITLE
Do not disable Google HTTP Client logging for custom logger in Gradle

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -546,14 +546,16 @@ com.google.api.client.http.level=CONFIG
 
 And then launch your build tool as follows:
 ```sh
-mvn -Djava.util.logging.config.file=path/to/log.properties -Djib.serialize=true -Djib.console=plain ...
+mvn --batch-mode -Djava.util.logging.config.file=path/to/log.properties -Djib.serialize=true -Djib.console=plain ...
 ```
 or
 ```sh
-gradle -Djava.util.logging.config.file=path/to/log.properties -Djib.serialize=true -Djib.console=plain ...
+gradle --no-daemon --console=plain -Djava.util.logging.config.file=path/to/log.properties -Djib.serialize=true -Djib.console=plain ...
 ```
 
-You may wish to enable the debug logs too (`-X` for Maven, or `--debug` for Gradle).
+**Note**: Jib Gradle plugins prior to version 2.2.0 has an issue generating HTTP logs ([#2356](https://github.com/GoogleContainerTools/jib/issues/2356)).
+
+You may wish to enable the debug logs too (`-X` for Maven, or `--debug --stacktrace` for Gradle).
 
 ### How do I view debug logs for Jib?
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -108,8 +108,8 @@ class TaskCommon {
           }
         });
 
-    // Disable only when not using custom logger.
-    // https://github.com/GoogleContainerTools/jib/issues/2356
+    // Disable Google HTTP Client network logging only when 'java.util.logging.config.file' system
+    // property is undefined: https://github.com/GoogleContainerTools/jib/issues/2356
     if (System.getProperty("java.util.logging.config.file") == null) {
       // Disables Google HTTP client logging.
       java.util.logging.Logger.getLogger(HttpTransport.class.getName()).setLevel(Level.OFF);

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -108,8 +108,12 @@ class TaskCommon {
           }
         });
 
-    // Disables Google HTTP client logging.
-    java.util.logging.Logger.getLogger(HttpTransport.class.getName()).setLevel(Level.OFF);
+    // Disable only when not using custom logger.
+    // https://github.com/GoogleContainerTools/jib/issues/2356
+    if (System.getProperty("java.util.logging.config.file") == null) {
+      // Disables Google HTTP client logging.
+      java.util.logging.Logger.getLogger(HttpTransport.class.getName()).setLevel(Level.OFF);
+    }
   }
 
   /**


### PR DESCRIPTION
Fixes #2356.

One of the ways to have a custom logger is through the system property `java.util.logging.config.file`. If it's defined, don't disable Google HTTP Client logging.