### PR TITLE
Convert most collections to empty instead of optional

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/ArchiveLayerSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/ArchiveLayerSpec.java
@@ -40,10 +40,10 @@ import javax.annotation.Nullable;
 @JsonDeserialize(using = JsonDeserializer.None.class) // required since LayerSpec overrides this
 public class ArchiveLayerSpec implements LayerSpec {
 
-  private String name;
+  private final String name;
   // TODO: arhive should maybe be a uri to support file paths or urls
-  private Path archive;
-  @Nullable private String mediaType;
+  private final Path archive;
+  @Nullable private final String mediaType;
 
   /**
    * Constructor for use by jackson to populate this object.

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpec.java
@@ -18,9 +18,8 @@ package com.google.cloud.tools.jib.cli.buildfile;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
-import java.util.Optional;
-import javax.annotation.Nullable;
 
 /**
  * A yaml block for specifying a base image with support for multi platform selections.
@@ -36,7 +35,7 @@ import javax.annotation.Nullable;
  */
 public class BaseImageSpec {
   private String image;
-  @Nullable private List<PlatformSpec> platforms;
+  private List<PlatformSpec> platforms;
 
   /**
    * Constructor for use by jackson to populate this object.
@@ -50,14 +49,14 @@ public class BaseImageSpec {
       @JsonProperty("platforms") List<PlatformSpec> platforms) {
     Validator.checkNotEmpty(image, "image");
     this.image = image;
-    this.platforms = platforms;
+    this.platforms = platforms == null ? ImmutableList.of() : platforms;
   }
 
   public String getImage() {
     return image;
   }
 
-  public Optional<List<PlatformSpec>> getPlatforms() {
-    return Optional.ofNullable(platforms);
+  public List<PlatformSpec> getPlatforms() {
+    return platforms;
   }
 }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpec.java
@@ -34,8 +34,8 @@ import java.util.List;
  * }</pre>
  */
 public class BaseImageSpec {
-  private String image;
-  private List<PlatformSpec> platforms;
+  private final String image;
+  private final List<PlatformSpec> platforms;
 
   /**
    * Constructor for use by jackson to populate this object.

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
@@ -23,6 +23,8 @@ import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
 import com.google.cloud.tools.jib.api.buildplan.Port;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -66,12 +68,14 @@ public class BuildFileSpec {
   @Nullable private BaseImageSpec from;
   @Nullable private Instant creationTime;
   @Nullable private ImageFormat format;
-  @Nullable private Map<String, String> environment;
-  @Nullable private Map<String, String> labels;
-  @Nullable private Set<AbsoluteUnixPath> volumes;
-  @Nullable private Set<Port> exposedPorts;
+  private Map<String, String> environment;
+  private Map<String, String> labels;
+  private Set<AbsoluteUnixPath> volumes;
+  private Set<Port> exposedPorts;
   @Nullable private String user;
   @Nullable private AbsoluteUnixPath workingDirectory;
+  // these two specific collection can be null as they can be set to empty to override
+  // the base image
   @Nullable private List<String> entrypoint;
   @Nullable private List<String> cmd;
 
@@ -124,14 +128,13 @@ public class BuildFileSpec {
     if (format != null) {
       this.format = ImageFormat.valueOf(format);
     }
-    this.environment = environment;
-    this.labels = labels;
-    if (volumes != null) {
-      this.volumes = volumes.stream().map(AbsoluteUnixPath::get).collect(Collectors.toSet());
-    }
-    if (exposedPorts != null) {
-      this.exposedPorts = Ports.parse(exposedPorts);
-    }
+    this.environment = (environment == null) ? ImmutableMap.of() : environment;
+    this.labels = (labels == null) ? ImmutableMap.of() : labels;
+    this.volumes =
+        (volumes == null)
+            ? ImmutableSet.of()
+            : volumes.stream().map(AbsoluteUnixPath::get).collect(Collectors.toSet());
+    this.exposedPorts = (exposedPorts == null) ? ImmutableSet.of() : Ports.parse(exposedPorts);
     this.user = user;
     if (workingDirectory != null) {
       this.workingDirectory = AbsoluteUnixPath.get(workingDirectory);
@@ -161,20 +164,20 @@ public class BuildFileSpec {
     return Optional.ofNullable(format);
   }
 
-  public Optional<Map<String, String>> getEnvironment() {
-    return Optional.ofNullable(environment);
+  public Map<String, String> getEnvironment() {
+    return environment;
   }
 
-  public Optional<Map<String, String>> getLabels() {
-    return Optional.ofNullable(labels);
+  public Map<String, String> getLabels() {
+    return labels;
   }
 
-  public Optional<Set<AbsoluteUnixPath>> getVolumes() {
-    return Optional.ofNullable(volumes);
+  public Set<AbsoluteUnixPath> getVolumes() {
+    return volumes;
   }
 
-  public Optional<Set<Port>> getExposedPorts() {
-    return Optional.ofNullable(exposedPorts);
+  public Set<Port> getExposedPorts() {
+    return exposedPorts;
   }
 
   public Optional<String> getUser() {

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
@@ -63,23 +63,29 @@ import javax.annotation.Nullable;
  * }</pre>
  */
 public class BuildFileSpec {
-  private String apiVersion;
-  private String kind;
-  @Nullable private BaseImageSpec from;
-  @Nullable private Instant creationTime;
-  @Nullable private ImageFormat format;
-  private Map<String, String> environment;
-  private Map<String, String> labels;
-  private Set<AbsoluteUnixPath> volumes;
-  private Set<Port> exposedPorts;
-  @Nullable private String user;
-  @Nullable private AbsoluteUnixPath workingDirectory;
-  // these two specific collection can be null as they can be set to empty to override
-  // the base image
-  @Nullable private List<String> entrypoint;
-  @Nullable private List<String> cmd;
+  private final String apiVersion;
+  private final String kind;
+  @Nullable private final BaseImageSpec from;
+  @Nullable private final Instant creationTime;
+  @Nullable private final ImageFormat format;
+  private final Map<String, String> environment;
+  private final Map<String, String> labels;
+  private final Set<AbsoluteUnixPath> volumes;
+  private final Set<Port> exposedPorts;
+  @Nullable private final String user;
+  @Nullable private final AbsoluteUnixPath workingDirectory;
+  /**
+   * Entrypoint has special behavior as a nullable list. When null, it delegates to the existing base image
+   * entrypoint. If non null (including empty) it overwrites the base image entrypoint.
+   */
+  @Nullable private final List<String> entrypoint;
+  /**
+   * Cmd has special behavior as a nullable list. When null, it delegates to the existing base image
+   * cmd. If non null (including empty) it overwrites the base image cmd.
+   */
+  @Nullable private final List<String> cmd;
 
-  @Nullable private LayersSpec layers;
+  @Nullable private final LayersSpec layers;
 
   /**
    * Constructor for use by jackson to populate this object.
@@ -122,12 +128,8 @@ public class BuildFileSpec {
         "BuildFile".equals(kind), "Field 'kind' must be BuildFile but is " + kind);
     this.kind = kind;
     this.from = from;
-    if (creationTime != null) {
-      this.creationTime = Instants.fromMillisOrIso8601(creationTime, "creationTime");
-    }
-    if (format != null) {
-      this.format = ImageFormat.valueOf(format);
-    }
+    this.creationTime = (creationTime == null) ? null : Instants.fromMillisOrIso8601(creationTime, "creationTime");
+    this.format = (format == null) ? null : ImageFormat.valueOf(format);
     this.environment = (environment == null) ? ImmutableMap.of() : environment;
     this.labels = (labels == null) ? ImmutableMap.of() : labels;
     this.volumes =
@@ -136,9 +138,7 @@ public class BuildFileSpec {
             : volumes.stream().map(AbsoluteUnixPath::get).collect(Collectors.toSet());
     this.exposedPorts = (exposedPorts == null) ? ImmutableSet.of() : Ports.parse(exposedPorts);
     this.user = user;
-    if (workingDirectory != null) {
-      this.workingDirectory = AbsoluteUnixPath.get(workingDirectory);
-    }
+    this.workingDirectory = (workingDirectory == null) ? null : AbsoluteUnixPath.get(workingDirectory);
     this.entrypoint = entrypoint;
     this.cmd = cmd;
     this.layers = layers;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
@@ -75,8 +75,8 @@ public class BuildFileSpec {
   @Nullable private final String user;
   @Nullable private final AbsoluteUnixPath workingDirectory;
   /**
-   * Entrypoint has special behavior as a nullable list. When null, it delegates to the existing base image
-   * entrypoint. If non null (including empty) it overwrites the base image entrypoint.
+   * Entrypoint has special behavior as a nullable list. When null, it delegates to the existing
+   * base image entrypoint. If non null (including empty) it overwrites the base image entrypoint.
    */
   @Nullable private final List<String> entrypoint;
   /**
@@ -128,7 +128,8 @@ public class BuildFileSpec {
         "BuildFile".equals(kind), "Field 'kind' must be BuildFile but is " + kind);
     this.kind = kind;
     this.from = from;
-    this.creationTime = (creationTime == null) ? null : Instants.fromMillisOrIso8601(creationTime, "creationTime");
+    this.creationTime =
+        (creationTime == null) ? null : Instants.fromMillisOrIso8601(creationTime, "creationTime");
     this.format = (format == null) ? null : ImageFormat.valueOf(format);
     this.environment = (environment == null) ? ImmutableMap.of() : environment;
     this.labels = (labels == null) ? ImmutableMap.of() : labels;
@@ -138,7 +139,8 @@ public class BuildFileSpec {
             : volumes.stream().map(AbsoluteUnixPath::get).collect(Collectors.toSet());
     this.exposedPorts = (exposedPorts == null) ? ImmutableSet.of() : Ports.parse(exposedPorts);
     this.user = user;
-    this.workingDirectory = (workingDirectory == null) ? null : AbsoluteUnixPath.get(workingDirectory);
+    this.workingDirectory =
+        (workingDirectory == null) ? null : AbsoluteUnixPath.get(workingDirectory);
     this.entrypoint = entrypoint;
     this.cmd = cmd;
     this.layers = layers;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/CopySpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/CopySpec.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.cli.buildfile;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
+import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -46,8 +47,8 @@ public class CopySpec {
   private final AbsoluteUnixPath dest;
 
   @Nullable private final FilePropertiesSpec properties;
-  @Nullable private final List<String> excludes;
-  @Nullable private final List<String> includes;
+  private final List<String> excludes;
+  private final List<String> includes;
 
   /**
    * Constructor for use by jackson to populate this object.
@@ -69,8 +70,8 @@ public class CopySpec {
     Validator.checkNotEmpty(dest, "dest");
     this.src = Paths.get(src);
     this.dest = AbsoluteUnixPath.get(dest);
-    this.excludes = excludes;
-    this.includes = includes;
+    this.excludes = (excludes == null) ? ImmutableList.of() : excludes;
+    this.includes = (includes == null) ? ImmutableList.of() : includes;
     this.properties = properties;
   }
 
@@ -82,12 +83,12 @@ public class CopySpec {
     return dest;
   }
 
-  public Optional<List<String>> getExcludes() {
-    return Optional.ofNullable(excludes);
+  public List<String> getExcludes() {
+    return excludes;
   }
 
-  public Optional<List<String>> getIncludes() {
-    return Optional.ofNullable(includes);
+  public List<String> getIncludes() {
+    return includes;
   }
 
   public Optional<FilePropertiesSpec> getProperties() {

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FileLayerSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FileLayerSpec.java
@@ -40,9 +40,9 @@ import javax.annotation.Nullable;
  */
 @JsonDeserialize(using = JsonDeserializer.None.class) // required since LayerSpec overrides this
 public class FileLayerSpec implements LayerSpec {
-  private String name;
-  private List<CopySpec> files;
-  @Nullable private FilePropertiesSpec properties;
+  private final String name;
+  private final List<CopySpec> files;
+  @Nullable private final FilePropertiesSpec properties;
 
   /**
    * Constructor for use by jackson to populate this object.

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/LayersSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/LayersSpec.java
@@ -35,8 +35,8 @@ import javax.annotation.Nullable;
  * }</pre>
  */
 public class LayersSpec {
-  private List<LayerSpec> entries;
-  @Nullable private FilePropertiesSpec properties;
+  private final List<LayerSpec> entries;
+  @Nullable private final FilePropertiesSpec properties;
 
   /**
    * Constructor for use by jackson to populate this object.

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
@@ -41,12 +41,12 @@ import javax.annotation.Nullable;
  * }</pre>
  */
 public class PlatformSpec {
-  @Nullable private String architecture;
-  @Nullable private String os;
-  @Nullable private String osVersion;
-  private List<String> osFeatures;
-  @Nullable private String variant;
-  private List<String> features;
+  @Nullable private final String architecture;
+  @Nullable private final String os;
+  @Nullable private final String osVersion;
+  private final List<String> osFeatures;
+  @Nullable private final String variant;
+  private final List<String> features;
 
   /**
    * Constructor for use by jackson to populate this object.

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.cli.buildfile;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -43,9 +44,9 @@ public class PlatformSpec {
   @Nullable private String architecture;
   @Nullable private String os;
   @Nullable private String osVersion;
-  @Nullable private List<String> osFeatures;
+  private List<String> osFeatures;
   @Nullable private String variant;
-  @Nullable private List<String> features;
+  private List<String> features;
 
   /**
    * Constructor for use by jackson to populate this object.
@@ -68,9 +69,9 @@ public class PlatformSpec {
     this.architecture = architecture;
     this.os = os;
     this.osVersion = osVersion;
-    this.osFeatures = osFeatures;
+    this.osFeatures = (osFeatures == null) ? ImmutableList.of() : osFeatures;
     this.variant = variant;
-    this.features = features;
+    this.features = (features == null) ? ImmutableList.of() : features;
   }
 
   public Optional<String> getArchitecture() {
@@ -85,15 +86,15 @@ public class PlatformSpec {
     return Optional.ofNullable(osVersion);
   }
 
-  public Optional<List<String>> getOsFeatures() {
-    return Optional.ofNullable(osFeatures);
+  public List<String> getOsFeatures() {
+    return osFeatures;
   }
 
   public Optional<String> getVariant() {
     return Optional.ofNullable(variant);
   }
 
-  public Optional<List<String>> getFeatures() {
-    return Optional.ofNullable(features);
+  public List<String> getFeatures() {
+    return features;
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpecTest.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.cli.buildfile;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.common.collect.ImmutableList;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -39,8 +40,8 @@ public class BaseImageSpecTest {
 
     BaseImageSpec baseImageSpec = mapper.readValue(data, BaseImageSpec.class);
     Assert.assertEquals("gcr.io/example/jib", baseImageSpec.getImage());
-    Assert.assertEquals("amd64", baseImageSpec.getPlatforms().get().get(0).getArchitecture().get());
-    Assert.assertEquals("linux", baseImageSpec.getPlatforms().get().get(0).getOs().get());
+    Assert.assertEquals("amd64", baseImageSpec.getPlatforms().get(0).getArchitecture().get());
+    Assert.assertEquals("linux", baseImageSpec.getPlatforms().get(0).getOs().get());
   }
 
   @Test
@@ -88,5 +89,13 @@ public class BaseImageSpecTest {
       MatcherAssert.assertThat(
           jpe.getMessage(), CoreMatchers.containsString("Property 'image' cannot be empty"));
     }
+  }
+
+  @Test
+  public void testBaseImageSpec_nullCollections() throws JsonProcessingException {
+    String data = "image: gcr.io/example/jib\n";
+
+    BaseImageSpec baseImageSpec = mapper.readValue(data, BaseImageSpec.class);
+    Assert.assertEquals(ImmutableList.of(), baseImageSpec.getPlatforms());
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpecTest.java
@@ -72,11 +72,10 @@ public class BuildFileSpecTest {
     Assert.assertEquals("gcr.io/example/jib", parsed.getFrom().get().getImage());
     Assert.assertEquals(Instant.ofEpochMilli(1), parsed.getCreationTime().get());
     Assert.assertEquals(ImageFormat.OCI, parsed.getFormat().get());
-    Assert.assertEquals(ImmutableMap.of("env_key", "env_value"), parsed.getEnvironment().get());
-    Assert.assertEquals(ImmutableMap.of("label_key", "label_value"), parsed.getLabels().get());
-    Assert.assertEquals(
-        ImmutableSet.of(AbsoluteUnixPath.get("/my/volume")), parsed.getVolumes().get());
-    Assert.assertEquals(Ports.parse(ImmutableList.of("8080")), parsed.getExposedPorts().get());
+    Assert.assertEquals(ImmutableMap.of("env_key", "env_value"), parsed.getEnvironment());
+    Assert.assertEquals(ImmutableMap.of("label_key", "label_value"), parsed.getLabels());
+    Assert.assertEquals(ImmutableSet.of(AbsoluteUnixPath.get("/my/volume")), parsed.getVolumes());
+    Assert.assertEquals(Ports.parse(ImmutableList.of("8080")), parsed.getExposedPorts());
     Assert.assertEquals("username", parsed.getUser().get());
     Assert.assertEquals(AbsoluteUnixPath.get("/workspace"), parsed.getWorkingDirectory().get());
     Assert.assertEquals(ImmutableList.of("java", "-jar"), parsed.getEntrypoint().get());
@@ -166,5 +165,19 @@ public class BuildFileSpecTest {
       MatcherAssert.assertThat(
           jpe.getMessage(), CoreMatchers.containsString("Property 'kind' cannot be null"));
     }
+  }
+
+  @Test
+  public void testBuildFileSpec_nullCollections() throws JsonProcessingException {
+    String data = "apiVersion: v1alpha1\n" + "kind: BuildFile\n";
+
+    BuildFileSpec parsed = mapper.readValue(data, BuildFileSpec.class);
+    Assert.assertEquals(ImmutableMap.of(), parsed.getEnvironment());
+    Assert.assertEquals(ImmutableMap.of(), parsed.getLabels());
+    Assert.assertEquals(ImmutableSet.of(), parsed.getVolumes());
+    Assert.assertEquals(ImmutableSet.of(), parsed.getExposedPorts());
+    // entrypoint and cmd CAN be not present
+    Assert.assertFalse(parsed.getEntrypoint().isPresent());
+    Assert.assertFalse(parsed.getCmd().isPresent());
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/CopySpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/CopySpecTest.java
@@ -48,8 +48,8 @@ public class CopySpecTest {
     CopySpec parsed = mapper.readValue(data, CopySpec.class);
     Assert.assertEquals(Paths.get("target/classes"), parsed.getSrc());
     Assert.assertEquals(AbsoluteUnixPath.get("/app/classes"), parsed.getDest());
-    Assert.assertEquals(ImmutableList.of("**/*.in"), parsed.getIncludes().get());
-    Assert.assertEquals(ImmutableList.of("**/*.ex"), parsed.getExcludes().get());
+    Assert.assertEquals(ImmutableList.of("**/*.in"), parsed.getIncludes());
+    Assert.assertEquals(ImmutableList.of("**/*.ex"), parsed.getExcludes());
     Assert.assertEquals(Instant.ofEpochMilli(1), parsed.getProperties().get().getTimestamp().get());
   }
 
@@ -129,5 +129,14 @@ public class CopySpecTest {
       MatcherAssert.assertThat(
           jpe.getMessage(), CoreMatchers.containsString("Property 'dest' cannot be empty"));
     }
+  }
+
+  @Test
+  public void testCopySpec_nullCollections() throws JsonProcessingException {
+    String data = "src: target/classes\n" + "dest: /app/classes\n";
+
+    CopySpec parsed = mapper.readValue(data, CopySpec.class);
+    Assert.assertEquals(ImmutableList.of(), parsed.getIncludes());
+    Assert.assertEquals(ImmutableList.of(), parsed.getExcludes());
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpecTest.java
@@ -45,8 +45,17 @@ public class PlatformSpecTest {
     Assert.assertEquals("amd64", parsed.getArchitecture().get());
     Assert.assertEquals("linux", parsed.getOs().get());
     Assert.assertEquals("1.0.0", parsed.getOsVersion().get());
-    Assert.assertEquals(ImmutableList.of("headless"), parsed.getOsFeatures().get());
+    Assert.assertEquals(ImmutableList.of("headless"), parsed.getOsFeatures());
     Assert.assertEquals("amd64v10", parsed.getVariant().get());
-    Assert.assertEquals(ImmutableList.of("sse4", "aes"), parsed.getFeatures().get());
+    Assert.assertEquals(ImmutableList.of("sse4", "aes"), parsed.getFeatures());
+  }
+
+  @Test
+  public void testPlatformSpec_nullCollections() throws JsonProcessingException {
+    String data = "architecture: amd64\n" + "os: linux\n";
+
+    PlatformSpec parsed = mapper.readValue(data, PlatformSpec.class);
+    Assert.assertEquals(ImmutableList.of(), parsed.getOsFeatures());
+    Assert.assertEquals(ImmutableList.of(), parsed.getFeatures());
   }
 }


### PR DESCRIPTION
- entrypoint and cmd are still optional as we have to
  differentiate between the user trying to erase a
  base image value vs not setting anything.

Doing some more thinking and reading about this (https://github.com/GoogleContainerTools/jib/pull/2598#discussion_r456577550). It seems like using optional for collections is probably not great, except in the case of entrypoint and cmd.