### PR TITLE
Temporary fix for registry not having htpassword

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
@@ -76,7 +76,7 @@ public class LocalRegistry extends ExternalResource {
                   "--rm",
                   "--entrypoint",
                   "htpasswd",
-                  "registry:2",
+                  "registry:2.7.0", // TODO: correctly fix this when using latest
                   "-Bbn",
                   username,
                   password)


### PR DESCRIPTION
This is a temporary workaround. Pin dockerhub registry contianer image to 2.7.0.

core issue: https://github.com/docker/distribution-library-image/issues/106
