### PR TITLE
Update Build Plan API to accept file ownership in layers

### DIFF
--- a/jib-build-plan/CHANGELOG.md
+++ b/jib-build-plan/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added file ownership information in `FileEntry` and `FileEntriesLayer`. ([#2494](https://github.com/GoogleContainerTools/jib/pull/2494))
+
 ### Changed
 
 ### Fixed

--- a/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/FileEntriesLayer.java
+++ b/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/FileEntriesLayer.java
@@ -170,8 +170,9 @@ public class FileEntriesLayer implements LayerObject {
      *     sourceFile}
      * @param permissions the file permissions on the container
      * @param modificationTime the file modification time
-     * @param ownership file ownership. For example, "0", "1234", "user", ":0", ":5678", ":group",
-     *     "0:0", "1234:5678", and "user:group".
+     * @param ownership file ownership. For example, "1234", "user", ":5678", ":group", "1234:5678",
+     *     and "user:group". Note that "" (empty string), ":" (single colon), "0:", ":0" are allowed
+     *     and representative of "0:0" or "root:root", but prefer an empty string for "0:0".
      * @return this
      * @see Builder#addEntry(Path, AbsoluteUnixPath)
      * @see FilePermissions#DEFAULT_FILE_PERMISSIONS
@@ -327,7 +328,7 @@ public class FileEntriesLayer implements LayerObject {
 
   /** Provider that returns default file ownership ("0:0"). */
   public static final BiFunction<Path, AbsoluteUnixPath, String> DEFAULT_OWNERSHIP_PROVIDER =
-      (sourcePath, destinationPath) -> "0:0";
+      (sourcePath, destinationPath) -> "";
 
   /**
    * Gets a new {@link Builder} for {@link FileEntriesLayer}.

--- a/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/FileEntriesLayer.java
+++ b/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/FileEntriesLayer.java
@@ -161,6 +161,33 @@ public class FileEntriesLayer implements LayerObject {
     }
 
     /**
+     * Adds an entry to the layer with the given permissions and file modification time. Only adds
+     * the single source file to the exact path in the container file system. See {@link
+     * Builder#addEntry(Path, AbsoluteUnixPath)} for more information.
+     *
+     * @param sourceFile the source file to add to the layer
+     * @param pathInContainer the path in the container file system corresponding to the {@code
+     *     sourceFile}
+     * @param permissions the file permissions on the container
+     * @param modificationTime the file modification time
+     * @param ownership file ownership. For example, "0", "1234", "user", ":0", ":5678", ":group",
+     *     "0:0", "1234:5678", and "user:group".
+     * @return this
+     * @see Builder#addEntry(Path, AbsoluteUnixPath)
+     * @see FilePermissions#DEFAULT_FILE_PERMISSIONS
+     * @see FilePermissions#DEFAULT_FOLDER_PERMISSIONS
+     */
+    public Builder addEntry(
+        Path sourceFile,
+        AbsoluteUnixPath pathInContainer,
+        FilePermissions permissions,
+        Instant modificationTime,
+        String ownership) {
+      return addEntry(
+          new FileEntry(sourceFile, pathInContainer, permissions, modificationTime, ownership));
+    }
+
+    /**
      * Adds an entry to the layer. If the source file is a directory, the directory and its contents
      * will be added recursively.
      *
@@ -221,9 +248,41 @@ public class FileEntriesLayer implements LayerObject {
         BiFunction<Path, AbsoluteUnixPath, FilePermissions> filePermissionProvider,
         BiFunction<Path, AbsoluteUnixPath, Instant> modificationTimeProvider)
         throws IOException {
+      return addEntryRecursive(
+          sourceFile,
+          pathInContainer,
+          filePermissionProvider,
+          modificationTimeProvider,
+          DEFAULT_OWNERSHIP_PROVIDER);
+    }
+
+    /**
+     * Adds an entry to the layer. If the source file is a directory, the directory and its contents
+     * will be added recursively.
+     *
+     * @param sourceFile the source file to add to the layer recursively
+     * @param pathInContainer the path in the container file system corresponding to the {@code
+     *     sourceFile}
+     * @param filePermissionProvider a provider that takes a source path and destination path on the
+     *     container and returns the file permissions that should be set for that path
+     * @param modificationTimeProvider a provider that takes a source path and destination path on
+     *     the container and returns the file modification time that should be set for that path
+     * @param ownershipProvider a provider that takes a source path and destination path on the
+     *     container and returns the ownership that should be set for that path
+     * @return this
+     * @throws IOException if an exception occurred when recursively listing the directory
+     */
+    public Builder addEntryRecursive(
+        Path sourceFile,
+        AbsoluteUnixPath pathInContainer,
+        BiFunction<Path, AbsoluteUnixPath, FilePermissions> filePermissionProvider,
+        BiFunction<Path, AbsoluteUnixPath, Instant> modificationTimeProvider,
+        BiFunction<Path, AbsoluteUnixPath, String> ownershipProvider)
+        throws IOException {
       FilePermissions permissions = filePermissionProvider.apply(sourceFile, pathInContainer);
       Instant modificationTime = modificationTimeProvider.apply(sourceFile, pathInContainer);
-      addEntry(sourceFile, pathInContainer, permissions, modificationTime);
+      String ownership = ownershipProvider.apply(sourceFile, pathInContainer);
+      addEntry(sourceFile, pathInContainer, permissions, modificationTime, ownership);
       if (!Files.isDirectory(sourceFile)) {
         return this;
       }
@@ -233,7 +292,8 @@ public class FileEntriesLayer implements LayerObject {
               file,
               pathInContainer.resolve(file.getFileName()),
               filePermissionProvider,
-              modificationTimeProvider);
+              modificationTimeProvider,
+              ownershipProvider);
         }
       }
       return this;
@@ -264,6 +324,10 @@ public class FileEntriesLayer implements LayerObject {
   public static final BiFunction<Path, AbsoluteUnixPath, Instant>
       DEFAULT_MODIFICATION_TIME_PROVIDER =
           (sourcePath, destinationPath) -> DEFAULT_MODIFICATION_TIME;
+
+  /** Provider that returns default file ownership ("0:0"). */
+  public static final BiFunction<Path, AbsoluteUnixPath, String> DEFAULT_OWNERSHIP_PROVIDER =
+      (sourcePath, destinationPath) -> "0:0";
 
   /**
    * Gets a new {@link Builder} for {@link FileEntriesLayer}.

--- a/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/FileEntriesLayer.java
+++ b/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/FileEntriesLayer.java
@@ -326,7 +326,10 @@ public class FileEntriesLayer implements LayerObject {
       DEFAULT_MODIFICATION_TIME_PROVIDER =
           (sourcePath, destinationPath) -> DEFAULT_MODIFICATION_TIME;
 
-  /** Provider that returns default file ownership ("0:0"). */
+  /**
+   * Provider that returns default file ownership (an empty string "" effectively representing
+   * "0:0").
+   */
   public static final BiFunction<Path, AbsoluteUnixPath, String> DEFAULT_OWNERSHIP_PROVIDER =
       (sourcePath, destinationPath) -> "";
 

--- a/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/FileEntry.java
+++ b/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/FileEntry.java
@@ -71,7 +71,7 @@ public class FileEntry {
     this.extractionPath = extractionPath;
     this.permissions = permissions;
     this.modificationTime = modificationTime;
-    ownership = "0:0";
+    ownership = "";
   }
 
   /**
@@ -84,8 +84,9 @@ public class FileEntry {
    *     sourceFile}
    * @param permissions the file permissions on the container
    * @param modificationTime the file modification time
-   * @param ownership file ownership. For example, "0", "1234", "user", ":0", ":5678", ":group",
-   *     "0:0", "1234:5678", and "user:group".
+   * @param ownership file ownership. For example, "1234", "user", ":5678", ":group", "1234:5678",
+   *     and "user:group". Note that "" (empty string), ":" (single colon), "0:", ":0" are allowed
+   *     and representative of "0:0" or "root:root", but prefer an empty string for "0:0".
    */
   public FileEntry(
       Path sourceFile,

--- a/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/FileEntry.java
+++ b/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/FileEntry.java
@@ -34,6 +34,7 @@ public class FileEntry {
   private final AbsoluteUnixPath extractionPath;
   private final FilePermissions permissions;
   private final Instant modificationTime;
+  private final String ownership;
 
   /**
    * Instantiates with a source file and the path to place the source file in the container file
@@ -70,6 +71,33 @@ public class FileEntry {
     this.extractionPath = extractionPath;
     this.permissions = permissions;
     this.modificationTime = modificationTime;
+    ownership = "0:0";
+  }
+
+  /**
+   * Instantiates with a source file and the path to place the source file in the container file
+   * system. See {@link #FileEntry(Path, AbsoluteUnixPath, FilePermissions, Instant)} for more
+   * information.
+   *
+   * @param sourceFile the source file to add to the layer
+   * @param extractionPath the path in the container file system corresponding to the {@code
+   *     sourceFile}
+   * @param permissions the file permissions on the container
+   * @param modificationTime the file modification time
+   * @param ownership file ownership. For example, "0", "1234", "user", ":0", ":5678", ":group",
+   *     "0:0", "1234:5678", and "user:group".
+   */
+  public FileEntry(
+      Path sourceFile,
+      AbsoluteUnixPath extractionPath,
+      FilePermissions permissions,
+      Instant modificationTime,
+      String ownership) {
+    this.sourceFile = sourceFile;
+    this.extractionPath = extractionPath;
+    this.permissions = permissions;
+    this.modificationTime = modificationTime;
+    this.ownership = ownership;
   }
 
   /**
@@ -110,6 +138,15 @@ public class FileEntry {
     return permissions;
   }
 
+  /**
+   * Gets the file ownership on the container.
+   *
+   * @return the file ownership on the container
+   */
+  public String getOwnership() {
+    return ownership;
+  }
+
   @Override
   public boolean equals(Object other) {
     if (this == other) {
@@ -121,12 +158,13 @@ public class FileEntry {
     FileEntry otherFileEntry = (FileEntry) other;
     return sourceFile.equals(otherFileEntry.sourceFile)
         && extractionPath.equals(otherFileEntry.extractionPath)
-        && Objects.equals(permissions, otherFileEntry.permissions)
-        && Objects.equals(modificationTime, otherFileEntry.modificationTime);
+        && permissions.equals(otherFileEntry.permissions)
+        && modificationTime.equals(otherFileEntry.modificationTime)
+        && ownership.equals(otherFileEntry.ownership);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(sourceFile, extractionPath, permissions, modificationTime);
+    return Objects.hash(sourceFile, extractionPath, permissions, modificationTime, ownership);
   }
 }

--- a/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/FileEntriesLayerTest.java
+++ b/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/FileEntriesLayerTest.java
@@ -66,7 +66,7 @@ public class FileEntriesLayerTest {
   }
 
   @Test
-  public void testAddEntryRecursive_permissionsAndTimestamps()
+  public void testAddEntryRecursive_otherFileEntryProperties()
       throws IOException, URISyntaxException {
     Path testDirectory = Paths.get(Resources.getResource("core/layer").toURI()).toAbsolutePath();
     Path testFile = Paths.get(Resources.getResource("core/fileA").toURI());
@@ -75,6 +75,8 @@ public class FileEntriesLayerTest {
     FilePermissions permissions2 = FilePermissions.fromOctalString("777");
     Instant timestamp1 = Instant.ofEpochSecond(123);
     Instant timestamp2 = Instant.ofEpochSecond(987);
+    String ownership1 = "root";
+    String ownership2 = "nobody:65432";
 
     BiFunction<Path, AbsoluteUnixPath, FilePermissions> permissionsProvider =
         (source, destination) ->
@@ -82,56 +84,81 @@ public class FileEntriesLayerTest {
     BiFunction<Path, AbsoluteUnixPath, Instant> timestampProvider =
         (source, destination) ->
             destination.toString().startsWith("/app/layer/a") ? timestamp1 : timestamp2;
+    BiFunction<Path, AbsoluteUnixPath, String> ownershipProvider =
+        (source, destination) ->
+            destination.toString().startsWith("/app/layer/a") ? ownership1 : ownership2;
 
     FileEntriesLayer layer =
         FileEntriesLayer.builder()
+            .addEntry(
+                new FileEntry(
+                    Paths.get("foo"), AbsoluteUnixPath.get("/foo"), permissions1, timestamp1))
             .addEntryRecursive(
                 testDirectory,
                 AbsoluteUnixPath.get("/app/layer/"),
                 permissionsProvider,
-                timestampProvider)
+                timestampProvider,
+                ownershipProvider)
             .addEntryRecursive(
                 testFile,
                 AbsoluteUnixPath.get("/app/fileA"),
                 permissionsProvider,
-                timestampProvider)
+                timestampProvider,
+                ownershipProvider)
             .build();
 
     ImmutableSet<FileEntry> expectedLayerEntries =
         ImmutableSet.of(
             new FileEntry(
-                testDirectory, AbsoluteUnixPath.get("/app/layer/"), permissions2, timestamp2),
+                Paths.get("foo"), AbsoluteUnixPath.get("/foo"), permissions1, timestamp1, "0:0"),
+            new FileEntry(
+                testDirectory,
+                AbsoluteUnixPath.get("/app/layer/"),
+                permissions2,
+                timestamp2,
+                ownership2),
             new FileEntry(
                 testDirectory.resolve("a"),
                 AbsoluteUnixPath.get("/app/layer/a/"),
                 permissions1,
-                timestamp1),
+                timestamp1,
+                ownership1),
             new FileEntry(
                 testDirectory.resolve("a/b"),
                 AbsoluteUnixPath.get("/app/layer/a/b/"),
                 permissions1,
-                timestamp1),
+                timestamp1,
+                ownership1),
             new FileEntry(
                 testDirectory.resolve("a/b/bar"),
                 AbsoluteUnixPath.get("/app/layer/a/b/bar/"),
                 permissions1,
-                timestamp1),
+                timestamp1,
+                ownership1),
             new FileEntry(
                 testDirectory.resolve("c/"),
                 AbsoluteUnixPath.get("/app/layer/c"),
                 permissions2,
-                timestamp2),
+                timestamp2,
+                ownership2),
             new FileEntry(
                 testDirectory.resolve("c/cat/"),
                 AbsoluteUnixPath.get("/app/layer/c/cat"),
                 permissions2,
-                timestamp2),
+                timestamp2,
+                ownership2),
             new FileEntry(
                 testDirectory.resolve("foo"),
                 AbsoluteUnixPath.get("/app/layer/foo"),
                 permissions2,
-                timestamp2),
-            new FileEntry(testFile, AbsoluteUnixPath.get("/app/fileA"), permissions2, timestamp2));
+                timestamp2,
+                ownership2),
+            new FileEntry(
+                testFile,
+                AbsoluteUnixPath.get("/app/fileA"),
+                permissions2,
+                timestamp2,
+                ownership2));
 
     Assert.assertEquals(expectedLayerEntries, ImmutableSet.copyOf(layer.getEntries()));
   }

