### PR TITLE
Inject Gradle project when creating extension-specific config object

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -469,7 +469,7 @@ public class GradleProjectProperties implements ProjectProperties {
         // config.getExtraConfiguration().get() is of type Action, so this cast always succeeds.
         // (Note generic <T> is erased at runtime.)
         Action<T> action = (Action<T>) config.getExtraConfiguration().get();
-        extraConfig = project.getObjects().newInstance(extraConfigType.get());
+        extraConfig = project.getObjects().newInstance(extraConfigType.get(), project);
         action.execute(extraConfig);
       }
     }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesExtensionTest.java
@@ -221,9 +221,13 @@ public class GradleProjectPropertiesExtensionTest {
     Mockito.when(mockProject.getGradle().getStartParameter().getConsoleOutput())
         .thenReturn(ConsoleOutput.Plain);
     Mockito.when(mockProject.getObjects()).thenReturn(mockObjectFactory);
-    Mockito.when(mockObjectFactory.newInstance(ExtensionDefinedFooConfig.class))
+    Mockito.when(
+            mockObjectFactory.newInstance(
+                Mockito.eq(ExtensionDefinedFooConfig.class), Mockito.any()))
         .thenReturn(new ExtensionDefinedFooConfig("uninitialized"));
-    Mockito.when(mockObjectFactory.newInstance(ExtensionDefinedBarConfig.class))
+    Mockito.when(
+            mockObjectFactory.newInstance(
+                Mockito.eq(ExtensionDefinedBarConfig.class), Mockito.any()))
         .thenReturn(new ExtensionDefinedBarConfig("uninitialized"));
 
     gradleProjectProperties =


### PR DESCRIPTION
I realized we [need to inject the Gradle project](https://github.com/GoogleContainerTools/jib-extensions/pull/7/files#diff-bad2ecb1f14b7db185ced1687bb8cfa6R108-R111) when instantiating an extension-specific config object.