### PR TITLE
Revert Error Prone back to 2.3.4 that Dependabot upgraded to 2.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ subprojects {
   dependencies {
     // NullAway errorprone plugin
     annotationProcessor 'com.uber.nullaway:nullaway:0.7.10'
-    errorprone 'com.google.errorprone:error_prone_core:2.4.0'
+    errorprone 'com.google.errorprone:error_prone_core:2.3.4'
     // Using github.com/google/error-prone-javac is required when running on
     // JDK 8. Remove when migrating to JDK 11.
     if (System.getProperty('java.version').startsWith('1.8.')) {


### PR DESCRIPTION
Dependabot upgraded it to 2.4.0 in #2553, but I already have PR #2510 that's not yet ready due to a bug in 2.4.0.