### PR TITLE
Update gradle plugin publishing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,7 +110,7 @@ To use a local build of the `jib-gradle-plugin`:
 
   1. Build and install `jib-gradle-plugin` into your local `~/.m2/repository`
      with `./gradlew jib-gradle-plugin:publish`
-  1. Add to your test project's `settings.gradle` the following:
+  1. Add a `pluginManagement` block to your test project's `settings.gradle` to enable reading plugins from the local maven repository. It must be the first block in the file before any `include` directives.
         ```groovy
         pluginManagement {
           repositories {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,26 +109,23 @@ If developing with Eclipse and M2Eclipse (the Maven tooling for Eclipse), just l
 To use a local build of the `jib-gradle-plugin`:
 
   1. Build and install `jib-gradle-plugin` into your local `~/.m2/repository`
-     with `./gradlew jib-gradle-plugin:install`;
-  1. Modify your test project's `build.gradle` to look like the following:
+     with `./gradlew jib-gradle-plugin:publish`
+  1. Add to your test project's `settings.gradle` the following:
         ```groovy
-        buildscript {
-            repositories {
-                mavenLocal() // resolve in ~/.m2/repository
-                mavenCentral()
-            }
-            dependencies {
-                classpath 'com.google.cloud.tools:jib-gradle-plugin:2.1.1-SNAPSHOT'
-            }
+        pluginManagement {
+          repositories {
+            mavenLocal()
+            gradlePluginPortal()
+          }
         }
-
+        ```
+  1. Modify your test project's `build.gradle` to use the snapshot version
+        ```groovy
         plugins {
-            // id 'com.google.cloud.tools.jib' version '2.1.0'
+          // id 'com.google.cloud.tools.jib' version '2.1.0'
+          id 'com.google.cloud.tools.jib' version '2.1.1-SNAPSHOT'
         }
 
-        // Applies the java plugin after Jib to make sure it works in this order.
-        apply plugin: 'com.google.cloud.tools.jib' // must explicitly apply local
-        apply plugin: 'java'
         ```
 
 ### Attaching a debugger
@@ -140,4 +137,3 @@ Attach a debugger to a Gradle instance by running Gradle as follows:
   --no-daemon \
   -Dorg.gradle.jvmargs='-agentlib:jdwp:transport=dt_socket,server=y,address=5005,suspend=y'
 ```
-

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'net.ltgt.apt' version '0.19' apply false
   id 'net.ltgt.errorprone' version '0.6' apply false
   id 'net.researchgate.release' version '2.7.0' apply false
-  id 'com.gradle.plugin-publish' version '0.10.1' apply false
+  id 'com.gradle.plugin-publish' version '0.11.0' apply false
   id 'io.freefair.maven-plugin' version '3.8.1' apply false
 
   // apply so we can correctly configure the test runner to be gradle at the project level

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -2,7 +2,7 @@ plugins {
   id 'java-gradle-plugin'
   id 'net.researchgate.release'
   id 'com.gradle.plugin-publish'
-  // for local build/test
+  // for local SNAPSHOT build/test
   id 'maven-publish'
   // for eclipse import modifications
   id 'eclipse'
@@ -61,7 +61,7 @@ gradlePlugin {
     }
   }
 }
-//tasks.publishPlugins.dependsOn integrationTest
+tasks.publishPlugins.dependsOn integrationTest
 /* RELEASE */
 
 /* ECLIPSE */
@@ -79,10 +79,10 @@ eclipse.classpath.file.whenMerged {
 }
 /* ECLIPSE */
 
-/* LOCAL DEV */
+/* LOCAL SNAPSHOT DEV */
 publishing {
   repositories {
     mavenLocal()
   }
 }
-/* LOCAL DEV */
+/* LOCAL SNAPSHOT DEV */

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -3,7 +3,7 @@ plugins {
   id 'net.researchgate.release'
   id 'com.gradle.plugin-publish'
   // for local build/test
-  id 'maven'
+  id 'maven-publish'
   // for eclipse import modifications
   id 'eclipse'
 }
@@ -48,17 +48,20 @@ release {
 pluginBundle {
   website = 'https://github.com/GoogleContainerTools/jib/'
   vcsUrl = 'https://github.com/GoogleContainerTools/jib/'
+  tags = ['google', 'java', 'containers', 'docker', 'kubernetes', 'microservices']
+}
 
+gradlePlugin {
   plugins {
     jibPlugin {
       id = 'com.google.cloud.tools.jib'
       displayName = 'Jib'
       description = 'Containerize your Java application'
-      tags = ['google', 'java', 'containers', 'docker', 'kubernetes', 'microservices']
+      implementationClass = 'com.google.cloud.tools.jib.gradle.JibPlugin'
     }
   }
 }
-tasks.publishPlugins.dependsOn integrationTest
+//tasks.publishPlugins.dependsOn integrationTest
 /* RELEASE */
 
 /* ECLIPSE */
@@ -75,3 +78,11 @@ eclipse.classpath.file.whenMerged {
   }
 }
 /* ECLIPSE */
+
+/* LOCAL DEV */
+publishing {
+  repositories {
+    mavenLocal()
+  }
+}
+/* LOCAL DEV */


### PR DESCRIPTION
- update plugin version
  - We had to update from 10.1 -> 11.0 because they were no longer supporting the 10.1 based publishings (https://blog.gradle.org/plugin-portal-update)
- use syntax from https://guides.gradle.org/publishing-plugins-to-gradle-plugin-portal/
  - This full syntax is required for local publishing to work correctly
- update local development workflow

I tested this release process and it seems to work fine. 