--- a/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/FileEntriesLayerTest.java
+++ b/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/FileEntriesLayerTest.java
@@ -110,7 +110,7 @@ public class FileEntriesLayerTest {
     ImmutableSet<FileEntry> expectedLayerEntries =
         ImmutableSet.of(
             new FileEntry(
-                Paths.get("foo"), AbsoluteUnixPath.get("/foo"), permissions1, timestamp1, "0:0"),
+                Paths.get("foo"), AbsoluteUnixPath.get("/foo"), permissions1, timestamp1, ""),
             new FileEntry(
                 testDirectory,
                 AbsoluteUnixPath.get("/app/layer/"),

--- a/proposals/container-build-plan-spec.md
+++ b/proposals/container-build-plan-spec.md
@@ -68,6 +68,7 @@ Although looking similar, the structure and semantics of similary named properti
           "dest": "/app/run.sh",
           "modificationTime": "2011-12-03T22:42:05Z",
           "permissions": "777",
+          "ownership": ""
         },
       ]
     },
@@ -139,7 +140,7 @@ A builder implementation must inherit the [`history` entries](https://github.com
 * `user`: string
 
    - `null` or omitted: inherits from the base image.
-   - Otherwise (including an empty string `""`, `":"`, `<user>:`, and `":<group>"`), sets the given user and group; it is not possible to only inherit either the user or the group.
+   - Otherwise (including an empty string `""`, `":"`, `"<user>:"`, and `":<group>"`), sets the given user and group; it is not possible to only inherit either the user or the group.
 
 * `workingDir`: string
 
@@ -179,3 +180,6 @@ A builder implementation must inherit the [`history` entries](https://github.com
 * `dest`: path in the container, required
 * `permissions`: POSIX permissions, required
 * `modificationTime`: if `null` or omitted, the epoch + 1 second by default
+* `ownership`:
+   - If `null`, omitted, or an empty string `""`, then effectively equivalent to `"0:0"` (`"root:root"`).
+   - Otherwise, in the form of `"<user>:<group>"` where `<user>` and `<group>` are optional. When `<user>` or `<group>` is omitted, it is equivalent to `0` (`root`).


### PR DESCRIPTION
Towards writing an extension for #1257 and #1955, as well as a workaround for #1270.

Once merged, we need to re-publish all the libraries one after another.