### PR TITLE
Run Gradle plugin extensions

### DIFF
--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -16,6 +16,7 @@ repositories {
 dependencies {
   sourceProject project(':jib-build-plan')
   sourceProject project(':jib-plugins-extension-common')
+  sourceProject project(':jib-gradle-plugin-extension-api')
   sourceProject project(':jib-core')
   sourceProject project(':jib-plugins-common')
   ensureNoProjectDependencies()

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleExtensionLogger.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleExtensionLogger.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.gradle;
+
+import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger;
+import java.util.function.Consumer;
+
+/** Logger for Gradle plugin extensions. */
+class GradleExtensionLogger implements ExtensionLogger {
+
+  private final Consumer<LogEvent> logger;
+
+  GradleExtensionLogger(Consumer<LogEvent> logger) {
+    this.logger = logger;
+  }
+
+  @Override
+  public void log(ExtensionLogger.LogLevel logLevel, String message) {
+    switch (logLevel) {
+      case ERROR:
+        logger.accept(LogEvent.error(message));
+        break;
+      case WARN:
+        logger.accept(LogEvent.warn(message));
+        break;
+      case LIFECYCLE:
+        logger.accept(LogEvent.lifecycle(message));
+        break;
+      case INFO:
+        logger.accept(LogEvent.info(message));
+        break;
+      case DEBUG:
+        logger.accept(LogEvent.debug(message));
+        break;
+      default:
+        throw new RuntimeException();
+    }
+  }
+}

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.api.Containerizer;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.JavaContainerBuilder;
 import com.google.cloud.tools.jib.api.JavaContainerBuilder.LayerType;
+import com.google.cloud.tools.jib.api.Jib;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.JibContainerBuilderTestHelper;
 import com.google.cloud.tools.jib.api.RegistryImage;
@@ -31,13 +32,17 @@ import com.google.cloud.tools.jib.api.buildplan.FilePermissions;
 import com.google.cloud.tools.jib.configuration.BuildContext;
 import com.google.cloud.tools.jib.filesystem.DirectoryWalker;
 import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
+import com.google.cloud.tools.jib.gradle.extension.JibGradlePluginExtension;
 import com.google.cloud.tools.jib.plugins.common.ContainerizingMode;
+import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger.LogLevel;
+import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Resources;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -594,6 +599,79 @@ public class GradleProjectPropertiesTest {
         .thenReturn("war.war");
 
     Assert.assertEquals("war.war", gradleProjectProperties.getWarFilePath());
+  }
+
+  @Test
+  public void testRunPluginExtensions_noExtensionsFound()
+      throws JibPluginExtensionException, InvalidImageReferenceException {
+    JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("from/nothing"));
+    JibContainerBuilder extendedBuilder =
+        gradleProjectProperties.runPluginExtensions(Collections.emptyIterator(), originalBuilder);
+    Assert.assertSame(extendedBuilder, originalBuilder);
+
+    gradleProjectProperties.waitForLoggingThread();
+    Mockito.verify(mockLogger).debug("No Jib plugin extensions discovered");
+  }
+
+  @Test
+  public void testRunPluginExtensions()
+      throws JibPluginExtensionException, InvalidImageReferenceException {
+    JibGradlePluginExtension extension =
+        (buildPlan, gradleData, logger) -> {
+          logger.log(LogLevel.ERROR, "awesome error from my extension");
+          return buildPlan.toBuilder().setUser("user from extension").build();
+        };
+
+    JibContainerBuilder extendedBuilder =
+        gradleProjectProperties.runPluginExtensions(
+            Arrays.asList(extension).iterator(), Jib.from(RegistryImage.named("from/nothing")));
+    Assert.assertEquals("user from extension", extendedBuilder.toContainerBuildPlan().getUser());
+
+    gradleProjectProperties.waitForLoggingThread();
+    Mockito.verify(mockLogger).error("awesome error from my extension");
+    Mockito.verify(mockLogger)
+        .lifecycle(
+            Mockito.startsWith(
+                "Running extension: com.google.cloud.tools.jib.gradle.GradleProjectProperties"));
+  }
+
+  @Test
+  public void testRunPluginExtensions_exceptionFromExtension()
+      throws InvalidImageReferenceException {
+    FileNotFoundException fakeException = new FileNotFoundException();
+    JibGradlePluginExtension extension =
+        (buildPlan, gradleData, logger) -> {
+          throw new JibPluginExtensionException(
+              JibGradlePluginExtension.class, "exception from extension", fakeException);
+        };
+
+    JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("scratch"));
+    try {
+      gradleProjectProperties.runPluginExtensions(
+          Arrays.asList(extension).iterator(), originalBuilder);
+      Assert.fail();
+    } catch (JibPluginExtensionException ex) {
+      Assert.assertEquals("exception from extension", ex.getMessage());
+      Assert.assertSame(fakeException, ex.getCause());
+    }
+  }
+
+  @Test
+  public void testRunPluginExtensions_invalidBaseImageFromExtension()
+      throws InvalidImageReferenceException {
+    JibGradlePluginExtension extension =
+        (buildPlan, gradleData, logger) -> buildPlan.toBuilder().setBaseImage(" in*val+id").build();
+
+    JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("from/nothing"));
+    try {
+      gradleProjectProperties.runPluginExtensions(
+          Arrays.asList(extension).iterator(), originalBuilder);
+      Assert.fail();
+    } catch (JibPluginExtensionException ex) {
+      Assert.assertEquals("invalid base image reference:  in*val+id", ex.getMessage());
+      Assert.assertThat(
+          ex.getCause(), CoreMatchers.instanceOf(InvalidImageReferenceException.class));
+    }
   }
 
   private BuildContext setupBuildContext(String appRoot)


### PR DESCRIPTION
Gradle counterpart of #2397.

Using the standard Service Provider Interfaces (SPI) mechanism to load and run Gradle plugin extensions.

This doesn't yet involve the new extension config option (like `jib.extensions=[ { implementation='com.example.ExtensionClass' }]`). The config option can be added in a later PR.

With this, we are actually enabling running and testing Gradle extensions. Extensions should be added to the classpath of the Gradle build script. Extensions added in this way apply to all sub-modules in a multi-module project, so we do need the new config option in the end.

```gradle
buildscript {
    dependencies {
        classpath 'com.google.cloud.tools.jib.plugins.extension.gradle.quarkus:quarkus-extension-gradle:0.1.0-SNAPSHOT'
    }
}
```