### PR TITLE
Return copies instead of exposing internal collections / and more

### DIFF
--- a/jib-build-plan/build.gradle
+++ b/jib-build-plan/build.gradle
@@ -25,7 +25,7 @@ jar {
     attributes 'Bundle-Vendor': 'Google LLC'
     attributes 'Bundle-DocURL': 'https://github.com/GoogleContainerTools/jib'
     attributes 'Bundle-License': 'https://www.apache.org/licenses/LICENSE-2.0'
-    attributes 'Export-Package': 'com.google.cloud.tools.jib.plugins.api.buildplan'
+    attributes 'Export-Package': 'com.google.cloud.tools.jib.api.buildplan'
   }
 }
 

--- a/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlan.java
+++ b/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlan.java
@@ -439,7 +439,7 @@ public class ContainerBuildPlan {
   }
 
   public Map<String, String> getLabels() {
-    return labels;
+    return new HashMap<>(labels);
   }
 
   public Set<Port> getExposedPorts() {
@@ -458,16 +458,16 @@ public class ContainerBuildPlan {
 
   @Nullable
   public List<String> getEntrypoint() {
-    return entrypoint;
+    return entrypoint == null ? null : new ArrayList<>(entrypoint);
   }
 
   @Nullable
   public List<String> getCmd() {
-    return cmd;
+    return cmd == null ? null : new ArrayList<>(cmd);
   }
 
   public List<? extends LayerObject> getLayers() {
-    return layers;
+    return new ArrayList<>(layers);
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -604,7 +604,6 @@ public class JibContainerBuilder {
    * @throws InvalidImageReferenceException if the base image value in {@code buildPlan} is an
    *     invalid reference
    */
-  @SuppressWarnings("unchecked")
   public JibContainerBuilder applyContainerBuildPlan(ContainerBuildPlan buildPlan)
       throws InvalidImageReferenceException {
     containerBuildPlanBuilder

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -642,9 +642,12 @@ public class JibContainerBuilder {
     baseImageConfiguration.getTarPath().ifPresent(builder::setTarPath);
     baseImageConfiguration = builder.build();
 
+    // For now, only FileEntriesLayer is supported in jib-core.
     Function<LayerObject, FileEntriesLayer> castToFileEntriesLayer =
         layer -> {
-          Verify.verify(layer instanceof FileEntriesLayer);
+          Verify.verify(
+              layer instanceof FileEntriesLayer,
+              "layer types other than FileEntriesLayer not yet supported in build plan layers");
           return (FileEntriesLayer) layer;
         };
     layerConfigurations =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -30,6 +30,7 @@ import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.docker.DockerClient;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Verify;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.nio.file.Path;
@@ -641,7 +642,9 @@ public class JibContainerBuilder {
     baseImageConfiguration = builder.build();
 
     // For now, only FileEntriesLayer is supported in jib-core.
-    layerConfigurations = (List<FileEntriesLayer>) buildPlan.getLayers();
+    List<?> layers = buildPlan.getLayers();
+    layers.forEach(layer -> Verify.verify(layer instanceof FileEntriesLayer));
+    layerConfigurations = (List<FileEntriesLayer>) layers;
 
     buildContextBuilder
         .setTargetFormat(buildPlan.getFormat())

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -304,7 +304,9 @@ public class PluginConfigurationProcessor {
     // ignore directories and provide only files to watch
     Set<Path> excludesExpanded = getAllFiles(excludes);
     for (LayerObject layerObject : jibContainerBuilder.toContainerBuildPlan().getLayers()) {
-      Verify.verify(layerObject instanceof FileEntriesLayer);
+      Verify.verify(
+          layerObject instanceof FileEntriesLayer,
+          "layer types other than FileEntriesLayer not yet supported in build plan layers");
       FileEntriesLayer layer = (FileEntriesLayer) layerObject;
       if (CONST_LAYERS.contains(layer.getName())) {
         continue;

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -31,6 +31,7 @@ import com.google.cloud.tools.jib.api.RegistryImage;
 import com.google.cloud.tools.jib.api.TarImage;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
+import com.google.cloud.tools.jib.api.buildplan.LayerObject;
 import com.google.cloud.tools.jib.frontend.CredentialRetrieverFactory;
 import com.google.cloud.tools.jib.global.JibSystemProperties;
 import com.google.common.annotations.VisibleForTesting;
@@ -302,7 +303,9 @@ public class PluginConfigurationProcessor {
     // since jib has already expanded out directories after processing everything, we just
     // ignore directories and provide only files to watch
     Set<Path> excludesExpanded = getAllFiles(excludes);
-    for (FileEntriesLayer layer : jibContainerBuilder.describeContainer().getFileEntriesLayers()) {
+    for (LayerObject layerObject : jibContainerBuilder.toContainerBuildPlan().getLayers()) {
+      Verify.verify(layerObject instanceof FileEntriesLayer);
+      FileEntriesLayer layer = (FileEntriesLayer) layerObject;
       if (CONST_LAYERS.contains(layer.getName())) {
         continue;
       }


### PR DESCRIPTION
- Returns copies of collections to achieve absolute immutable. I missed some fields by mistake.
- Fixes wrong OSGi package export in `jib-build-plan`.

Misc:
- Removes the deprecated `describeContainer`.
- Ensure type before casting; we can remove `@SuppressWarnings`.