### PR TITLE
Remove useless settings.gradle files

### DIFF
--- a/jib-build-plan/settings.gradle
+++ b/jib-build-plan/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'jib-build-plan'

--- a/jib-core/settings.gradle
+++ b/jib-core/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'jib-core'

--- a/jib-gradle-plugin/settings.gradle
+++ b/jib-gradle-plugin/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'jib-gradle-plugin'


### PR DESCRIPTION
These don't do anything of use, we always run gradle from the root. And we *should* always run gradle from root.

further reading: https://docs.gradle.org/current/javadoc/org/gradle/api/initialization/Settings.html