### PR TITLE
Adding the V22ManifestListTemplate media type to the list of supported manifest files

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -88,7 +88,8 @@ public class ManifestPullerIntegrationTest {
     // Generic call to 11-jre-slim should NOT pull a manifest list (delegate to registry default)
     ManifestTemplate manifestTemplate = registryClient.pullManifest("11-jre-slim").getManifest();
     Assert.assertEquals(2, manifestTemplate.getSchemaVersion());
-    MatcherAssert.assertThat(manifestTemplate, CoreMatchers.instanceOf(V22ManifestTemplate.class));
+    MatcherAssert.assertThat(
+        manifestTemplate, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
 
     // Make sure we can't cast a v22ManifestTemplate to v22ManifestListTemplate in ManifestPuller
     try {

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -85,7 +85,7 @@ public class ManifestPullerIntegrationTest {
     Assert.assertEquals(2, manifestListTemplate.getSchemaVersion());
     Assert.assertTrue(manifestListTemplate.getManifests().size() > 0);
 
-    // Generic call to 11-jre-slim should NOT pull a manifest list (delegate to registry default)
+    // Generic call to 11-jre-slim pulls a manifest list
     ManifestTemplate manifestTemplate = registryClient.pullManifest("11-jre-slim").getManifest();
     Assert.assertEquals(2, manifestTemplate.getSchemaVersion());
     MatcherAssert.assertThat(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AbstractManifestPuller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AbstractManifestPuller.java
@@ -79,13 +79,11 @@ abstract class AbstractManifestPuller<T extends ManifestTemplate, R>
       return Collections.singletonList(V22ManifestListTemplate.MANIFEST_MEDIA_TYPE);
     }
 
-    // V22ManifestListTemplate is not included by default, we don't explicitly accept
-    // it, we only handle it if referenced by sha256 (see getManifestTemplateFromJson) in which
-    // case registries ignore the "accept" directive and just return a manifest list anyway.
     return Arrays.asList(
         OciManifestTemplate.MANIFEST_MEDIA_TYPE,
         V22ManifestTemplate.MANIFEST_MEDIA_TYPE,
-        V21ManifestTemplate.MEDIA_TYPE);
+        V21ManifestTemplate.MEDIA_TYPE,
+        V22ManifestListTemplate.MANIFEST_MEDIA_TYPE);
   }
 
   /** Parses the response body into a {@link ManifestAndDigest}. */

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPullerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPullerTest.java
@@ -236,7 +236,8 @@ public class ManifestPullerTest {
         Arrays.asList(
             OciManifestTemplate.MANIFEST_MEDIA_TYPE,
             V22ManifestTemplate.MANIFEST_MEDIA_TYPE,
-            V21ManifestTemplate.MEDIA_TYPE),
+            V21ManifestTemplate.MEDIA_TYPE,
+            V22ManifestListTemplate.MANIFEST_MEDIA_TYPE),
         testManifestPuller.getAccept());
 
     Assert.assertEquals(


### PR DESCRIPTION
This enables `ManifestPuller` (and `ManifestChecker`) pulling a Docker manifest list for any image reference (hence ultimately enabling Jib to do so). Previously, Jib was pulling a manifest list only when the image reference used a digest.