### PR TITLE
Allow null tags

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - `ImageReference#isValidTag` no longer returns `true` for digests.
 - `ImageReference#isTagDigest` has been removed; use `#getDigest` with `Optional#isPresent()` to check if an `ImageReference` uses a digest.
 - `ImageReference#withTag` has been removed; use `withQualifier()` instead.
+- `ImageReference#isDefaultTag` and `usesDefaultTag` no longer return `true` for `null` or empty tags.
 
 ### Fixed
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to this project will be documented in this file.
 - `ImageReference#toStringWithTag` has been renamed to `toStringWithQualifier`.
 - `ImageReference#isValidTag` no longer returns `true` for digests.
 - `ImageReference#isTagDigest` has been removed; use `#getDigest` with `Optional#isPresent()` to check if an `ImageReference` uses a digest.
-- `ImageReference#withTag` can no longer be used to change the image's digest; use `withQualifier()` instead.
+- `ImageReference#withTag` has been removed; use `withQualifier()` instead.
 
 ### Fixed
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -10,12 +10,15 @@ All notable changes to this project will be documented in this file.
     - `isValidDigest(digest)` to check if a string is a valid digest.
     - `getDigest()` to get the digest.
     - `parse()` now supports image reference strings containing both a tag and a digest.
+    - `getQualifier()` to return the digest, or the tag if no digest is set.
+    - `withQualifier()` to change the image's tag or digest (old behavior of `withTag()`)
 
 ### Changed
 
 - `ImageReference#toStringWithTag` has been renamed to `toStringWithQualifier`.
 - `ImageReference#isValidTag` no longer returns `true` for digests.
 - `ImageReference#isTagDigest` has been removed; use `#getDigest` with `Optional#isPresent()` to check if an `ImageReference` uses a digest.
+- `ImageReference#withTag` can no longer be used to change the image's digest; use `withQualifier()` instead.
 
 ### Fixed
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
@@ -89,7 +89,7 @@ public class JibIntegrationTest {
     Assert.assertEquals(
         "Hello World\n",
         pullAndRunBuiltImage(
-            targetImageReference.withTag(jibContainer.getDigest().toString()).toString()));
+            targetImageReference.withQualifier(jibContainer.getDigest().toString()).toString()));
   }
 
   @Test
@@ -113,7 +113,7 @@ public class JibIntegrationTest {
     Assert.assertEquals(
         "Hello World\n",
         pullAndRunBuiltImage(
-            targetImageReference.withTag(jibContainer.getDigest().toString()).toString()));
+            targetImageReference.withQualifier(jibContainer.getDigest().toString()).toString()));
   }
 
   @Test
@@ -155,7 +155,7 @@ public class JibIntegrationTest {
     Assert.assertEquals(
         "Hello World\n",
         pullAndRunBuiltImage(
-            targetImageReference.withTag(jibContainer.getDigest().toString()).toString()));
+            targetImageReference.withQualifier(jibContainer.getDigest().toString()).toString()));
   }
 
   @Test
@@ -181,7 +181,7 @@ public class JibIntegrationTest {
     Assert.assertEquals(
         "Hello World\n",
         pullAndRunBuiltImage(
-            targetImageReference.withTag(jibContainer.getDigest().toString()).toString()));
+            targetImageReference.withQualifier(jibContainer.getDigest().toString()).toString()));
   }
 
   @Test
@@ -213,7 +213,7 @@ public class JibIntegrationTest {
     Assert.assertEquals(
         "Hello World\n",
         pullAndRunBuiltImage(
-            targetImageReference.withTag(jibContainer.getDigest().toString()).toString()));
+            targetImageReference.withQualifier(jibContainer.getDigest().toString()).toString()));
   }
 
   @Test
@@ -239,7 +239,7 @@ public class JibIntegrationTest {
     Assert.assertEquals(
         "Hello World\n",
         pullAndRunBuiltImage(
-            targetImageReference.withTag(jibContainer.getDigest().toString()).toString()));
+            targetImageReference.withQualifier(jibContainer.getDigest().toString()).toString()));
   }
 
   @Test

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageReference.java
@@ -415,20 +415,18 @@ public class ImageReference {
     }
 
     if (singleQualifier) {
-      // Include the digest if set, else include the tag
       if (!Strings.isNullOrEmpty(digest)) {
         referenceString.append('@').append(digest);
-      } else if (!Strings.isNullOrEmpty(tag)) {
+      } else {
         referenceString.append(':').append(tag);
       }
-      return referenceString.toString();
-    }
-
-    if (!Strings.isNullOrEmpty(tag) && !usesDefaultTag()) {
-      referenceString.append(':').append(tag);
-    }
-    if (!Strings.isNullOrEmpty(digest)) {
-      referenceString.append('@').append(digest);
+    } else {
+      if (!Strings.isNullOrEmpty(tag) && !usesDefaultTag()) {
+        referenceString.append(':').append(tag);
+      }
+      if (!Strings.isNullOrEmpty(digest)) {
+        referenceString.append('@').append(digest);
+      }
     }
 
     return referenceString.toString();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageReference.java
