### PR TITLE
Update Micronaut to a recent 2.0 version

### DIFF
--- a/examples/micronaut/build.gradle
+++ b/examples/micronaut/build.gradle
@@ -1,45 +1,55 @@
 plugins {
-    id 'application'
-    id 'groovy'
-    id 'io.spring.dependency-management' version '1.0.6.RELEASE'
-    id 'net.ltgt.apt-idea' version '0.18'
+    id "groovy"
+    id "com.github.johnrengelman.shadow" version "5.2.0"
+    id "application"
     id 'com.google.cloud.tools.jib' version '2.2.0'
 }
 
-version '0.1'
+version "0.1"
 group 'example.micronaut-jib'
 
 repositories {
+    jcenter()
     mavenCentral()
-    maven { url 'https://jcenter.bintray.com' }
 }
 
-dependencyManagement {
-    imports {
-        mavenBom 'io.micronaut:micronaut-bom:1.0.3'
-    }
+configurations {
+    // for dependencies that are needed for development only
+    developmentOnly
 }
 
 dependencies {
-    annotationProcessor 'io.micronaut:micronaut-inject-java'
-    compile 'io.micronaut:micronaut-http-client'
-    compile 'io.micronaut:micronaut-http-server-netty'
-    compile 'io.micronaut:micronaut-runtime-groovy'
-    compile 'io.micronaut:micronaut-inject'
-    compile 'io.micronaut:micronaut-runtime'
-    compileOnly 'io.micronaut:micronaut-inject-groovy'
-    compileOnly 'io.micronaut:micronaut-inject-java'
-    runtime 'ch.qos.logback:logback-classic:1.2.3'
-    testCompile 'io.micronaut:micronaut-inject-groovy'
-    testCompile('org.spockframework:spock-core:1.2-groovy-2.5') {
-        exclude group: 'org.codehaus.groovy', module: 'groovy-all'
+    compileOnly(enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion"))
+    compileOnly("io.micronaut:micronaut-inject-groovy")
+    implementation(enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion"))
+    implementation("io.micronaut:micronaut-inject")
+    implementation("io.micronaut:micronaut-validation")
+    implementation("io.micronaut:micronaut-runtime-groovy")
+    implementation("javax.annotation:javax.annotation-api")
+    implementation("io.micronaut:micronaut-http-server-netty")
+    implementation("io.micronaut:micronaut-http-client")
+    runtimeOnly("ch.qos.logback:logback-classic:1.2.3")
+    testImplementation enforcedPlatform("io.micronaut:micronaut-bom:$micronautVersion")
+    testImplementation("io.micronaut:micronaut-inject-groovy")
+    testImplementation("org.spockframework:spock-core") {
+        exclude group: "org.codehaus.groovy", module: "groovy-all"
     }
-    testCompile 'io.micronaut:micronaut-inject-java'
+    testImplementation("io.micronaut.test:micronaut-test-spock")
 }
 
-compileJava.options.compilerArgs += '-parameters'
-compileTestJava.options.compilerArgs += '-parameters'
-mainClassName = 'example.micronaut.Application'
+test.classpath += configurations.developmentOnly
 
-/** CHANGE THIS TO THE IMAGE YOU WANT TO PUSH TO */
-// jib.to.image = 'gcr.io/PROJECT_ID/micronaut-jib'
+mainClassName = "example.micronaut.Application"
+
+tasks.withType(GroovyCompile) {
+    groovyOptions.forkOptions.jvmArgs.add('-Dgroovy.parameters=true')
+}
+
+shadowJar {
+    mergeServiceFiles()
+}
+
+tasks.withType(JavaExec) {
+    classpath += configurations.developmentOnly
+    jvmArgs('-XX:TieredStopAtLevel=1', '-Dcom.sun.management.jmxremote')
+}

--- a/examples/micronaut/gradle.properties
+++ b/examples/micronaut/gradle.properties
@@ -1,0 +1,1 @@
+micronautVersion=2.0.0.M3


### PR DESCRIPTION
Upgrade Micronaut to a recent version.
This sample is used in the [Jib + Micronaut + Kubernetes codelab](https://codelabs.developers.google.com/codelabs/cloud-micronaut-kubernetes).
Fixes #2468