### PR TITLE
Ignore SNAPSHOT dependencies of plugin extension sub-projects when publishing

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -33,6 +33,7 @@ import com.google.cloud.tools.jib.plugins.common.ContainerizingMode;
 import com.google.cloud.tools.jib.plugins.common.JavaContainerBuilderHelper;
 import com.google.cloud.tools.jib.plugins.common.ProjectProperties;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
+import com.google.cloud.tools.jib.plugins.common.RawConfiguration.ExtensionConfiguration;
 import com.google.cloud.tools.jib.plugins.common.TimerEventHandler;
 import com.google.cloud.tools.jib.plugins.common.ZipUtil;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
@@ -396,7 +397,8 @@ public class GradleProjectProperties implements ProjectProperties {
   }
 
   @Override
-  public JibContainerBuilder runPluginExtensions(JibContainerBuilder jibContainerBuilder)
+  public JibContainerBuilder runPluginExtensions(
+      List<ExtensionConfiguration> extensionConfigs, JibContainerBuilder jibContainerBuilder)
       throws JibPluginExtensionException {
     return runPluginExtensions(
         ServiceLoader.load(JibGradlePluginExtension.class).iterator(), jibContainerBuilder);

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
 import com.google.cloud.tools.jib.plugins.common.RawConfiguration;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -198,5 +199,10 @@ public class GradleRawConfiguration implements RawConfiguration {
   @Override
   public Path getImageJsonOutputPath() {
     return jibExtension.getOutputPaths().getImageJsonPath();
+  }
+
+  @Override
+  public List<ExtensionConfiguration> getPluginExtensions() {
+    return Collections.emptyList();
   }
 }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesExtensionTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.gradle;
+
+import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
+import com.google.cloud.tools.jib.api.Jib;
+import com.google.cloud.tools.jib.api.JibContainerBuilder;
+import com.google.cloud.tools.jib.api.RegistryImage;
+import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
+import com.google.cloud.tools.jib.gradle.extension.JibGradlePluginExtension;
+import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger.LogLevel;
+import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
+import java.io.FileNotFoundException;
+import java.util.Arrays;
+import java.util.Collections;
+import org.gradle.api.Project;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.configuration.ConsoleOutput;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Answers;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Plugin extension test for {@link GradleProjectProperties}. */
+@RunWith(MockitoJUnitRunner.class)
+public class GradleProjectPropertiesExtensionTest {
+
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Mock private TempDirectoryProvider mockTempDirectoryProvider;
+  @Mock private Logger mockLogger;
+
+  @Mock(answer = Answers.RETURNS_DEEP_STUBS)
+  private Project mockProject;
+
+  private GradleProjectProperties gradleProjectProperties;
+
+  @Before
+  public void setUp() {
+    Mockito.when(mockLogger.isDebugEnabled()).thenReturn(true);
+    Mockito.when(mockLogger.isInfoEnabled()).thenReturn(true);
+    Mockito.when(mockLogger.isWarnEnabled()).thenReturn(true);
+    Mockito.when(mockLogger.isErrorEnabled()).thenReturn(true);
+
+    Mockito.when(mockProject.getGradle().getStartParameter().getConsoleOutput())
+        .thenReturn(ConsoleOutput.Plain);
+
+    gradleProjectProperties =
+        new GradleProjectProperties(mockProject, mockLogger, mockTempDirectoryProvider);
+  }
+
+  @Test
+  public void testRunPluginExtensions_noExtensionsFound()
+      throws JibPluginExtensionException, InvalidImageReferenceException {
+    JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("from/nothing"));
+    JibContainerBuilder extendedBuilder =
+        gradleProjectProperties.runPluginExtensions(Collections.emptyIterator(), originalBuilder);
+    Assert.assertSame(extendedBuilder, originalBuilder);
+
+    gradleProjectProperties.waitForLoggingThread();
+    Mockito.verify(mockLogger).debug("No Jib plugin extensions discovered");
+  }
+
+  @Test
+  public void testRunPluginExtensions()
+      throws JibPluginExtensionException, InvalidImageReferenceException {
+    JibGradlePluginExtension extension =
+        (buildPlan, gradleData, logger) -> {
+          logger.log(LogLevel.ERROR, "awesome error from my extension");
+          return buildPlan.toBuilder().setUser("user from extension").build();
+        };
+
+    JibContainerBuilder extendedBuilder =
+        gradleProjectProperties.runPluginExtensions(
+            Arrays.asList(extension).iterator(), Jib.from(RegistryImage.named("from/nothing")));
+    Assert.assertEquals("user from extension", extendedBuilder.toContainerBuildPlan().getUser());
+
+    gradleProjectProperties.waitForLoggingThread();
+    Mockito.verify(mockLogger).error("awesome error from my extension");
+    Mockito.verify(mockLogger)
+        .lifecycle(
+            Mockito.startsWith(
+                "Running extension: com.google.cloud.tools.jib.gradle.GradleProjectProperties"));
+  }
+
+  @Test
+  public void testRunPluginExtensions_exceptionFromExtension()
+      throws InvalidImageReferenceException {
+    FileNotFoundException fakeException = new FileNotFoundException();
+    JibGradlePluginExtension extension =
+        (buildPlan, gradleData, logger) -> {
+          throw new JibPluginExtensionException(
+              JibGradlePluginExtension.class, "exception from extension", fakeException);
+        };
+
+    JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("scratch"));
+    try {
+      gradleProjectProperties.runPluginExtensions(
+          Arrays.asList(extension).iterator(), originalBuilder);
+      Assert.fail();
+    } catch (JibPluginExtensionException ex) {
+      Assert.assertEquals("exception from extension", ex.getMessage());
+      Assert.assertSame(fakeException, ex.getCause());
+    }
+  }
+
+  @Test
+  public void testRunPluginExtensions_invalidBaseImageFromExtension()
+      throws InvalidImageReferenceException {
+    JibGradlePluginExtension extension =
+        (buildPlan, gradleData, logger) -> buildPlan.toBuilder().setBaseImage(" in*val+id").build();
+
+    JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("from/nothing"));
+    try {
+      gradleProjectProperties.runPluginExtensions(
+          Arrays.asList(extension).iterator(), originalBuilder);
+      Assert.fail();
+    } catch (JibPluginExtensionException ex) {
+      Assert.assertEquals("invalid base image reference:  in*val+id", ex.getMessage());
+      Assert.assertThat(
+          ex.getCause(), CoreMatchers.instanceOf(InvalidImageReferenceException.class));
+    }
+  }
+}

