### PR TITLE
Programmatically generate htpasswd file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ subprojects {
     MOCKITO_CORE: '3.2.4',
     SLF4J_API: '1.7.25',
     SYSTEM_RULES: '1.19.0',
+    JBCRYPT: '0.4',
   ]
 
   // Use this to ensure we correctly override transitive dependencies

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -19,6 +19,7 @@ dependencies {
   testImplementation "org.mockito:mockito-core:${dependencyVersions.MOCKITO_CORE}"
   testImplementation "org.slf4j:slf4j-api:${dependencyVersions.SLF4J_API}"
   testImplementation "com.github.stefanbirkner:system-rules:${dependencyVersions.SYSTEM_RULES}"
+  testImplementation "org.mindrot:jbcrypt:${dependencyVersions.JBCRYPT}"
 }
 
 jar {

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
@@ -69,7 +69,7 @@ public class LocalRegistry extends ExternalResource {
             Arrays.asList(
                 "docker", "run", "--rm", "-d", "-p", port + ":5000", "--name", containerName));
     if (username != null && password != null) {
-      // since registry:2 no longer contains htpasswd, generate the htpasswd file manually
+      // Equivalent of "$ htpasswd -nbB username password".
       // https://httpd.apache.org/docs/2.4/misc/password_encryptions.html
       // BCrypt generates hashes using $2a$ algorithm (instead of $2y$ from docs), but this seems
       // to work okay


### PR DESCRIPTION
Turn out you must use bcrypt. md5 doesn't work for registry even if the htpasswd file is right.

The jbcrypt java library uses $2a$, not $2y$ (described in htpasswd docs: https://httpd.apache.org/docs/2.4/misc/password_encryptions.html), but $2y$ vs $2a$ doesn't seem to matter (integration tests passing).

core issue: docker/distribution-library-image#106
longterm solution for: #2538 

fixes #2537

