### PR TITLE
Modify dependencies info to include the full dependency path instead of just the version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,44 +48,44 @@ subprojects {
 
   /* PROJECT DEPENDENCY VERSIONS */
   // define all common versioned dependencies here
-  project.ext.dependencyVersions = [
+  project.ext.dependencyStrings = [
     // For Google libraries, check <http-client-bom.version>, <google.auth.version>, <guava.version>,
     // ... in https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-clients/pom.xml
     // for best compatibility.
-    GOOGLE_HTTP_CLIENT: '1.34.0',
-    GOOGLE_HTTP_CLIENT_APACHE_V2: '1.34.0',
-    GOOGLE_AUTH_LIBRARY_OAUTH2_HTTP: '0.18.0',
-    GUAVA: '28.1-jre',
-    JSR305: '3.0.2', // transitively pulled in by GUAVA
+    GOOGLE_HTTP_CLIENT: "com.google.http-client:google-http-client:1.34.0",
+    GOOGLE_HTTP_CLIENT_APACHE_V2: "com.google.http-client:google-http-client-apache-v2:1.34.0",
+    GOOGLE_AUTH_LIBRARY_OAUTH2_HTTP: "com.google.auth:google-auth-library-oauth2-http:0.18.0",
+    GUAVA: "com.google.guava:guava:28.1-jre",
+    JSR305: "com.google.code.findbugs:jsr305:3.0.2", // transitively pulled in by GUAVA
 
     // for Build Plan and Jib Plugins Extension API
-    BUILD_PLAN: '0.3.1',
-    EXTENSION_COMMON: '0.2.0',
-    GRADLE_EXTENSION: '0.3.0',
-    MAVEN_EXTENSION: '0.3.0',
+    BUILD_PLAN: "com.google.cloud.tools:jib-build-plan:0.3.1",
+    EXTENSION_COMMON: "com.google.cloud.tools:jib-plugins-extension-common:0.2.0",
+    GRADLE_EXTENSION: "com.google.cloud.tools:jib-gradle-plugin-extension-api:0.3.0",
+    MAVEN_EXTENSION: "com.google.cloud.tools:jib-maven-plugin-extension-api:0.3.0",
 
-    COMMONS_COMPRESS: '1.19',
-    JACKSON_DATABIND: '2.11.0',
-    JACKSON_DATAFORMAT_YAML: '2.11.0',
-    ASM: '7.3.1',
-    PICOCLI: '4.2.0',
+    COMMONS_COMPRESS: "org.apache.commons:commons-compress:1.19",
+    JACKSON_DATABIND: "com.fasterxml.jackson.core:jackson-databind:2.11.0",
+    JACKSON_DATAFORMAT_YAML: "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.0",
+    ASM: "org.ow2.asm:asm:7.3.1",
+    PICOCLI: "info.picocli:picocli:4.2.0",
 
-    MAVEN_API: '3.5.2',
+    MAVEN_API: "org.apache.maven:maven-plugin-api:3.5.2",
 
     //test
-    JUNIT: '4.13',
-    MOCKITO_CORE: '3.2.4',
-    SLF4J_API: '1.7.25',
-    SYSTEM_RULES: '1.19.0',
-    JBCRYPT: '0.4',
+    JUNIT: "junit:junit:4.13",
+    MOCKITO_CORE: "org.mockito:mockito-core:3.2.4",
+    SLF4J_API: "org.slf4j:slf4j-api:1.7.25",
+    SYSTEM_RULES:  "com.github.stefanbirkner:system-rules:1.19.0",
+    JBCRYPT: "org.mindrot:jbcrypt:0.4",
   ]
 
   // Use this to ensure we correctly override transitive dependencies
   // TODO: There might be a plugin that does this
   task ensureTransitiveDependencyOverrides {
     def rules = [
-        'google-http-client': dependencyVersions.GOOGLE_HTTP_CLIENT,
-        'google-http-client-apache-v2': dependencyVersions.GOOGLE_HTTP_CLIENT_APACHE_V2,
+        'google-http-client': dependencyStrings.GOOGLE_HTTP_CLIENT.split(':')[-1],
+        'google-http-client-apache-v2': dependencyStrings.GOOGLE_HTTP_CLIENT_APACHE_V2.split(':')[-1],
     ]
     doLast {
       configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts.each { artifact ->

--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ subprojects {
   // TODO: There might be a plugin that does this
   task ensureTransitiveDependencyOverrides {
     def dependenciesList = [dependencyStrings.GOOGLE_HTTP_CLIENT, dependencyStrings.GOOGLE_HTTP_CLIENT_APACHE_V2]
-    def rules = dependenciesList.collectEntries{[/*name: */ it.split(':')[1], /*version: */ it.split(':')[2]]}
+    def rules = dependenciesList.collectEntries{[/*name*/ it.split(':')[1], /*version*/ it.split(':')[2]]}
     doLast {
       configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts.each { artifact ->
         def dependency = artifact.moduleVersion.id

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,8 @@ subprojects {
     PICOCLI: "info.picocli:picocli:4.2.0",
 
     MAVEN_API: "org.apache.maven:maven-plugin-api:3.5.2",
+    MAVEN_CORE: "org.apache.maven:maven-core:3.5.2",
+    MAVEN_COMPAT: "org.apache.maven:maven-compat:3.5.2",
 
     //test
     JUNIT: "junit:junit:4.13",

--- a/build.gradle
+++ b/build.gradle
@@ -75,13 +75,11 @@ subprojects {
     MAVEN_COMPAT: 'org.apache.maven:maven-compat:3.5.2',
     MAVEN_ANNOTATIONS_LATEST: 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.0',
     MAVEN_ANNOTATIONS_OLD: 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.5',
-    MAVEN_TESTING_HARNESS: 'org.apache.maven.plugin-testing:maven-plugin-testing-harness:3.3.0',
-    MAVEN_VERIFIER: 'org.apache.maven.shared:maven-verifier:1.7.2',
-
-
 
     //test
     JUNIT: 'junit:junit:4.13',
+    MAVEN_TESTING_HARNESS: 'org.apache.maven.plugin-testing:maven-plugin-testing-harness:3.3.0',
+    MAVEN_VERIFIER: 'org.apache.maven.shared:maven-verifier:1.7.2',
     MOCKITO_CORE: 'org.mockito:mockito-core:3.2.4',
     SISU_PLEXUS: 'org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.4',
     SLF4J_API_OLD: 'org.slf4j:slf4j-api:1.7.25',
@@ -95,7 +93,7 @@ subprojects {
   // TODO: There might be a plugin that does this
   task ensureTransitiveDependencyOverrides {
     def dependenciesList = [dependencyStrings.GOOGLE_HTTP_CLIENT, dependencyStrings.GOOGLE_HTTP_CLIENT_APACHE_V2]
-    def rules = dependenciesList.collectEntries{[/*name: */ it.split(':')[1], /*version: */ it.split(':')[-1]]}
+    def rules = dependenciesList.collectEntries{[/*name: */ it.split(':')[1], /*version: */ it.split(':')[2]]}
     doLast {
       configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts.each { artifact ->
         def dependency = artifact.moduleVersion.id

--- a/build.gradle
+++ b/build.gradle
@@ -52,43 +52,50 @@ subprojects {
     // For Google libraries, check <http-client-bom.version>, <google.auth.version>, <guava.version>,
     // ... in https://github.com/googleapis/google-cloud-java/blob/master/google-cloud-clients/pom.xml
     // for best compatibility.
-    GOOGLE_HTTP_CLIENT: "com.google.http-client:google-http-client:1.34.0",
-    GOOGLE_HTTP_CLIENT_APACHE_V2: "com.google.http-client:google-http-client-apache-v2:1.34.0",
-    GOOGLE_AUTH_LIBRARY_OAUTH2_HTTP: "com.google.auth:google-auth-library-oauth2-http:0.18.0",
-    GUAVA: "com.google.guava:guava:28.1-jre",
-    JSR305: "com.google.code.findbugs:jsr305:3.0.2", // transitively pulled in by GUAVA
+    GOOGLE_HTTP_CLIENT: 'com.google.http-client:google-http-client:1.34.0',
+    GOOGLE_HTTP_CLIENT_APACHE_V2: 'com.google.http-client:google-http-client-apache-v2:1.34.0',
+    GOOGLE_AUTH_LIBRARY_OAUTH2_HTTP: 'com.google.auth:google-auth-library-oauth2-http:0.18.0',
+    GUAVA: 'com.google.guava:guava:28.1-jre',
+    JSR305: 'com.google.code.findbugs:jsr305:3.0.2', // transitively pulled in by GUAVA
 
     // for Build Plan and Jib Plugins Extension API
-    BUILD_PLAN: "com.google.cloud.tools:jib-build-plan:0.3.1",
-    EXTENSION_COMMON: "com.google.cloud.tools:jib-plugins-extension-common:0.2.0",
-    GRADLE_EXTENSION: "com.google.cloud.tools:jib-gradle-plugin-extension-api:0.3.0",
-    MAVEN_EXTENSION: "com.google.cloud.tools:jib-maven-plugin-extension-api:0.3.0",
+    BUILD_PLAN: 'com.google.cloud.tools:jib-build-plan:0.3.1',
+    EXTENSION_COMMON: 'com.google.cloud.tools:jib-plugins-extension-common:0.2.0',
+    GRADLE_EXTENSION: 'com.google.cloud.tools:jib-gradle-plugin-extension-api:0.3.0',
+    MAVEN_EXTENSION: 'com.google.cloud.tools:jib-maven-plugin-extension-api:0.3.0',
 
-    COMMONS_COMPRESS: "org.apache.commons:commons-compress:1.19",
-    JACKSON_DATABIND: "com.fasterxml.jackson.core:jackson-databind:2.11.0",
-    JACKSON_DATAFORMAT_YAML: "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.0",
-    ASM: "org.ow2.asm:asm:7.3.1",
-    PICOCLI: "info.picocli:picocli:4.2.0",
+    COMMONS_COMPRESS: 'org.apache.commons:commons-compress:1.19',
+    JACKSON_DATABIND: 'com.fasterxml.jackson.core:jackson-databind:2.11.0',
+    JACKSON_DATAFORMAT_YAML: 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.0',
+    ASM: 'org.ow2.asm:asm:7.3.1',
+    PICOCLI: 'info.picocli:picocli:4.2.0',
 
-    MAVEN_API: "org.apache.maven:maven-plugin-api:3.5.2",
-    MAVEN_CORE: "org.apache.maven:maven-core:3.5.2",
-    MAVEN_COMPAT: "org.apache.maven:maven-compat:3.5.2",
+    MAVEN_API: 'org.apache.maven:maven-plugin-api:3.5.2',
+    MAVEN_CORE: 'org.apache.maven:maven-core:3.5.2',
+    MAVEN_COMPAT: 'org.apache.maven:maven-compat:3.5.2',
+    MAVEN_ANNOTATIONS_LATEST: 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.0',
+    MAVEN_ANNOTATIONS_OLD: 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.5',
+    MAVEN_TESTING_HARNESS: 'org.apache.maven.plugin-testing:maven-plugin-testing-harness:3.3.0',
+    MAVEN_VERIFIER: 'org.apache.maven.shared:maven-verifier:1.7.2',
+
+
 
     //test
-    JUNIT: "junit:junit:4.13",
-    MOCKITO_CORE: "org.mockito:mockito-core:3.2.4",
-    SLF4J_API: "org.slf4j:slf4j-api:1.7.25",
-    SYSTEM_RULES:  "com.github.stefanbirkner:system-rules:1.19.0",
-    JBCRYPT: "org.mindrot:jbcrypt:0.4",
+    JUNIT: 'junit:junit:4.13',
+    MOCKITO_CORE: 'org.mockito:mockito-core:3.2.4',
+    SISU_PLEXUS: 'org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.4',
+    SLF4J_API_OLD: 'org.slf4j:slf4j-api:1.7.25',
+    SLF4J_API_LATEST: 'org.slf4j:slf4j-api:1.7.30',
+    SLF4J_SIMPLE: 'org.slf4j:slf4j-simple:1.7.30',
+    SYSTEM_RULES:  'com.github.stefanbirkner:system-rules:1.19.0',
+    JBCRYPT: 'org.mindrot:jbcrypt:0.4',
   ]
 
   // Use this to ensure we correctly override transitive dependencies
   // TODO: There might be a plugin that does this
   task ensureTransitiveDependencyOverrides {
-    def rules = [
-        'google-http-client': dependencyStrings.GOOGLE_HTTP_CLIENT.split(':')[-1],
-        'google-http-client-apache-v2': dependencyStrings.GOOGLE_HTTP_CLIENT_APACHE_V2.split(':')[-1],
-    ]
+    def dependenciesList = [dependencyStrings.GOOGLE_HTTP_CLIENT, dependencyStrings.GOOGLE_HTTP_CLIENT_APACHE_V2]
+    def rules = dependenciesList.collectEntries{[/*name: */ it.split(':')[1], /*version: */ it.split(':')[-1]]}
     doLast {
       configurations.runtimeClasspath.resolvedConfiguration.resolvedArtifacts.each { artifact ->
         def dependency = artifact.moduleVersion.id

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,5 @@
-#Mon Jul 20 16:42:33 EDT 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Mon Jul 20 16:42:33 EDT 2020
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/jib-build-plan/build.gradle
+++ b/jib-build-plan/build.gradle
@@ -10,7 +10,7 @@ dependencies {
   testImplementation dependencyStrings.GUAVA
   testImplementation dependencyStrings.JUNIT
   testImplementation dependencyStrings.MOCKITO_CORE
-  testImplementation dependencyStrings.SLF4J_API
+  testImplementation dependencyStrings.SLF4J_API_OLD
   testImplementation dependencyStrings.SYSTEM_RULES
 }
 

--- a/jib-build-plan/build.gradle
+++ b/jib-build-plan/build.gradle
@@ -5,13 +5,13 @@ plugins {
 }
 
 dependencies {
-  compileOnly "com.google.code.findbugs:jsr305:${dependencyVersions.JSR305}"
+  compileOnly dependencyStrings.JSR305
 
-  testImplementation "com.google.guava:guava:${dependencyVersions.GUAVA}"
-  testImplementation "junit:junit:${dependencyVersions.JUNIT}"
-  testImplementation "org.mockito:mockito-core:${dependencyVersions.MOCKITO_CORE}"
-  testImplementation "org.slf4j:slf4j-api:${dependencyVersions.SLF4J_API}"
-  testImplementation "com.github.stefanbirkner:system-rules:${dependencyVersions.SYSTEM_RULES}"
+  testImplementation dependencyStrings.GUAVA
+  testImplementation dependencyStrings.JUNIT
+  testImplementation dependencyStrings.MOCKITO_CORE
+  testImplementation dependencyStrings.SLF4J_API
+  testImplementation dependencyStrings.SYSTEM_RULES
 }
 
 jar {

--- a/jib-cli/build.gradle
+++ b/jib-cli/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 
   testImplementation dependencyStrings.JUNIT
   testImplementation dependencyStrings.MOCKITO_CORE
-  testImplementation dependencyStrings.SLF4J_API
+  testImplementation dependencyStrings.SLF4J_API_OLD
   testImplementation dependencyStrings.SYSTEM_RULES
 }
 

--- a/jib-cli/build.gradle
+++ b/jib-cli/build.gradle
@@ -16,15 +16,15 @@ application {
 
 dependencies {
   implementation project(':jib-core')
-  implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${dependencyVersions.JACKSON_DATAFORMAT_YAML}"
-  implementation "com.fasterxml.jackson.core:jackson-databind:${dependencyVersions.JACKSON_DATABIND}"
-  implementation "com.google.guava:guava:${dependencyVersions.GUAVA}"
-  implementation "info.picocli:picocli:${dependencyVersions.PICOCLI}"
+  implementation dependencyStrings.JACKSON_DATAFORMAT_YAML
+  implementation dependencyStrings.JACKSON_DATABIND
+  implementation dependencyStrings.GUAVA
+  implementation dependencyStrings.PICOCLI
 
-  testImplementation "junit:junit:${dependencyVersions.JUNIT}"
-  testImplementation "org.mockito:mockito-core:${dependencyVersions.MOCKITO_CORE}"
-  testImplementation "org.slf4j:slf4j-api:${dependencyVersions.SLF4J_API}"
-  testImplementation "com.github.stefanbirkner:system-rules:${dependencyVersions.SYSTEM_RULES}"
+  testImplementation dependencyStrings.JUNIT
+  testImplementation dependencyStrings.MOCKITO_CORE
+  testImplementation dependencyStrings.SLF4J_API
+  testImplementation dependencyStrings.SYSTEM_RULES
 }
 
 /* ECLIPSE */

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -5,22 +5,22 @@ plugins {
 }
 
 dependencies {
-  api "com.google.cloud.tools:jib-build-plan:${dependencyVersions.BUILD_PLAN}"
-  implementation "com.google.http-client:google-http-client:${dependencyVersions.GOOGLE_HTTP_CLIENT}"
-  implementation "com.google.http-client:google-http-client-apache-v2:${dependencyVersions.GOOGLE_HTTP_CLIENT_APACHE_V2}"
-  implementation "com.google.auth:google-auth-library-oauth2-http:${dependencyVersions.GOOGLE_AUTH_LIBRARY_OAUTH2_HTTP}"
+  api dependencyStrings.BUILD_PLAN
+  implementation dependencyStrings.GOOGLE_HTTP_CLIENT
+  implementation dependencyStrings.GOOGLE_HTTP_CLIENT_APACHE_V2
+  implementation dependencyStrings.GOOGLE_AUTH_LIBRARY_OAUTH2_HTTP
 
-  implementation "org.apache.commons:commons-compress:${dependencyVersions.COMMONS_COMPRESS}"
-  implementation "com.google.guava:guava:${dependencyVersions.GUAVA}"
-  implementation "com.fasterxml.jackson.core:jackson-databind:${dependencyVersions.JACKSON_DATABIND}"
-  implementation "org.ow2.asm:asm:${dependencyVersions.ASM}"
+  implementation dependencyStrings.COMMONS_COMPRESS
+  implementation dependencyStrings.GUAVA
+  implementation dependencyStrings.JACKSON_DATABIND
+  implementation dependencyStrings.ASM
 
-  testImplementation "junit:junit:${dependencyVersions.JUNIT}"
-  testImplementation "org.mockito:mockito-core:${dependencyVersions.MOCKITO_CORE}"
-  testImplementation "org.slf4j:slf4j-api:${dependencyVersions.SLF4J_API}"
-  testImplementation "com.github.stefanbirkner:system-rules:${dependencyVersions.SYSTEM_RULES}"
+  testImplementation dependencyStrings.JUNIT
+  testImplementation dependencyStrings.MOCKITO_CORE
+  testImplementation dependencyStrings.SLF4J_API
+  testImplementation dependencyStrings.SYSTEM_RULES
 
-  integrationTestImplementation "org.mindrot:jbcrypt:${dependencyVersions.JBCRYPT}"
+  integrationTestImplementation dependencyStrings.JBCRYPT
 }
 
 jar {

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
   testImplementation dependencyStrings.JUNIT
   testImplementation dependencyStrings.MOCKITO_CORE
-  testImplementation dependencyStrings.SLF4J_API
+  testImplementation dependencyStrings.SLF4J_API_OLD
   testImplementation dependencyStrings.SYSTEM_RULES
 
   integrationTestImplementation dependencyStrings.JBCRYPT

--- a/jib-gradle-plugin-extension-api/build.gradle
+++ b/jib-gradle-plugin-extension-api/build.gradle
@@ -4,8 +4,8 @@ plugins {
 }
 
 dependencies {
-  api "com.google.cloud.tools:jib-build-plan:${dependencyVersions.BUILD_PLAN}"
-  api "com.google.cloud.tools:jib-plugins-extension-common:${dependencyVersions.EXTENSION_COMMON}"
+  api dependencyStrings.BUILD_PLAN
+  api dependencyStrings.EXTENSION_COMMON
   api gradleApi()
 }
 

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -39,7 +39,7 @@ dependencies {
 
   testImplementation dependencyStrings.JUNIT
   testImplementation dependencyStrings.MOCKITO_CORE
-  testImplementation dependencyStrings.SLF4J_API
+  testImplementation dependencyStrings.SLF4J_API_OLD
   testImplementation dependencyStrings.SYSTEM_RULES
 
 

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -35,18 +35,18 @@ dependencies {
   sourceProject project(':jib-plugins-common')
   ensureNoProjectDependencies()
 
-  implementation "com.google.cloud.tools:jib-gradle-plugin-extension-api:${dependencyVersions.GRADLE_EXTENSION}"
+  implementation dependencyStrings.GRADLE_EXTENSION
 
-  testImplementation "junit:junit:${dependencyVersions.JUNIT}"
-  testImplementation "org.mockito:mockito-core:${dependencyVersions.MOCKITO_CORE}"
-  testImplementation "org.slf4j:slf4j-api:${dependencyVersions.SLF4J_API}"
-  testImplementation "com.github.stefanbirkner:system-rules:${dependencyVersions.SYSTEM_RULES}"
+  testImplementation dependencyStrings.JUNIT
+  testImplementation dependencyStrings.MOCKITO_CORE
+  testImplementation dependencyStrings.SLF4J_API
+  testImplementation dependencyStrings.SYSTEM_RULES
 
 
   testImplementation project(path:':jib-plugins-common', configuration:'tests')
   integrationTestImplementation project(path:':jib-core', configuration:'integrationTests')
 
-  integrationTestImplementation "org.mindrot:jbcrypt:${dependencyVersions.JBCRYPT}"
+  integrationTestImplementation dependencyStrings.JBCRYPT
 
   // only for testing a concrete Spring Boot example in a test (not for test infrastructure)
   testImplementation 'org.springframework.boot:spring-boot-gradle-plugin:2.2.8.RELEASE'

--- a/jib-maven-plugin-extension-api/build.gradle
+++ b/jib-maven-plugin-extension-api/build.gradle
@@ -4,9 +4,9 @@ plugins {
 }
 
 dependencies {
-  api "com.google.cloud.tools:jib-build-plan:${dependencyVersions.BUILD_PLAN}"
-  api "com.google.cloud.tools:jib-plugins-extension-common:${dependencyVersions.EXTENSION_COMMON}"
-  api "org.apache.maven:maven-core:${dependencyVersions.MAVEN_API}"
+  api dependencyStrings.BUILD_PLAN
+  api dependencyStrings.EXTENSION_COMMON
+  api dependencyStrings.MAVEN_API
 }
 
 jar {

--- a/jib-maven-plugin-extension-api/build.gradle
+++ b/jib-maven-plugin-extension-api/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
   api dependencyStrings.BUILD_PLAN
   api dependencyStrings.EXTENSION_COMMON
-  api dependencyStrings.MAVEN_API
+  api dependencyStrings.MAVEN_CORE
 }
 
 jar {

--- a/jib-maven-plugin/build.gradle
+++ b/jib-maven-plugin/build.gradle
@@ -18,24 +18,24 @@ dependencies {
   implementation dependencyStrings.MAVEN_CORE
 
   // compileOnly + testImplementation equivalent to "provided"
-  compileOnly 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.0'
+  compileOnly dependencyStrings.MAVEN_ANNOTATIONS_LATEST
   // needed to suppress "unknown enum constant" warnings
-  testImplementation 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.5'
+  testImplementation dependencyStrings.MAVEN_ANNOTATIONS_OLD
 
   // maven-plugin-testing-harness pulls in conflicting implementations of DefaultPlexusContainer
   // (sisu (correct) vs default-plexus-container (wrong)) so ensure this is first in the test classpath
-  testImplementation 'org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.4'
-  testImplementation 'org.apache.maven.plugin-testing:maven-plugin-testing-harness:3.3.0'
+  testImplementation dependencyStrings.SISU_PLEXUS
+  testImplementation dependencyStrings.MAVEN_TESTING_HARNESS
 
   testImplementation dependencyStrings.JUNIT
   testImplementation dependencyStrings.MOCKITO_CORE
-  testImplementation dependencyStrings.SLF4J_API
+  testImplementation dependencyStrings.SLF4J_API_OLD
   testImplementation dependencyStrings.SYSTEM_RULES
 
-  testImplementation 'org.apache.maven.shared:maven-verifier:1.7.2'
+  testImplementation dependencyStrings.MAVEN_VERIFIER
   testImplementation dependencyStrings.MAVEN_COMPAT
-  testImplementation 'org.slf4j:slf4j-api:1.7.30'
-  testImplementation 'org.slf4j:slf4j-simple:1.7.30'
+  testImplementation dependencyStrings.SLF4J_API_LATEST
+  testImplementation dependencyStrings.SLF4J_SIMPLE
 
   integrationTestImplementation dependencyStrings.JBCRYPT
 

--- a/jib-maven-plugin/build.gradle
+++ b/jib-maven-plugin/build.gradle
@@ -12,10 +12,10 @@ dependencies {
   sourceProject project(':jib-plugins-common')
   ensureNoProjectDependencies()
 
-  implementation "com.google.cloud.tools:jib-maven-plugin-extension-api:${dependencyVersions.MAVEN_EXTENSION}"
+  implementation dependencyStrings.MAVEN_EXTENSION
 
-  implementation "org.apache.maven:maven-plugin-api:${dependencyVersions.MAVEN_API}"
-  implementation "org.apache.maven:maven-core:${dependencyVersions.MAVEN_API}"
+  implementation dependencyStrings.MAVEN_API
+  implementation dependencyStrings.MAVEN_API
 
   // compileOnly + testImplementation equivalent to "provided"
   compileOnly 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.0'
@@ -27,17 +27,17 @@ dependencies {
   testImplementation 'org.eclipse.sisu:org.eclipse.sisu.plexus:0.3.4'
   testImplementation 'org.apache.maven.plugin-testing:maven-plugin-testing-harness:3.3.0'
 
-  testImplementation "junit:junit:${dependencyVersions.JUNIT}"
-  testImplementation "org.mockito:mockito-core:${dependencyVersions.MOCKITO_CORE}"
-  testImplementation "org.slf4j:slf4j-api:${dependencyVersions.SLF4J_API}"
-  testImplementation "com.github.stefanbirkner:system-rules:${dependencyVersions.SYSTEM_RULES}"
+  testImplementation dependencyStrings.JUNIT
+  testImplementation dependencyStrings.MOCKITO_CORE
+  testImplementation dependencyStrings.SLF4J_API
+  testImplementation dependencyStrings.SYSTEM_RULES
 
   testImplementation 'org.apache.maven.shared:maven-verifier:1.7.2'
-  testImplementation "org.apache.maven:maven-compat:${dependencyVersions.MAVEN_API}"
+  testImplementation dependencyStrings.MAVEN_API
   testImplementation 'org.slf4j:slf4j-api:1.7.30'
   testImplementation 'org.slf4j:slf4j-simple:1.7.30'
 
-  integrationTestImplementation "org.mindrot:jbcrypt:${dependencyVersions.JBCRYPT}"
+  integrationTestImplementation dependencyStrings.JBCRYPT
 
   testImplementation project(path:':jib-plugins-common', configuration:'tests')
   integrationTestImplementation project(path:':jib-core', configuration:'integrationTests')

--- a/jib-maven-plugin/build.gradle
+++ b/jib-maven-plugin/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation dependencyStrings.MAVEN_EXTENSION
 
   implementation dependencyStrings.MAVEN_API
-  implementation dependencyStrings.MAVEN_API
+  implementation dependencyStrings.MAVEN_CORE
 
   // compileOnly + testImplementation equivalent to "provided"
   compileOnly 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.0'
@@ -33,7 +33,7 @@ dependencies {
   testImplementation dependencyStrings.SYSTEM_RULES
 
   testImplementation 'org.apache.maven.shared:maven-verifier:1.7.2'
-  testImplementation dependencyStrings.MAVEN_API
+  testImplementation dependencyStrings.MAVEN_COMPAT
   testImplementation 'org.slf4j:slf4j-api:1.7.30'
   testImplementation 'org.slf4j:slf4j-simple:1.7.30'
 

--- a/jib-plugins-common/build.gradle
+++ b/jib-plugins-common/build.gradle
@@ -11,12 +11,12 @@ dependencies {
   // for an unpublished library.
   implementation project(':jib-core').configurations.implementation.dependencies
 
-  implementation "com.google.cloud.tools:jib-plugins-extension-common:${dependencyVersions.EXTENSION_COMMON}"
+  implementation dependencyStrings.EXTENSION_COMMON
 
-  testImplementation "junit:junit:${dependencyVersions.JUNIT}"
-  testImplementation "org.mockito:mockito-core:${dependencyVersions.MOCKITO_CORE}"
-  testImplementation "org.slf4j:slf4j-api:${dependencyVersions.SLF4J_API}"
-  testImplementation "com.github.stefanbirkner:system-rules:${dependencyVersions.SYSTEM_RULES}"
+  testImplementation dependencyStrings.JUNIT
+  testImplementation dependencyStrings.MOCKITO_CORE
+  testImplementation dependencyStrings.SLF4J_API
+  testImplementation dependencyStrings.SYSTEM_RULES
   testImplementation project(path:':jib-core', configuration:'tests')
 }
 

--- a/jib-plugins-common/build.gradle
+++ b/jib-plugins-common/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
   testImplementation dependencyStrings.JUNIT
   testImplementation dependencyStrings.MOCKITO_CORE
-  testImplementation dependencyStrings.SLF4J_API
+  testImplementation dependencyStrings.SLF4J_API_OLD
   testImplementation dependencyStrings.SYSTEM_RULES
   testImplementation project(path:':jib-core', configuration:'tests')
 }


### PR DESCRIPTION
Modify the main build.gradle and related build files to reference the full dependency data instead of just the version. This change attempts to make our dependency info more friendly with dependabot, which is currently unable to parse through our dependencies.
For #2602