### PR TITLE
Set up sub-project for Gradle plugin extension and define extension API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,9 @@ idea.project.settings {
 
 import net.ltgt.gradle.errorprone.CheckSeverity
 
+project('jib-gradle-plugin-extension-api') {
+  apply plugin: 'java-library'
+}
 project('jib-maven-plugin-extension-api') {
   apply plugin: 'java-library'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,10 @@ idea.project.settings {
 
 import net.ltgt.gradle.errorprone.CheckSeverity
 
-project('jib-gradle-plugin-extension-api') {
-  apply plugin: 'java-library'
-}
-project('jib-maven-plugin-extension-api') {
-  apply plugin: 'java-library'
+['jib-gradle-plugin-extension-api', 'jib-maven-plugin-extension-api'].each { projectName ->
+  project(projectName) {
+    apply plugin: 'java-library'
+  }
 }
 
 subprojects {

--- a/jib-build-plan/build.gradle
+++ b/jib-build-plan/build.gradle
@@ -29,9 +29,9 @@ jar {
   }
 }
 
+/* RELEASE */
 configureMavenRelease()
 
-/* RELEASE */
 publishing {
   publications {
     mavenJava(MavenPublication) {

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -37,9 +37,9 @@ jar {
   }
 }
 
+/* RELEASE */
 configureMavenRelease()
 
-/* RELEASE */
 publishing {
   publications {
     mavenJava(MavenPublication) {

--- a/jib-gradle-plugin-extension-api/build.gradle
+++ b/jib-gradle-plugin-extension-api/build.gradle
@@ -1,6 +1,4 @@
 plugins {
-  // Is this the only option? Can't we do something simiar to Maven Extension API?
-  id 'java-gradle-plugin'
   id 'net.researchgate.release'
   id 'maven-publish'
 }
@@ -8,6 +6,7 @@ plugins {
 dependencies {
   api project(':jib-build-plan')
   api project(':jib-plugins-extension-common')
+  api gradleApi()
 }
 
 jar {

--- a/jib-gradle-plugin-extension-api/build.gradle
+++ b/jib-gradle-plugin-extension-api/build.gradle
@@ -24,9 +24,9 @@ jar {
   }
 }
 
+/* RELEASE */
 configureMavenRelease()
 
-/* RELEASE */
 publishing {
   publications {
     mavenJava(MavenPublication) {

--- a/jib-gradle-plugin-extension-api/build.gradle
+++ b/jib-gradle-plugin-extension-api/build.gradle
@@ -1,0 +1,42 @@
+plugins {
+  // Is this the only option? Can't we do something simiar to Maven Extension API?
+  id 'java-gradle-plugin'
+  id 'net.researchgate.release'
+  id 'maven-publish'
+}
+
+dependencies {
+  api project(':jib-build-plan')
+  api project(':jib-plugins-extension-common')
+}
+
+jar {
+  manifest {
+    attributes 'Implementation-Version': version
+    attributes 'Automatic-Module-Name': 'com.google.cloud.tools.jib.gradle.extension'
+
+    // OSGi metadata
+    attributes 'Bundle-SymbolicName': 'com.google.cloud.tools.jib.gradle.extension'
+    attributes 'Bundle-Name': 'Extension API for Jib Gradle Plugin'
+    attributes 'Bundle-Vendor': 'Google LLC'
+    attributes 'Bundle-DocURL': 'https://github.com/GoogleContainerTools/jib'
+    attributes 'Bundle-License': 'https://www.apache.org/licenses/LICENSE-2.0'
+    attributes 'Export-Package': 'com.google.cloud.tools.jib.gradle.extension'
+  }
+}
+
+configureMavenRelease()
+
+/* RELEASE */
+publishing {
+  publications {
+    mavenJava(MavenPublication) {
+      pom {
+        name = 'Extension API for Jib Gradle Plugin'
+        description = 'Provides API to extend Jib Gradle Plugin containerization.'
+      }
+      from components.java
+    }
+  }
+}
+/* RELEASE */

--- a/jib-gradle-plugin-extension-api/gradle.properties
+++ b/jib-gradle-plugin-extension-api/gradle.properties
@@ -1,0 +1,1 @@
+version = 0.1.0-SNAPSHOT

--- a/jib-gradle-plugin-extension-api/settings.gradle
+++ b/jib-gradle-plugin-extension-api/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'jib-gradle-plugin-extension-api'

--- a/jib-gradle-plugin-extension-api/src/main/java/com/google/cloud/tools/jib/gradle/extension/GradleData.java
+++ b/jib-gradle-plugin-extension-api/src/main/java/com/google/cloud/tools/jib/gradle/extension/GradleData.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.gradle.extension;
+
+import org.gradle.api.Project;
+
+/** Holds Gradle-specific data and properties. */
+public interface GradleData {
+
+  Project getProject();
+}

--- a/jib-gradle-plugin-extension-api/src/main/java/com/google/cloud/tools/jib/gradle/extension/JibGradlePluginExtension.java
+++ b/jib-gradle-plugin-extension-api/src/main/java/com/google/cloud/tools/jib/gradle/extension/JibGradlePluginExtension.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.gradle.extension;
+
+import com.google.cloud.tools.jib.api.buildplan.ContainerBuildPlan;
+import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger;
+import com.google.cloud.tools.jib.plugins.extension.JibPluginExtension;
+import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
+
+/**
+ * Jib Gradle plugin extension API.
+ *
+ * <p>If a class implementing the interface is visible on the classpath of the Jib Gradle plugin and
+ * the plugin is configured to load the extension class, the Jib plugin extension framework calls
+ * the interface method of the class.
+ */
+public interface JibGradlePluginExtension extends JibPluginExtension {
+
+  /**
+   * Extends the build plan prepared by the Jib Gradle plugin.
+   *
+   * @param buildPlan original build plan prepared by the Jib Gradle plugin
+   * @param gradleData {@link GradleData} providing Gradle-specific data and properties
+   * @param logger logger for writing log messages
+   * @return updated build plan
+   * @throws JibPluginExtensionException if an error occurs while running the plugin extension
+   */
+  ContainerBuildPlan extendContainerBuildPlan(
+      ContainerBuildPlan buildPlan, GradleData gradleData, ExtensionLogger logger)
+      throws JibPluginExtensionException;
+}

--- a/jib-maven-plugin-extension-api/build.gradle
+++ b/jib-maven-plugin-extension-api/build.gradle
@@ -24,9 +24,9 @@ jar {
   }
 }
 
+/* RELEASE */
 configureMavenRelease()
 
-/* RELEASE */
 publishing {
   publications {
     mavenJava(MavenPublication) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 include ":jib-build-plan"
 include ":jib-plugins-extension-common"
+include ":jib-gradle-plugin-extension-api"
 include ":jib-maven-plugin-extension-api"
 include ":jib-core"
 include ":jib-plugins-common"


### PR DESCRIPTION
Continued work on establish the Jib plugin extension framework.

- Sets up a sub-project for Gradle plugin extension (counterpart of #2368)
- Defines Gradle plugin extension API (counterpart of #2380)
   ```
   ContainerBuildPlan extendContainerBuildPlan(
       ContainerBuildPlan buildPlan, GradleData gradleData, ExtensionLogger logger)
       throws JibPluginExtensionException;
   ```

One problem due to a difference from Maven: while the Maven Core API was defined with
```
dependencies {
  api "org.apache.maven:maven-core:${dependencyVersions.MAVEN_API}"
```
here the Gradle API dependency is though applying `java-gradle-plugin`.
```gradle
plugins {
  id 'java-gradle-plugin'
```
The problem (I think) is that the Gradle API version is not pinned. So the Gradle version that the extension dev uses will determined the API version. 