### PR TITLE
Upgrade to Junit 4.13

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ subprojects {
     MAVEN_API: '3.5.2',
 
     //test
-    JUNIT: '4.12',
+    JUNIT: '4.13',
     MOCKITO_CORE: '3.2.4',
     SLF4J_API: '1.7.25',
     SYSTEM_RULES: '1.19.0',

--- a/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlanTest.java
+++ b/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlanTest.java
@@ -23,6 +23,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -70,7 +71,8 @@ public class ContainerBuildPlanTest {
     Assert.assertEquals(Arrays.asList("bar", "cmd"), plan.getCmd());
 
     Assert.assertEquals(1, plan.getLayers().size());
-    Assert.assertThat(plan.getLayers().get(0), CoreMatchers.instanceOf(FileEntriesLayer.class));
+    MatcherAssert.assertThat(
+        plan.getLayers().get(0), CoreMatchers.instanceOf(FileEntriesLayer.class));
     Assert.assertEquals(
         Arrays.asList(
             new FileEntry(
@@ -102,7 +104,8 @@ public class ContainerBuildPlanTest {
     Assert.assertEquals(Arrays.asList("bar", "cmd"), plan.getCmd());
 
     Assert.assertEquals(1, plan.getLayers().size());
-    Assert.assertThat(plan.getLayers().get(0), CoreMatchers.instanceOf(FileEntriesLayer.class));
+    MatcherAssert.assertThat(
+        plan.getLayers().get(0), CoreMatchers.instanceOf(FileEntriesLayer.class));
     Assert.assertEquals(
         Arrays.asList(
             new FileEntry(

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/LayerDefinitionParserTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/LayerDefinitionParserTest.java
@@ -31,6 +31,7 @@ import java.time.Instant;
 import java.time.format.DateTimeParseException;
 import java.util.function.BiFunction;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,7 +46,7 @@ public class LayerDefinitionParserTest {
 
   @Test
   public void testParseTimestampsDirective_actual() {
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         LayerDefinitionParser.parseTimestampsDirective("actual"),
         CoreMatchers.instanceOf(ActualTimestampProvider.class));
   }
@@ -54,7 +55,7 @@ public class LayerDefinitionParserTest {
   public void testParseTimestampsDirective_secondsSinceEpoch() {
     BiFunction<Path, AbsoluteUnixPath, Instant> provider =
         LayerDefinitionParser.parseTimestampsDirective("1");
-    Assert.assertThat(provider, CoreMatchers.instanceOf(FixedTimestampProvider.class));
+    MatcherAssert.assertThat(provider, CoreMatchers.instanceOf(FixedTimestampProvider.class));
     Assert.assertEquals(Instant.ofEpochSecond(1), ((FixedTimestampProvider) provider).fixed);
   }
 
@@ -62,7 +63,7 @@ public class LayerDefinitionParserTest {
   public void testParseTimestampsDirective_is8601Date() {
     BiFunction<Path, AbsoluteUnixPath, Instant> provider =
         LayerDefinitionParser.parseTimestampsDirective("1970-01-01T00:00:01.000Z");
-    Assert.assertThat(provider, CoreMatchers.instanceOf(FixedTimestampProvider.class));
+    MatcherAssert.assertThat(provider, CoreMatchers.instanceOf(FixedTimestampProvider.class));
     Assert.assertEquals(Instant.ofEpochSecond(1), ((FixedTimestampProvider) provider).fixed);
   }
 
@@ -72,13 +73,13 @@ public class LayerDefinitionParserTest {
       LayerDefinitionParser.parseTimestampsDirective("invalid");
       Assert.fail();
     } catch (RuntimeException ex) {
-      Assert.assertThat(ex, CoreMatchers.instanceOf(DateTimeParseException.class));
+      MatcherAssert.assertThat(ex, CoreMatchers.instanceOf(DateTimeParseException.class));
     }
   }
 
   @Test
   public void testParsePermissionsDirective_actual() {
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         LayerDefinitionParser.parsePermissionsDirective("actual"),
         CoreMatchers.instanceOf(ActualPermissionsProvider.class));
   }
@@ -87,7 +88,7 @@ public class LayerDefinitionParserTest {
   public void testParsePermissionsDirective_fileOnly() {
     BiFunction<Path, AbsoluteUnixPath, FilePermissions> provider =
         LayerDefinitionParser.parsePermissionsDirective("555");
-    Assert.assertThat(provider, CoreMatchers.instanceOf(FixedPermissionsProvider.class));
+    MatcherAssert.assertThat(provider, CoreMatchers.instanceOf(FixedPermissionsProvider.class));
     Assert.assertEquals(
         0555, ((FixedPermissionsProvider) provider).filePermissions.getPermissionBits());
     Assert.assertSame(
@@ -99,7 +100,7 @@ public class LayerDefinitionParserTest {
   public void testParsePermissionsDirective_fileOAndDirectory() {
     BiFunction<Path, AbsoluteUnixPath, FilePermissions> provider =
         LayerDefinitionParser.parsePermissionsDirective("555:666");
-    Assert.assertThat(provider, CoreMatchers.instanceOf(FixedPermissionsProvider.class));
+    MatcherAssert.assertThat(provider, CoreMatchers.instanceOf(FixedPermissionsProvider.class));
     Assert.assertEquals(
         0555, ((FixedPermissionsProvider) provider).filePermissions.getPermissionBits());
     Assert.assertEquals(
@@ -112,7 +113,7 @@ public class LayerDefinitionParserTest {
       LayerDefinitionParser.parsePermissionsDirective("811:922");
       Assert.fail();
     } catch (RuntimeException ex) {
-      Assert.assertThat(ex, CoreMatchers.instanceOf(IllegalArgumentException.class));
+      MatcherAssert.assertThat(ex, CoreMatchers.instanceOf(IllegalArgumentException.class));
     }
   }
 
@@ -122,7 +123,7 @@ public class LayerDefinitionParserTest {
       LayerDefinitionParser.parsePermissionsDirective("invalid");
       Assert.fail();
     } catch (RuntimeException ex) {
-      Assert.assertThat(ex, CoreMatchers.instanceOf(IllegalArgumentException.class));
+      MatcherAssert.assertThat(ex, CoreMatchers.instanceOf(IllegalArgumentException.class));
     }
   }
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.stream.Stream;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -113,7 +114,7 @@ public class ContainerizerIntegrationTest {
   private static void assertDockerInspect(String imageReference)
       throws IOException, InterruptedException {
     String dockerContainerConfig = new Command("docker", "inspect", imageReference).run();
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerContainerConfig,
         CoreMatchers.containsString(
             "            \"ExposedPorts\": {\n"
@@ -122,7 +123,7 @@ public class ContainerizerIntegrationTest {
                 + "                \"2001/tcp\": {},\n"
                 + "                \"2002/tcp\": {},\n"
                 + "                \"3000/udp\": {}"));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerContainerConfig,
         CoreMatchers.containsString(
             "            \"Labels\": {\n"
@@ -131,11 +132,11 @@ public class ContainerizerIntegrationTest {
                 + "            }"));
     String dockerConfigEnv =
         new Command("docker", "inspect", "-f", "{{.Config.Env}}", imageReference).run();
-    Assert.assertThat(dockerConfigEnv, CoreMatchers.containsString("env1=envvalue1"));
-    Assert.assertThat(dockerConfigEnv, CoreMatchers.containsString("env2=envvalue2"));
+    MatcherAssert.assertThat(dockerConfigEnv, CoreMatchers.containsString("env1=envvalue1"));
+    MatcherAssert.assertThat(dockerConfigEnv, CoreMatchers.containsString("env2=envvalue2"));
     String history = new Command("docker", "history", imageReference).run();
-    Assert.assertThat(history, CoreMatchers.containsString("jib-integration-test"));
-    Assert.assertThat(history, CoreMatchers.containsString("bazel build ..."));
+    MatcherAssert.assertThat(history, CoreMatchers.containsString("jib-integration-test"));
+    MatcherAssert.assertThat(history, CoreMatchers.containsString("bazel build ..."));
   }
 
   private static void assertLayerSize(int expected, String imageReference)
@@ -255,7 +256,7 @@ public class ContainerizerIntegrationTest {
           "jib.skipExistingImages was enabled and digest was already pushed, "
               + "hence new_testtag shouldn't have been pushed.");
     } catch (RuntimeException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "manifest for localhost:5000/testimagerepo:new_testtag not found"));

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.security.DigestException;
 import java.util.concurrent.atomic.LongAdder;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -94,7 +95,7 @@ public class BlobPullerIntegrationTest {
       if (!(ex.getCause() instanceof RegistryErrorException)) {
         throw ex;
       }
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "pull BLOB for localhost:5000/busybox with digest " + nonexistentDigest));

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.jib.image.json.V22ManifestListTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import java.io.IOException;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -87,7 +88,7 @@ public class ManifestPullerIntegrationTest {
     // Generic call to 11-jre-slim should NOT pull a manifest list (delegate to registry default)
     ManifestTemplate manifestTemplate = registryClient.pullManifest("11-jre-slim").getManifest();
     Assert.assertEquals(2, manifestTemplate.getSchemaVersion());
-    Assert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V22ManifestTemplate.class));
+    MatcherAssert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V22ManifestTemplate.class));
 
     // Make sure we can't cast a v22ManifestTemplate to v22ManifestListTemplate in ManifestPuller
     try {
@@ -101,7 +102,8 @@ public class ManifestPullerIntegrationTest {
     ManifestTemplate sha256ManifestList =
         registryClient.pullManifest(KNOWN_MANIFEST_LIST_SHA).getManifest();
     Assert.assertEquals(2, sha256ManifestList.getSchemaVersion());
-    Assert.assertThat(sha256ManifestList, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
+    MatcherAssert.assertThat(
+        sha256ManifestList, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
     Assert.assertTrue(((V22ManifestListTemplate) sha256ManifestList).getManifests().size() > 0);
   }
 
@@ -115,7 +117,7 @@ public class ManifestPullerIntegrationTest {
       Assert.fail("Trying to pull nonexistent image should have errored");
 
     } catch (RegistryErrorException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "pull image manifest for localhost:5000/busybox:nonexistent-tag"));

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelperIntegrationTest.java
@@ -24,6 +24,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -77,7 +78,7 @@ public class DockerCredentialHelperIntegrationTest {
       Assert.fail("Retrieve should have failed for nonexistent server URL");
 
     } catch (CredentialHelperUnhandledServerUrlException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "The credential helper (docker-credential-gcr) has nothing for server URL: fake.server.url"));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/ImageReferenceTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/ImageReferenceTest.java
@@ -20,6 +20,7 @@ import com.google.common.base.Strings;
 import java.util.Arrays;
 import java.util.List;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -88,7 +89,7 @@ public class ImageReferenceTest {
         Assert.fail(badImageReference + " should not be a valid image reference");
 
       } catch (InvalidImageReferenceException ex) {
-        Assert.assertThat(ex.getMessage(), CoreMatchers.containsString(badImageReference));
+        MatcherAssert.assertThat(ex.getMessage(), CoreMatchers.containsString(badImageReference));
       }
     }
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
@@ -40,6 +40,7 @@ import java.util.Collections;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -274,7 +275,7 @@ public class JibContainerBuilderTest {
     Assert.assertEquals(Arrays.asList("program", "arguments"), buildPlan.getCmd());
 
     Assert.assertEquals(1, buildPlan.getLayers().size());
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildPlan.getLayers().get(0), CoreMatchers.instanceOf(FileEntriesLayer.class));
     Assert.assertEquals(
         Arrays.asList(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/MainClassFinderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/MainClassFinderTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Consumer;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,7 +44,7 @@ public class MainClassFinderTest {
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
     Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("HelloWorld"));
   }
 
@@ -55,7 +56,7 @@ public class MainClassFinderTest {
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
     Assert.assertSame(
         MainClassFinder.Result.Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         mainClassFinderResult.getFoundMainClass(),
         CoreMatchers.containsString("multi.layered.HelloWorld"));
   }
@@ -90,7 +91,7 @@ public class MainClassFinderTest {
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
     Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("main.MainClass"));
   }
 
@@ -102,7 +103,7 @@ public class MainClassFinderTest {
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
     Assert.assertSame(
         MainClassFinder.Result.Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("main.MainClass"));
   }
 
@@ -114,7 +115,7 @@ public class MainClassFinderTest {
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
     Assert.assertSame(
         MainClassFinder.Result.Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("main.MainClass"));
   }
 
@@ -125,7 +126,7 @@ public class MainClassFinderTest {
     MainClassFinder.Result mainClassFinderResult =
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
     Assert.assertSame(Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         mainClassFinderResult.getFoundMainClass(),
         CoreMatchers.containsString("HelloWorld$InnerClass"));
   }
@@ -138,7 +139,7 @@ public class MainClassFinderTest {
         MainClassFinder.find(new DirectoryWalker(rootDirectory).walk(), logEventConsumer);
     Assert.assertSame(
         MainClassFinder.Result.Type.MAIN_CLASS_FOUND, mainClassFinderResult.getType());
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         mainClassFinderResult.getFoundMainClass(), CoreMatchers.containsString("HelloWorld"));
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageFilesTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageFilesTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.DigestException;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -67,10 +68,10 @@ public class CacheStorageFilesTest {
       Assert.fail("Should have thrown CacheCorruptedException");
 
     } catch (CacheCorruptedException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.startsWith("Layer file did not include valid hash: not long enough"));
-      Assert.assertThat(ex.getCause(), CoreMatchers.instanceOf(DigestException.class));
+      MatcherAssert.assertThat(ex.getCause(), CoreMatchers.instanceOf(DigestException.class));
     }
 
     try {
@@ -80,12 +81,12 @@ public class CacheStorageFilesTest {
       Assert.fail("Should have thrown CacheCorruptedException");
 
     } catch (CacheCorruptedException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.startsWith(
               "Layer file did not include valid hash: "
                   + "not valid hash bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"));
-      Assert.assertThat(ex.getCause(), CoreMatchers.instanceOf(DigestException.class));
+      MatcherAssert.assertThat(ex.getCause(), CoreMatchers.instanceOf(DigestException.class));
     }
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageReaderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageReaderTest.java
@@ -35,6 +35,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Optional;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -103,9 +104,9 @@ public class CacheStorageReaderTest {
       Assert.fail("Listing digests should have failed");
 
     } catch (CacheCorruptedException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(), CoreMatchers.startsWith("Found non-digest file in layers directory"));
-      Assert.assertThat(ex.getCause(), CoreMatchers.instanceOf(DigestException.class));
+      MatcherAssert.assertThat(ex.getCause(), CoreMatchers.instanceOf(DigestException.class));
     }
   }
 
@@ -195,7 +196,7 @@ public class CacheStorageReaderTest {
       Assert.fail("Should have thrown CacheCorruptedException");
 
     } catch (CacheCorruptedException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.startsWith(
               "No or multiple layer files found for layer hash "
@@ -238,7 +239,7 @@ public class CacheStorageReaderTest {
       Assert.fail("Should have thrown CacheCorruptedException");
 
     } catch (CacheCorruptedException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.startsWith(
               "No or multiple layer files found for layer hash "
@@ -294,7 +295,7 @@ public class CacheStorageReaderTest {
       Assert.fail("Should have thrown CacheCorruptedException");
 
     } catch (CacheCorruptedException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.startsWith(
               "Expected valid layer digest as contents of selector file `"

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
@@ -35,6 +35,7 @@ import java.time.Instant;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -151,7 +152,8 @@ public class CacheTest {
       Assert.fail();
 
     } catch (CacheDirectoryCreationException ex) {
-      Assert.assertThat(ex.getCause(), CoreMatchers.instanceOf(FileAlreadyExistsException.class));
+      MatcherAssert.assertThat(
+          ex.getCause(), CoreMatchers.instanceOf(FileAlreadyExistsException.class));
     }
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CachedLayerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CachedLayerTest.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.blob.Blobs;
 import java.io.IOException;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,7 +41,7 @@ public class CachedLayerTest {
       Assert.fail("missing required");
 
     } catch (NullPointerException ex) {
-      Assert.assertThat(ex.getMessage(), CoreMatchers.containsString("layerDigest"));
+      MatcherAssert.assertThat(ex.getMessage(), CoreMatchers.containsString("layerDigest"));
     }
 
     try {
@@ -48,7 +49,7 @@ public class CachedLayerTest {
       Assert.fail("missing required");
 
     } catch (NullPointerException ex) {
-      Assert.assertThat(ex.getMessage(), CoreMatchers.containsString("layerDiffId"));
+      MatcherAssert.assertThat(ex.getMessage(), CoreMatchers.containsString("layerDiffId"));
     }
 
     try {
@@ -56,7 +57,7 @@ public class CachedLayerTest {
       Assert.fail("missing required");
 
     } catch (NullPointerException ex) {
-      Assert.assertThat(ex.getMessage(), CoreMatchers.containsString("layerBlob"));
+      MatcherAssert.assertThat(ex.getMessage(), CoreMatchers.containsString("layerBlob"));
     }
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/RetryTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/RetryTest.java
@@ -40,21 +40,21 @@ public class RetryTest {
   }
 
   @Test
-  public void testSuccessfulAction() {
+  public void testSuccessfulAction() throws Exception {
     boolean result = Retry.action(this::successfulAction).run();
     Assert.assertTrue(result);
     Assert.assertEquals(1, actionCount);
   }
 
   @Test
-  public void testMaximumRetries_default() {
+  public void testMaximumRetries_default() throws Exception {
     boolean result = Retry.action(this::unsuccessfulAction).run();
     Assert.assertFalse(result);
     Assert.assertEquals(5, actionCount);
   }
 
   @Test
-  public void testMaximumRetries_specified() {
+  public void testMaximumRetries_specified() throws Exception {
     boolean result = Retry.action(this::unsuccessfulAction).maximumRetries(2).run();
     Assert.assertFalse(result);
     Assert.assertEquals(2, actionCount);
@@ -85,7 +85,7 @@ public class RetryTest {
   }
 
   @Test
-  public void testInterruptSleep() {
+  public void testInterruptSleep() throws Exception {
     // interrupt the current thread so as to cause the retry's sleep() to throw
     // an InterruptedException
     Thread.currentThread().interrupt();

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerFailoverHttpClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerFailoverHttpClientTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import javax.net.ssl.SSLException;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -140,7 +141,7 @@ public class WithServerFailoverHttpClientTest {
       System.setProperty("http.proxyPassword", "pass_sys_prop");
 
       try (Response response = httpClient.get(new URL("http://does.not.matter"), request)) {
-        Assert.assertThat(
+        MatcherAssert.assertThat(
             server.getInputRead(),
             CoreMatchers.containsString(
                 "Proxy-Authorization: Basic dXNlcl9zeXNfcHJvcDpwYXNzX3N5c19wcm9w"));
@@ -193,21 +194,21 @@ public class WithServerFailoverHttpClientTest {
     try (TestWebServer server = new TestWebServer(false, responses, 1)) {
       httpClient.get(new URL(server.getEndpoint()), request);
 
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           server.getInputRead(),
           CoreMatchers.containsString("GET /?id=301&_auth_=exp=1572285389~hmac=f0a387f0 "));
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           server.getInputRead(),
           CoreMatchers.containsString(
               "GET /?id=302&Signature=2wYOD0a%2BDAkK%2F9lQJUOuIpYti8o%3D&Expires=1569997614 "));
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           server.getInputRead(),
           CoreMatchers.containsString("GET /?id=303&_auth_=exp=1572285389~hmac=f0a387f0 "));
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           server.getInputRead(),
           CoreMatchers.containsString(
               "GET /?id=307&Signature=2wYOD0a%2BDAkK%2F9lQJUOuIpYti8o%3D&Expires=1569997614 "));
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           server.getInputRead(),
           CoreMatchers.containsString("GET /?id=308&_auth_=exp=1572285389~hmac=f0a387f0 "));
     }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilderTest.java
@@ -41,6 +41,7 @@ import java.util.Date;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -190,7 +191,7 @@ public class ReproducibleLayerBuilderTest {
     byte[] layerContent = Blobs.writeToByteArray(layer);
     byte[] reproducedLayerContent = Blobs.writeToByteArray(reproduced);
 
-    Assert.assertThat(layerContent, CoreMatchers.is(reproducedLayerContent));
+    MatcherAssert.assertThat(layerContent, CoreMatchers.is(reproducedLayerContent));
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/json/JsonTemplateMapperTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/json/JsonTemplateMapperTest.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -95,18 +96,19 @@ public class JsonTemplateMapperTest {
     // Deserializes into a metadata JSON object.
     TestJson testJson = JsonTemplateMapper.readJsonFromFileWithLock(jsonFile, TestJson.class);
 
-    Assert.assertThat(testJson.number, CoreMatchers.is(54));
-    Assert.assertThat(testJson.text, CoreMatchers.is("crepecake"));
-    Assert.assertThat(
+    MatcherAssert.assertThat(testJson.number, CoreMatchers.is(54));
+    MatcherAssert.assertThat(testJson.text, CoreMatchers.is("crepecake"));
+    MatcherAssert.assertThat(
         testJson.digest,
         CoreMatchers.is(
             DescriptorDigest.fromDigest(
                 "sha256:8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad")));
-    Assert.assertThat(testJson.innerObject, CoreMatchers.instanceOf(TestJson.InnerObject.class));
-    Assert.assertThat(testJson.innerObject.number, CoreMatchers.is(23));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
+        testJson.innerObject, CoreMatchers.instanceOf(TestJson.InnerObject.class));
+    MatcherAssert.assertThat(testJson.innerObject.number, CoreMatchers.is(23));
+    MatcherAssert.assertThat(
         testJson.innerObject.texts, CoreMatchers.is(Arrays.asList("first text", "second text")));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         testJson.innerObject.digests,
         CoreMatchers.is(
             Arrays.asList(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/AuthenticationMethodRetrieverTest.java
@@ -26,6 +26,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -109,7 +110,7 @@ public class AuthenticationMethodRetrieverTest {
           "Authentication method retriever should fail if 'WWW-Authenticate' header is not found");
 
     } catch (RegistryErrorException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(), CoreMatchers.containsString("'WWW-Authenticate' header not found"));
     }
   }
@@ -129,7 +130,7 @@ public class AuthenticationMethodRetrieverTest {
           "Authentication method retriever should fail if 'WWW-Authenticate' header failed to parse");
 
     } catch (RegistryErrorException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "Failed get authentication method from 'WWW-Authenticate' header"));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobCheckerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobCheckerTest.java
@@ -29,6 +29,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.DigestException;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -76,7 +77,7 @@ public class BlobCheckerTest {
       Assert.fail("Should throw exception if Content-Length header is not present");
 
     } catch (RegistryErrorException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(), CoreMatchers.containsString("Did not receive Content-Length header"));
     }
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobPusherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/BlobPusherTest.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.atomic.LongAdder;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -106,7 +107,7 @@ public class BlobPusherTest {
       Assert.fail("Multiple 'Location' headers should be a registry error");
 
     } catch (RegistryErrorException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString("Expected 1 'Location' header, but found 2"));
     }
@@ -120,7 +121,7 @@ public class BlobPusherTest {
       Assert.fail("Multiple 'Location' headers should be a registry error");
 
     } catch (RegistryErrorException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(), CoreMatchers.containsString("Received unrecognized status code -1"));
     }
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPullerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPullerTest.java
@@ -39,6 +39,7 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -77,7 +78,7 @@ public class ManifestPullerTest {
                 fakeRegistryEndpointRequestProperties, "test-image-tag", V21ManifestTemplate.class)
             .handleResponse(mockResponse);
 
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         manifestAndDigest.getManifest(), CoreMatchers.instanceOf(V21ManifestTemplate.class));
     Assert.assertEquals(expectedDigest, manifestAndDigest.getDigest());
   }
@@ -97,7 +98,7 @@ public class ManifestPullerTest {
                 fakeRegistryEndpointRequestProperties, "test-image-tag", V22ManifestTemplate.class)
             .handleResponse(mockResponse);
 
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         manifestAndDigest.getManifest(), CoreMatchers.instanceOf(V22ManifestTemplate.class));
     Assert.assertEquals(expectedDigest, manifestAndDigest.getDigest());
   }
@@ -136,7 +137,8 @@ public class ManifestPullerTest {
             .handleResponse(mockResponse);
     ManifestTemplate manifestTemplate = manifestAndDigest.getManifest();
 
-    Assert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
+    MatcherAssert.assertThat(
+        manifestTemplate, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
     Assert.assertTrue(((V22ManifestListTemplate) manifestTemplate).getManifests().size() > 0);
     Assert.assertEquals(expectedDigest, manifestAndDigest.getDigest());
   }
@@ -160,7 +162,8 @@ public class ManifestPullerTest {
             .handleResponse(mockResponse);
     V22ManifestListTemplate manifestTemplate = manifestAndDigest.getManifest();
 
-    Assert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
+    MatcherAssert.assertThat(
+        manifestTemplate, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
     Assert.assertTrue(manifestTemplate.getManifests().size() > 0);
     Assert.assertEquals(expectedDigest, manifestAndDigest.getDigest());
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPusherTest.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import org.apache.http.HttpStatus;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -168,7 +169,7 @@ public class ManifestPusherTest {
       Assert.fail();
 
     } catch (RegistryErrorException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "Registry may not support pushing OCI Manifest or "
@@ -191,7 +192,7 @@ public class ManifestPusherTest {
       Assert.fail();
 
     } catch (RegistryErrorException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "Registry may not support pushing OCI Manifest or "
@@ -214,7 +215,7 @@ public class ManifestPusherTest {
       Assert.fail();
 
     } catch (RegistryErrorException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "Registry may not support pushing OCI Manifest or "

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.util.Collections;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -247,7 +248,7 @@ public class RegistryAuthenticatorTest {
       } catch (RegistryAuthenticationFailedException ex) {
         // Doesn't matter if auth fails. We only examine what we sent.
       }
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           server.getInputRead(), CoreMatchers.containsString("User-Agent: Competent-Agent"));
     }
   }
@@ -263,7 +264,7 @@ public class RegistryAuthenticatorTest {
                 httpClient)
             .get();
     authenticator.authenticatePush(null);
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         urlCaptor.getValue().toString(),
         CoreMatchers.endsWith(
             "scope=repository:someimage:pull,push&scope=repository:anotherimage:pull"));
@@ -280,7 +281,7 @@ public class RegistryAuthenticatorTest {
                 httpClient)
             .get();
     authenticator.authenticatePush(null);
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         urlCaptor.getValue().toString(),
         CoreMatchers.endsWith("service=someserver&scope=repository:someimage:pull,push"));
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryClientTest.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -209,7 +210,7 @@ public class RegistryClientTest {
 
     Optional<BlobDescriptor> digestAndSize = registryClient.checkBlob(digest);
     Assert.assertEquals(56789, digestAndSize.get().getSize());
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         registry.getInputRead(), CoreMatchers.containsString("Authorization: Basic dXNlcjpwYXNz"));
   }
 
@@ -246,7 +247,7 @@ public class RegistryClientTest {
         manifest.getContainerConfiguration().getDigest().toString());
     Assert.assertEquals(7023, manifest.getContainerConfiguration().getSize());
 
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         registry.getInputRead(),
         CoreMatchers.containsString("GET /v2/foo/bar/manifests/image-tag "));
   }
@@ -288,7 +289,7 @@ public class RegistryClientTest {
         Arrays.asList("sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f"),
         manifestList.getDigestsForPlatform("amd64", "linux"));
 
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         registry.getInputRead(),
         CoreMatchers.containsString("GET /v2/foo/bar/manifests/image-tag "));
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
@@ -45,6 +45,7 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLPeerUnverifiedException;
 import org.apache.http.NoHttpResponseException;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -488,7 +489,7 @@ public class RegistryEndpointCallerTest {
       Assert.fail("Call should have failed");
 
     } catch (RegistryErrorException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.startsWith(
               "Tried to actionDescription but failed because: unknown error code: code (message)"));

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/DefaultTargetProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/DefaultTargetProjectIntegrationTest.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.security.DigestException;
 import org.gradle.testkit.runner.UnexpectedBuildFailure;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -41,7 +42,7 @@ public class DefaultTargetProjectIntegrationTest {
   private static void assertDockerInspect(String imageReference)
       throws IOException, InterruptedException {
     String dockerInspect = new Command("docker", "inspect", imageReference).run();
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerInspect,
         CoreMatchers.containsString(
             "            \"ExposedPorts\": {\n"
@@ -50,7 +51,7 @@ public class DefaultTargetProjectIntegrationTest {
                 + "                \"2001/udp\": {},\n"
                 + "                \"2002/udp\": {},\n"
                 + "                \"2003/udp\": {}"));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerInspect,
         CoreMatchers.containsString(
             "            \"Labels\": {\n"
@@ -67,7 +68,7 @@ public class DefaultTargetProjectIntegrationTest {
           "clean", "jib", "-Djib.useOnlyProjectCache=true", "-x=classes");
       Assert.fail();
     } catch (UnexpectedBuildFailure ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "Missing target image parameter, perhaps you should add a 'jib.to.image' "

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/EmptyProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/EmptyProjectIntegrationTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.security.DigestException;
 import java.time.Instant;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class EmptyProjectIntegrationTest {
   private static void assertDockerInspect(String imageReference)
       throws IOException, InterruptedException {
     String dockerInspect = new Command("docker", "inspect", imageReference).run();
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerInspect,
         CoreMatchers.containsString(
             "            \"ExposedPorts\": {\n"
@@ -51,7 +52,7 @@ public class EmptyProjectIntegrationTest {
                 + "                \"2001/udp\": {},\n"
                 + "                \"2002/udp\": {},\n"
                 + "                \"2003/udp\": {}"));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerInspect,
         CoreMatchers.containsString(
             "            \"Labels\": {\n"

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibRunHelper.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/JibRunHelper.java
@@ -38,6 +38,7 @@ import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 
 /** Helper class to run integration tests. */
@@ -83,7 +84,7 @@ public class JibRunHelper {
             "-b=" + gradleBuildFile);
     assertBuildSuccess(buildResult, "jib", "Built and pushed image as ");
     assertImageDigestAndId(testProject.getProjectRoot());
-    Assert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(imageReference));
+    MatcherAssert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(imageReference));
 
     return pullAndRunBuiltImage(imageReference, extraRunArguments);
   }
@@ -102,7 +103,7 @@ public class JibRunHelper {
             "-b=" + "build-local-base.gradle");
     assertBuildSuccess(buildResult, "jib", "Built and pushed image as ");
     assertImageDigestAndId(SingleProjectIntegrationTest.simpleTestProject.getProjectRoot());
-    Assert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(target));
+    MatcherAssert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(target));
     return pullAndRunBuiltImage(target);
   }
 
@@ -120,11 +121,11 @@ public class JibRunHelper {
             "-D_ADDITIONAL_TAG=" + additionalTag);
     assertBuildSuccess(buildResult, "jib", "Built and pushed image as ");
     assertImageDigestAndId(testProject.getProjectRoot());
-    Assert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(imageReference));
+    MatcherAssert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(imageReference));
 
     String additionalImageReference =
         ImageReference.parse(imageReference).withQualifier(additionalTag).toString();
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         buildResult.getOutput(), CoreMatchers.containsString(additionalImageReference));
 
     Assert.assertEquals(expectedOutput, pullAndRunBuiltImage(imageReference));
@@ -147,10 +148,10 @@ public class JibRunHelper {
             "-b=" + gradleBuildFile);
     assertBuildSuccess(buildResult, "jibDockerBuild", "Built image to Docker daemon as ");
     assertImageDigestAndId(testProject.getProjectRoot());
-    Assert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(imageReference));
+    MatcherAssert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(imageReference));
 
     String history = new Command("docker", "history", imageReference).run();
-    Assert.assertThat(history, CoreMatchers.containsString("jib-gradle-plugin"));
+    MatcherAssert.assertThat(history, CoreMatchers.containsString("jib-gradle-plugin"));
 
     return buildResult;
   }
@@ -177,7 +178,7 @@ public class JibRunHelper {
     Assert.assertEquals(TaskOutcome.SUCCESS, classesTask.getOutcome());
     Assert.assertNotNull(jibTask);
     Assert.assertEquals(TaskOutcome.SUCCESS, jibTask.getOutcome());
-    Assert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(successMessage));
+    MatcherAssert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(successMessage));
   }
 
   static void assertSimpleCreationTimeIsEqual(Instant match, String imageReference)