--- a/jib-maven-plugin-extension-api/src/main/java/com/google/cloud/tools/jib/maven/extension/JibMavenPluginExtension.java
+++ b/jib-maven-plugin-extension-api/src/main/java/com/google/cloud/tools/jib/maven/extension/JibMavenPluginExtension.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.api.buildplan.ContainerBuildPlan;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger;
 import com.google.cloud.tools.jib.plugins.extension.JibPluginExtension;
 import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
+import java.util.Map;
 
 /**
  * Jib Maven plugin extension API.
@@ -34,12 +35,16 @@ public interface JibMavenPluginExtension extends JibPluginExtension {
    * Extends the build plan prepared by the Jib Maven plugin.
    *
    * @param buildPlan original build plan prepared by the Jib Maven plugin
+   * @param properties custom properties configured for the plugin extension
    * @param mavenData {@link MavenData} providing Maven-specific data and properties
    * @param logger logger for writing log messages
    * @return updated build plan
    * @throws JibPluginExtensionException if an error occurs while running the plugin extension
    */
   ContainerBuildPlan extendContainerBuildPlan(
-      ContainerBuildPlan buildPlan, MavenData mavenData, ExtensionLogger logger)
+      ContainerBuildPlan buildPlan,
+      Map<String, String> properties,
+      MavenData mavenData,
+      ExtensionLogger logger)
       throws JibPluginExtensionException;
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -222,13 +222,13 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
 
   public static class ExtensionParameters implements ExtensionConfiguration {
 
-    @Nullable @Parameter private String implementation;
+    @Parameter private String implementation = "undefined";
 
     @Parameter private Map<String, String> properties = Collections.emptyMap();
 
     @Override
-    public Optional<String> getExtensionClass() {
-      return Optional.ofNullable(implementation);
+    public String getExtensionClass() {
+      return implementation;
     }
 
     @Override

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.maven;
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
 import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
+import com.google.cloud.tools.jib.plugins.common.RawConfiguration.ExtensionConfiguration;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -219,6 +220,23 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
     @Nullable @Parameter private File imageJson;
   }
 
+  public static class ExtensionParameters implements ExtensionConfiguration {
+
+    @Nullable @Parameter private String implementation;
+
+    @Parameter private Map<String, String> properties = Collections.emptyMap();
+
+    @Override
+    public Optional<String> getExtensionClass() {
+      return Optional.ofNullable(implementation);
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+      return properties;
+    }
+  }
+
   @Nullable
   @Parameter(defaultValue = "${session}", readonly = true)
   private MavenSession session;
@@ -252,6 +270,8 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
 
   @Parameter(property = PropertyNames.SKIP)
   private boolean skip;
+
+  @Parameter private List<ExtensionParameters> extensions = Collections.emptyList();
 
   @Component protected SettingsDecrypter settingsDecrypter;
 
@@ -652,6 +672,10 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
 
   boolean isSkipped() {
     return skip;
+  }
+
+  List<ExtensionParameters> getPluginExtensions() {
+    return extensions;
   }
 
   /**

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -546,10 +546,6 @@ public class MavenProjectProperties implements ProjectProperties {
       List<ExtensionConfiguration> extensionConfigs,
       JibContainerBuilder jibContainerBuilder)
       throws JibPluginExtensionException {
-    if (services.isEmpty()) {
-      log(LogEvent.debug("No Jib plugin extensions discovered on Jib runtime classpath"));
-      return jibContainerBuilder;
-    }
     if (extensionConfigs.isEmpty()) {
       log(LogEvent.debug("No Jib plugin extensions configured to load"));
       return jibContainerBuilder;

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
@@ -204,4 +204,11 @@ public class MavenRawConfiguration implements RawConfiguration {
   public Path getImageJsonOutputPath() {
     return jibPluginConfiguration.getImageJsonOutputPath();
   }
+
+  @SuppressWarnings("unchecked")
+  @Override
+  public List<ExtensionConfiguration> getPluginExtensions() {
+    return (List<ExtensionConfiguration>)
+        (List<? extends ExtensionConfiguration>) jibPluginConfiguration.getPluginExtensions();
+  }
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesExtensionTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesExtensionTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2018 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.maven;
+
+import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
+import com.google.cloud.tools.jib.api.Jib;
+import com.google.cloud.tools.jib.api.JibContainerBuilder;
+import com.google.cloud.tools.jib.api.RegistryImage;
+import com.google.cloud.tools.jib.api.buildplan.ContainerBuildPlan;
+import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
+import com.google.cloud.tools.jib.maven.extension.JibMavenPluginExtension;
+import com.google.cloud.tools.jib.maven.extension.MavenData;
+import com.google.cloud.tools.jib.plugins.common.RawConfiguration.ExtensionConfiguration;
+import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger;
+import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger.LogLevel;
+import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
+import java.io.FileNotFoundException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.maven.execution.MavenExecutionRequest;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.descriptor.PluginDescriptor;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.project.MavenProject;
+import org.hamcrest.CoreMatchers;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Plugin extension test for {@link MavenProjectProperties}. */
+@RunWith(MockitoJUnitRunner.class)
+public class MavenProjectPropertiesExtensionTest {
+
+  // Interface defined only to give a type name.
+  private static class FakeJibMavenPluginExtension implements JibMavenPluginExtension {
+
+    private final JibMavenPluginExtension extension;
+
+    private FakeJibMavenPluginExtension(JibMavenPluginExtension extension) {
+      this.extension = extension;
+    }
+
+    @Override
+    public ContainerBuildPlan extendContainerBuildPlan(
+        ContainerBuildPlan buildPlan,
+        Map<String, String> properties,
+        MavenData mavenData,
+        ExtensionLogger logger)
+        throws JibPluginExtensionException {
+      return extension.extendContainerBuildPlan(buildPlan, properties, mavenData, logger);
+    }
+  }
+
+  private static class FakeExtensionConfiguration implements ExtensionConfiguration {
+
+    private String extensionClass = FakeJibMavenPluginExtension.class.getName();
+    private Map<String, String> properties = Collections.emptyMap();
+
+    private FakeExtensionConfiguration() {}
+
+    private FakeExtensionConfiguration(String extensionClass, Map<String, String> properties) {
+      this.extensionClass = extensionClass;
+      this.properties = properties;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+      return properties;
+    }
+
+    @Override
+    public Optional<String> getExtensionClass() {
+      return Optional.of(extensionClass);
+    }
+  }
+
+  @Rule public final TestRepository testRepository = new TestRepository();
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Mock private PluginDescriptor mockJibPluginDescriptor;
+  @Mock private MavenProject mockMavenProject;
+  @Mock private MavenSession mockMavenSession;
+  @Mock private MavenExecutionRequest mockMavenRequest;
+  @Mock private Log mockLog;
+  @Mock private TempDirectoryProvider mockTempDirectoryProvider;
+
+  private MavenProjectProperties mavenProjectProperties;
+
+  @Before
+  public void setUp() {
+    Mockito.when(mockLog.isDebugEnabled()).thenReturn(true);
+    Mockito.when(mockLog.isWarnEnabled()).thenReturn(true);
+    Mockito.when(mockLog.isErrorEnabled()).thenReturn(true);
+
+    Mockito.when(mockMavenSession.getRequest()).thenReturn(mockMavenRequest);
+    mavenProjectProperties =
+        new MavenProjectProperties(
+            mockJibPluginDescriptor,
+            mockMavenProject,
+            mockMavenSession,
+            mockLog,
+            mockTempDirectoryProvider);
+  }
+
+  @Test
+  public void testRunPluginExtensions_noExtensionsFound()
+      throws JibPluginExtensionException, InvalidImageReferenceException {
+    JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("from/nothing"));
+    JibContainerBuilder extendedBuilder =
+        mavenProjectProperties.runPluginExtensions(
+            Collections.emptyIterator(), Collections.emptyList(), originalBuilder);
+    Assert.assertSame(extendedBuilder, originalBuilder);
+
+    mavenProjectProperties.waitForLoggingThread();
+    Mockito.verify(mockLog).debug("No Jib plugin extensions discovered on Jib runtime classpath");
+  }
+
+  @Test
+  public void testRunPluginExtensions()
+      throws JibPluginExtensionException, InvalidImageReferenceException {
+    JibMavenPluginExtension extension =
+        new FakeJibMavenPluginExtension(
+            (buildPlan, properties, mavenData, logger) -> {
+              logger.log(LogLevel.ERROR, "awesome error from my extension");
+              return buildPlan.toBuilder().setUser("user from extension").build();
+            });
+
+    JibContainerBuilder extendedBuilder =
+        mavenProjectProperties.runPluginExtensions(
+            Arrays.asList(extension).iterator(),
+            Arrays.asList(new FakeExtensionConfiguration()),
+            Jib.from(RegistryImage.named("from/nothing")));
+    Assert.assertEquals("user from extension", extendedBuilder.toContainerBuildPlan().getUser());
+
+    mavenProjectProperties.waitForLoggingThread();
+    Mockito.verify(mockLog).error("awesome error from my extension");
+    Mockito.verify(mockLog)
+        .info(
+            Mockito.startsWith(
+                "Running extension: com.google.cloud.tools.jib.maven.MavenProjectProperties"));
+  }
+
+  @Test
+  public void testRunPluginExtensions_exceptionFromExtension()
+      throws InvalidImageReferenceException {
+    FileNotFoundException fakeException = new FileNotFoundException();
+    JibMavenPluginExtension extension =
+        new FakeJibMavenPluginExtension(
+            (buildPlan, properties, mavenData, logger) -> {
+              throw new JibPluginExtensionException(
+                  JibMavenPluginExtension.class, "exception from extension", fakeException);
+            });
+
+    JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("scratch"));
+    try {
+      mavenProjectProperties.runPluginExtensions(
+          Arrays.asList(extension).iterator(),
+          Arrays.asList(new FakeExtensionConfiguration()),
+          originalBuilder);
+      Assert.fail();
+    } catch (JibPluginExtensionException ex) {
+      Assert.assertEquals("exception from extension", ex.getMessage());
+      Assert.assertSame(fakeException, ex.getCause());
+    }
+  }
+
+  @Test
+  public void testRunPluginExtensions_invalidBaseImageFromExtension()
+      throws InvalidImageReferenceException {
+    JibMavenPluginExtension extension =
+        new FakeJibMavenPluginExtension(
+            (buildPlan, properties, mavenData, logger) ->
+                buildPlan.toBuilder().setBaseImage(" in*val+id").build());
+
+    JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("from/nothing"));
+    try {
+      mavenProjectProperties.runPluginExtensions(
+          Arrays.asList(extension).iterator(),
+          Arrays.asList(new FakeExtensionConfiguration()),
+          originalBuilder);
+      Assert.fail();
+    } catch (JibPluginExtensionException ex) {
+      Assert.assertEquals("invalid base image reference:  in*val+id", ex.getMessage());
+      Assert.assertThat(
+          ex.getCause(), CoreMatchers.instanceOf(InvalidImageReferenceException.class));
+    }
+  }
+}

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -26,13 +26,17 @@ import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.JibContainerBuilderTestHelper;
 import com.google.cloud.tools.jib.api.RegistryImage;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.api.buildplan.ContainerBuildPlan;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.FileEntry;
 import com.google.cloud.tools.jib.configuration.BuildContext;
 import com.google.cloud.tools.jib.filesystem.DirectoryWalker;
 import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
 import com.google.cloud.tools.jib.maven.extension.JibMavenPluginExtension;
