### PR TITLE
Make os and architecture required in PlatformSpec

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
@@ -41,8 +41,8 @@ import javax.annotation.Nullable;
  * }</pre>
  */
 public class PlatformSpec {
-  @Nullable private final String architecture;
-  @Nullable private final String os;
+  private final String architecture;
+  private final String os;
   @Nullable private final String osVersion;
   private final List<String> osFeatures;
   @Nullable private final String variant;
@@ -60,12 +60,14 @@ public class PlatformSpec {
    */
   @JsonCreator
   public PlatformSpec(
-      @JsonProperty("architecture") String architecture,
-      @JsonProperty("os") String os,
+      @JsonProperty(value = "architecture", required = true) String architecture,
+      @JsonProperty(value = "os", required = true) String os,
       @JsonProperty("os.version") String osVersion,
       @JsonProperty("os.features") List<String> osFeatures,
       @JsonProperty("variant") String variant,
       @JsonProperty("features") List<String> features) {
+    Validator.checkNotEmpty(architecture, "architecture");
+    Validator.checkNotEmpty(os, "os");
     this.architecture = architecture;
     this.os = os;
     this.osVersion = osVersion;
@@ -74,12 +76,12 @@ public class PlatformSpec {
     this.features = (features == null) ? ImmutableList.of() : features;
   }
 
-  public Optional<String> getArchitecture() {
-    return Optional.ofNullable(architecture);
+  public String getArchitecture() {
+    return architecture;
   }
 
-  public Optional<String> getOs() {
-    return Optional.ofNullable(os);
+  public String getOs() {
+    return os;
   }
 
   public Optional<String> getOsVersion() {

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpecTest.java
@@ -40,8 +40,8 @@ public class BaseImageSpecTest {
 
     BaseImageSpec baseImageSpec = mapper.readValue(data, BaseImageSpec.class);
     Assert.assertEquals("gcr.io/example/jib", baseImageSpec.getImage());
-    Assert.assertEquals("amd64", baseImageSpec.getPlatforms().get(0).getArchitecture().get());
-    Assert.assertEquals("linux", baseImageSpec.getPlatforms().get(0).getOs().get());
+    Assert.assertEquals("amd64", baseImageSpec.getPlatforms().get(0).getArchitecture());
+    Assert.assertEquals("linux", baseImageSpec.getPlatforms().get(0).getOs());
   }
 
   @Test

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpecTest.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.ImmutableList;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -42,12 +44,91 @@ public class PlatformSpecTest {
             + "  - aes\n";
 
     PlatformSpec parsed = mapper.readValue(data, PlatformSpec.class);
-    Assert.assertEquals("amd64", parsed.getArchitecture().get());
-    Assert.assertEquals("linux", parsed.getOs().get());
+    Assert.assertEquals("amd64", parsed.getArchitecture());
+    Assert.assertEquals("linux", parsed.getOs());
     Assert.assertEquals("1.0.0", parsed.getOsVersion().get());
     Assert.assertEquals(ImmutableList.of("headless"), parsed.getOsFeatures());
     Assert.assertEquals("amd64v10", parsed.getVariant().get());
     Assert.assertEquals(ImmutableList.of("sse4", "aes"), parsed.getFeatures());
+  }
+
+  @Test
+  public void testPlatformSpec_osRequired() {
+    String data = "architecture: amd64\n";
+
+    try {
+      mapper.readValue(data, PlatformSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.startsWith("Missing required creator property 'os'"));
+    }
+  }
+
+  @Test
+  public void testPlatformSpec_osNotNull() {
+    String data = "architecture: amd64\n" + "os: null";
+
+    try {
+      mapper.readValue(data, PlatformSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'os' cannot be null"));
+    }
+  }
+
+  @Test
+  public void testPlatformSpec_osNotEmpty() {
+    String data = "architecture: amd64\n" + "os: ''";
+
+    try {
+      mapper.readValue(data, PlatformSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'os' cannot be empty"));
+    }
+  }
+
+  @Test
+  public void testPlatformSpec_architectureRequired() {
+    String data = "os: linux\n";
+
+    try {
+      mapper.readValue(data, PlatformSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(),
+          CoreMatchers.startsWith("Missing required creator property 'architecture'"));
+    }
+  }
+
+  @Test
+  public void testPlatformSpec_architectureNotNull() {
+    String data = "architecture: null\n" + "os: linux";
+
+    try {
+      mapper.readValue(data, PlatformSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'architecture' cannot be null"));
+    }
+  }
+
+  @Test
+  public void testPlatformSpec_architectureNotEmpty() {
+    String data = "architecture: ''\n" + "os: linux";
+
+    try {
+      mapper.readValue(data, PlatformSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'architecture' cannot be empty"));
+    }
   }
 
   @Test


### PR DESCRIPTION
`os` and `architecture` are required when defining a platform.

part of #2570 