### PR TITLE
rework main class finding

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the problem not inheriting `USER` container configuration from a base image. ([#2421](https://github.com/GoogleContainerTools/jib/pull/2421))
 - Fixed wrong capitalization of JSON properties in a loadable Docker manifest when building a tar image. ([#2430](https://github.com/GoogleContainerTools/jib/issues/2430))
 - Fixed an issue when using a base image whose image creation timestamp contains timezone offset. ([#2428](https://github.com/GoogleContainerTools/jib/issues/2428))
+- Fixed an issue inferring a wrong main class or using an invalid main class (for example, Spring Boot project containing multiple main classes). ([#2456](https://github.com/GoogleContainerTools/jib/issues/2456))
 
 ## 2.2.0
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -323,7 +323,7 @@ public class GradleProjectProperties implements ProjectProperties {
 
   @Nullable
   @Override
-  public String getMainClassFromJar() {
+  public String getMainClassFromJarPlugin() {
     Jar jarTask = (Jar) project.getTasks().findByName("jar");
     if (jarTask == null) {
       return null;

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -267,13 +267,13 @@ public class GradleProjectPropertiesTest {
     Jar mockJar = Mockito.mock(Jar.class);
     Mockito.when(mockJar.getManifest()).thenReturn(manifest);
     Mockito.when(mockTaskContainer.findByName("jar")).thenReturn(mockJar);
-    Assert.assertEquals("some.main.class", gradleProjectProperties.getMainClassFromJar());
+    Assert.assertEquals("some.main.class", gradleProjectProperties.getMainClassFromJarPlugin());
   }
 
   @Test
   public void testGetMainClassFromJar_missing() {
     Mockito.when(mockTaskContainer.findByName("jar")).thenReturn(null);
-    Assert.assertNull(gradleProjectProperties.getMainClassFromJar());
+    Assert.assertNull(gradleProjectProperties.getMainClassFromJarPlugin());
   }
 
   @Test

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the problem not inheriting `USER` container configuration from a base image. ([#2421](https://github.com/GoogleContainerTools/jib/pull/2421))
 - Fixed wrong capitalization of JSON properties in a loadable Docker manifest when building a tar image. ([#2430](https://github.com/GoogleContainerTools/jib/issues/2430))
 - Fixed an issue when using a base image whose image creation timestamp contains timezone offset. ([#2428](https://github.com/GoogleContainerTools/jib/issues/2428))
+- Fixed an issue inferring a wrong main class or using an invalid main class (for example, Spring Boot project containing multiple main classes). ([#2456](https://github.com/GoogleContainerTools/jib/issues/2456))
 
 ## 2.2.0
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -365,7 +365,7 @@ public class MavenProjectProperties implements ProjectProperties {
 
   @Nullable
   @Override
-  public String getMainClassFromJar() {
+  public String getMainClassFromJarPlugin() {
     Plugin mavenJarPlugin = project.getPlugin("org.apache.maven.plugins:maven-jar-plugin");
     if (mavenJarPlugin != null) {
       return getChildValue(

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -294,7 +294,7 @@ public class MavenProjectPropertiesTest {
     archive.addChild(manifest);
     manifest.addChild(newXpp3Dom("mainClass", "some.main.class"));
 
-    Assert.assertEquals("some.main.class", mavenProjectProperties.getMainClassFromJar());
+    Assert.assertEquals("some.main.class", mavenProjectProperties.getMainClassFromJarPlugin());
   }
 
   @Test
@@ -306,7 +306,7 @@ public class MavenProjectPropertiesTest {
     archive.addChild(new Xpp3Dom("manifest"));
     pluginConfiguration.addChild(archive);
 
-    Assert.assertNull(mavenProjectProperties.getMainClassFromJar());
+    Assert.assertNull(mavenProjectProperties.getMainClassFromJarPlugin());
   }
 
   @Test
@@ -316,7 +316,7 @@ public class MavenProjectPropertiesTest {
     Mockito.when(mockPlugin.getConfiguration()).thenReturn(pluginConfiguration);
     pluginConfiguration.addChild(new Xpp3Dom("archive"));
 
-    Assert.assertNull(mavenProjectProperties.getMainClassFromJar());
+    Assert.assertNull(mavenProjectProperties.getMainClassFromJarPlugin());
   }
 
   @Test
@@ -325,7 +325,7 @@ public class MavenProjectPropertiesTest {
         .thenReturn(mockPlugin);
     Mockito.when(mockPlugin.getConfiguration()).thenReturn(pluginConfiguration);
 
-    Assert.assertNull(mavenProjectProperties.getMainClassFromJar());
+    Assert.assertNull(mavenProjectProperties.getMainClassFromJarPlugin());
   }
 
   @Test
@@ -333,12 +333,12 @@ public class MavenProjectPropertiesTest {
     Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
         .thenReturn(mockPlugin);
 
-    Assert.assertNull(mavenProjectProperties.getMainClassFromJar());
+    Assert.assertNull(mavenProjectProperties.getMainClassFromJarPlugin());
   }
 
   @Test
   public void testGetMainClassFromJar_missingPlugin() {
-    Assert.assertNull(mavenProjectProperties.getMainClassFromJar());
+    Assert.assertNull(mavenProjectProperties.getMainClassFromJarPlugin());
   }
 
   @Test

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/MainClassResolver.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/MainClassResolver.java
@@ -68,18 +68,18 @@ public class MainClassResolver {
                 + projectProperties.getPluginName()
                 + "' to improve build speed."));
 
-    String mainClassFromJar = projectProperties.getMainClassFromJar();
-    if (mainClassFromJar != null && isValidJavaClass(mainClassFromJar)) {
-      return mainClassFromJar;
+    String mainClassFromJarPlugin = projectProperties.getMainClassFromJarPlugin();
+    if (mainClassFromJarPlugin != null && isValidJavaClass(mainClassFromJarPlugin)) {
+      return mainClassFromJarPlugin;
     }
 
-    if (mainClassFromJar != null) {
+    if (mainClassFromJarPlugin != null) {
       projectProperties.log(
           LogEvent.warn(
               "'mainClass' configured in "
                   + projectProperties.getJarPluginName()
                   + " is not a valid Java class: "
-                  + mainClassFromJar));
+                  + mainClassFromJarPlugin));
     }
     projectProperties.log(
         LogEvent.info(
@@ -87,11 +87,11 @@ public class MainClassResolver {
                 + projectProperties.getJarPluginName()
                 + "; looking into all class files to infer main class."));
 
-    MainClassFinder.Result result =
+    MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(projectProperties.getClassFiles(), projectProperties::log);
-    switch (result.getType()) {
+    switch (mainClassFinderResult.getType()) {
       case MAIN_CLASS_FOUND:
-        return result.getFoundMainClass();
+        return mainClassFinderResult.getFoundMainClass();
 
       case MAIN_CLASS_NOT_FOUND:
         throw new MainClassInferenceException(
@@ -102,7 +102,7 @@ public class MainClassResolver {
         throw new MainClassInferenceException(
             HelpfulSuggestions.forMainClassNotFound(
                 "Multiple valid main classes were found: "
-                    + String.join(", ", result.getFoundMainClasses()),
+                    + String.join(", ", mainClassFinderResult.getFoundMainClasses()),
                 projectProperties.getPluginName()));
 
       default:

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
@@ -76,7 +76,7 @@ public interface ProjectProperties {
    * @return the name of the main class configured in a jar plugin, or {@code null} if none is found
    */
   @Nullable
-  String getMainClassFromJar();
+  String getMainClassFromJarPlugin();
 
   boolean isWarProject();
 

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/MainClassResolverTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/MainClassResolverTest.java
@@ -70,9 +70,10 @@ public class MainClassResolverTest {
   }
 
   @Test
-  public void testResolveMainClass_validMainClassFromJar()
+  public void testResolveMainClass_validMainClassFromJarPlugin()
       throws MainClassInferenceException, IOException {
-    Mockito.when(mockProjectProperties.getMainClassFromJar()).thenReturn("main.class.from.jar");
+    Mockito.when(mockProjectProperties.getMainClassFromJarPlugin())
+        .thenReturn("main.class.from.jar");
     Assert.assertEquals(
         "main.class.from.jar", MainClassResolver.resolveMainClass(null, mockProjectProperties));
 
@@ -83,9 +84,9 @@ public class MainClassResolverTest {
   }
 
   @Test
-  public void testResolveMainClass_multipleInferredWithInvalidMainClassFromJar()
+  public void testResolveMainClass_multipleInferredWithInvalidMainClassFromJarPlugin()
       throws URISyntaxException, IOException {
-    Mockito.when(mockProjectProperties.getMainClassFromJar()).thenReturn("${start-class}");
+    Mockito.when(mockProjectProperties.getMainClassFromJarPlugin()).thenReturn("${start-class}");
     Mockito.when(mockProjectProperties.getClassFiles())
         .thenReturn(
             new DirectoryWalker(
@@ -118,7 +119,7 @@ public class MainClassResolverTest {
   }
 
   @Test
-  public void testResolveMainClass_multipleInferredWithoutMainClassFromJar()
+  public void testResolveMainClass_multipleInferredWithoutMainClassFromJarPlugin()
       throws URISyntaxException, IOException {
     Mockito.when(mockProjectProperties.getClassFiles())
         .thenReturn(
@@ -148,8 +149,9 @@ public class MainClassResolverTest {
   }
 
   @Test
-  public void testResolveMainClass_noneInferredWithInvalidMainClassFromJar() throws IOException {
-    Mockito.when(mockProjectProperties.getMainClassFromJar()).thenReturn("${start-class}");
+  public void testResolveMainClass_noneInferredWithInvalidMainClassFromJarPlugin()
+      throws IOException {
+    Mockito.when(mockProjectProperties.getMainClassFromJarPlugin()).thenReturn("${start-class}");
     Mockito.when(mockProjectProperties.getClassFiles())
         .thenReturn(ImmutableList.of(Paths.get("ignored")));
     try {

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/MainClassResolverTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/MainClassResolverTest.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.hamcrest.CoreMatchers;
 import org.junit.Assert;
@@ -37,39 +36,55 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class MainClassResolverTest {
 
-  private static final Path FAKE_CLASSES_PATH = Paths.get("a/b/c");
-
   @Mock private ProjectProperties mockProjectProperties;
 
   @Before
   public void setup() {
-    Mockito.when(mockProjectProperties.getPluginName()).thenReturn("plugin");
+    Mockito.when(mockProjectProperties.getPluginName()).thenReturn("jib-plugin");
     Mockito.when(mockProjectProperties.getJarPluginName()).thenReturn("jar-plugin");
   }
 
   @Test
-  public void testResolveMainClass() throws MainClassInferenceException, IOException {
-    Mockito.when(mockProjectProperties.getMainClassFromJar()).thenReturn("some.main.class");
+  public void testResolveMainClass_validMainClassConfigured()
+      throws MainClassInferenceException, IOException {
     Assert.assertEquals(
-        "some.main.class", MainClassResolver.resolveMainClass(null, mockProjectProperties));
-    Assert.assertEquals(
-        "configured", MainClassResolver.resolveMainClass("configured", mockProjectProperties));
+        "configured.main.class",
+        MainClassResolver.resolveMainClass("configured.main.class", mockProjectProperties));
+    Mockito.verify(mockProjectProperties, Mockito.never()).log(Mockito.any());
   }
 
   @Test
-  public void testResolveMainClass_notValid() throws MainClassInferenceException, IOException {
-    Mockito.when(mockProjectProperties.getMainClassFromJar()).thenReturn("${start-class}");
-    Mockito.when(mockProjectProperties.getClassFiles())
-        .thenReturn(ImmutableList.of(FAKE_CLASSES_PATH));
-    Assert.assertEquals(
-        "${start-class}", MainClassResolver.resolveMainClass(null, mockProjectProperties));
-    Mockito.verify(mockProjectProperties)
-        .log(LogEvent.warn("'mainClass' is not a valid Java class : ${start-class}"));
+  public void testResolveMainClass_invalidMainClassConfigured() throws IOException {
+    try {
+      MainClassResolver.resolveMainClass("In Val id", mockProjectProperties);
+      Assert.fail();
+
+    } catch (MainClassInferenceException ex) {
+      Assert.assertThat(
+          ex.getMessage(),
+          CoreMatchers.containsString(
+              "'mainClass' configured in jib-plugin is not a valid Java class: In Val id"));
+
+      Mockito.verify(mockProjectProperties, Mockito.never()).log(Mockito.any());
+    }
   }
 
   @Test
-  public void testResolveMainClass_multipleInferredWithBackup()
-      throws MainClassInferenceException, URISyntaxException, IOException {
+  public void testResolveMainClass_validMainClassFromJar()
+      throws MainClassInferenceException, IOException {
+    Mockito.when(mockProjectProperties.getMainClassFromJar()).thenReturn("main.class.from.jar");
+    Assert.assertEquals(
+        "main.class.from.jar", MainClassResolver.resolveMainClass(null, mockProjectProperties));
+
+    String info =
+        "Searching for main class... Add a 'mainClass' configuration to 'jib-plugin' to "
+            + "improve build speed.";
+    Mockito.verify(mockProjectProperties).log(LogEvent.info(info));
+  }
+
+  @Test
+  public void testResolveMainClass_multipleInferredWithInvalidMainClassFromJar()
+      throws URISyntaxException, IOException {
     Mockito.when(mockProjectProperties.getMainClassFromJar()).thenReturn("${start-class}");
     Mockito.when(mockProjectProperties.getClassFiles())
         .thenReturn(
@@ -77,16 +92,34 @@ public class MainClassResolverTest {
                     Paths.get(Resources.getResource("core/class-finder-tests/multiple").toURI()))
                 .walk()
                 .asList());
-    Assert.assertEquals(
-        "${start-class}", MainClassResolver.resolveMainClass(null, mockProjectProperties));
-    Mockito.verify(mockProjectProperties)
-        .log(LogEvent.warn("'mainClass' is not a valid Java class : ${start-class}"));
+
+    try {
+      MainClassResolver.resolveMainClass(null, mockProjectProperties);
+      Assert.fail();
+
+    } catch (MainClassInferenceException ex) {
+      Assert.assertThat(
+          ex.getMessage(),
+          CoreMatchers.containsString(
+              "Multiple valid main classes were found: HelloWorld, multi.layered.HelloMoon"));
+
+      String info1 =
+          "Searching for main class... Add a 'mainClass' configuration to 'jib-plugin' to "
+              + "improve build speed.";
+      String info2 =
+          "Could not find a valid main class from jar-plugin; looking into all class files to "
+              + "infer main class.";
+      String warn =
+          "'mainClass' configured in jar-plugin is not a valid Java class: ${start-class}";
+      Mockito.verify(mockProjectProperties).log(LogEvent.info(info1));
+      Mockito.verify(mockProjectProperties).log(LogEvent.info(info2));
+      Mockito.verify(mockProjectProperties).log(LogEvent.warn(warn));
+    }
   }
 
   @Test
-  public void testResolveMainClass_multipleInferredWithoutBackup()
+  public void testResolveMainClass_multipleInferredWithoutMainClassFromJar()
       throws URISyntaxException, IOException {
-    Mockito.when(mockProjectProperties.getMainClassFromJar()).thenReturn(null);
     Mockito.when(mockProjectProperties.getClassFiles())
         .thenReturn(
             new DirectoryWalker(
@@ -102,23 +135,21 @@ public class MainClassResolverTest {
           ex.getMessage(),
           CoreMatchers.containsString(
               "Multiple valid main classes were found: HelloWorld, multi.layered.HelloMoon"));
+
+      String info1 =
+          "Searching for main class... Add a 'mainClass' configuration to 'jib-plugin' to "
+              + "improve build speed.";
+      String info2 =
+          "Could not find a valid main class from jar-plugin; looking into all class files to "
+              + "infer main class.";
+      Mockito.verify(mockProjectProperties).log(LogEvent.info(info1));
+      Mockito.verify(mockProjectProperties).log(LogEvent.info(info2));
     }
   }
 
   @Test
-  public void testResolveMainClass_noneInferredWithBackup()
-      throws MainClassInferenceException, IOException {
+  public void testResolveMainClass_noneInferredWithInvalidMainClassFromJar() throws IOException {
     Mockito.when(mockProjectProperties.getMainClassFromJar()).thenReturn("${start-class}");
-    Mockito.when(mockProjectProperties.getClassFiles())
-        .thenReturn(ImmutableList.of(Paths.get("ignored")));
-    Assert.assertEquals(
-        "${start-class}", MainClassResolver.resolveMainClass(null, mockProjectProperties));
-    Mockito.verify(mockProjectProperties)
-        .log(LogEvent.warn("'mainClass' is not a valid Java class : ${start-class}"));
-  }
-
-  @Test
-  public void testResolveMainClass_noneInferredWithoutBackup() throws IOException {
     Mockito.when(mockProjectProperties.getClassFiles())
         .thenReturn(ImmutableList.of(Paths.get("ignored")));
     try {
@@ -127,6 +158,40 @@ public class MainClassResolverTest {
 
     } catch (MainClassInferenceException ex) {
       Assert.assertThat(ex.getMessage(), CoreMatchers.containsString("Main class was not found"));
+
+      String info1 =
+          "Searching for main class... Add a 'mainClass' configuration to 'jib-plugin' to "
+              + "improve build speed.";
+      String info2 =
+          "Could not find a valid main class from jar-plugin; looking into all class files to "
+              + "infer main class.";
+      String warn =
+          "'mainClass' configured in jar-plugin is not a valid Java class: ${start-class}";
+      Mockito.verify(mockProjectProperties).log(LogEvent.info(info1));
+      Mockito.verify(mockProjectProperties).log(LogEvent.info(info2));
+      Mockito.verify(mockProjectProperties).log(LogEvent.warn(warn));
+    }
+  }
+
+  @Test
+  public void testResolveMainClass_noneInferredWithoutMainClassFromJar() throws IOException {
+    Mockito.when(mockProjectProperties.getClassFiles())
+        .thenReturn(ImmutableList.of(Paths.get("ignored")));
+    try {
+      MainClassResolver.resolveMainClass(null, mockProjectProperties);
+      Assert.fail();
+
+    } catch (MainClassInferenceException ex) {
+      Assert.assertThat(ex.getMessage(), CoreMatchers.containsString("Main class was not found"));
+
+      String info1 =
+          "Searching for main class... Add a 'mainClass' configuration to 'jib-plugin' to "
+              + "improve build speed.";
+      String info2 =
+          "Could not find a valid main class from jar-plugin; looking into all class files to "
+              + "infer main class.";
+      Mockito.verify(mockProjectProperties).log(LogEvent.info(info1));
+      Mockito.verify(mockProjectProperties).log(LogEvent.info(info2));
     }
   }
 

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -114,7 +114,7 @@ public class PluginConfigurationProcessorTest {
     Mockito.when(rawConfiguration.getContainerizingMode()).thenReturn("exploded");
     Mockito.when(projectProperties.getToolName()).thenReturn("tool");
     Mockito.when(projectProperties.getToolVersion()).thenReturn("tool-version");
-    Mockito.when(projectProperties.getMainClassFromJar()).thenReturn("java.lang.Object");
+    Mockito.when(projectProperties.getMainClassFromJarPlugin()).thenReturn("java.lang.Object");
     Mockito.when(projectProperties.getDefaultCacheDirectory()).thenReturn(Paths.get("cache"));
     Mockito.when(
             projectProperties.createJibContainerBuilder(


### PR DESCRIPTION
Fixes #2456.

The logic has changed:

1. main class explicitly configured (via `jib.container.mainClass`) but invalid
   - before: attempted to infer a main class under `src/`.
      - problems and weirdness:
         - never looked into mainClassFromJar despite checking `src/` (inconsistency)
         - configured `jib.container.mainClass` ignored if a valid main is found under `src/', no warning at all
   - after: error

2. main class not configured, invalid mainClassFromJar, and no or multiple mains found under `src/` (i.e., the only main class we could ever get is from the jar-plugin)
   - before: warned mainClassFromJar is invalid, but proceeded with it (this mainClassFromJar used to be called "backup" in our tests)
   - after: error

So, the case in #2456 falls into 2) with multiple mains, and now Jib will fail while printing

`[WARNING] 'mainClass' configured in 'maven-jar-plugin' is not a valid Java class: ${start-class}`

and

`[ERROR] ... Multiple valid main classes were found: hello.Application, hello.Foo, perhaps you should add a 'mainClass' configuration to jib-maven-plugin`

As usual, if only one (valid) main is found under `src/` while mainClassFromJar is invalid, Jib will continue to use the inferred one rather than mainClassFromJar.