### PR TITLE
Make local test web server always return a loopback address

### DIFF
--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/TestWebServer.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URISyntaxException;
@@ -90,8 +91,8 @@ public class TestWebServer implements Closeable {
   }
 
   public String getEndpoint() {
-    String host = serverSocket.getInetAddress().getHostAddress();
-    return (https ? "https" : "http") + "://" + host + ":" + serverSocket.getLocalPort();
+    String localhost = InetAddress.getLoopbackAddress().getHostAddress();
+    return (https ? "https" : "http") + "://" + localhost + ":" + serverSocket.getLocalPort();
   }
 
   @Override


### PR DESCRIPTION
`serverSocket.getInetAddress().getHostAddress()` returns `0.0.0.0` (in the IPv4 case) because the server socket [binds the port to all network interfaces](https://stackoverflow.com/questions/11097189/is-binding-to-0-0-0-0-in-java-guaranteed-to-bind-to-all-network-interfaces). (That is, connection is accepted through any network interface addresses.)

However, `getEndpoint()` is meant to return an address that an HTTP client should use to connect to the server. Although using `0.0.0.0` as a destination address for a localhost often works, it is actually wrong to use it. `0.0.0.0` is a special address that is only meant for source, not destination:

https://stackoverflow.com/a/3655736/1701388
https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml

Since this is a local test web server, we should rather return a loopback address. Returning `127.0.0.1` or `localhost` should equally work and will never cause trouble in practice (as IPv4 will work in practice for decades and every machine defines the name `localhost`), but I'm going for the purist approach to ask Java to get me the loopback address.

@mpeddada1 this should fix your issue.