### PR TITLE
Fix ImageReference.toString() for "scratch"

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageReference.java
@@ -316,7 +316,7 @@ public class ImageReference {
    */
   @Override
   public String toString() {
-    if (registry.isEmpty() && repository.equals("scratch") && tag.isEmpty()) {
+    if (isScratch()) {
       return "scratch";
     }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageReference.java
@@ -316,6 +316,10 @@ public class ImageReference {
    */
   @Override
   public String toString() {
+    if (registry.isEmpty() && repository.equals("scratch") && tag.isEmpty()) {
+      return "scratch";
+    }
+
     StringBuilder referenceString = new StringBuilder();
 
     if (!DOCKER_HUB_REGISTRY.equals(registry)) {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/ImageReferenceTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/ImageReferenceTest.java
@@ -189,6 +189,11 @@ public class ImageReferenceTest {
   }
 
   @Test
+  public void testToString_scratch() {
+    Assert.assertEquals("scratch", ImageReference.scratch().toString());
+  }
+
+  @Test
   public void testGetRegistry() {
     Assert.assertEquals(
         "registry-1.docker.io", ImageReference.of(null, "someimage", null).getRegistry());
@@ -236,11 +241,6 @@ public class ImageReferenceTest {
 
     Assert.assertNotEquals(image1, image2);
     Assert.assertNotEquals(image1.hashCode(), image2.hashCode());
-  }
-
-  @Test
-  public void testToString_scratch() {
-    Assert.assertEquals("scratch", ImageReference.scratch().toString());
   }
 
   private void verifyParse(String registry, String repository, String tagSeparator, String tag)

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/ImageReferenceTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/ImageReferenceTest.java
@@ -238,6 +238,11 @@ public class ImageReferenceTest {
     Assert.assertNotEquals(image1.hashCode(), image2.hashCode());
   }
 
+  @Test
+  public void testToString_scratch() {
+    Assert.assertEquals("scratch", ImageReference.scratch().toString());
+  }
+
   private void verifyParse(String registry, String repository, String tagSeparator, String tag)
       throws InvalidImageReferenceException {
     // Gets the expected parsed components.

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -603,8 +603,8 @@ public class GradleProjectPropertiesTest {
             .setAppRoot(AbsoluteUnixPath.get(appRoot))
             .setModificationTimeProvider((ignored1, ignored2) -> SAMPLE_FILE_MODIFICATION_TIME);
     JibContainerBuilder jibContainerBuilder =
-        new GradleProjectProperties(mockProject, mockLogger, mockTempDirectoryProvider)
-            .createJibContainerBuilder(javaContainerBuilder, ContainerizingMode.EXPLODED);
+        gradleProjectProperties.createJibContainerBuilder(
+            javaContainerBuilder, ContainerizingMode.EXPLODED);
     return JibContainerBuilderTestHelper.toBuildContext(
         jibContainerBuilder, Containerizer.to(RegistryImage.named("to")));
   }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -674,13 +674,7 @@ public class MavenProjectPropertiesTest {
             newArtifact("com.test", "projectC", "3.0"));
 
     Map<LayerType, List<Path>> classifyDependencies =
-        new MavenProjectProperties(
-                mockJibPluginDescriptor,
-                mockMavenProject,
-                mockMavenSession,
-                mockLog,
-                mockTempDirectoryProvider)
-            .classifyDependencies(artifacts, projectArtifacts);
+        mavenProjectProperties.classifyDependencies(artifacts, projectArtifacts);
 
     Assert.assertEquals(
         classifyDependencies.get(LayerType.DEPENDENCIES),
@@ -1015,13 +1009,7 @@ public class MavenProjectPropertiesTest {
             .setAppRoot(AbsoluteUnixPath.get(appRoot))
             .setModificationTimeProvider((ignored1, ignored2) -> SAMPLE_FILE_MODIFICATION_TIME);
     JibContainerBuilder jibContainerBuilder =
-        new MavenProjectProperties(
-                mockJibPluginDescriptor,
-                mockMavenProject,
-                mockMavenSession,
-                mockLog,
-                mockTempDirectoryProvider)
-            .createJibContainerBuilder(javaContainerBuilder, containerizingMode);
+        mavenProjectProperties.createJibContainerBuilder(javaContainerBuilder, containerizingMode);
     return JibContainerBuilderTestHelper.toBuildContext(
         jibContainerBuilder, Containerizer.to(RegistryImage.named("to")));
   }


### PR DESCRIPTION
`ImageReference.scratch().toString()` was returning `/scratch` (with the leading slash).

Also cleaned up some test code.