### PR TITLE
Adding support for PullBaseImageStep to search a manifest list using a user specified os/arch pair

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.builder.steps;
 
-import com.google.api.client.util.Preconditions;
 import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.ImageReference;
@@ -270,9 +269,6 @@ class PullBaseImageStep implements Callable<ImageAndRegistryClient> {
       throws IOException, RegistryException {
 
     Set<Platform> platforms = buildContext.getContainerConfiguration().getPlatforms();
-    Preconditions.checkArgument(
-        platforms.size() == 1,
-        "multiple base image platforms is not yet supported; please specify only one platform");
     Platform platform = platforms.iterator().next();
     String architecture = platform.getArchitecture();
     String os = platform.getOs();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.builder.steps;
 
+import com.google.api.client.util.Preconditions;
 import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.ImageReference;
@@ -269,6 +270,9 @@ class PullBaseImageStep implements Callable<ImageAndRegistryClient> {
       throws IOException, RegistryException {
 
     Set<Platform> platforms = buildContext.getContainerConfiguration().getPlatforms();
+    Preconditions.checkArgument(
+        platforms.size() == 1,
+        "multiple base image platforms is not yet supported; please specify only one platform");
     Platform platform = platforms.iterator().next();
     String architecture = platform.getArchitecture();
     String os = platform.getOs();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -294,7 +294,7 @@ class PullBaseImageStep implements Callable<ImageAndRegistryClient> {
               + os
               + ". If your intention was to specify a platform for your image,"
               + " see https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#how-do-i-specify-a-platform-in-the-manifest-list-or-oci-index-of-a-base-image"
-              + " to learn more about specifyng a platform";
+              + " to learn more about specifying a platform";
 
       eventHandlers.dispatch(LogEvent.error(errorMessage));
       throw new RegistryException(errorMessage);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -271,32 +271,27 @@ class PullBaseImageStep implements Callable<ImageAndRegistryClient> {
       RegistryClient registryClient, V22ManifestListTemplate manifestListTemplate)
       throws RegistryException, IOException {
 
-    String architecture = "amd64";
-    String os = "linux";
-
-    if (buildContext.getContainerConfiguration() != null) {
-      Set<Platform> platforms = buildContext.getContainerConfiguration().getPlatforms();
-      Platform platform = platforms.iterator().next();
-      architecture = platform.getArchitecture();
-      os = platform.getOs();
-    }
+    Set<Platform> platforms = buildContext.getContainerConfiguration().getPlatforms();
+    Platform platform = platforms.iterator().next();
+    String architecture = platform.getArchitecture();
+    String os = platform.getOs();
 
     buildContext
         .getEventHandlers()
         .dispatch(
-            LogEvent.error(
+            LogEvent.lifecycle(
                 "Searching the manifest list for the platfrom, architecture =  "
                     + architecture
                     + ", os = "
                     + os));
 
-    List<String> digests = manifestListTemplate.getDigestsForPlatform(os, architecture);
+    List<String> digests = manifestListTemplate.getDigestsForPlatform(architecture, os);
     if (digests.size() == 0) {
       String errorMessage =
           buildContext.getBaseImageConfiguration().getImage()
-              + " is a manifest list, but the list does not contain an image manifest for "
+              + " is a manifest list, but the list does not contain an image manifest for the platform arch = "
               + architecture
-              + "/"
+              + ", os = "
               + os
               + ". If your intention was to specify a platform for your image,"
               + " see https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#how-do-i-specify-a-platform-in-the-manifest-list-or-oci-index-of-a-base-image"

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -204,7 +204,7 @@ class PullBaseImageStep implements Callable<ImageAndRegistryClient> {
     if (manifestTemplate instanceof V22ManifestListTemplate) {
       eventHandlers.dispatch(
           LogEvent.lifecycle(
-              "The base image reference is manifest list, searching for linux/amd64"));
+              "The base image reference is manifest list, searching for the user specified platform"));
       manifestAndDigest =
           obtainPlatformSpecificImageManifest(
               registryClient, (V22ManifestListTemplate) manifestTemplate);
@@ -273,12 +273,22 @@ class PullBaseImageStep implements Callable<ImageAndRegistryClient> {
       RegistryClient registryClient, V22ManifestListTemplate manifestListTemplate)
       throws RegistryException, IOException {
 
+    LogEvent.lifecycle("Found Manifest List ");
     if (buildContext.getContainerConfiguration() != null) {
       Set<Platform> platforms = buildContext.getContainerConfiguration().getPlatforms();
       Platform platform = platforms.stream().findFirst().get();
       architecture = platform.getArchitecture();
       os = platform.getOs();
     }
+
+    buildContext
+        .getEventHandlers()
+        .dispatch(
+            LogEvent.lifecycle(
+                "Searching the manifest list for the platfrom , architecture =  "
+                    + architecture
+                    + " , os = "
+                    + os));
 
     List<String> digests = manifestListTemplate.getDigestsForPlatform(architecture, os);
     if (digests.size() == 0) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -200,9 +200,6 @@ class PullBaseImageStep implements Callable<ImageAndRegistryClient> {
     // special handling if we happen upon a manifest list, redirect to a manifest and continue
     // handling it normally
     if (manifestTemplate instanceof V22ManifestListTemplate) {
-      eventHandlers.dispatch(
-          LogEvent.lifecycle(
-              "The base image reference is manifest list, searching for the user specified platform"));
       manifestAndDigest =
           obtainPlatformSpecificImageManifest(
               registryClient, (V22ManifestListTemplate) manifestTemplate);
@@ -278,8 +275,8 @@ class PullBaseImageStep implements Callable<ImageAndRegistryClient> {
 
     EventHandlers eventHandlers = buildContext.getEventHandlers();
     eventHandlers.dispatch(
-        LogEvent.info(
-            "Searching the manifest list for the platform, architecture="
+        LogEvent.lifecycle(
+            "The base image reference is manifest list, searching for architecture="
                 + architecture
                 + ", os="
                 + os));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
@@ -175,6 +175,6 @@ public class PullBaseImageStepTest {
     ManifestAndDigest<?> returnManifest =
         pullBaseImageStep.obtainPlatformSpecificImageManifest(registryClient, manifestList);
 
-    Assert.assertEquals(manifest, returnManifest);
+    Assert.assertSame(manifest, returnManifest);
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
@@ -41,8 +41,6 @@ import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.cloud.tools.jib.registry.credentials.CredentialRetrievalException;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
-import java.net.URISyntaxException;
-import java.security.GeneralSecurityException;
 import java.util.Optional;
 import org.junit.Assert;
 import org.junit.Before;
@@ -137,9 +135,7 @@ public class PullBaseImageStepTest {
   }
 
   @Test
-  public void testObtainPlatformSpecificImageManifest()
-      throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException,
-          RegistryException {
+  public void testObtainPlatformSpecificImageManifest() throws IOException, RegistryException {
     String manifestListJson =
         " {\n"
             + "   \"schemaVersion\": 2,\n"

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
@@ -63,7 +63,6 @@ public class PullBaseImageStepTest {
   @Mock private BuildContext buildContext;
   @Mock private RegistryClient registryClient;
   @Mock private ImageConfiguration imageConfiguration;
-  @Mock private ImageReference imageReference;
   @Mock private ContainerConfiguration containerConfiguration;
   @Mock private Cache cache;
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.builder.steps;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.RegistryException;
@@ -29,7 +28,6 @@ import com.google.cloud.tools.jib.configuration.BuildContext;
 import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
 import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.event.EventHandlers;
-import com.google.cloud.tools.jib.hash.Digests;
 import com.google.cloud.tools.jib.image.LayerCountMismatchException;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.cloud.tools.jib.image.json.BadContainerConfigurationFormatException;
@@ -77,7 +75,6 @@ public class PullBaseImageStepTest {
   public void setUp() {
     containerConfig.setOs("fat system");
     Mockito.when(buildContext.getBaseImageConfiguration()).thenReturn(imageConfiguration);
-    Mockito.when(buildContext.getBaseImageConfiguration().getImage()).thenReturn(imageReference);
     Mockito.when(buildContext.getEventHandlers()).thenReturn(EventHandlers.NONE);
     Mockito.when(buildContext.getBaseImageLayersCache()).thenReturn(cache);
     RegistryClient.Factory registryClientFactory = Mockito.mock(RegistryClient.Factory.class);
@@ -143,7 +140,7 @@ public class PullBaseImageStepTest {
   public void testObtainPlatformSpecificImageManifest()
       throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException,
           RegistryException {
-    String testManifestListTemplate =
+    String manifestListJson =
         " {\n"
             + "   \"schemaVersion\": 2,\n"
             + "   \"mediaType\": \"application/vnd.docker.distribution.manifest.list.v2+json\",\n"
@@ -151,67 +148,38 @@ public class PullBaseImageStepTest {
             + "      {\n"
             + "         \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n"
             + "         \"size\": 424,\n"
-            + "         \"digest\": \"sha256:f67dcc5fc786f04f0743abfe0ee5dae9bd8caf8efa6c8144f7f2a43889dc513b\",\n"
+            + "         \"digest\": \"sha256:111111111111111111111111111111111111111111111111111111111111111\",\n"
             + "         \"platform\": {\n"
-            + "            \"architecture\": \"testArchitecture\",\n"
-            + "            \"os\": \"testOS\"\n"
+            + "            \"architecture\": \"arm64\",\n"
+            + "            \"os\": \"linux\"\n"
             + "         }\n"
             + "      },\n"
             + "      {\n"
             + "         \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n"
             + "         \"size\": 425,\n"
-            + "         \"digest\": \"sha256:5bb8e50aa2edd408bdf3ddf61efb7338ff34a07b762992c9432f1c02fc0e5e62\",\n"
+            + "         \"digest\": \"sha256:222222222222222222222222222222222222222222222222222222222222222222\",\n"
             + "         \"platform\": {\n"
-            + "            \"architecture\": \"Architecture\",\n"
-            + "            \"os\": \"OS\"\n"
+            + "            \"architecture\": \"targetArchitecture\",\n"
+            + "            \"os\": \"targetOS\"\n"
             + "         }\n"
             + "      }\n"
             + "   ]\n"
             + "}";
 
-    String testManifestTemplate =
-        "{\n"
-            + "    \"schemaVersion\": 2,\n"
-            + "    \"mediaType\": \"application/vnd.docker.distribution.manifest.v2+json\",\n"
-            + "    \"config\": {\n"
-            + "        \"mediaType\": \"application/vnd.docker.container.image.v1+json\",\n"
-            + "        \"size\": 424,\n"
-            + "        \"digest\": \"sha256:5bb8e50aa2edd408bdf3ddf61efb7338ff34a07b762992c9432f1c02fc0e5e62\"\n"
-            + "    }\n"
-            + "}";
     Mockito.when(buildContext.getContainerConfiguration()).thenReturn(containerConfiguration);
     Mockito.when(containerConfiguration.getPlatforms())
-        .thenReturn(ImmutableSet.of(new Platform("testArchitecture", "testOS")));
-    V22ManifestListTemplate testManifestList =
-        JsonTemplateMapper.readJson(testManifestListTemplate, V22ManifestListTemplate.class);
-
-    V22ManifestTemplate testManifest =
-        new ObjectMapper().readValue(testManifestTemplate, V22ManifestTemplate.class);
-
-    ManifestAndDigest<?> manifestAndDigest =
-        new ManifestAndDigest(testManifest, Digests.computeJsonDigest(testManifest));
-
+        .thenReturn(ImmutableSet.of(new Platform("targetArchitecture", "targetOS")));
+    V22ManifestListTemplate manifestList =
+        JsonTemplateMapper.readJson(manifestListJson, V22ManifestListTemplate.class);
+    ManifestAndDigest<?> manifest = Mockito.mock(ManifestAndDigest.class);
     Mockito.<ManifestAndDigest<?>>when(
             registryClient.pullManifest(
-                "sha256:f67dcc5fc786f04f0743abfe0ee5dae9bd8caf8efa6c8144f7f2a43889dc513b"))
-        .thenReturn(manifestAndDigest);
+                "sha256:222222222222222222222222222222222222222222222222222222222222222222"))
+        .thenReturn(manifest);
 
-    ManifestAndDigest<?> returnManifestAndDigest =
-        pullBaseImageStep.obtainPlatformSpecificImageManifest(registryClient, testManifestList);
+    ManifestAndDigest<?> returnManifest =
+        pullBaseImageStep.obtainPlatformSpecificImageManifest(registryClient, manifestList);
 
-    Assert.assertEquals(
-        Digests.computeJsonDigest(testManifest).toString(),
-        returnManifestAndDigest.getDigest().toString());
-
-    Assert.assertTrue(returnManifestAndDigest.getManifest() instanceof V22ManifestTemplate);
-    V22ManifestTemplate returnedManifest = (V22ManifestTemplate) manifestAndDigest.getManifest();
-    Assert.assertEquals(2, returnedManifest.getSchemaVersion());
-    Assert.assertEquals(
-        "application/vnd.docker.distribution.manifest.v2+json",
-        returnedManifest.getManifestMediaType());
-    Assert.assertEquals(
-        "sha256:5bb8e50aa2edd408bdf3ddf61efb7338ff34a07b762992c9432f1c02fc0e5e62",
-        returnedManifest.getContainerConfiguration().getDigest().toString());
-    Assert.assertEquals(424, returnedManifest.getContainerConfiguration().getSize());
+    Assert.assertEquals(manifest, returnManifest);
   }
 }


### PR DESCRIPTION
This PR adds support for a user to specify the platform he/she wants to use when building an image