@@ -223,7 +224,7 @@ public class JibRunHelper {
       throws IOException, InterruptedException {
     new Command("docker", "pull", imageReference).run();
     String history = new Command("docker", "history", imageReference).run();
-    Assert.assertThat(history, CoreMatchers.containsString("jib-gradle-plugin"));
+    MatcherAssert.assertThat(history, CoreMatchers.containsString("jib-gradle-plugin"));
 
     List<String> command = new ArrayList<>(Arrays.asList("docker", "run", "--rm"));
     command.addAll(Arrays.asList(extraRunArguments));

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -32,6 +32,7 @@ import java.time.Instant;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.UnexpectedBuildFailure;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
@@ -96,14 +97,14 @@ public class SingleProjectIntegrationTest {
   private static void assertDockerInspect(String imageReference)
       throws IOException, InterruptedException {
     String dockerInspect = new Command("docker", "inspect", imageReference).run();
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerInspect,
         CoreMatchers.containsString(
             "            \"Volumes\": {\n"
                 + "                \"/var/log\": {},\n"
                 + "                \"/var/log2\": {}\n"
                 + "            },"));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerInspect,
         CoreMatchers.containsString(
             "            \"ExposedPorts\": {\n"
@@ -112,7 +113,7 @@ public class SingleProjectIntegrationTest {
                 + "                \"2001/udp\": {},\n"
                 + "                \"2002/udp\": {},\n"
                 + "                \"2003/udp\": {}"));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerInspect,
         CoreMatchers.containsString(
             "            \"Labels\": {\n"
@@ -144,12 +145,12 @@ public class SingleProjectIntegrationTest {
             "-b=complex-build.gradle");
 
     JibRunHelper.assertBuildSuccess(buildResult, "jib", "Built and pushed image as ");
-    Assert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(imageReference));
+    MatcherAssert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(imageReference));
 
     targetRegistry.pull(imageReference);
     assertDockerInspect(imageReference);
     String history = new Command("docker", "history", imageReference).run();
-    Assert.assertThat(history, CoreMatchers.containsString("jib-gradle-plugin"));
+    MatcherAssert.assertThat(history, CoreMatchers.containsString("jib-gradle-plugin"));
 
     String output = new Command("docker", "run", "--rm", imageReference).run();
     Assert.assertEquals(
@@ -186,7 +187,7 @@ public class SingleProjectIntegrationTest {
       Assert.fail();
 
     } catch (UnexpectedBuildFailure ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "No classes files were found - did you compile your project?"));
@@ -263,7 +264,7 @@ public class SingleProjectIntegrationTest {
           "-D_TARGET_IMAGE=" + targetImage);
       Assert.fail();
     } catch (UnexpectedBuildFailure ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString("Cannot build to a container registry in offline mode"));
     }
