### PR TITLE
Ignore SNAPSHOT dependencies of plugin extension sub-projects when publishing

### DIFF
--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -38,8 +38,11 @@ dependencies {
 release {
   tagTemplate = 'v$version-gradle'
   ignoredSnapshotDependencies = [
+    'com.google.cloud.tools:jib-build-plan',
     'com.google.cloud.tools:jib-core',
     'com.google.cloud.tools:jib-plugins-common',
+    'com.google.cloud.tools:jib-plugins-extension-common',
+    'com.google.cloud.tools:jib-gradle-plugin-extension-api',
   ]
   git {
     requireBranch = /^gradle_release_v\d+.*$/  //regex

--- a/jib-maven-plugin/build.gradle
+++ b/jib-maven-plugin/build.gradle
@@ -65,8 +65,11 @@ publishing {
 release {
   tagTemplate = 'v$version-maven'
   ignoredSnapshotDependencies = [
+    'com.google.cloud.tools:jib-build-plan',
     'com.google.cloud.tools:jib-core',
     'com.google.cloud.tools:jib-plugins-common',
+    'com.google.cloud.tools:jib-plugins-extension-common',
+    'com.google.cloud.tools:jib-maven-plugin-extension-api',
   ]
   git {
     requireBranch = /^maven_release_v\d+.*$/  //regex


### PR DESCRIPTION
We are not yet publishing these artifacts to Maven Central. Will ignore SNAPSHOT versions for now.