### PR TITLE
Add gradle extra directory target configuration

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- `jib.extraDirectories.paths` closure to allow configuring the source and target of an extra directory. ([#1581](https://github.com/GoogleContainerTools/jib/issues/1581))
+
 ### Changed
 
 ### Fixed

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -308,7 +308,7 @@ public class SingleProjectIntegrationTest {
     String targetImage = "localhost:6000/simpleimage:gradle" + System.nanoTime();
     Assert.assertEquals(
         "Hello, world. \n1970-01-01T00:00:01Z\nrw-r--r--\nrw-r--r--\nfoo\ncat\n"
-            + "1970-01-01T00:00:01Z\n1970-01-01T00:00:01Z\nbaz\n1970-01-01T00:00:01Z\n",
+            + "1970-01-01T00:00:01Z\n1970-01-01T00:00:01Z\n",
         JibRunHelper.buildToDockerDaemonAndRun(
             simpleTestProject, targetImage, "build-extra-dirs.gradle"));
     assertLayerSize(9, targetImage); // one more than usual
@@ -320,9 +320,21 @@ public class SingleProjectIntegrationTest {
     String targetImage = "localhost:6000/simpleimage:gradle" + System.nanoTime();
     Assert.assertEquals(
         "Hello, world. \n1970-01-01T00:00:01Z\nrw-r--r--\nrw-r--r--\nfoo\ncat\n"
-            + "1970-01-01T00:00:01Z\n1970-01-01T00:00:01Z\nbaz\n1970-01-01T00:00:01Z\n",
+            + "1970-01-01T00:00:01Z\n1970-01-01T00:00:01Z\n",
         JibRunHelper.buildToDockerDaemonAndRun(
             simpleTestProject, targetImage, "build-extra-dirs2.gradle"));
+    assertLayerSize(9, targetImage); // one more than usual
+  }
+
+  @Test
+  public void testDockerDaemon_simple_multipleExtraDirectoriesWithClosure()
+      throws DigestException, IOException, InterruptedException {
+    String targetImage = "localhost:6000/simpleimage:gradle" + System.nanoTime();
+    Assert.assertEquals(
+        "Hello, world. \n1970-01-01T00:00:01Z\nrw-r--r--\nrw-r--r--\nfoo\ncat\n"
+            + "1970-01-01T00:00:01Z\n1970-01-01T00:00:01Z\nbaz\n1970-01-01T00:00:01Z\n",
+        JibRunHelper.buildToDockerDaemonAndRun(
+            simpleTestProject, targetImage, "build-extra-dirs3.gradle"));
     assertLayerSize(9, targetImage); // one more than usual
   }
 

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-extra-dirs3.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-extra-dirs3.gradle
@@ -1,0 +1,29 @@
+plugins {
+  id 'java'
+  id 'com.google.cloud.tools.jib'
+}
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compile files('libs/dependency-1.0.0.jar')
+}
+
+jib.to.image = System.getProperty("_TARGET_IMAGE")
+jib.extraDirectories {
+  paths {
+    path {
+      from = 'src/main/custom-extra-dir'
+      into = '/'
+    }
+    path {
+      from = 'src/main/custom-extra-dir2'
+      into = '/target/on/container'
+    }
+  }
+}

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/src/main/java/com/test/HelloWorld.java
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/src/main/java/com/test/HelloWorld.java
@@ -61,10 +61,12 @@ public class HelloWorld {
         System.out.println(Files.getLastModifiedTime(Paths.get("/bar/cat")).toString());
       }
       // Prints the contents of the files in the second extra directory.
-      if (Files.exists(Paths.get("/baz"))) {
+      if (Files.exists(Paths.get("/target/on/container/baz"))) {
         System.out.println(
-            new String(Files.readAllBytes(Paths.get("/baz")), StandardCharsets.UTF_8));
-        System.out.println(Files.getLastModifiedTime(Paths.get("/baz")).toString());
+            new String(
+                Files.readAllBytes(Paths.get("/target/on/container/baz")), StandardCharsets.UTF_8));
+        System.out.println(
+            Files.getLastModifiedTime(Paths.get("/target/on/container/baz")).toString());
       }
 
       // Prints jvm flags

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Future;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
@@ -85,7 +86,12 @@ public class BuildTarTask extends DefaultTask implements JibTask {
   @InputFiles
   public FileCollection getInputFiles() {
     List<Path> extraDirectories =
-        Preconditions.checkNotNull(jibExtension).getExtraDirectories().getPaths();
+        Preconditions.checkNotNull(jibExtension)
+            .getExtraDirectories()
+            .getPaths()
+            .stream()
+            .map(ExtraDirectoryParameters::getFrom)
+            .collect(Collectors.toList());
     return GradleProjectProperties.getInputFiles(getProject(), extraDirectories);
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoriesParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoriesParameters.java
@@ -26,7 +26,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
+import org.gradle.api.Action;
 import org.gradle.api.Project;
+import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 
@@ -35,34 +37,51 @@ public class ExtraDirectoriesParameters {
 
   private final Project project;
 
-  private List<Path> paths;
+  private ListProperty<ExtraDirectoryParameters> paths;
+  private ExtraDirectoryParametersSpec spec;
   private Map<String, String> permissions = Collections.emptyMap();
 
   @Inject
   public ExtraDirectoriesParameters(Project project) {
     this.project = project;
-    paths =
-        Collections.singletonList(
-            project.getProjectDir().toPath().resolve("src").resolve("main").resolve("jib"));
+    paths = project.getObjects().listProperty(ExtraDirectoryParameters.class).empty();
+    spec = project.getObjects().newInstance(ExtraDirectoryParametersSpec.class, project, paths);
+  }
+
+  public void paths(Action<? super ExtraDirectoryParametersSpec> action) {
+    action.execute(spec);
   }
 
   @Input
   public List<String> getPathStrings() {
     // Gradle warns about @Input annotations on File objects, so we have to expose a getter for a
     // String to make them go away.
-    return getPaths().stream().map(Path::toString).collect(Collectors.toList());
+    return getPaths()
+        .stream()
+        .map(extraDirectoryParameters -> extraDirectoryParameters.getFrom().toString())
+        .collect(Collectors.toList());
   }
 
   @Internal
-  public List<Path> getPaths() {
+  public List<ExtraDirectoryParameters> getPaths() {
     // Gradle warns about @Input annotations on File objects, so we have to expose a getter for a
     // String to make them go away.
     String property = System.getProperty(PropertyNames.EXTRA_DIRECTORIES_PATHS);
     if (property != null) {
       List<String> pathStrings = ConfigurationPropertyValidator.parseListProperty(property);
-      return pathStrings.stream().map(Paths::get).collect(Collectors.toList());
+      return pathStrings
+          .stream()
+          .map(path -> new ExtraDirectoryParameters(project, Paths.get(path), "/"))
+          .collect(Collectors.toList());
     }
-    return paths;
+    if (paths.get().isEmpty()) {
+      return Collections.singletonList(
+          new ExtraDirectoryParameters(
+              project,
+              project.getProjectDir().toPath().resolve("src").resolve("main").resolve("jib"),
+              "/"));
+    }
+    return paths.get();
   }
 
   /**
@@ -72,8 +91,12 @@ public class ExtraDirectoriesParameters {
    * @param paths paths to set.
    */
   public void setPaths(Object paths) {
-    this.paths =
+    List<Path> froms =
         project.files(paths).getFiles().stream().map(File::toPath).collect(Collectors.toList());
+    this.paths = project.getObjects().listProperty(ExtraDirectoryParameters.class).empty();
+    for (Path path : froms) {
+      this.paths.add(new ExtraDirectoryParameters(project, path, "/"));
+    }
   }
 
   /**

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoriesParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoriesParameters.java
@@ -93,10 +93,11 @@ public class ExtraDirectoriesParameters {
   public void setPaths(Object paths) {
     List<Path> froms =
         project.files(paths).getFiles().stream().map(File::toPath).collect(Collectors.toList());
-    this.paths = project.getObjects().listProperty(ExtraDirectoryParameters.class).empty();
-    for (Path path : froms) {
-      this.paths.add(new ExtraDirectoryParameters(project, path, "/"));
-    }
+    this.paths.set(
+        froms
+            .stream()
+            .map(from -> new ExtraDirectoryParameters(project, from, "/"))
+            .collect(Collectors.toList()));
   }
 
   /**

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoriesParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoriesParameters.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.jib.gradle;
 import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import java.io.File;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
@@ -91,12 +90,12 @@ public class ExtraDirectoriesParameters {
    * @param paths paths to set.
    */
   public void setPaths(Object paths) {
-    List<Path> froms =
-        project.files(paths).getFiles().stream().map(File::toPath).collect(Collectors.toList());
     this.paths.set(
-        froms
+        project
+            .files(paths)
+            .getFiles()
             .stream()
-            .map(from -> new ExtraDirectoryParameters(project, from, "/"))
+            .map(file -> new ExtraDirectoryParameters(project, file.toPath(), "/"))
             .collect(Collectors.toList()));
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParameters.java
@@ -23,6 +23,7 @@ import org.gradle.api.Project;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 
+/** Configuration of an extra directory. */
 public class ExtraDirectoryParameters {
 
   private Project project;
@@ -55,7 +56,7 @@ public class ExtraDirectoryParameters {
   }
 
   public void setFrom(Object from) {
-    this.from = project.file(from).toPath();
+    this.from = project.file(from).getAbsoluteFile().toPath();
   }
 
   @Input

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParameters.java
@@ -56,7 +56,7 @@ public class ExtraDirectoryParameters {
   }
 
   public void setFrom(Object from) {
-    this.from = project.file(from).getAbsoluteFile().toPath();
+    this.from = project.file(from).toPath();
   }
 
   @Input

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParameters.java
@@ -27,14 +27,12 @@ import org.gradle.api.tasks.Internal;
 public class ExtraDirectoryParameters {
 
   private Project project;
-  private Path from;
-  private String into;
+  private Path from = Paths.get("");
+  private String into = "/";
 
   @Inject
   public ExtraDirectoryParameters(Project project) {
     this.project = project;
-    from = Paths.get("");
-    into = "/";
   }
 
   public ExtraDirectoryParameters(Project project, Path from, String into) {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParameters.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.gradle;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import javax.inject.Inject;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
+
+public class ExtraDirectoryParameters {
+
+  private Project project;
+  private Path from;
+  private String into;
+
+  @Inject
+  public ExtraDirectoryParameters(Project project) {
+    this.project = project;
+    from = Paths.get("");
+    into = "/";
+  }
+
+  public ExtraDirectoryParameters(Project project, Path from, String into) {
+    this.project = project;
+    this.from = from;
+    this.into = into;
+  }
+
+  @Input
+  public String getFromString() {
+    // Gradle warns about @Input annotations on File objects, so we have to expose a getter for a
+    // String to make them go away.
+    return from.toString();
+  }
+
+  @Internal
+  public Path getFrom() {
+    return from;
+  }
+
+  public void setFrom(Object from) {
+    this.from = project.file(from).toPath();
+  }
+
+  @Input
+  public String getInto() {
+    return into;
+  }
+
+  public void setInto(String into) {
+    this.into = into;
+  }
+}

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParametersSpec.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParametersSpec.java
@@ -21,6 +21,7 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.provider.ListProperty;
 
+/** Allows to add {@link ExtraDirectoryParameters} objects to the list property of the same type. */
 public class ExtraDirectoryParametersSpec {
 
   private final Project project;
@@ -33,6 +34,11 @@ public class ExtraDirectoryParametersSpec {
     this.paths = paths;
   }
 
+  /**
+   * Adds a new extra directory configuration to the list.
+   *
+   * @param action closure representing an extra directory configuration
+   */
   public void path(Action<? super ExtraDirectoryParameters> action) {
     ExtraDirectoryParameters extraDirectory =
         project.getObjects().newInstance(ExtraDirectoryParameters.class, project);

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParametersSpec.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtraDirectoryParametersSpec.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.gradle;
+
+import javax.inject.Inject;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.provider.ListProperty;
+
+public class ExtraDirectoryParametersSpec {
+
+  private final Project project;
+  private final ListProperty<ExtraDirectoryParameters> paths;
+
+  @Inject
+  public ExtraDirectoryParametersSpec(
+      Project project, ListProperty<ExtraDirectoryParameters> paths) {
+    this.project = project;
+    this.paths = paths;
+  }
+
+  public void path(Action<? super ExtraDirectoryParameters> action) {
+    ExtraDirectoryParameters extraDirectory =
+        project.getObjects().newInstance(ExtraDirectoryParameters.class, project);
+    action.execute(extraDirectory);
+    paths.add(extraDirectory);
+  }
+}

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -22,6 +22,7 @@ import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
 import com.google.cloud.tools.jib.plugins.common.RawConfiguration;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -161,6 +162,10 @@ public class GradleRawConfiguration implements RawConfiguration {
   public Map<Path, AbsoluteUnixPath> getExtraDirectories() {
     Map<Path, AbsoluteUnixPath> directoryMap = new LinkedHashMap<>();
     for (ExtraDirectoryParameters path : jibExtension.getExtraDirectories().getPaths()) {
+      if (path.getFrom().equals(Paths.get(""))) {
+        throw new IllegalArgumentException(
+            "Incomplete extraDirectories.paths configuration; source directory must be set");
+      }
       directoryMap.put(path.getFrom(), AbsoluteUnixPath.get(path.getInto()));
     }
     return directoryMap;

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -160,8 +160,8 @@ public class GradleRawConfiguration implements RawConfiguration {
   @Override
   public Map<Path, AbsoluteUnixPath> getExtraDirectories() {
     Map<Path, AbsoluteUnixPath> directoryMap = new LinkedHashMap<>();
-    for (Path path : jibExtension.getExtraDirectories().getPaths()) {
-      directoryMap.put(path, AbsoluteUnixPath.get("/"));
+    for (ExtraDirectoryParameters path : jibExtension.getExtraDirectories().getPaths()) {
+      directoryMap.put(path.getFrom(), AbsoluteUnixPath.get(path.getInto()));
     }
     return directoryMap;
   }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.gradle.skaffold;
 
+import com.google.cloud.tools.jib.gradle.ExtraDirectoryParameters;
 import com.google.cloud.tools.jib.gradle.JibExtension;
 import com.google.cloud.tools.jib.plugins.common.SkaffoldFilesOutput;
 import com.google.common.base.Preconditions;
@@ -28,6 +29,7 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
@@ -76,7 +78,13 @@ public class FilesTaskV2 extends DefaultTask {
     addProjectFiles(project);
 
     // Add extra layer
-    List<Path> extraDirectories = jibExtension.getExtraDirectories().getPaths();
+    List<Path> extraDirectories =
+        jibExtension
+            .getExtraDirectories()
+            .getPaths()
+            .stream()
+            .map(ExtraDirectoryParameters::getFrom)
+            .collect(Collectors.toList());
     extraDirectories.stream().filter(Files::exists).forEach(skaffoldFilesOutput::addInput);
 
     // Find project dependencies


### PR DESCRIPTION
Fixes #1581. Adds the following to the gradle configuration:

```
jib.extraDirectories.paths {
  path {
    from = 'from/path'
    into = '/'
  }
  path {
    from = 'another/path'
    into = '/target/directory'
  }
}
```

The old configuration also still works:

```
jib.extraDirectories.paths = ['from/path', 'another/path']
```