### PR TITLE
Always set image format configuration

### DIFF
--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -31,6 +31,7 @@ import com.google.cloud.tools.jib.api.RegistryImage;
 import com.google.cloud.tools.jib.api.TarImage;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
+import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
 import com.google.cloud.tools.jib.api.buildplan.LayerObject;
 import com.google.cloud.tools.jib.frontend.CredentialRetrieverFactory;
 import com.google.cloud.tools.jib.global.JibSystemProperties;
@@ -120,7 +121,8 @@ public class PluginConfigurationProcessor {
     Containerizer containerizer = Containerizer.to(targetImage);
     JibContainerBuilder jibContainerBuilder =
         processCommonConfiguration(
-            rawConfiguration, inferredAuthProvider, projectProperties, containerizer);
+                rawConfiguration, inferredAuthProvider, projectProperties, containerizer)
+            .setFormat(ImageFormat.Docker);
 
     return JibBuildRunner.forBuildToDockerDaemon(
             jibContainerBuilder,
@@ -177,9 +179,6 @@ public class PluginConfigurationProcessor {
     JibContainerBuilder jibContainerBuilder =
         processCommonConfiguration(
             rawConfiguration, inferredAuthProvider, projectProperties, containerizer);
-
-    // Note Docker build doesn't set the configured format.
-    jibContainerBuilder.setFormat(rawConfiguration.getImageFormat());
 
     return JibBuildRunner.forBuildTar(
             jibContainerBuilder,
@@ -251,9 +250,6 @@ public class PluginConfigurationProcessor {
     JibContainerBuilder jibContainerBuilder =
         processCommonConfiguration(
             rawConfiguration, inferredAuthProvider, projectProperties, containerizer);
-
-    // Note Docker build doesn't set the configured format.
-    jibContainerBuilder.setFormat(rawConfiguration.getImageFormat());
 
     return JibBuildRunner.forBuildImage(
             jibContainerBuilder,
@@ -373,6 +369,7 @@ public class PluginConfigurationProcessor {
             .createJibContainerBuilder(
                 javaContainerBuilder,
                 getContainerizingModeChecked(rawConfiguration, projectProperties))
+            .setFormat(rawConfiguration.getImageFormat())
             .setEntrypoint(computeEntrypoint(rawConfiguration, projectProperties))
             .setProgramArguments(rawConfiguration.getProgramArguments().orElse(null))
             .setEnvironment(rawConfiguration.getEnvironment())


### PR DESCRIPTION
We were calling `.setFormat()` only when `jib:build` and `jib:buildTar`. For `jib:dockerBuild`, we relied on the assumption that the default format of `JibContainerBuilder` is Docker. However, I think it's cleaner to enforce consistency; it's more natural to override the config when the goal is `jib:dockerBuild`.