### PR TITLE
Respect DOCKER_CONFIG environment variable when finding credentials

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Glob pattern support for `jib.extraDirectories.permissions`. ([#1200](https://github.com/GoogleContainerTools/jib/issues/1200))
 - Support for image references with both a tag and a digest. ([#1481](https://github.com/GoogleContainerTools/jib/issues/1481))
-- The `DOCKER_CONFIG` environment variable is now checked for retrieving credentials from the docker config. ([#1618](https://github.com/GoogleContainerTools/jib/issues/1618))
+- The `DOCKER_CONFIG` environment variable specifying the directory containing docker configs is now checked during credential retrieval. ([#1618](https://github.com/GoogleContainerTools/jib/issues/1618))
 
 ### Changed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Glob pattern support for `jib.extraDirectories.permissions`. ([#1200](https://github.com/GoogleContainerTools/jib/issues/1200))
 - Support for image references with both a tag and a digest. ([#1481](https://github.com/GoogleContainerTools/jib/issues/1481))
+- The `DOCKER_CONFIG` environment variable is now checked for retrieving credentials from the docker config. ([#1618](https://github.com/GoogleContainerTools/jib/issues/1618))
 
 ### Changed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Glob pattern support for `<extraDirectories><permissions>`. ([#1200](https://github.com/GoogleContainerTools/jib/issues/1200))
 - Support for image references with both a tag and a digest. ([#1481](https://github.com/GoogleContainerTools/jib/issues/1481))
+- The `DOCKER_CONFIG` environment variable is now checked for retrieving credentials from the docker config. ([#1618](https://github.com/GoogleContainerTools/jib/issues/1618))
 
 ### Changed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Glob pattern support for `<extraDirectories><permissions>`. ([#1200](https://github.com/GoogleContainerTools/jib/issues/1200))
 - Support for image references with both a tag and a digest. ([#1481](https://github.com/GoogleContainerTools/jib/issues/1481))
-- The `DOCKER_CONFIG` environment variable is now checked for retrieving credentials from the docker config. ([#1618](https://github.com/GoogleContainerTools/jib/issues/1618))
+- The `DOCKER_CONFIG` environment variable specifying the directory containing docker configs is now checked during credential retrieval. ([#1618](https://github.com/GoogleContainerTools/jib/issues/1618))
 
 ### Changed
 

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
@@ -166,19 +166,29 @@ public class DefaultCredentialRetrievers {
       credentialRetrievers.add(inferredCredentialRetriever);
     }
 
+    List<Path> checkedDockerDirs = new ArrayList<>();
     String dockerConfigEnv = environment.get("DOCKER_CONFIG");
     if (dockerConfigEnv != null) {
+      Path dockerConfigEnvPath = Paths.get(dockerConfigEnv);
       addDockerFiles(credentialRetrievers, Paths.get(dockerConfigEnv));
+      checkedDockerDirs.add(dockerConfigEnvPath);
     }
 
     String homeProperty = systemProperties.getProperty("user.home");
     if (homeProperty != null) {
-      addDockerFiles(credentialRetrievers, Paths.get(homeProperty).resolve(DOCKER_DIRECTORY));
+      Path homePropertyPath = Paths.get(homeProperty).resolve(DOCKER_DIRECTORY);
+      if (!checkedDockerDirs.contains(homePropertyPath)) {
+        addDockerFiles(credentialRetrievers, homePropertyPath);
+        checkedDockerDirs.add(homePropertyPath);
+      }
     }
 
     String homeEnvVar = environment.get("HOME");
     if (homeEnvVar != null && !homeEnvVar.equals(homeProperty)) {
-      addDockerFiles(credentialRetrievers, Paths.get(homeEnvVar).resolve(DOCKER_DIRECTORY));
+      Path homeEnvDockerPath = Paths.get(homeEnvVar).resolve(DOCKER_DIRECTORY);
+      if (!checkedDockerDirs.contains(homeEnvDockerPath)) {
+        addDockerFiles(credentialRetrievers, homeEnvDockerPath);
+      }
     }
 
     credentialRetrievers.add(credentialRetrieverFactory.wellKnownCredentialHelpers());

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
@@ -184,7 +184,7 @@ public class DefaultCredentialRetrievers {
     }
 
     String homeEnvVar = environment.get("HOME");
-    if (homeEnvVar != null && !homeEnvVar.equals(homeProperty)) {
+    if (homeEnvVar != null) {
       Path homeEnvDockerPath = Paths.get(homeEnvVar).resolve(DOCKER_DIRECTORY);
       if (!checkedDockerDirs.contains(homeEnvDockerPath)) {
         addDockerFiles(credentialRetrievers, homeEnvDockerPath);

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
@@ -247,5 +247,23 @@ public class DefaultCredentialRetrieversTest {
             mockWellKnownCredentialHelpersCredentialRetriever,
             mockApplicationDefaultCredentialRetriever),
         credentialRetrievers);
+
+    environment =
+        ImmutableMap.of(
+            "HOME",
+            Paths.get("/env/home").toString(),
+            "DOCKER_CONFIG",
+            Paths.get("/env/home/.docker").toString());
+    credentialRetrievers =
+        new DefaultCredentialRetrievers(mockCredentialRetrieverFactory, properties, environment)
+            .asList();
+    Assert.assertEquals(
+        Arrays.asList(
+            mockEnvHomeDockerConfigCredentialRetriever,
+            mockEnvHomeKubernetesDockerConfigCredentialRetriever,
+            mockEnvHomeLegacyDockerConfigCredentialRetriever,
+            mockWellKnownCredentialHelpersCredentialRetriever,
+            mockApplicationDefaultCredentialRetriever),
+        credentialRetrievers);
   }
 }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
@@ -51,6 +51,9 @@ public class DefaultCredentialRetrieversTest {
   @Mock private CredentialRetriever mockKnownCredentialRetriever;
   @Mock private CredentialRetriever mockInferredCredentialRetriever;
   @Mock private CredentialRetriever mockWellKnownCredentialHelpersCredentialRetriever;
+  @Mock private CredentialRetriever mockDockerConfigEnvDockerConfigCredentialRetriever;
+  @Mock private CredentialRetriever mockDockerConfigEnvKubernetesDockerConfigCredentialRetriever;
+  @Mock private CredentialRetriever mockDockerConfigEnvLegacyDockerConfigCredentialRetriever;
   @Mock private CredentialRetriever mockSystemHomeDockerConfigCredentialRetriever;
   @Mock private CredentialRetriever mockSystemHomeKubernetesDockerConfigCredentialRetriever;
   @Mock private CredentialRetriever mockSystemHomeLegacyDockerConfigCredentialRetriever;
@@ -69,7 +72,12 @@ public class DefaultCredentialRetrieversTest {
   public void setUp() {
     properties = new Properties();
     properties.setProperty("user.home", Paths.get("/system/home").toString());
-    environment = ImmutableMap.of("HOME", Paths.get("/env/home").toString());
+    environment =
+        ImmutableMap.of(
+            "HOME",
+            Paths.get("/env/home").toString(),
+            "DOCKER_CONFIG",
+            Paths.get("/docker_config").toString());
 
     Mockito.when(mockCredentialRetrieverFactory.dockerCredentialHelper(Mockito.anyString()))
         .thenReturn(mockDockerCredentialHelperCredentialRetriever);
@@ -80,6 +88,17 @@ public class DefaultCredentialRetrieversTest {
         .thenReturn(mockInferredCredentialRetriever);
     Mockito.when(mockCredentialRetrieverFactory.wellKnownCredentialHelpers())
         .thenReturn(mockWellKnownCredentialHelpersCredentialRetriever);
+    Mockito.when(
+            mockCredentialRetrieverFactory.dockerConfig(Paths.get("/docker_config/config.json")))
+        .thenReturn(mockDockerConfigEnvDockerConfigCredentialRetriever);
+    Mockito.when(
+            mockCredentialRetrieverFactory.dockerConfig(
+                Paths.get("/docker_config/.dockerconfigjson")))
+        .thenReturn(mockDockerConfigEnvKubernetesDockerConfigCredentialRetriever);
+    Mockito.when(
+            mockCredentialRetrieverFactory.legacyDockerConfig(
+                Paths.get("/docker_config/.dockercfg")))
+        .thenReturn(mockDockerConfigEnvLegacyDockerConfigCredentialRetriever);
     Mockito.when(
             mockCredentialRetrieverFactory.dockerConfig(
                 Paths.get("/system/home/.docker/config.json")))
@@ -114,6 +133,9 @@ public class DefaultCredentialRetrieversTest {
             .asList();
     Assert.assertEquals(
         Arrays.asList(
+            mockDockerConfigEnvDockerConfigCredentialRetriever,
+            mockDockerConfigEnvKubernetesDockerConfigCredentialRetriever,
+            mockDockerConfigEnvLegacyDockerConfigCredentialRetriever,
             mockSystemHomeDockerConfigCredentialRetriever,
             mockSystemHomeKubernetesDockerConfigCredentialRetriever,
             mockSystemHomeLegacyDockerConfigCredentialRetriever,
@@ -138,6 +160,9 @@ public class DefaultCredentialRetrieversTest {
             mockKnownCredentialRetriever,
             mockDockerCredentialHelperCredentialRetriever,
             mockInferredCredentialRetriever,
+            mockDockerConfigEnvDockerConfigCredentialRetriever,
+            mockDockerConfigEnvKubernetesDockerConfigCredentialRetriever,
+            mockDockerConfigEnvLegacyDockerConfigCredentialRetriever,
             mockSystemHomeDockerConfigCredentialRetriever,
             mockSystemHomeKubernetesDockerConfigCredentialRetriever,
             mockSystemHomeLegacyDockerConfigCredentialRetriever,
@@ -166,6 +191,9 @@ public class DefaultCredentialRetrieversTest {
     Assert.assertEquals(
         Arrays.asList(
             mockDockerCredentialHelperCredentialRetriever,
+            mockDockerConfigEnvDockerConfigCredentialRetriever,
+            mockDockerConfigEnvKubernetesDockerConfigCredentialRetriever,
+            mockDockerConfigEnvLegacyDockerConfigCredentialRetriever,
             mockSystemHomeDockerConfigCredentialRetriever,
             mockSystemHomeKubernetesDockerConfigCredentialRetriever,
             mockSystemHomeLegacyDockerConfigCredentialRetriever,
@@ -210,6 +238,9 @@ public class DefaultCredentialRetrieversTest {
             .asList();
     Assert.assertEquals(
         Arrays.asList(
+            mockDockerConfigEnvDockerConfigCredentialRetriever,
+            mockDockerConfigEnvKubernetesDockerConfigCredentialRetriever,
+            mockDockerConfigEnvLegacyDockerConfigCredentialRetriever,
             mockEnvHomeDockerConfigCredentialRetriever,
             mockEnvHomeKubernetesDockerConfigCredentialRetriever,
             mockEnvHomeLegacyDockerConfigCredentialRetriever,


### PR DESCRIPTION
Part of #1618. Maybe we can follow-up with some sort of `jib.docker.config` system property (config parameter might not make sense since this path is platform dependent).