### PR TITLE
Fixing the default platform in the build plan api

### DIFF
--- a/jib-build-plan/CHANGELOG.md
+++ b/jib-build-plan/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Removed `get/setOsHint()` and `get/setArchitectureHint()` in faver of `get/setPlatforms()` and `addPlatform()`. ([#2584](https://github.com/GoogleContainerTools/jib/pull/2584))
+- Removed `get/setOsHint()` and `get/setArchitectureHint()` in favor of `get/setPlatforms()` and `addPlatform()`. ([#2584](https://github.com/GoogleContainerTools/jib/pull/2584))
+- Fixed the critical bug that the default `Platform` in `ContainerBuildPlan` has OS and architecture values switched with each other. ([#2597](https://github.com/GoogleContainerTools/jib/pull/2597)
 
 ### Fixed
 

--- a/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlan.java
+++ b/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlan.java
@@ -42,7 +42,7 @@ public class ContainerBuildPlan {
     // note that a LinkedHashSet instead of HashSet has been used so as to preserve the platform
     // order
     private Set<Platform> platforms =
-        new LinkedHashSet<>(Collections.singleton(new Platform("linux", "amd64")));
+        new LinkedHashSet<>(Collections.singleton(new Platform("amd64", "linux")));
 
     // image execution parameters
     private Map<String, String> environment = new HashMap<>();

--- a/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlanTest.java
+++ b/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlanTest.java
@@ -35,7 +35,7 @@ public class ContainerBuildPlanTest {
     ContainerBuildPlan plan = ContainerBuildPlan.builder().build();
 
     Assert.assertEquals("scratch", plan.getBaseImage());
-    Assert.assertEquals(ImmutableSet.of(new Platform("linux", "amd64")), plan.getPlatforms());
+    Assert.assertEquals(ImmutableSet.of(new Platform("amd64", "linux")), plan.getPlatforms());
     Assert.assertEquals(ImageFormat.Docker, plan.getFormat());
     Assert.assertEquals(Instant.EPOCH, plan.getCreationTime());
     Assert.assertEquals(Collections.emptyMap(), plan.getEnvironment());
@@ -123,7 +123,7 @@ public class ContainerBuildPlanTest {
             .addPlatform("testOS", "testArchitecture")
             .build();
     Assert.assertEquals(
-        ImmutableSet.of(new Platform("linux", "amd64"), new Platform("testOS", "testArchitecture")),
+        ImmutableSet.of(new Platform("amd64", "linux"), new Platform("testOS", "testArchitecture")),
         plan.getPlatforms());
   }
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -8,7 +8,6 @@ All notable changes to this project will be documented in this file.
 - New system property `jib.skipExistingImages` (false by default) to skip pushing images (manifests) if the image already exists in the registry. ([#2360](https://github.com/GoogleContainerTools/jib/issues/2360)
 
 ### Changed
-- Changed the default platform in jib-build-plan from `linux/amd64` to `amd64/linux`. ([#2597](https://github.com/GoogleContainerTools/jib/pull/2597)
 
 ### Fixed
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - New system property `jib.skipExistingImages` (false by default) to skip pushing images (manifests) if the image already exists in the registry. ([#2360](https://github.com/GoogleContainerTools/jib/issues/2360)
 
 ### Changed
+- Changed the default platform in jib-build-plan from `linux/amd64` to `amd64/linux`. ([#2597](https://github.com/GoogleContainerTools/jib/pull/2597)
 
 ### Fixed
 


### PR DESCRIPTION
This PR fixes the default platform in our api from ` linux/amd64` to `amd64/linux`