@@ -372,7 +372,7 @@ public class ImageReference {
    */
   @Override
   public String toString() {
-    return toString(true);
+    return toString(false);
   }
 
   /**
@@ -383,13 +383,18 @@ public class ImageReference {
    * @return the image reference in Docker-readable format including a qualifier.
    */
   public String toStringWithQualifier() {
-    if (Strings.isNullOrEmpty(digest)) {
-      return toString(false) + (usesDefaultTag() ? ":" + DEFAULT_TAG : "");
-    }
-    return toString(false);
+    return toString(true);
   }
 
-  private String toString(boolean includeTagIfDigestPresent) {
+  /**
+   * Stringifies the {@link ImageReference}.
+   *
+   * @param singleQualifier when {@code true}, the result will include exactly one qualifier (i.e.
+   *     the digest, or the tag if the digest is missing). When {@code false}, the result will
+   *     include all specified qualifiers (omitting tag if the default {@code latest} is used).
+   * @return the image reference in a Docker-readable format.
+   */
+  private String toString(boolean singleQualifier) {
     if (isScratch()) {
       return "scratch";
     }
@@ -409,13 +414,19 @@ public class ImageReference {
       referenceString.append(repository);
     }
 
-    if (Strings.isNullOrEmpty(digest) || includeTagIfDigestPresent) {
-      // Use tag if not the default tag.
-      if (!Strings.isNullOrEmpty(tag) && !isDefaultTag(tag)) {
+    if (singleQualifier) {
+      // Include the digest if set, else include the tag
+      if (!Strings.isNullOrEmpty(digest)) {
+        referenceString.append('@').append(digest);
+      } else if (!Strings.isNullOrEmpty(tag)) {
         referenceString.append(':').append(tag);
       }
+      return referenceString.toString();
     }
 
+    if (!Strings.isNullOrEmpty(tag) && !usesDefaultTag()) {
+      referenceString.append(':').append(tag);
+    }
     if (!Strings.isNullOrEmpty(digest)) {
       referenceString.append('@').append(digest);
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -191,7 +191,7 @@ class PullBaseImageStep implements Callable<ImageAndRegistryClient> {
     EventHandlers eventHandlers = buildContext.getEventHandlers();
 
     ManifestAndDigest<?> manifestAndDigest =
-        registryClient.pullManifest(buildContext.getBaseImageConfiguration().getImageTag());
+        registryClient.pullManifest(buildContext.getBaseImageConfiguration().getImageQualifier());
     ManifestTemplate manifestTemplate = manifestAndDigest.getManifest();
 
     // special handling if we happen upon a manifest list, redirect to a manifest and continue

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
@@ -419,7 +419,7 @@ public class BuildContext implements Closeable {
   public ImmutableSet<String> getAllTargetImageTags() {
     ImmutableSet.Builder<String> allTargetImageTags =
         ImmutableSet.builderWithExpectedSize(1 + additionalTargetImageTags.size());
-    allTargetImageTags.add(targetImageConfiguration.getImageTag());
+    allTargetImageTags.add(targetImageConfiguration.getImageQualifier());
     allTargetImageTags.addAll(additionalTargetImageTags);
     return allTargetImageTags.build();
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
@@ -136,8 +136,8 @@ public class ImageConfiguration {
     return image.getRepository();
   }
 
-  public String getImageTag() {
-    return image.getTag();
+  public String getImageQualifier() {
+    return image.getQualifier();
   }
 
   public ImmutableList<CredentialRetriever> getCredentialRetrievers() {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageTarball.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageTarball.java
@@ -140,7 +140,7 @@ public class ImageTarball {
 
     // Adds the manifest to tarball.
     for (String tag : allTargetImageTags) {
-      manifestTemplate.addRepoTag(imageReference.withTag(tag).toStringWithQualifier());
+      manifestTemplate.addRepoTag(imageReference.withQualifier(tag).toStringWithQualifier());
     }
     tarStreamBuilder.addByteEntry(
         JsonTemplateMapper.toByteArray(Collections.singletonList(manifestTemplate)),

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/ImageReferenceTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/ImageReferenceTest.java
@@ -67,7 +67,7 @@ public class ImageReferenceTest {
 
     Assert.assertEquals("registry-1.docker.io", imageReference.getRegistry());
     Assert.assertEquals("library/busybox", imageReference.getRepository());
-    Assert.assertEquals("latest", imageReference.getTag());
+    Assert.assertEquals("latest", imageReference.getTag().orElse(null));
   }
 
   @Test
@@ -77,7 +77,7 @@ public class ImageReferenceTest {
 
     Assert.assertEquals("registry-1.docker.io", imageReference.getRegistry());
     Assert.assertEquals("someuser/someimage", imageReference.getRepository());
-    Assert.assertEquals("latest", imageReference.getTag());
+    Assert.assertEquals("latest", imageReference.getTag().orElse(null));
   }
 
   @Test
@@ -106,15 +106,18 @@ public class ImageReferenceTest {
         expectedRepository,
         ImageReference.of(expectedRegistry, expectedRepository, expectedTag).getRepository());
     Assert.assertEquals(
-        expectedTag, ImageReference.of(expectedRegistry, expectedRepository, expectedTag).getTag());
+        expectedTag,
+        ImageReference.of(expectedRegistry, expectedRepository, expectedTag).getTag().orElse(null));
     Assert.assertEquals(
         "registry-1.docker.io",
         ImageReference.of(null, expectedRepository, expectedTag).getRegistry());
     Assert.assertEquals(
         "registry-1.docker.io", ImageReference.of(null, expectedRepository, null).getRegistry());
     Assert.assertEquals(
-        "latest", ImageReference.of(expectedRegistry, expectedRepository, null).getTag());
-    Assert.assertEquals("latest", ImageReference.of(null, expectedRepository, null).getTag());
+        "latest",
+        ImageReference.of(expectedRegistry, expectedRepository, null).getTag().orElse(null));
+    Assert.assertEquals(
+        "latest", ImageReference.of(null, expectedRepository, null).getTag().orElse(null));
     Assert.assertEquals(
         expectedRepository, ImageReference.of(null, expectedRepository, null).getRepository());
   }
@@ -254,8 +257,16 @@ public class ImageReferenceTest {
       expectedRepository = "library/" + expectedRepository;
     }
     String expectedTag = tag;
-    if (Strings.isNullOrEmpty(expectedTag)) {
+    if (Strings.isNullOrEmpty(expectedTag) && Strings.isNullOrEmpty(digest)) {
       expectedTag = "latest";
+    }
+    if (Strings.isNullOrEmpty(expectedTag)) {
+      expectedTag = null;
+    }
+
+    String expectedDigest = digest;
+    if (Strings.isNullOrEmpty(digest)) {
+      expectedDigest = null;
     }
 
     // Builds the image reference to parse.
@@ -275,7 +286,7 @@ public class ImageReferenceTest {
 
     Assert.assertEquals(expectedRegistry, imageReference.getRegistry());
     Assert.assertEquals(expectedRepository, imageReference.getRepository());
-    Assert.assertEquals(expectedTag, imageReference.getTag());
-    Assert.assertEquals(digest, imageReference.getDigest().orElse(null));
+    Assert.assertEquals(expectedTag, imageReference.getTag().orElse(null));
+    Assert.assertEquals(expectedDigest, imageReference.getDigest().orElse(null));
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildContextTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildContextTest.java
@@ -126,13 +126,13 @@ public class BuildContextTest {
     Assert.assertEquals(
         expectedBaseImageName, buildContext.getBaseImageConfiguration().getImageRepository());
     Assert.assertEquals(
-        expectedBaseImageTag, buildContext.getBaseImageConfiguration().getImageTag());
+        expectedBaseImageTag, buildContext.getBaseImageConfiguration().getImageQualifier());
     Assert.assertEquals(
         expectedTargetServerUrl, buildContext.getTargetImageConfiguration().getImageRegistry());
     Assert.assertEquals(
         expectedTargetImageName, buildContext.getTargetImageConfiguration().getImageRepository());
     Assert.assertEquals(
-        expectedTargetTag, buildContext.getTargetImageConfiguration().getImageTag());
+        expectedTargetTag, buildContext.getTargetImageConfiguration().getImageQualifier());
     Assert.assertEquals(expectedTargetImageTags, buildContext.getAllTargetImageTags());
     Assert.assertEquals(
         Credential.from("username", "password"),

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibRunHelper.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibRunHelper.java
@@ -123,7 +123,7 @@ public class JibRunHelper {
     Assert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(imageReference));
 
     String additionalImageReference =
-        ImageReference.parse(imageReference).withTag(additionalTag).toString();
+        ImageReference.parse(imageReference).withQualifier(additionalTag).toString();
     Assert.assertThat(
         buildResult.getOutput(), CoreMatchers.containsString(additionalImageReference));
 

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -201,7 +201,8 @@ public class SingleProjectIntegrationTest {
 
     String digest =
         readDigestFile(simpleTestProject.getProjectRoot().resolve("build/jib-image.digest"));
-    String imageReferenceWithDigest = ImageReference.parse(targetImage).withTag(digest).toString();
+    String imageReferenceWithDigest =
+        ImageReference.parse(targetImage).withQualifier(digest).toString();
     Assert.assertEquals(output, JibRunHelper.pullAndRunBuiltImage(imageReferenceWithDigest));
 
     String id = readDigestFile(simpleTestProject.getProjectRoot().resolve("build/jib-image.id"));
@@ -335,7 +336,8 @@ public class SingleProjectIntegrationTest {
     String digest =
         readDigestFile(
             simpleTestProject.getProjectRoot().resolve("build/different-jib-image.digest"));
-    String imageReferenceWithDigest = ImageReference.parse(targetImage).withTag(digest).toString();
+    String imageReferenceWithDigest =
+        ImageReference.parse(targetImage).withQualifier(digest).toString();
     localRegistry2.pull(imageReferenceWithDigest);
     Assert.assertEquals(
         output, new Command("docker", "run", "--rm", imageReferenceWithDigest).run());

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -137,7 +137,7 @@ public class BuildImageMojoIntegrationTest {
       // Test pulling/running using image digest
       String digest = readDigestFile(projectRoot.resolve("target/jib-image.digest"));
       String imageReferenceWithDigest =
-          ImageReference.parse(imageReference).withTag(digest).toString();
+          ImageReference.parse(imageReference).withQualifier(digest).toString();
       Assert.assertEquals(output, pullAndRunBuiltImage(imageReferenceWithDigest));
 
       // Test running using image id
@@ -198,14 +198,15 @@ public class BuildImageMojoIntegrationTest {
     verifier.verifyErrorFreeLog();
 
     String additionalImageReference =
-        ImageReference.parse(imageReference).withTag(additionalTag).toString();
+        ImageReference.parse(imageReference).withQualifier(additionalTag).toString();
 
     String output = pullAndRunBuiltImage(imageReference);
     String additionalOutput = pullAndRunBuiltImage(additionalImageReference);
     Assert.assertEquals(output, additionalOutput);
 
     String digest = readDigestFile(projectRoot.resolve("target/jib-image.digest"));
-    String digestImageReference = ImageReference.parse(imageReference).withTag(digest).toString();
+    String digestImageReference =
+        ImageReference.parse(imageReference).withQualifier(digest).toString();
     String digestOutput = pullAndRunBuiltImage(digestImageReference);
     Assert.assertEquals(output, digestOutput);
 

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunner.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunner.java
@@ -73,7 +73,7 @@ public class JibBuildRunner {
     StringJoiner successMessageBuilder = new StringJoiner(", ", prefix, suffix);
     successMessageBuilder.add(colorCyan(targetImageReference.toString()));
     for (String tag : additionalTags) {
-      successMessageBuilder.add(colorCyan(targetImageReference.withTag(tag).toString()));
+      successMessageBuilder.add(colorCyan(targetImageReference.withQualifier(tag).toString()));
     }
     return successMessageBuilder.toString();
   }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidatorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ConfigurationPropertyValidatorTest.java
@@ -37,7 +37,6 @@ public class ConfigurationPropertyValidatorTest {
 
   @Mock private Consumer<LogEvent> mockLogger;
   @Mock private AuthProperty mockAuth;
-  @Mock private ImageReference mockImageReference;
   @Mock private RawConfiguration mockConfiguration;
 
   @Test
@@ -113,7 +112,7 @@ public class ConfigurationPropertyValidatorTest {
         ConfigurationPropertyValidator.getGeneratedTargetDockerTag(
             "a/b:c", mockProjectProperties, helpfulSuggestions);
     Assert.assertEquals("a/b", result.getRepository());
-    Assert.assertEquals("c", result.getTag());
+    Assert.assertEquals("c", result.getTag().orElse(null));
     Mockito.verify(mockLogger, Mockito.never()).accept(LogEvent.lifecycle(Mockito.any()));
 
     // Target not configured
@@ -121,7 +120,7 @@ public class ConfigurationPropertyValidatorTest {
         ConfigurationPropertyValidator.getGeneratedTargetDockerTag(
             null, mockProjectProperties, helpfulSuggestions);
     Assert.assertEquals("project-name", result.getRepository());
-    Assert.assertEquals("project-version", result.getTag());
+    Assert.assertEquals("project-version", result.getTag().orElse(null));
     Mockito.verify(mockProjectProperties)
         .log(
             LogEvent.lifecycle(


### PR DESCRIPTION
Fixes #2390. If the digest is set, the tag may now be null, rather than taking on the default value of `latest`. If neither the tag nor digest is specified in the creation of the `ImageReference`, then it will use the default tag `latest`.

We used digest and tag interchangeably throughout the codebase before this change, so it's possible I maybe have missed something small. To make this easier, I added two methods: `getQualifier()` and `withQualifier()`, which use the old behavior of `getTag()` and `withTag()`.