@@ -292,7 +293,7 @@ public class SingleProjectIntegrationTest {
       Assert.fail();
 
     } catch (UnexpectedBuildFailure ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "Your project is using Java 11 but the base image is for Java 8, perhaps you should "
@@ -443,8 +444,8 @@ public class SingleProjectIntegrationTest {
     JibRunHelper.assertBuildSuccess(
         buildResult, "jibDockerBuild", "Built image to Docker daemon as ");
     JibRunHelper.assertImageDigestAndId(simpleTestProject.getProjectRoot());
-    Assert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(targetImage));
-    Assert.assertThat(
+    MatcherAssert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(targetImage));
+    MatcherAssert.assertThat(
         buildResult.getOutput(), CoreMatchers.containsString("Docker load called. value1 value2"));
   }
 
@@ -467,7 +468,7 @@ public class SingleProjectIntegrationTest {
             "-D_TARGET_IMAGE=" + targetImage);
 
     JibRunHelper.assertBuildSuccess(buildResult, "jibBuildTar", "Built image tarball at ");
-    Assert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(outputPath));
+    MatcherAssert.assertThat(buildResult.getOutput(), CoreMatchers.containsString(outputPath));
 
     new Command("docker", "load", "--input", outputPath).run();
     Assert.assertEquals(

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesExtensionTest.java
@@ -40,6 +40,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.model.ObjectFactory;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -321,7 +322,7 @@ public class GradleProjectPropertiesExtensionTest {
       Assert.fail();
     } catch (JibPluginExtensionException ex) {
       Assert.assertEquals("invalid base image reference:  in*val+id", ex.getMessage());
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getCause(), CoreMatchers.instanceOf(InvalidImageReferenceException.class));
     }
   }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -35,6 +35,7 @@ import org.gradle.testfixtures.ProjectBuilder;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.UnexpectedBuildFailure;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -273,12 +274,12 @@ public class JibPluginTest {
       tasks.getByPath(":jar");
       Assert.fail();
     } catch (GradleException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getCause().getMessage(),
           CoreMatchers.startsWith(
               "Both 'bootJar' and 'jar' tasks are enabled, but they write their jar file into the "
                   + "same location at "));
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getCause().getMessage(),
           CoreMatchers.endsWith(
               "root.jar. Did you forget to set 'archiveClassifier' on either task?"));

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2Test.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2Test.java
@@ -29,6 +29,7 @@ import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -62,7 +63,7 @@ public class FilesTaskV2Test {
     Assert.assertNotNull(jibTask);
     Assert.assertEquals(TaskOutcome.SUCCESS, jibTask.getOutcome());
     String output = buildResult.getOutput().trim();
-    Assert.assertThat(output, CoreMatchers.startsWith("BEGIN JIB JSON"));
+    MatcherAssert.assertThat(output, CoreMatchers.startsWith("BEGIN JIB JSON"));
 
     // Return task output with header removed
     return output.replace("BEGIN JIB JSON", "").trim();

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/skaffold/InitTaskTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/skaffold/InitTaskTest.java
@@ -28,6 +28,7 @@ import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.BuildTask;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -53,7 +54,7 @@ public class InitTaskTest {
     Assert.assertNotNull(jibTask);
     Assert.assertEquals(TaskOutcome.SUCCESS, jibTask.getOutcome());
     String output = buildResult.getOutput().trim();
-    Assert.assertThat(output, CoreMatchers.startsWith("BEGIN JIB JSON"));
+    MatcherAssert.assertThat(output, CoreMatchers.startsWith("BEGIN JIB JSON"));
 
     Pattern pattern = Pattern.compile("BEGIN JIB JSON\r?\n(\\{.*})");
     Matcher matcher = pattern.matcher(output);

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.ClassRule;
@@ -63,14 +64,14 @@ public class BuildDockerMojoIntegrationTest {
     buildToDockerDaemon(projectRoot, imageReference, "pom.xml");
 
     String dockerInspect = new Command("docker", "inspect", imageReference).run();
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerInspect,
         CoreMatchers.containsString(
             "            \"Volumes\": {\n"
                 + "                \"/var/log\": {},\n"
                 + "                \"/var/log2\": {}\n"
                 + "            },"));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerInspect,
         CoreMatchers.containsString(
             "            \"ExposedPorts\": {\n"
@@ -79,7 +80,7 @@ public class BuildDockerMojoIntegrationTest {
                 + "                \"2001/udp\": {},\n"
                 + "                \"2002/udp\": {},\n"
                 + "                \"2003/udp\": {}"));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerInspect,
         CoreMatchers.containsString(
             "            \"Labels\": {\n"
@@ -210,7 +211,7 @@ public class BuildDockerMojoIntegrationTest {
       Assert.fail();
 
     } catch (VerificationException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "Obtaining project build output files failed; make sure you have packaged your "
@@ -242,7 +243,7 @@ public class BuildDockerMojoIntegrationTest {
       verifier.executeGoals(Arrays.asList("package", "jib:dockerBuild"));
       Assert.fail();
     } catch (VerificationException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(), CoreMatchers.containsString("but is required to be [,1.0]"));
     }
   }

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -38,6 +38,7 @@ import javax.annotation.Nullable;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -260,7 +261,7 @@ public class BuildImageMojoIntegrationTest {
   private static void assertDockerInspectParameters(String imageReference)
       throws IOException, InterruptedException {
     String dockerInspect = new Command("docker", "inspect", imageReference).run();
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerInspect,
         CoreMatchers.containsString(
             "            \"ExposedPorts\": {\n"
@@ -269,7 +270,7 @@ public class BuildImageMojoIntegrationTest {
                 + "                \"2001/udp\": {},\n"
                 + "                \"2002/udp\": {},\n"
                 + "                \"2003/udp\": {}"));
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         dockerInspect,
         CoreMatchers.containsString(
             "            \"Labels\": {\n"
@@ -277,7 +278,7 @@ public class BuildImageMojoIntegrationTest {
                 + "                \"key2\": \"value2\"\n"
                 + "            }"));
     String history = new Command("docker", "history", imageReference).run();
-    Assert.assertThat(history, CoreMatchers.containsString("jib-maven-plugin"));
+    MatcherAssert.assertThat(history, CoreMatchers.containsString("jib-maven-plugin"));
   }
 
   private static float getBuildTimeFromVerifierLog(Verifier verifier) throws IOException {
@@ -377,7 +378,7 @@ public class BuildImageMojoIntegrationTest {
       Assert.fail();
 
     } catch (VerificationException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "Obtaining project build output files failed; make sure you have compiled your "
@@ -460,7 +461,7 @@ public class BuildImageMojoIntegrationTest {
       Assert.fail();
 
     } catch (VerificationException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString("Cannot build to a container registry in offline mode"));
     }
@@ -487,7 +488,7 @@ public class BuildImageMojoIntegrationTest {
           simpleTestProject.getProjectRoot(), "willnotbuild", "pom-java11-incompatible.xml", false);
       Assert.fail();
     } catch (VerificationException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "Your project is using Java 11 but the base image is for Java 8, perhaps you should "
@@ -539,7 +540,7 @@ public class BuildImageMojoIntegrationTest {
       Assert.fail();
 
     } catch (VerificationException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "Missing target image parameter, perhaps you should add a <to><image> configuration "
@@ -662,7 +663,7 @@ public class BuildImageMojoIntegrationTest {
       verifier.executeGoals(Arrays.asList("package", "jib:build"));
       Assert.fail();
     } catch (VerificationException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(), CoreMatchers.containsString("but is required to be [,1.0]"));
     }
   }
@@ -695,7 +696,7 @@ public class BuildImageMojoIntegrationTest {
                 "-c",
                 "/app/classpath/spring-boot-0.1.0.original.jar")
             .run();
-    Assert.assertThat(
+    MatcherAssert.assertThat(
         sizeOutput, CoreMatchers.containsString(" /app/classpath/spring-boot-0.1.0.original.jar"));
     int fileSize = Integer.parseInt(sizeOutput.substring(0, sizeOutput.indexOf(' ')));
     Assert.assertTrue(fileSize < 3000); // should not be a large fat jar

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildTarMojoIntegrationTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import org.apache.maven.it.VerificationException;
 import org.apache.maven.it.Verifier;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -101,7 +102,7 @@ public class BuildTarMojoIntegrationTest {
       verifier.executeGoals(Arrays.asList("package", "jib:buildTar"));
       Assert.fail();
     } catch (VerificationException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(), CoreMatchers.containsString("but is required to be [,1.0]"));
     }
   }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -282,9 +283,9 @@ public class DefaultCredentialRetrieversTest {
       credentialRetrievers.asList();
       Assert.fail("shouldn't check .cmd suffix on non-Windows");
     } catch (FileNotFoundException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(), CoreMatchers.startsWith("Specified credential helper was not found:"));
-      Assert.assertThat(ex.getMessage(), CoreMatchers.endsWith("foo"));
+      MatcherAssert.assertThat(ex.getMessage(), CoreMatchers.endsWith("foo"));
     }
 
     properties.setProperty("os.name", "winDOWs");
@@ -323,9 +324,9 @@ public class DefaultCredentialRetrieversTest {
       credentialRetrievers.asList();
       Assert.fail("shouldn't check .exe suffix on non-Windows");
     } catch (FileNotFoundException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(), CoreMatchers.startsWith("Specified credential helper was not found:"));
-      Assert.assertThat(ex.getMessage(), CoreMatchers.endsWith("foo"));
+      MatcherAssert.assertThat(ex.getMessage(), CoreMatchers.endsWith("foo"));
     }
 
     properties.setProperty("os.name", "winDOWs");

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/MainClassResolverTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/MainClassResolverTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -60,7 +61,7 @@ public class MainClassResolverTest {
       Assert.fail();
 
     } catch (MainClassInferenceException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "'mainClass' configured in jib-plugin is not a valid Java class: In Val id"));