+import com.google.cloud.tools.jib.maven.extension.MavenData;
 import com.google.cloud.tools.jib.plugins.common.ContainerizingMode;
+import com.google.cloud.tools.jib.plugins.common.RawConfiguration.ExtensionConfiguration;
+import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger;
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger.LogLevel;
 import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
 import com.google.common.collect.ImmutableList;
@@ -88,6 +92,49 @@ public class MavenProjectPropertiesTest {
 
   private static final ContainerizingMode DEFAULT_CONTAINERIZING_MODE = ContainerizingMode.EXPLODED;
   private static final Instant SAMPLE_FILE_MODIFICATION_TIME = Instant.ofEpochSecond(32);
+
+  // Interface defined only to give a type name.
+  private static class FakeJibMavenPluginExtension implements JibMavenPluginExtension {
+
+    private final JibMavenPluginExtension extension;
+
+    private FakeJibMavenPluginExtension(JibMavenPluginExtension extension) {
+      this.extension = extension;
+    }
+
+    @Override
+    public ContainerBuildPlan extendContainerBuildPlan(
+        ContainerBuildPlan buildPlan,
+        Map<String, String> properties,
+        MavenData mavenData,
+        ExtensionLogger logger)
+        throws JibPluginExtensionException {
+      return extension.extendContainerBuildPlan(buildPlan, properties, mavenData, logger);
+    }
+  }
+
+  private static class FakeExtensionConfiguration implements ExtensionConfiguration {
+
+    private String extensionClass = FakeJibMavenPluginExtension.class.getName();
+    private Map<String, String> properties = Collections.emptyMap();
+
+    private FakeExtensionConfiguration() {}
+
+    private FakeExtensionConfiguration(String extensionClass, Map<String, String> properties) {
+      this.extensionClass = extensionClass;
+      this.properties = properties;
+    }
+
+    @Override
+    public Map<String, String> getProperties() {
+      return properties;
+    }
+
+    @Override
+    public Optional<String> getExtensionClass() {
+      return Optional.of(extensionClass);
+    }
+  }
 
   /** Helper for reading back layers in a {@link BuildContext}. */
   private static class ContainerBuilderLayers {
@@ -1013,25 +1060,29 @@ public class MavenProjectPropertiesTest {
       throws JibPluginExtensionException, InvalidImageReferenceException {
     JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("from/nothing"));
     JibContainerBuilder extendedBuilder =
-        mavenProjectProperties.runPluginExtensions(Collections.emptyIterator(), originalBuilder);
+        mavenProjectProperties.runPluginExtensions(
+            Collections.emptyIterator(), Collections.emptyList(), originalBuilder);
     Assert.assertSame(extendedBuilder, originalBuilder);
 
     mavenProjectProperties.waitForLoggingThread();
-    Mockito.verify(mockLog).debug("No Jib plugin extensions discovered");
+    Mockito.verify(mockLog).debug("No Jib plugin extensions discovered on Jib runtime classpath");
   }
 
   @Test
   public void testRunPluginExtensions()
       throws JibPluginExtensionException, InvalidImageReferenceException {
     JibMavenPluginExtension extension =
-        (buildPlan, mavenData, logger) -> {
-          logger.log(LogLevel.ERROR, "awesome error from my extension");
-          return buildPlan.toBuilder().setUser("user from extension").build();
-        };
+        new FakeJibMavenPluginExtension(
+            (buildPlan, properties, mavenData, logger) -> {
+              logger.log(LogLevel.ERROR, "awesome error from my extension");
+              return buildPlan.toBuilder().setUser("user from extension").build();
+            });
 
     JibContainerBuilder extendedBuilder =
         mavenProjectProperties.runPluginExtensions(
-            Arrays.asList(extension).iterator(), Jib.from(RegistryImage.named("from/nothing")));
+            Arrays.asList(extension).iterator(),
+            Arrays.asList(new FakeExtensionConfiguration()),
+            Jib.from(RegistryImage.named("from/nothing")));
     Assert.assertEquals("user from extension", extendedBuilder.toContainerBuildPlan().getUser());
 
     mavenProjectProperties.waitForLoggingThread();
@@ -1047,15 +1098,18 @@ public class MavenProjectPropertiesTest {
       throws InvalidImageReferenceException {
     FileNotFoundException fakeException = new FileNotFoundException();
     JibMavenPluginExtension extension =
-        (buildPlan, mavenData, logger) -> {
-          throw new JibPluginExtensionException(
-              JibMavenPluginExtension.class, "exception from extension", fakeException);
-        };
+        new FakeJibMavenPluginExtension(
+            (buildPlan, properties, mavenData, logger) -> {
+              throw new JibPluginExtensionException(
+                  JibMavenPluginExtension.class, "exception from extension", fakeException);
+            });
 
     JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("scratch"));
     try {
       mavenProjectProperties.runPluginExtensions(
-          Arrays.asList(extension).iterator(), originalBuilder);
+          Arrays.asList(extension).iterator(),
+          Arrays.asList(new FakeExtensionConfiguration()),
+          originalBuilder);
       Assert.fail();
     } catch (JibPluginExtensionException ex) {
       Assert.assertEquals("exception from extension", ex.getMessage());
@@ -1067,12 +1121,16 @@ public class MavenProjectPropertiesTest {
   public void testRunPluginExtensions_invalidBaseImageFromExtension()
       throws InvalidImageReferenceException {
     JibMavenPluginExtension extension =
-        (buildPlan, mavenData, logger) -> buildPlan.toBuilder().setBaseImage(" in*val+id").build();
+        new FakeJibMavenPluginExtension(
+            (buildPlan, properties, mavenData, logger) ->
+                buildPlan.toBuilder().setBaseImage(" in*val+id").build());
 
     JibContainerBuilder originalBuilder = Jib.from(RegistryImage.named("from/nothing"));
     try {
       mavenProjectProperties.runPluginExtensions(
-          Arrays.asList(extension).iterator(), originalBuilder);
+          Arrays.asList(extension).iterator(),
+          Arrays.asList(new FakeExtensionConfiguration()),
+          originalBuilder);
       Assert.fail();
     } catch (JibPluginExtensionException ex) {
       Assert.assertEquals("invalid base image reference:  in*val+id", ex.getMessage());

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -125,7 +125,9 @@ public class PluginConfigurationProcessor {
         processCommonConfiguration(
             rawConfiguration, inferredAuthProvider, projectProperties, containerizer);
     JibContainerBuilder updatedContainerBuilder =
-        projectProperties.runPluginExtensions(jibContainerBuilder).setFormat(ImageFormat.Docker);
+        projectProperties
+            .runPluginExtensions(rawConfiguration.getPluginExtensions(), jibContainerBuilder)
+            .setFormat(ImageFormat.Docker);
 
     return JibBuildRunner.forBuildToDockerDaemon(
             updatedContainerBuilder,
@@ -184,7 +186,8 @@ public class PluginConfigurationProcessor {
         processCommonConfiguration(
             rawConfiguration, inferredAuthProvider, projectProperties, containerizer);
     JibContainerBuilder updatedContainerBuilder =
-        projectProperties.runPluginExtensions(jibContainerBuilder);
+        projectProperties.runPluginExtensions(
+            rawConfiguration.getPluginExtensions(), jibContainerBuilder);
 
     return JibBuildRunner.forBuildTar(
             updatedContainerBuilder,
@@ -258,7 +261,8 @@ public class PluginConfigurationProcessor {
         processCommonConfiguration(
             rawConfiguration, inferredAuthProvider, projectProperties, containerizer);
     JibContainerBuilder updatedContainerBuilder =
-        projectProperties.runPluginExtensions(jibContainerBuilder);
+        projectProperties.runPluginExtensions(
+            rawConfiguration.getPluginExtensions(), jibContainerBuilder);
 
     return JibBuildRunner.forBuildImage(
             updatedContainerBuilder,

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.api.Containerizer;
 import com.google.cloud.tools.jib.api.JavaContainerBuilder;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.plugins.common.RawConfiguration.ExtensionConfiguration;
 import com.google.cloud.tools.jib.plugins.extension.JibPluginExtensionException;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -87,6 +88,7 @@ public interface ProjectProperties {
 
   boolean isOffline();
 
-  JibContainerBuilder runPluginExtensions(JibContainerBuilder jibContainerBuilder)
+  JibContainerBuilder runPluginExtensions(
+      List<ExtensionConfiguration> extensionConfigs, JibContainerBuilder jibContainerBuilder)
       throws JibPluginExtensionException;
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
@@ -32,7 +32,7 @@ public interface RawConfiguration {
 
   static interface ExtensionConfiguration {
 
-    Optional<String> getExtensionClass();
+    String getExtensionClass();
 
     Map<String, String> getProperties();
   }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
@@ -30,6 +30,13 @@ import java.util.Set;
  */
 public interface RawConfiguration {
 
+  static interface ExtensionConfiguration {
+
+    Optional<String> getExtensionClass();
+
+    Map<String, String> getProperties();
+  }
+
   Optional<String> getFromImage();
 
   Optional<String> getToImage();
@@ -95,4 +102,6 @@ public interface RawConfiguration {
   Path getImageIdOutputPath();
 
   Path getImageJsonOutputPath();
+
+  List<ExtensionConfiguration> getPluginExtensions();
 }


### PR DESCRIPTION
We are not yet publishing these artifacts to Maven Central. Will ignore SNAPSHOT versions for now.