### PR TITLE
Add validation to required yaml properties

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/ArchiveLayerSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/ArchiveLayerSpec.java
@@ -57,6 +57,8 @@ public class ArchiveLayerSpec implements LayerSpec {
       @JsonProperty(value = "name", required = true) String name,
       @JsonProperty(value = "archive", required = true) String archive,
       @JsonProperty("mediaType") String mediaType) {
+    Validator.checkNotEmpty(name, "name");
+    Validator.checkNotEmpty(archive, "archive");
     this.name = name;
     this.archive = Paths.get(archive);
     this.mediaType = mediaType;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpec.java
@@ -48,6 +48,7 @@ public class BaseImageSpec {
   public BaseImageSpec(
       @JsonProperty(value = "image", required = true) String image,
       @JsonProperty("platforms") List<PlatformSpec> platforms) {
+    Validator.checkNotEmpty(image, "image");
     this.image = image;
     this.platforms = platforms;
   }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
@@ -111,6 +111,8 @@ public class BuildFileSpec {
       @JsonProperty("entrypoint") List<String> entrypoint,
       @JsonProperty("cmd") List<String> cmd,
       @JsonProperty("layers") LayersSpec layers) {
+    Validator.checkNotEmpty(apiVersion, "apiVersion");
+    Validator.checkEquals(kind, "kind", "BuildFile");
     this.apiVersion = apiVersion;
     Preconditions.checkArgument(
         "BuildFile".equals(kind), "Field 'kind' must be BuildFile but is " + kind);

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/CopySpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/CopySpec.java
@@ -65,6 +65,8 @@ public class CopySpec {
       @JsonProperty("includes") List<String> includes,
       @JsonProperty("excludes") List<String> excludes,
       @JsonProperty("properties") FilePropertiesSpec properties) {
+    Validator.checkNotEmpty(src, "src");
+    Validator.checkNotEmpty(dest, "dest");
     this.src = Paths.get(src);
     this.dest = AbsoluteUnixPath.get(dest);
     this.excludes = excludes;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FileLayerSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FileLayerSpec.java
@@ -56,6 +56,8 @@ public class FileLayerSpec implements LayerSpec {
       @JsonProperty(value = "name", required = true) String name,
       @JsonProperty(value = "files", required = true) List<CopySpec> files,
       @JsonProperty("properties") FilePropertiesSpec properties) {
+    Validator.checkNotEmpty(name, "name");
+    Validator.checkNotEmpty(files, "files");
     this.name = name;
     this.properties = properties;
     this.files = files;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/LayersSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/LayersSpec.java
@@ -48,8 +48,9 @@ public class LayersSpec {
   public LayersSpec(
       @JsonProperty(value = "entries", required = true) List<LayerSpec> entries,
       @JsonProperty("properties") FilePropertiesSpec properties) {
-    this.properties = properties;
+    Validator.checkNotEmpty(entries, "entries");
     this.entries = entries;
+    this.properties = properties;
   }
 
   public Optional<FilePropertiesSpec> getProperties() {

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Validator.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Validator.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.cli.buildfile;
+
+import com.google.common.base.Preconditions;
+import java.util.Collection;
+
+/**
+ * Utility helper class to detect errors in parsed yaml values. This class is mostly concerned with
+ * error message formatting, checking is delegated to guava.
+ */
+public class Validator {
+
+  /**
+   * Checks if an object reference is not null.
+   *
+   * @param value the object in question
+   * @param propertyName the equivalent 'yaml' property name
+   * @throws NullPointerException if {@code value} is null
+   */
+  public static void checkNotNull(Object value, String propertyName) {
+    Preconditions.checkNotNull(value, "Property '" + propertyName + "' cannot be null");
+  }
+
+  /**
+   * Checks if string is null, empty or only whitespace.
+   *
+   * @param value the string in question
+   * @param propertyName the equivalent 'yaml' property name
+   * @throws NullPointerException if {@code value} is null
+   * @throws IllegalArgumentException if {@code value} is empty or only whitespace
+   */
+  public static void checkNotEmpty(String value, String propertyName) {
+    checkNotNull(value, propertyName);
+    Preconditions.checkArgument(
+        !value.trim().isEmpty(), "Property '" + propertyName + "' cannot be empty");
+  }
+
+  /**
+   * Checks if a collection is null or empty.
+   *
+   * @param value the string in question
+   * @param propertyName the equivalent 'yaml' property name
+   * @throws NullPointerException if {@code value} is null
+   * @throws IllegalArgumentException if {@code value} is empty
+   */
+  public static void checkNotEmpty(Collection<?> value, String propertyName) {
+    checkNotNull(value, propertyName);
+    Preconditions.checkArgument(
+        !value.isEmpty(), "Property '" + propertyName + "' cannot be an empty collection");
+  }
+
+  /**
+   * Checks if string is what is expected.
+   *
+   * @param value the string in question
+   * @param propertyName the equivalent 'yaml' property name
+   * @param expectedValue the value we expect {@code value} to be
+   * @throws NullPointerException if {@code value} is null
+   * @throws IllegalArgumentException if {@code value} is not equal to {@code expectedValue}
+   */
+  public static void checkEquals(String value, String propertyName, String expectedValue) {
+    checkNotNull(value, propertyName);
+    Preconditions.checkArgument(
+        expectedValue.equals(value),
+        "Property '" + propertyName + "' must be '" + expectedValue + "' but is '" + value + "'");
+  }
+}

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Validator.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Validator.java
@@ -18,23 +18,13 @@ package com.google.cloud.tools.jib.cli.buildfile;
 
 import com.google.common.base.Preconditions;
 import java.util.Collection;
+import javax.annotation.Nullable;
 
 /**
  * Utility helper class to detect errors in parsed yaml values. This class is mostly concerned with
  * error message formatting, checking is delegated to guava.
  */
 public class Validator {
-
-  /**
-   * Checks if an object reference is not null.
-   *
-   * @param value the object in question
-   * @param propertyName the equivalent 'yaml' property name
-   * @throws NullPointerException if {@code value} is null
-   */
-  public static void checkNotNull(Object value, String propertyName) {
-    Preconditions.checkNotNull(value, "Property '" + propertyName + "' cannot be null");
-  }
 
   /**
    * Checks if string is null, empty or only whitespace.
@@ -44,8 +34,8 @@ public class Validator {
    * @throws NullPointerException if {@code value} is null
    * @throws IllegalArgumentException if {@code value} is empty or only whitespace
    */
-  public static void checkNotEmpty(String value, String propertyName) {
-    checkNotNull(value, propertyName);
+  public static void checkNotEmpty(@Nullable String value, String propertyName) {
+    Preconditions.checkNotNull(value, "Property '" + propertyName + "' cannot be null");
     Preconditions.checkArgument(
         !value.trim().isEmpty(), "Property '" + propertyName + "' cannot be empty");
   }
@@ -58,8 +48,8 @@ public class Validator {
    * @throws NullPointerException if {@code value} is null
    * @throws IllegalArgumentException if {@code value} is empty
    */
-  public static void checkNotEmpty(Collection<?> value, String propertyName) {
-    checkNotNull(value, propertyName);
+  public static void checkNotEmpty(@Nullable Collection<?> value, String propertyName) {
+    Preconditions.checkNotNull(value, "Property '" + propertyName + "' cannot be null");
     Preconditions.checkArgument(
         !value.isEmpty(), "Property '" + propertyName + "' cannot be an empty collection");
   }
@@ -73,10 +63,11 @@ public class Validator {
    * @throws NullPointerException if {@code value} is null
    * @throws IllegalArgumentException if {@code value} is not equal to {@code expectedValue}
    */
-  public static void checkEquals(String value, String propertyName, String expectedValue) {
-    checkNotNull(value, propertyName);
+  public static void checkEquals(
+      @Nullable String value, String propertyName, String expectedValue) {
+    Preconditions.checkNotNull(value, "Property '" + propertyName + "' cannot be null");
     Preconditions.checkArgument(
-        expectedValue.equals(value),
+        value.equals(expectedValue),
         "Property '" + propertyName + "' must be '" + expectedValue + "' but is '" + value + "'");
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ArchiveLayerSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ArchiveLayerSpecTest.java
@@ -28,14 +28,14 @@ import org.junit.Test;
 /** Tests for {@link ArchiveLayerSpec}. */
 public class ArchiveLayerSpecTest {
 
-  private static final ObjectMapper archiveLayerSpecMapper = new ObjectMapper(new YAMLFactory());
+  private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
 
   @Test
   public void testArchiveLayerSpec_full() throws JsonProcessingException {
     String data =
         "name: layer name\n" + "archive: out/archive.tgz\n" + "mediaType: test.media.type";
 
-    ArchiveLayerSpec parsed = archiveLayerSpecMapper.readValue(data, ArchiveLayerSpec.class);
+    ArchiveLayerSpec parsed = mapper.readValue(data, ArchiveLayerSpec.class);
     Assert.assertEquals("layer name", parsed.getName());
     Assert.assertEquals(Paths.get("out/archive.tgz"), parsed.getArchive());
     Assert.assertEquals("test.media.type", parsed.getMediaType().get());
@@ -46,11 +46,37 @@ public class ArchiveLayerSpecTest {
     String data = "archive: out/archive";
 
     try {
-      archiveLayerSpecMapper.readValue(data, ArchiveLayerSpec.class);
+      mapper.readValue(data, ArchiveLayerSpec.class);
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
           jpe.getMessage(), CoreMatchers.startsWith("Missing required creator property 'name'"));
+    }
+  }
+
+  @Test
+  public void testArchiveLayerSpec_nameNonNull() {
+    String data = "name: null\n" + "archive: out/archive";
+
+    try {
+      mapper.readValue(data, ArchiveLayerSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'name' cannot be null"));
+    }
+  }
+
+  @Test
+  public void testArchiveLayerSpec_nameNonEmpty() {
+    String data = "name: ''\n" + "archive: out/archive";
+
+    try {
+      mapper.readValue(data, ArchiveLayerSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'name' cannot be empty"));
     }
   }
 
@@ -61,11 +87,37 @@ public class ArchiveLayerSpecTest {
     String data = "name: layer name";
 
     try {
-      archiveLayerSpecMapper.readValue(data, ArchiveLayerSpec.class);
+      mapper.readValue(data, ArchiveLayerSpec.class);
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
           jpe.getMessage(), CoreMatchers.startsWith("Missing required creator property 'archive'"));
+    }
+  }
+
+  @Test
+  public void testArchiveLayerSpec_archiveNonNull() {
+    String data = "name: layer name\n" + "archive: null";
+
+    try {
+      mapper.readValue(data, ArchiveLayerSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'archive' cannot be null"));
+    }
+  }
+
+  @Test
+  public void testArchiveLayerSpec_archiveNonEmpty() {
+    String data = "name: layer name\n" + "archive: ''";
+
+    try {
+      mapper.readValue(data, ArchiveLayerSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'archive' cannot be empty"));
     }
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpecTest.java
@@ -57,4 +57,36 @@ public class BaseImageSpecTest {
           jpe.getMessage(), CoreMatchers.startsWith("Missing required creator property 'image'"));
     }
   }
+
+  @Test
+  public void testBaseImageSpec_imageNotNull() {
+    String data =
+        "image: null\n"
+            + "platforms:\n" // trivial platform spec
+            + "  - architecture: amd64\n"
+            + "    os: linux\n";
+    try {
+      mapper.readValue(data, BaseImageSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'image' cannot be null"));
+    }
+  }
+
+  @Test
+  public void testBaseImageSpec_imageNotEmpty() {
+    String data =
+        "image: ''\n"
+            + "platforms:\n" // trivial platform spec
+            + "  - architecture: amd64\n"
+            + "    os: linux\n";
+    try {
+      mapper.readValue(data, BaseImageSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'image' cannot be empty"));
+    }
+  }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpecTest.java
@@ -103,6 +103,32 @@ public class BuildFileSpecTest {
   }
 
   @Test
+  public void testBuildFileSpec_apiVersionNotNull() {
+    String data = "apiVersion: null\n" + "kind: BuildFile\n";
+
+    try {
+      mapper.readValue(data, BuildFileSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'apiVersion' cannot be null"));
+    }
+  }
+
+  @Test
+  public void testBuildFileSpec_apiVersionNotEmpty() {
+    String data = "apiVersion: ''\n" + "kind: BuildFile\n";
+
+    try {
+      mapper.readValue(data, BuildFileSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'apiVersion' cannot be empty"));
+    }
+  }
+
+  @Test
   public void testBuildFileSpec_kindRequired() {
     String data = "apiVersion: v1alpha1\n";
 
@@ -125,7 +151,20 @@ public class BuildFileSpecTest {
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
           jpe.getMessage(),
-          CoreMatchers.containsString("Field 'kind' must be BuildFile but is NotBuildFile"));
+          CoreMatchers.containsString("Property 'kind' must be 'BuildFile' but is 'NotBuildFile'"));
+    }
+  }
+
+  @Test
+  public void testBuildFileSpec_kindNotNull() {
+    String data = "apiVersion: v1alpha1\n" + "kind: null\n";
+
+    try {
+      mapper.readValue(data, BuildFileSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'kind' cannot be null"));
     }
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/CopySpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/CopySpecTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 /** Tests for {@link CopySpec}. */
 public class CopySpecTest {
 
-  private static final ObjectMapper copySpecMapper = new ObjectMapper(new YAMLFactory());
+  private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
 
   @Test
   public void testCopySpec_full() throws JsonProcessingException {
@@ -45,7 +45,7 @@ public class CopySpecTest {
             + "properties:\n" // only trivial test of file properties
             + "  timestamp: 1\n";
 
-    CopySpec parsed = copySpecMapper.readValue(data, CopySpec.class);
+    CopySpec parsed = mapper.readValue(data, CopySpec.class);
     Assert.assertEquals(Paths.get("target/classes"), parsed.getSrc());
     Assert.assertEquals(AbsoluteUnixPath.get("/app/classes"), parsed.getDest());
     Assert.assertEquals(ImmutableList.of("**/*.in"), parsed.getIncludes().get());
@@ -58,7 +58,7 @@ public class CopySpecTest {
     String data = "dest: /app/classes\n";
 
     try {
-      copySpecMapper.readValue(data, CopySpec.class);
+      mapper.readValue(data, CopySpec.class);
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
@@ -71,11 +71,63 @@ public class CopySpecTest {
     String data = "src: target/classes\n";
 
     try {
-      copySpecMapper.readValue(data, CopySpec.class);
+      mapper.readValue(data, CopySpec.class);
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
           jpe.getMessage(), CoreMatchers.startsWith("Missing required creator property 'dest'"));
+    }
+  }
+
+  @Test
+  public void testCopySpec_srcNotNull() {
+    String data = "src: null\n" + "dest: /app/classes\n";
+
+    try {
+      mapper.readValue(data, CopySpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'src' cannot be null"));
+    }
+  }
+
+  @Test
+  public void testCopySpec_srcNotEmpty() {
+    String data = "src: ''\n" + "dest: /app/classes\n";
+
+    try {
+      mapper.readValue(data, CopySpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'src' cannot be empty"));
+    }
+  }
+
+  @Test
+  public void testCopySpec_destNotNull() {
+    String data = "src: target/classes\n" + "dest: null\n";
+
+    try {
+      mapper.readValue(data, CopySpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'dest' cannot be null"));
+    }
+  }
+
+  @Test
+  public void testCopySpec_destNotEmpty() {
+    String data = "src: target/classes\n" + "dest: ''\n";
+
+    try {
+      mapper.readValue(data, CopySpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'dest' cannot be empty"));
     }
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesSpecTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 /** Tests for {@link FilePropertiesSpec}. */
 public class FilePropertiesSpecTest {
 
-  private static final ObjectMapper filePropertiesSpecMapper = new ObjectMapper(new YAMLFactory());
+  private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
 
   @Test
   public void testFilePropertiesSpec_full() throws JsonProcessingException {
@@ -42,7 +42,7 @@ public class FilePropertiesSpecTest {
             + "group: birds\n"
             + "timestamp: 1\n";
 
-    FilePropertiesSpec parsed = filePropertiesSpecMapper.readValue(data, FilePropertiesSpec.class);
+    FilePropertiesSpec parsed = mapper.readValue(data, FilePropertiesSpec.class);
     Assert.assertEquals(FilePermissions.fromOctalString("644"), parsed.getFilePermissions().get());
     Assert.assertEquals(
         FilePermissions.fromOctalString("755"), parsed.getDirectoryPermissions().get());
@@ -56,7 +56,7 @@ public class FilePropertiesSpecTest {
     String data = "filePermissions: 888";
 
     try {
-      filePropertiesSpecMapper.readValue(data, FilePropertiesSpec.class);
+      mapper.readValue(data, FilePropertiesSpec.class);
       Assert.fail();
     } catch (JsonMappingException ex) {
       Assert.assertEquals(
@@ -69,7 +69,7 @@ public class FilePropertiesSpecTest {
     String data = "directoryPermissions: 888";
 
     try {
-      filePropertiesSpecMapper.readValue(data, FilePropertiesSpec.class);
+      mapper.readValue(data, FilePropertiesSpec.class);
       Assert.fail();
     } catch (JsonMappingException ex) {
       Assert.assertEquals(
@@ -81,7 +81,7 @@ public class FilePropertiesSpecTest {
   public void testFilePropertiesSpec_timestampSpecIso8601() throws JsonProcessingException {
     String data = "timestamp: 2020-06-08T14:54:36+00:00";
 
-    FilePropertiesSpec parsed = filePropertiesSpecMapper.readValue(data, FilePropertiesSpec.class);
+    FilePropertiesSpec parsed = mapper.readValue(data, FilePropertiesSpec.class);
     Assert.assertEquals(Instant.parse("2020-06-08T14:54:36Z"), parsed.getTimestamp().get());
   }
 
@@ -90,7 +90,7 @@ public class FilePropertiesSpecTest {
     String data = "timestamp: hi";
 
     try {
-      filePropertiesSpecMapper.readValue(data, FilePropertiesSpec.class);
+      mapper.readValue(data, FilePropertiesSpec.class);
       Assert.fail();
     } catch (JsonMappingException ex) {
       Assert.assertEquals(
@@ -104,7 +104,7 @@ public class FilePropertiesSpecTest {
     String data = "badkey: badvalue";
 
     try {
-      filePropertiesSpecMapper.readValue(data, FilePropertiesSpec.class);
+      mapper.readValue(data, FilePropertiesSpec.class);
       Assert.fail();
     } catch (UnrecognizedPropertyException upe) {
       MatcherAssert.assertThat(

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/LayerSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/LayerSpecTest.java
@@ -27,7 +27,7 @@ import org.junit.Test;
 /** Tests for {@link LayerSpec}. */
 public class LayerSpecTest {
 
-  private static final ObjectMapper LayerSpecMapper = new ObjectMapper(new YAMLFactory());
+  private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
 
   @Test
   public void deserialize_toFileLayer() throws JsonProcessingException {
@@ -37,7 +37,7 @@ public class LayerSpecTest {
             + "  - src: source\n"
             + "    dest: /dest\n";
 
-    LayerSpec layerSpec = LayerSpecMapper.readValue(data, LayerSpec.class);
+    LayerSpec layerSpec = mapper.readValue(data, LayerSpec.class);
     MatcherAssert.assertThat(layerSpec, CoreMatchers.instanceOf(FileLayerSpec.class));
   }
 
@@ -45,7 +45,7 @@ public class LayerSpecTest {
   public void deserialize_toArchiveLayer() throws JsonProcessingException {
     String data = "name: layer name\n" + "archive: out/archive.tgz\n";
 
-    LayerSpec layerSpec = LayerSpecMapper.readValue(data, LayerSpec.class);
+    LayerSpec layerSpec = mapper.readValue(data, LayerSpec.class);
     MatcherAssert.assertThat(layerSpec, CoreMatchers.instanceOf(ArchiveLayerSpec.class));
   }
 
@@ -54,7 +54,7 @@ public class LayerSpecTest {
     String data = "name: layer name\n";
 
     try {
-      LayerSpecMapper.readValue(data, LayerSpec.class);
+      mapper.readValue(data, LayerSpec.class);
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
@@ -68,7 +68,7 @@ public class LayerSpecTest {
     String data = "archive: out/archive.tgz\n";
 
     try {
-      LayerSpecMapper.readValue(data, LayerSpec.class);
+      mapper.readValue(data, LayerSpec.class);
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/LayersSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/LayersSpecTest.java
@@ -61,4 +61,37 @@ public class LayersSpecTest {
           jpe.getMessage(), CoreMatchers.startsWith("Missing required creator property 'entries'"));
     }
   }
+
+  @Test
+  public void testLayersSpec_entriesNotNull() {
+    String data =
+        "entries: null\n"
+            + "properties:\n" // trivial file properties spec
+            + "  timestamp: 1\n";
+
+    try {
+      mapper.readValue(data, LayersSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'entries' cannot be null"));
+    }
+  }
+
+  @Test
+  public void testLayersSpec_entriesNotEmpty() {
+    String data =
+        "entries: []\n"
+            + "properties:\n" // trivial file properties spec
+            + "  timestamp: 1\n";
+
+    try {
+      mapper.readValue(data, LayersSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(),
+          CoreMatchers.containsString("Property 'entries' cannot be an empty collection"));
+    }
+  }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpecTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 /** Tests for {@link PlatformSpec}. */
 public class PlatformSpecTest {
 
-  private static final ObjectMapper platformSpecMapper = new ObjectMapper(new YAMLFactory());
+  private static final ObjectMapper mapper = new ObjectMapper(new YAMLFactory());
 
   @Test
   public void testPlatformSpec_full() throws JsonProcessingException {
@@ -41,7 +41,7 @@ public class PlatformSpecTest {
             + "  - sse4\n"
             + "  - aes\n";
 
-    PlatformSpec parsed = platformSpecMapper.readValue(data, PlatformSpec.class);
+    PlatformSpec parsed = mapper.readValue(data, PlatformSpec.class);
     Assert.assertEquals("amd64", parsed.getArchitecture().get());
     Assert.assertEquals("linux", parsed.getOs().get());
     Assert.assertEquals("1.0.0", parsed.getOsVersion().get());

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ValidatorTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ValidatorTest.java
@@ -17,27 +17,12 @@
 package com.google.cloud.tools.jib.cli.buildfile;
 
 import com.google.common.collect.ImmutableList;
+import java.util.Collection;
 import org.junit.Assert;
 import org.junit.Test;
 
 /** Tests for {@link Validator}. */
 public class ValidatorTest {
-
-  @Test
-  public void testCheckNotNull_pass() {
-    Validator.checkNotNull("value", "ignored");
-    // pass
-  }
-
-  @Test
-  public void testCheckNotNull_fail() {
-    try {
-      Validator.checkNotNull(null, "test");
-      Assert.fail();
-    } catch (NullPointerException npe) {
-      Assert.assertEquals("Property 'test' cannot be null", npe.getMessage());
-    }
-  }
 
   @Test
   public void testCheckNotEmpty_stringPass() {
@@ -46,7 +31,17 @@ public class ValidatorTest {
   }
 
   @Test
-  public void testCheckNotEmpty_stringFail() {
+  public void testCheckNotEmpty_stringFailNull() {
+    try {
+      Validator.checkNotEmpty((String) null, "test");
+      Assert.fail();
+    } catch (NullPointerException npe) {
+      Assert.assertEquals("Property 'test' cannot be null", npe.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckNotEmpty_stringFailEmpty() {
     try {
       Validator.checkNotEmpty("  ", "test");
       Assert.fail();
@@ -62,7 +57,17 @@ public class ValidatorTest {
   }
 
   @Test
-  public void testCheckNotEmpty_collectionFail() {
+  public void testCheckNotEmpty_collectionFailNull() {
+    try {
+      Validator.checkNotEmpty((Collection<?>) null, "test");
+      Assert.fail();
+    } catch (NullPointerException npe) {
+      Assert.assertEquals("Property 'test' cannot be null", npe.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckNotEmpty_collectionFailEmpty() {
     try {
       Validator.checkNotEmpty(ImmutableList.of(), "test");
       Assert.fail();
@@ -78,7 +83,17 @@ public class ValidatorTest {
   }
 
   @Test
-  public void testCheckEquals_fails() {
+  public void testCheckEquals_failsNull() {
+    try {
+      Validator.checkEquals(null, "test", "something");
+      Assert.fail();
+    } catch (NullPointerException npe) {
+      Assert.assertEquals("Property 'test' cannot be null", npe.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckEquals_failsNotEquals() {
     try {
       Validator.checkEquals("somethingElse", "test", "something");
       Assert.fail();

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ValidatorTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ValidatorTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.cli.buildfile;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Tests for {@link Validator}. */
+public class ValidatorTest {
+
+  @Test
+  public void testCheckNotNull_pass() {
+    Validator.checkNotNull("value", "ignored");
+    // pass
+  }
+
+  @Test
+  public void testCheckNotNull_fail() {
+    try {
+      Validator.checkNotNull(null, "test");
+      Assert.fail();
+    } catch (NullPointerException npe) {
+      Assert.assertEquals("Property 'test' cannot be null", npe.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckNotEmpty_stringPass() {
+    Validator.checkNotEmpty("value", "ignored");
+    // pass
+  }
+
+  @Test
+  public void testCheckNotEmpty_stringFail() {
+    try {
+      Validator.checkNotEmpty("  ", "test");
+      Assert.fail();
+    } catch (IllegalArgumentException iae) {
+      Assert.assertEquals("Property 'test' cannot be empty", iae.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckNotEmpty_collectionPass() {
+    Validator.checkNotEmpty(ImmutableList.of("value"), "ignored");
+    // pass
+  }
+
+  @Test
+  public void testCheckNotEmpty_collectionFail() {
+    try {
+      Validator.checkNotEmpty(ImmutableList.of(), "test");
+      Assert.fail();
+    } catch (IllegalArgumentException iae) {
+      Assert.assertEquals("Property 'test' cannot be an empty collection", iae.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckEquals_pass() {
+    Validator.checkEquals("value", "ignored", "value");
+    // pass
+  }
+
+  @Test
+  public void testCheckEquals_fails() {
+    try {
+      Validator.checkEquals("somethingElse", "test", "something");
+      Assert.fail();
+    } catch (IllegalArgumentException iae) {
+      Assert.assertEquals(
+          "Property 'test' must be 'something' but is 'somethingElse'", iae.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
- Only check required values
- Add validator class with standard error messages
- Add in tests for value validation

Why not `@JsonInclude`?
Because `@JsonCreator` and `@JsonInclude` do not work at all
with eachother. We use `@JsonCreator` since it handles **required** fields
and we can validate non-null, non-empty at creation time. Using `@JsonInclude`
with jackson bean initialized of fields (vs creator) would give us access
to automatic non-null, non-empty validation, but we would have to push
our own **required** infrastructure. This cannot happen at yaml parse time, and
would happen after parsing in some sort of post-parsing step (or there is some
jackson validation framework that I was unable to find). I find the
`@JsonCreator` workflow slightly cleaner.

part of #2570 