### PR TITLE
Bring JDK current in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,14 @@ matrix:
       dist: trusty # oraclejdk8 absent in Xenial
     - name: OpenJDK 11
       jdk: openjdk11
+    - name: OpenJDK 12
+      jdk: openjdk12
+    - name: OpenJDK 13
+      jdk: openjdk13
+    - name: OpenJDK 14
+      jdk: openjdk14
+    - name: OpenJDK 15
+      jdk: openjdk15
 env:
   global:
   - TERM=dumb         # for gradle

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,7 @@ subprojects {
   dependencies {
     // NullAway errorprone plugin
     annotationProcessor 'com.uber.nullaway:nullaway:0.7.9'
-    errorprone 'com.google.errorprone:error_prone_core:2.3.4'
+    errorprone 'com.google.errorprone:error_prone_core:2.4.0'
     // Using github.com/google/error-prone-javac is required when running on
     // JDK 8. Remove when migrating to JDK 11.
     if (System.getProperty('java.version').startsWith('1.8.')) {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
```Gradle 6.0.1``` breaks ```build.gradle``` "inheritance"

https://travis-ci.com/github/gliptak/jib/jobs/342161039#L492

https://github.com/GoogleContainerTools/jib/pull/2503