### PR TITLE
Conditionally allow installs of local SNAPSHOT

### DIFF
--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 /* LOCAL SNAPSHOT DEV */
 // to install for local testing - do not load this plugin when publishing to plugin portal
-// 'maven-publish' and 'com.gradle.plugin-publish' do no interact well with eachother
+// 'maven-publish' and 'com.gradle.plugin-publish' do not interact well with eachother
 // https://discuss.gradle.org/t/debug-an-issue-in-publish-plugin-gradle-plugin-not-being-prepended-to-groupid/32720
 if (version.contains("SNAPSHOT")) {
   apply plugin: 'maven-publish'

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -8,7 +8,7 @@ plugins {
 
 /* LOCAL SNAPSHOT DEV */
 // to install for local testing - do not load this plugin when publishing to plugin portal
-// 'maven-publish' and 'com.gradle.plugin-publish' do not interact well with eachother
+// 'maven-publish' and 'com.gradle.plugin-publish' do not interact well with each other
 // https://discuss.gradle.org/t/debug-an-issue-in-publish-plugin-gradle-plugin-not-being-prepended-to-groupid/32720
 if (version.contains("SNAPSHOT")) {
   apply plugin: 'maven-publish'

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -2,11 +2,28 @@ plugins {
   id 'java-gradle-plugin'
   id 'net.researchgate.release'
   id 'com.gradle.plugin-publish'
-  // for local SNAPSHOT build/test
-  id 'maven-publish'
   // for eclipse import modifications
   id 'eclipse'
 }
+
+/* LOCAL SNAPSHOT DEV */
+// to install for local testing - do not load this plugin when publishing to plugin portal
+// 'maven-publish' and 'com.gradle.plugin-publish' do no interact well with eachother
+// https://discuss.gradle.org/t/debug-an-issue-in-publish-plugin-gradle-plugin-not-being-prepended-to-groupid/32720
+if (version.contains("SNAPSHOT")) {
+  apply plugin: 'maven-publish'
+
+  publishing {
+    repositories {
+      mavenLocal()
+    }
+  }
+
+  task install {
+    dependsOn publishToMavenLocal
+  }
+}
+/* LOCAL SNAPSHOT DEV */
 
 repositories {
   // because gradle plugin dependencies are pulling from jcenter
@@ -82,15 +99,3 @@ eclipse.classpath.file.whenMerged {
   }
 }
 /* ECLIPSE */
-
-/* LOCAL SNAPSHOT DEV */
-publishing {
-  repositories {
-    mavenLocal()
-  }
-}
-
-task install {
-  dependsOn publishToMavenLocal
-}
-/* LOCAL SNAPSHOT DEV */


### PR DESCRIPTION
This prevents maven-publish from messing with plugin-publish

fixes #2424 (more specifically addresses the bug at: https://discuss.gradle.org/t/debug-an-issue-in-publish-plugin-gradle-plugin-not-being-prepended-to-groupid/32720)

I also tested the plugin release process, and it goes back to the normal behavior.