### PR TITLE
Also try .exe for cred helpers on Windows

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
@@ -118,6 +118,7 @@ public class DockerCredentialHelper {
       try {
         return retrieve(Arrays.asList(credentialHelper.toString() + suffix, "get"));
       } catch (CredentialHelperNotFoundException ignored) {
+        // ignored
       }
     }
     // On Windows, launching a process from Java without a file extension should normally fail, but

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
@@ -113,7 +113,7 @@ public class DockerCredentialHelper {
       return retrieve(Arrays.asList(credentialHelper.toString(), "get"));
     }
 
-    // We are on Windows.
+    // We are on Windows with undefined/unknown file extension.
     for (String suffix : Arrays.asList(".cmd", ".exe")) {
       try {
         return retrieve(Arrays.asList(credentialHelper.toString() + suffix, "get"));
@@ -121,7 +121,8 @@ public class DockerCredentialHelper {
         // ignored
       }
     }
-    // On Windows, launching a process from Java without a file extension should normally fail, but
+    // On Windows, launching a process from Java without a file extension should normally fail
+    // (https://github.com/GoogleContainerTools/jib/issues/2399#issuecomment-612972912), but
     // running Jib on Linux-like environment (e.g., Cygwin) might succeed?
     return retrieve(Arrays.asList(credentialHelper.toString(), "get"));
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
@@ -113,16 +113,16 @@ public class DockerCredentialHelper {
       return retrieve(Arrays.asList(credentialHelper.toString(), "get"));
     }
 
-    try {
-      return retrieve(Arrays.asList(credentialHelper.toString() + ".cmd", "get"));
-
-    } catch (CredentialHelperNotFoundException ex) {
+    // We are on Windows.
+    for (String suffix : Arrays.asList(".cmd", ".exe")) {
       try {
-        return retrieve(Arrays.asList(credentialHelper.toString(), "get"));
+        return retrieve(Arrays.asList(credentialHelper.toString() + suffix, "get"));
       } catch (CredentialHelperNotFoundException ignored) {
-        throw ex;
       }
     }
+    // On Windows, launching a process from Java without a file extension should normally fail, but
+    // running Jib on Linux-like environment (e.g., Cygwin) might succeed?
+    return retrieve(Arrays.asList(credentialHelper.toString(), "get"));
   }
 
   private Credential retrieve(List<String> credentialHelperCommand)
@@ -177,7 +177,8 @@ public class DockerCredentialHelper {
 
       // Checks if the failure is due to a nonexistent credential helper CLI.
       if (ex.getMessage().contains("No such file or directory")
-          || ex.getMessage().contains("cannot find the file")) {
+          || ex.getMessage().contains("cannot find the file")
+          || ex.getMessage().contains("error=2")) /* errno=2 (ENOENT) */ {
         throw new CredentialHelperNotFoundException(credentialHelper, ex);
       }
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Also tries `.exe` file extension for credential helpers on Windows. ([#2527](https://github.com/GoogleContainerTools/jib/issues/2527))
+
 ### Changed
 
 ### Fixed
+
+- Fixed reporting a wrong credential helper name when the helper does not exist on Windows. ([#2527](https://github.com/GoogleContainerTools/jib/issues/2527))
 
 ## 2.4.0
 
@@ -44,6 +48,7 @@ All notable changes to this project will be documented in this file.
 - Glob pattern support for `jib.extraDirectories.permissions`. ([#1200](https://github.com/GoogleContainerTools/jib/issues/1200))
 - Support for image references with both a tag and a digest. ([#1481](https://github.com/GoogleContainerTools/jib/issues/1481))
 - The `DOCKER_CONFIG` environment variable specifying the directory containing docker configs is now checked during credential retrieval. ([#1618](https://github.com/GoogleContainerTools/jib/issues/1618))
+- Also tries `.cmd` file extension for credential helpers on Windows. ([#2399](https://github.com/GoogleContainerTools/jib/issues/2399))
 
 ### Changed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Also tries `.exe` file extension for credential helpers on Windows. ([#2527](https://github.com/GoogleContainerTools/jib/issues/2527))
+
 ### Changed
 
 ### Fixed
+
+- Fixed reporting a wrong credential helper name when the helper does not exist on Windows. ([#2527](https://github.com/GoogleContainerTools/jib/issues/2527))
 
 ## 2.4.0
 
@@ -44,6 +48,7 @@ All notable changes to this project will be documented in this file.
 - Glob pattern support for `<extraDirectories><permissions>`. ([#1200](https://github.com/GoogleContainerTools/jib/issues/1200))
 - Support for image references with both a tag and a digest. ([#1481](https://github.com/GoogleContainerTools/jib/issues/1481))
 - The `DOCKER_CONFIG` environment variable specifying the directory containing docker configs is now checked during credential retrieval. ([#1618](https://github.com/GoogleContainerTools/jib/issues/1618))
+- Also tries `.cmd` file extension for credential helpers on Windows. ([#2399](https://github.com/GoogleContainerTools/jib/issues/2399))
 
 ### Changed
 

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
@@ -154,8 +154,8 @@ public class DefaultCredentialRetrievers {
         if (!Files.exists(Paths.get(credentialHelper))) {
           String osName = systemProperties.getProperty("os.name").toLowerCase(Locale.ENGLISH);
           if (!osName.contains("windows")
-              || !Files.exists(Paths.get(credentialHelper + ".cmd"))
-                  && !Files.exists(Paths.get(credentialHelper + ".exe"))) {
+              || (!Files.exists(Paths.get(credentialHelper + ".cmd"))
+                  && !Files.exists(Paths.get(credentialHelper + ".exe")))) {
             throw new FileNotFoundException(
                 "Specified credential helper was not found: " + credentialHelper);
           }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
@@ -153,7 +153,9 @@ public class DefaultCredentialRetrievers {
       if (credentialHelper.contains(FileSystems.getDefault().getSeparator())) {
         if (!Files.exists(Paths.get(credentialHelper))) {
           String osName = systemProperties.getProperty("os.name").toLowerCase(Locale.ENGLISH);
-          if (!osName.contains("windows") || !Files.exists(Paths.get(credentialHelper + ".cmd"))) {
+          if (!osName.contains("windows")
+              || !Files.exists(Paths.get(credentialHelper + ".cmd"))
+                  && !Files.exists(Paths.get(credentialHelper + ".exe"))) {
             throw new FileNotFoundException(
                 "Specified credential helper was not found: " + credentialHelper);
           }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
@@ -270,7 +270,7 @@ public class DefaultCredentialRetrieversTest {
   }
 
   @Test
-  public void testCredentialHelper() throws IOException {
+  public void testCredentialHelper_cmdExtension() throws IOException {
     Path credHelper = temporaryFolder.newFile("foo.cmd").toPath();
     Path pathWithoutCmd = credHelper.getParent().resolve("foo");
     Assert.assertEquals(pathWithoutCmd.getParent().resolve("foo.cmd"), credHelper);
@@ -291,6 +291,47 @@ public class DefaultCredentialRetrieversTest {
     List<CredentialRetriever> retrieverList =
         new DefaultCredentialRetrievers(mockCredentialRetrieverFactory, properties, environment)
             .setCredentialHelper(pathWithoutCmd.toString())
+            .asList();
+
+    Assert.assertEquals(
+        Arrays.asList(
+            mockDockerCredentialHelperCredentialRetriever,
+            mockDockerConfigEnvDockerConfigCredentialRetriever,
+            mockDockerConfigEnvKubernetesDockerConfigCredentialRetriever,
+            mockDockerConfigEnvLegacyDockerConfigCredentialRetriever,
+            mockSystemHomeDockerConfigCredentialRetriever,
+            mockSystemHomeKubernetesDockerConfigCredentialRetriever,
+            mockSystemHomeLegacyDockerConfigCredentialRetriever,
+            mockEnvHomeDockerConfigCredentialRetriever,
+            mockEnvHomeKubernetesDockerConfigCredentialRetriever,
+            mockEnvHomeLegacyDockerConfigCredentialRetriever,
+            mockWellKnownCredentialHelpersCredentialRetriever,
+            mockApplicationDefaultCredentialRetriever),
+        retrieverList);
+  }
+
+  @Test
+  public void testCredentialHelper_exeExtension() throws IOException {
+    Path credHelper = temporaryFolder.newFile("foo.exe").toPath();
+    Path pathWithoutExe = credHelper.getParent().resolve("foo");
+    Assert.assertEquals(pathWithoutExe.getParent().resolve("foo.exe"), credHelper);
+
+    DefaultCredentialRetrievers credentialRetrievers =
+        new DefaultCredentialRetrievers(mockCredentialRetrieverFactory, properties, environment)
+            .setCredentialHelper(pathWithoutExe.toString());
+    try {
+      credentialRetrievers.asList();
+      Assert.fail("shouldn't check .exe suffix on non-Windows");
+    } catch (FileNotFoundException ex) {
+      Assert.assertThat(
+          ex.getMessage(), CoreMatchers.startsWith("Specified credential helper was not found:"));
+      Assert.assertThat(ex.getMessage(), CoreMatchers.endsWith("foo"));
+    }
+
+    properties.setProperty("os.name", "winDOWs");
+    List<CredentialRetriever> retrieverList =
+        new DefaultCredentialRetrievers(mockCredentialRetrieverFactory, properties, environment)
+            .setCredentialHelper(pathWithoutExe.toString())
             .asList();
 
     Assert.assertEquals(


### PR DESCRIPTION
Fixes #2527 

The logic to determine whether a file does not exist isn't reliable; in #2527, the exception message was localized. (Note the logic wasn't changed in #2403. We had it like that from the beginning.)

However, I think we still have to rely on `CredentialHelperNotFoundException`. Otherwise, when attempting multiple filenames (.cmd, .exe., no file ext), there's no way to distinguish which one failed because of a wrong filename, insufficient permissions, or an IO error while running.