### PR TITLE
Run Maven plugin extensions

### DIFF
--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenExtensionData.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenExtensionData.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven;
+
+import com.google.cloud.tools.jib.maven.extension.MavenData;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.project.MavenProject;
+
+/** Maven-specific data and properties to supply to plugin extensions. */
+public class MavenExtensionData implements MavenData {
+
+  private final MavenProject project;
+  private final MavenSession session;
+
+  MavenExtensionData(MavenProject project, MavenSession session) {
+    this.project = project;
+    this.session = session;
+  }
+
+  @Override
+  public MavenProject getMavenProject() {
+    return project;
+  }
+
+  @Override
+  public MavenSession getMavenSession() {
+    return session;
+  }
+}

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenExtensionData.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenExtensionData.java
@@ -21,7 +21,7 @@ import org.apache.maven.execution.MavenSession;
 import org.apache.maven.project.MavenProject;
 
 /** Maven-specific data and properties to supply to plugin extensions. */
-public class MavenExtensionData implements MavenData {
+class MavenExtensionData implements MavenData {
 
   private final MavenProject project;
   private final MavenSession session;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenExtensionLogger.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenExtensionLogger.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven;
+
+import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger;
+import java.util.function.Consumer;
+
+/** Logger for Maven plugin extensions. */
+class MavenExtensionLogger implements ExtensionLogger {
+
+  private final Consumer<LogEvent> logger;
+
+  MavenExtensionLogger(Consumer<LogEvent> logger) {
+    this.logger = logger;
+  }
+
+  @Override
+  public void log(ExtensionLogger.LogLevel logLevel, String message) {
+    switch (logLevel) {
+      case ERROR:
+        logger.accept(LogEvent.error(message));
+        break;
+      case WARN:
+        logger.accept(LogEvent.warn(message));
+        break;
+      case LIFECYCLE:
+        logger.accept(LogEvent.lifecycle(message));
+        break;
+      case INFO:
+        logger.accept(LogEvent.info(message));
+        break;
+      case DEBUG:
+        logger.accept(LogEvent.debug(message));
+        break;
+      default:
+        throw new RuntimeException();
+    }
+  }
+}

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -542,7 +542,7 @@ public class MavenProjectProperties implements ProjectProperties {
       Iterator<JibMavenPluginExtension> services, JibContainerBuilder jibContainerBuilder)
       throws JibPluginExtensionException {
     if (!services.hasNext()) {
-      log(LogEvent.debug("No Jib plugin extension discovered"));
+      log(LogEvent.debug("No Jib plugin extensions discovered"));
       return jibContainerBuilder;
     }
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.api.Containerizer;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.JavaContainerBuilder;
 import com.google.cloud.tools.jib.api.JavaContainerBuilder.LayerType;
+import com.google.cloud.tools.jib.api.Jib;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.JibContainerBuilderTestHelper;
 import com.google.cloud.tools.jib.api.RegistryImage;
@@ -30,12 +31,16 @@ import com.google.cloud.tools.jib.api.buildplan.FileEntry;
 import com.google.cloud.tools.jib.configuration.BuildContext;
 import com.google.cloud.tools.jib.filesystem.DirectoryWalker;
 import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
+import com.google.cloud.tools.jib.maven.extension.JibMavenPluginExtension;
 import com.google.cloud.tools.jib.plugins.common.ContainerizingMode;
+import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger.LogLevel;
+import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Resources;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -66,6 +71,7 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.archiver.zip.ZipEntry;
 import org.codehaus.plexus.archiver.zip.ZipOutputStream;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
+import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -1000,6 +1006,79 @@ public class MavenProjectPropertiesTest {
 
     Assert.assertEquals(
         Paths.get("/foo/bar/helloworld-1.war"), mavenProjectProperties.getWarArtifact());
+  }
+
+  @Test
+  public void testRunPluginExtensions_noExtensionsFound()
+      throws JibPluginExtensionException, InvalidImageReferenceException {
+    JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("from/nothing"));
+    JibContainerBuilder extendedBuilder =
+        mavenProjectProperties.runPluginExtensions(Collections.emptyIterator(), originalBuilder);
+    Assert.assertSame(extendedBuilder, originalBuilder);
+
+    mavenProjectProperties.waitForLoggingThread();
+    Mockito.verify(mockLog).debug("No Jib plugin extension discovered");
+  }
+
+  @Test
+  public void testRunPluginExtensions()
+      throws JibPluginExtensionException, InvalidImageReferenceException {
+    JibMavenPluginExtension extension =
+        (buildPlan, mavenData, logger) -> {
+          logger.log(LogLevel.ERROR, "awesome error from my extension");
+          return buildPlan.toBuilder().setUser("user from extension").build();
+        };
+
+    JibContainerBuilder extendedBuilder =
+        mavenProjectProperties.runPluginExtensions(
+            Arrays.asList(extension).iterator(), Jib.from(RegistryImage.named("from/nothing")));
+    Assert.assertEquals("user from extension", extendedBuilder.toContainerBuildPlan().getUser());
+
+    mavenProjectProperties.waitForLoggingThread();
+    Mockito.verify(mockLog).error("awesome error from my extension");
+    Mockito.verify(mockLog)
+        .info(
+            Mockito.startsWith(
+                "Running extension: com.google.cloud.tools.jib.maven.MavenProjectProperties"));
+  }
+
+  @Test
+  public void testRunPluginExtensions_exceptionFromExtension()
+      throws InvalidImageReferenceException {
+    FileNotFoundException fakeException = new FileNotFoundException();
+    JibMavenPluginExtension extension =
+        (buildPlan, mavenData, logger) -> {
+          throw new JibPluginExtensionException(
+              JibMavenPluginExtension.class, "exception from extension", fakeException);
+        };
+
+    JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("scratch"));
+    try {
+      mavenProjectProperties.runPluginExtensions(
+          Arrays.asList(extension).iterator(), originalBuilder);
+      Assert.fail();
+    } catch (JibPluginExtensionException ex) {
+      Assert.assertEquals("exception from extension", ex.getMessage());
+      Assert.assertSame(fakeException, ex.getCause());
+    }
+  }
+
+  @Test
+  public void testRunPluginExtensions_invalidBaseImageFromExtension()
+      throws InvalidImageReferenceException {
+    JibMavenPluginExtension extension =
+        (buildPlan, mavenData, logger) -> buildPlan.toBuilder().setBaseImage(" in*val+id").build();
+
+    JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("from/nothing"));
+    try {
+      mavenProjectProperties.runPluginExtensions(
+          Arrays.asList(extension).iterator(), originalBuilder);
+      Assert.fail();
+    } catch (JibPluginExtensionException ex) {
+      Assert.assertEquals("invalid base image reference:  in*val+id", ex.getMessage());
+      Assert.assertThat(
+          ex.getCause(), CoreMatchers.instanceOf(InvalidImageReferenceException.class));
+    }
   }
 
   private BuildContext setUpBuildContext(String appRoot, ContainerizingMode containerizingMode)

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -1017,7 +1017,7 @@ public class MavenProjectPropertiesTest {
     Assert.assertSame(extendedBuilder, originalBuilder);
 
     mavenProjectProperties.waitForLoggingThread();
-    Mockito.verify(mockLog).debug("No Jib plugin extension discovered");
+    Mockito.verify(mockLog).debug("No Jib plugin extensions discovered");
   }
 
   @Test


### PR DESCRIPTION
Using the standard Service Provider Interfaces (SPI) mechanism to load and run Maven plugin extensions.

This doesn't yet involve the new extension config option (like `<extensions><extension><implementation>com.example.ExtensionClass`). The config option can be added in a later PR.

With this, we are actually enabling running and testing Maven extensions. A configuration will look like this.

```xml
<plugin>
  <groupId>com.google.cloud.tools</groupId>
  <artifactId>jib-maven-plugin</artifactId>
  <version>2.1.1-SNAPSHOT</version>
  <dependencies>
    <dependency>
      <groupId>com.example</groupId>
      <artifactId>quarkus-extension-maven</artifactId>
      <version>0.1.0-SNAPSHOT</version>
    </dependency>
  </dependencies>
</plugin>
```