### PR TITLE
Sync Maven API versions in project build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,8 @@ subprojects {
     ASM: '7.3.1',
     PICOCLI: '4.2.0',
 
+    MAVEN_API: '3.5.2',
+
     //test
     JUNIT: '4.12',
     MOCKITO_CORE: '3.2.4',

--- a/jib-maven-plugin/build.gradle
+++ b/jib-maven-plugin/build.gradle
@@ -12,8 +12,8 @@ dependencies {
   sourceProject project(':jib-core')
   sourceProject project(':jib-plugins-common')
 
-  implementation 'org.apache.maven:maven-plugin-api:3.5.2'
-  implementation 'org.apache.maven:maven-core:3.5.2'
+  implementation "org.apache.maven:maven-plugin-api:${dependencyVersions.MAVEN_API}"
+  implementation "org.apache.maven:maven-core:${dependencyVersions.MAVEN_API}"
 
   // compileOnly + testImplementation equivalent to "provided"
   compileOnly 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.5'
@@ -31,7 +31,7 @@ dependencies {
   testImplementation "com.github.stefanbirkner:system-rules:${dependencyVersions.SYSTEM_RULES}"
 
   testImplementation 'org.apache.maven.shared:maven-verifier:1.6'
-  testImplementation 'org.apache.maven:maven-compat:3.5.4'
+  testImplementation "org.apache.maven:maven-compat:${dependencyVersions.MAVEN_API}"
   testImplementation 'org.slf4j:slf4j-api:1.7.30'
   testImplementation 'org.slf4j:slf4j-simple:1.7.30'
 


### PR DESCRIPTION
Comparing [maven-core](https://search.maven.org/artifact/org.apache.maven/maven-core) and [maven-compat](https://search.maven.org/artifact/org.apache.maven/maven-compat) releases, I think they should match.

