### PR TITLE
fix more error prone issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,10 +88,10 @@ subprojects {
   compileJava.dependsOn ensureTransitiveDependencyOverrides
   /* PROJECT DEPENDENCY VERSIONS */
 
-  /* NULLAWAY */
+  /* ERROR PRONE */
   dependencies {
     // NullAway errorprone plugin
-    annotationProcessor 'com.uber.nullaway:nullaway:0.6.4'
+    annotationProcessor 'com.uber.nullaway:nullaway:0.7.9'
     errorprone 'com.google.errorprone:error_prone_core:2.3.4'
     // Using github.com/google/error-prone-javac is required when running on
     // JDK 8. Remove when migrating to JDK 11.
@@ -110,7 +110,7 @@ subprojects {
       }
     }
   }
-  /* NULLAWAY */
+  /* ERROR PRONE */
 
   /* GOOGLE JAVA FORMAT */
   googleJavaFormat {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/MainClassFinder.java
@@ -42,7 +42,7 @@ public class MainClassFinder {
   public static class Result {
 
     /** The type of result. */
-    public enum Type {
+    public enum Category {
 
       // Found a single main class.
       MAIN_CLASS_FOUND,
@@ -55,32 +55,33 @@ public class MainClassFinder {
     }
 
     private static Result success(String foundMainClass) {
-      return new Result(Type.MAIN_CLASS_FOUND, Collections.singletonList(foundMainClass));
+      return new Result(Category.MAIN_CLASS_FOUND, Collections.singletonList(foundMainClass));
     }
 
     private static Result mainClassNotFound() {
-      return new Result(Type.MAIN_CLASS_NOT_FOUND, Collections.emptyList());
+      return new Result(Category.MAIN_CLASS_NOT_FOUND, Collections.emptyList());
     }
 
     private static Result multipleMainClasses(List<String> foundMainClasses) {
-      return new Result(Type.MULTIPLE_MAIN_CLASSES, foundMainClasses);
+      return new Result(Category.MULTIPLE_MAIN_CLASSES, foundMainClasses);
     }
 
-    private final Type type;
+    private final Category category;
     private final List<String> foundMainClasses;
 
-    private Result(Type type, List<String> foundMainClasses) {
+    private Result(Category category, List<String> foundMainClasses) {
       this.foundMainClasses = foundMainClasses;
-      this.type = type;
+      this.category = category;
     }
 
     /**
-     * Gets the found main class. Only call if {@link #getType} is {@link Type#MAIN_CLASS_FOUND}.
+     * Gets the found main class. Only call if {@link #getCategory} is {@link
+     * Category#MAIN_CLASS_FOUND}.
      *
      * @return the found main class
      */
     public String getFoundMainClass() {
-      Preconditions.checkState(Type.MAIN_CLASS_FOUND == type);
+      Preconditions.checkState(Category.MAIN_CLASS_FOUND == category);
       Preconditions.checkState(foundMainClasses.size() == 1);
       return foundMainClasses.get(0);
     }
@@ -90,8 +91,8 @@ public class MainClassFinder {
      *
      * @return the type of the result
      */
-    public Type getType() {
-      return type;
+    public Category getCategory() {
+      return category;
     }
 
     /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/MainClassFinder.java
@@ -30,7 +30,6 @@ import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 
 /**
  * Finds main classes in a list of class files. Main classes are classes that define the {@code
@@ -42,7 +41,7 @@ public class MainClassFinder {
   public static class Result {
 
     /** The type of result. */
-    public enum Category {
+    public enum Type {
 
       // Found a single main class.
       MAIN_CLASS_FOUND,
@@ -55,33 +54,32 @@ public class MainClassFinder {
     }
 
     private static Result success(String foundMainClass) {
-      return new Result(Category.MAIN_CLASS_FOUND, Collections.singletonList(foundMainClass));
+      return new Result(Type.MAIN_CLASS_FOUND, Collections.singletonList(foundMainClass));
     }
 
     private static Result mainClassNotFound() {
-      return new Result(Category.MAIN_CLASS_NOT_FOUND, Collections.emptyList());
+      return new Result(Type.MAIN_CLASS_NOT_FOUND, Collections.emptyList());
     }
 
     private static Result multipleMainClasses(List<String> foundMainClasses) {
-      return new Result(Category.MULTIPLE_MAIN_CLASSES, foundMainClasses);
+      return new Result(Type.MULTIPLE_MAIN_CLASSES, foundMainClasses);
     }
 
-    private final Category category;
+    private final Type type;
     private final List<String> foundMainClasses;
 
-    private Result(Category category, List<String> foundMainClasses) {
+    private Result(Type type, List<String> foundMainClasses) {
       this.foundMainClasses = foundMainClasses;
-      this.category = category;
+      this.type = type;
     }
 
     /**
-     * Gets the found main class. Only call if {@link #getCategory} is {@link
-     * Category#MAIN_CLASS_FOUND}.
+     * Gets the found main class. Only call if {@link #getType} is {@link Type#MAIN_CLASS_FOUND}.
      *
      * @return the found main class
      */
     public String getFoundMainClass() {
-      Preconditions.checkState(Category.MAIN_CLASS_FOUND == category);
+      Preconditions.checkState(Type.MAIN_CLASS_FOUND == type);
       Preconditions.checkState(foundMainClasses.size() == 1);
       return foundMainClasses.get(0);
     }
@@ -91,8 +89,8 @@ public class MainClassFinder {
      *
      * @return the type of the result
      */
-    public Category getCategory() {
-      return category;
+    public Type getType() {
+      return type;
     }
 
     /**
@@ -110,7 +108,8 @@ public class MainClassFinder {
 
     /** The return/argument types for main. */
     private static final String MAIN_DESCRIPTOR =
-        Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(String[].class));
+        org.objectweb.asm.Type.getMethodDescriptor(
+            org.objectweb.asm.Type.VOID_TYPE, org.objectweb.asm.Type.getType(String[].class));
 
     /** Accessors that main may or may not have. */
     private static final int OPTIONAL_ACCESS =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
@@ -43,7 +43,10 @@ public interface BuildableManifestTemplate extends ManifestTemplate {
   @VisibleForTesting
   class ContentDescriptorTemplate implements JsonTemplate {
 
-    @Nullable private String mediaType;
+    @SuppressWarnings("unused")
+    @Nullable
+    private String mediaType;
+
     @Nullable private DescriptorDigest digest;
     private long size;
     @Nullable private List<String> urls;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ContainerConfigurationTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ContainerConfigurationTemplate.java
@@ -158,6 +158,7 @@ public class ContainerConfigurationTemplate implements JsonTemplate {
   private static class RootFilesystemObjectTemplate implements JsonTemplate {
 
     /** The type must always be {@code "layers"}. */
+    @SuppressWarnings("unused")
     private final String type = "layers";
 
     /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/OciIndexTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/OciIndexTemplate.java
@@ -49,7 +49,9 @@ import java.util.List;
  */
 public class OciIndexTemplate implements JsonTemplate {
 
+  @SuppressWarnings("unused")
   private final int schemaVersion = 2;
+
   private final List<BuildableManifestTemplate.ContentDescriptorTemplate> manifests =
       new ArrayList<>();
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/OciManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/OciManifestTemplate.java
@@ -67,6 +67,8 @@ public class OciManifestTemplate implements BuildableManifestTemplate {
   private static final String LAYER_MEDIA_TYPE = "application/vnd.oci.image.layer.v1.tar+gzip";
 
   private final int schemaVersion = 2;
+
+  @SuppressWarnings("unused")
   private final String mediaType = MANIFEST_MEDIA_TYPE;
 
   /** The container configuration reference. */

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/V22ManifestListTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/V22ManifestListTemplate.java
@@ -111,7 +111,10 @@ public class V22ManifestListTemplate implements ManifestTemplate {
 
     @Nullable private String mediaType;
     @Nullable private String digest;
+
+    @SuppressWarnings("unused")
     private long size;
+
     @Nullable private Platform platform;
 
     @Nullable

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/V22ManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/V22ManifestTemplate.java
@@ -69,6 +69,8 @@ public class V22ManifestTemplate implements BuildableManifestTemplate {
       "application/vnd.docker.image.rootfs.diff.tar.gzip";
 
   private final int schemaVersion = 2;
+
+  @SuppressWarnings("unused")
   private final String mediaType = MANIFEST_MEDIA_TYPE;
 
   /** The container configuration reference. */

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/MainClassFinderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/MainClassFinderTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.jib.api;
 
-import com.google.cloud.tools.jib.api.MainClassFinder.Result.Category;
+import com.google.cloud.tools.jib.api.MainClassFinder.Result.Type;
 import com.google.cloud.tools.jib.filesystem.DirectoryWalker;
 import com.google.common.io.Resources;
 import java.io.IOException;
@@ -42,7 +42,7 @@ public class MainClassFinderTest {
     Path rootDirectory = Paths.get(Resources.getResource("core/class-finder-tests/simple").toURI());
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
-    Assert.assertSame(Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
+    Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("HelloWorld"));
   }
@@ -54,7 +54,7 @@ public class MainClassFinderTest {
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
     Assert.assertSame(
-        MainClassFinder.Result.Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
+        MainClassFinder.Result.Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(),
         CoreMatchers.containsString("multi.layered.HelloWorld"));
@@ -66,7 +66,7 @@ public class MainClassFinderTest {
         Paths.get(Resources.getResource("core/class-finder-tests/no-main").toURI());
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
-    Assert.assertEquals(Category.MAIN_CLASS_NOT_FOUND, mainClassFinderResult.getCategory());
+    Assert.assertEquals(Type.MAIN_CLASS_NOT_FOUND, mainClassFinderResult.getType());
   }
 
   @Test
@@ -76,7 +76,7 @@ public class MainClassFinderTest {
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
     Assert.assertEquals(
-        MainClassFinder.Result.Category.MULTIPLE_MAIN_CLASSES, mainClassFinderResult.getCategory());
+        MainClassFinder.Result.Type.MULTIPLE_MAIN_CLASSES, mainClassFinderResult.getType());
     Assert.assertEquals(2, mainClassFinderResult.getFoundMainClasses().size());
     Assert.assertTrue(
         mainClassFinderResult.getFoundMainClasses().contains("multi.layered.HelloMoon"));
@@ -89,7 +89,7 @@ public class MainClassFinderTest {
         Paths.get(Resources.getResource("core/class-finder-tests/extension").toURI());
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
-    Assert.assertSame(Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
+    Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("main.MainClass"));
   }
@@ -101,7 +101,7 @@ public class MainClassFinderTest {
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
     Assert.assertSame(
-        MainClassFinder.Result.Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
+        MainClassFinder.Result.Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("main.MainClass"));
   }
@@ -113,7 +113,7 @@ public class MainClassFinderTest {
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
     Assert.assertSame(
-        MainClassFinder.Result.Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
+        MainClassFinder.Result.Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("main.MainClass"));
   }
@@ -124,7 +124,7 @@ public class MainClassFinderTest {
         Paths.get(Resources.getResource("core/class-finder-tests/inner-classes").toURI());
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
-    Assert.assertSame(Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
+    Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(),
         CoreMatchers.containsString("HelloWorld$InnerClass"));
@@ -137,7 +137,7 @@ public class MainClassFinderTest {
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
     Assert.assertSame(
-        MainClassFinder.Result.Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
+        MainClassFinder.Result.Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("HelloWorld"));
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/MainClassFinderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/MainClassFinderTest.java
@@ -16,7 +16,7 @@
 
 package com.google.cloud.tools.jib.api;
 
-import com.google.cloud.tools.jib.api.MainClassFinder.Result.Type;
+import com.google.cloud.tools.jib.api.MainClassFinder.Result.Category;
 import com.google.cloud.tools.jib.filesystem.DirectoryWalker;
 import com.google.common.io.Resources;
 import java.io.IOException;
@@ -42,7 +42,7 @@ public class MainClassFinderTest {
     Path rootDirectory = Paths.get(Resources.getResource("core/class-finder-tests/simple").toURI());
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
-    Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
+    Assert.assertSame(Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("HelloWorld"));
   }
@@ -53,7 +53,8 @@ public class MainClassFinderTest {
         Paths.get(Resources.getResource("core/class-finder-tests/subdirectories").toURI());
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
-    Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
+    Assert.assertSame(
+        MainClassFinder.Result.Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(),
         CoreMatchers.containsString("multi.layered.HelloWorld"));
@@ -65,7 +66,7 @@ public class MainClassFinderTest {
         Paths.get(Resources.getResource("core/class-finder-tests/no-main").toURI());
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
-    Assert.assertEquals(Type.MAIN_CLASS_NOT_FOUND, mainClassFinderResult.getType());
+    Assert.assertEquals(Category.MAIN_CLASS_NOT_FOUND, mainClassFinderResult.getCategory());
   }
 
   @Test
@@ -75,7 +76,7 @@ public class MainClassFinderTest {
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
     Assert.assertEquals(
-        MainClassFinder.Result.Type.MULTIPLE_MAIN_CLASSES, mainClassFinderResult.getType());
+        MainClassFinder.Result.Category.MULTIPLE_MAIN_CLASSES, mainClassFinderResult.getCategory());
     Assert.assertEquals(2, mainClassFinderResult.getFoundMainClasses().size());
     Assert.assertTrue(
         mainClassFinderResult.getFoundMainClasses().contains("multi.layered.HelloMoon"));
@@ -88,7 +89,7 @@ public class MainClassFinderTest {
         Paths.get(Resources.getResource("core/class-finder-tests/extension").toURI());
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
-    Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
+    Assert.assertSame(Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("main.MainClass"));
   }
@@ -99,7 +100,8 @@ public class MainClassFinderTest {
         Paths.get(Resources.getResource("core/class-finder-tests/imported-methods").toURI());
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
-    Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
+    Assert.assertSame(
+        MainClassFinder.Result.Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("main.MainClass"));
   }
@@ -110,7 +112,8 @@ public class MainClassFinderTest {
         Paths.get(Resources.getResource("core/class-finder-tests/external-classes").toURI());
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
-    Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
+    Assert.assertSame(
+        MainClassFinder.Result.Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("main.MainClass"));
   }
@@ -121,7 +124,7 @@ public class MainClassFinderTest {
         Paths.get(Resources.getResource("core/class-finder-tests/inner-classes").toURI());
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
-    Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
+    Assert.assertSame(Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(),
         CoreMatchers.containsString("HelloWorld$InnerClass"));
@@ -133,7 +136,8 @@ public class MainClassFinderTest {
         Paths.get(Resources.getResource("core/class-finder-tests/varargs").toURI());
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
-    Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
+    Assert.assertSame(
+        MainClassFinder.Result.Category.MAIN_CLASS_FOUND, mainClassFinderResult.getCategory());
     Assert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("HelloWorld"));
   }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/MainClassResolver.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/MainClassResolver.java
@@ -114,7 +114,7 @@ public class MainClassResolver {
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(projectProperties.getClassFiles(), projectProperties::log);
 
-    switch (mainClassFinderResult.getCategory()) {
+    switch (mainClassFinderResult.getType()) {
       case MAIN_CLASS_FOUND:
         return mainClassFinderResult.getFoundMainClass();
 

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/MainClassResolver.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/MainClassResolver.java
@@ -114,7 +114,7 @@ public class MainClassResolver {
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(projectProperties.getClassFiles(), projectProperties::log);
 
-    switch (mainClassFinderResult.getType()) {
+    switch (mainClassFinderResult.getCategory()) {
       case MAIN_CLASS_FOUND:
         return mainClassFinderResult.getFoundMainClass();
 


### PR DESCRIPTION
- mark unused variable in jsontemplates
- rename conflicting type: Type (`org.objectweb.asm.Type` and `MainClassFinder.Result.Type`)
  - although this could also just be fixed using fqn of the types.