@@ -99,7 +100,7 @@ public class MainClassResolverTest {
       Assert.fail();
 
     } catch (MainClassInferenceException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "Multiple valid main classes were found: HelloWorld, multi.layered.HelloMoon"));
@@ -132,7 +133,7 @@ public class MainClassResolverTest {
       Assert.fail();
 
     } catch (MainClassInferenceException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
               "Multiple valid main classes were found: HelloWorld, multi.layered.HelloMoon"));
@@ -159,7 +160,8 @@ public class MainClassResolverTest {
       Assert.fail();
 
     } catch (MainClassInferenceException ex) {
-      Assert.assertThat(ex.getMessage(), CoreMatchers.containsString("Main class was not found"));
+      MatcherAssert.assertThat(
+          ex.getMessage(), CoreMatchers.containsString("Main class was not found"));
 
       String info1 =
           "Searching for main class... Add a 'mainClass' configuration to 'jib-plugin' to "
@@ -184,7 +186,8 @@ public class MainClassResolverTest {
       Assert.fail();
 
     } catch (MainClassInferenceException ex) {
-      Assert.assertThat(ex.getMessage(), CoreMatchers.containsString("Main class was not found"));
+      MatcherAssert.assertThat(
+          ex.getMessage(), CoreMatchers.containsString("Main class was not found"));
 
       String info1 =
           "Searching for main class... Add a 'mainClass' configuration to 'jib-plugin' to "

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/UpdateCheckerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/UpdateCheckerTest.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.Optional;
 import java.util.concurrent.Future;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -241,7 +242,7 @@ public class UpdateCheckerTest {
           UpdateChecker.performUpdateCheck(
               logEvent -> {
                 Assert.assertEquals(Level.DEBUG, logEvent.getLevel());
-                Assert.assertThat(
+                MatcherAssert.assertThat(
                     logEvent.getMessage(), CoreMatchers.containsString("Update check failed; "));
               },
               "1.0.2",

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ZipUtilTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ZipUtilTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Rule;
@@ -86,7 +87,7 @@ public class ZipUtilTest {
       ZipUtil.unzip(archive, tempFolder.getRoot().toPath());
       Assert.fail("Should block Zip-Slip");
     } catch (IOException ex) {
-      Assert.assertThat(
+      MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.startsWith("Blocked unzipping files outside destination: "));
     }


### PR DESCRIPTION
- fix deprecated assertThat references
- fix test exception handling in RetryTest.java
  (intellij issue that causes build to fail *only* in IDE)

===

followup to #2573 on all modules.

turns out a maven test dependency was forcing junit 4.13 on the maven-plugin and so we only saw it there.

Intellij build issue: https://youtrack.jetbrains.com/issue/IDEA-245569