### PR TITLE
Rename Maven extension config name

### DIFF
--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -271,7 +271,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   @Parameter(property = PropertyNames.SKIP)
   private boolean skip;
 
-  @Parameter private List<ExtensionParameters> extensions = Collections.emptyList();
+  @Parameter private List<ExtensionParameters> pluginExtensions = Collections.emptyList();
 
   @Component protected SettingsDecrypter settingsDecrypter;
 
@@ -675,7 +675,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
   }
 
   List<ExtensionParameters> getPluginExtensions() {
-    return extensions;
+    return pluginExtensions;
   }
 
   /**


### PR DESCRIPTION
`<extensions>` --> `<pluginExtensions>`

This is to match parity with Gradle as explained in https://github.com/GoogleContainerTools/jib/pull/2431#issue-409784549.