### PR TITLE
Update contributor docs to include more details on running integration tests. 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ following environment variables:
   - If you are using a GCP project then set `JIB_INTEGRATION_TESTING_PROJECT` to the GCP project to use for testing;
     the registry tested will be `gcr.io/<JIB_INTEGRATION_TESTING_PROJECT>`.
     - Configure authentication to Container Registry by following these [steps](https://cloud.google.com/container-registry/docs/advanced-authentication).
-    - Enable the Google Container Registry api [here](https://pantheon.corp.google.com/apis/library/containerregistry.googleapis.com).
+    - Enable the Google Container Registry API [here](https://console.cloud.google.com/apis/library/containerregistry.googleapis.com).
   - If you're not using a GCP project then set `JIB_INTEGRATION_TESTING_LOCATION` to a specific registry for testing. (For example, you can run `docker run -d -p 9990:5000 registry:2` to set up a local registry and set the variable to `localhost:9990`.)
 
 You will also need Docker installed with the daemon running. Note that the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,14 +47,18 @@ local maven repository.
 5. Associate the change with an existing issue or file a [new issue](../../issues).
 6. Create a pull request!
 
+### Integration Tests
 **Note** that in order to run integration tests, you will need to set one of the
-following environment variables:
+following environment variables:                                                
 
-  - `JIB_INTEGRATION_TESTING_PROJECT`: the GCP project to use for testing;
+  - If you are using a GCP project then set `JIB_INTEGRATION_TESTING_PROJECT` to the GCP project to use for testing;
     the registry tested will be `gcr.io/<JIB_INTEGRATION_TESTING_PROJECT>`.
-  - `JIB_INTEGRATION_TESTING_LOCATION`: a specific registry for testing.
-    To run the integration tests locally, you can run
-    `docker run -d -p 9990:5000 registry:2` and use `localhost:9990`.
+    - Make sure that you have `docker-credential-gcr` installed.
+    - Configure authentication to Container Registry by following these [steps](https://cloud.google.com/container-registry/docs/advanced-authentication).
+    - Enable the google container registry api [here](https://pantheon.corp.google.com/apis/library/containerregistry.googleapis.com). This can also be done through the command line.
+  - If you're not using a GCP project then set `JIB_INTEGRATION_TESTING_LOCATION` to a specific registry for testing.        
+
+To run the integration tests locally, you can run `docker run -d -p 9990:5000 registry:2` and use `localhost:9990`.
 
 You will also need Docker installed with the daemon running. Note that the
 integration tests will create local registries on ports 5000 and 6000.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,13 +53,10 @@ following environment variables:
 
   - If you are using a GCP project then set `JIB_INTEGRATION_TESTING_PROJECT` to the GCP project to use for testing;
     the registry tested will be `gcr.io/<JIB_INTEGRATION_TESTING_PROJECT>`.
-    - Make sure that you have `docker-credential-gcr` installed.
     - Configure authentication to Container Registry by following these [steps](https://cloud.google.com/container-registry/docs/advanced-authentication).
-    - Enable the google container registry api [here](https://pantheon.corp.google.com/apis/library/containerregistry.googleapis.com). This can also be done through the command line.
-  - If you're not using a GCP project then set `JIB_INTEGRATION_TESTING_LOCATION` to a specific registry for testing.        
-
-To run the integration tests locally, you can run `docker run -d -p 9990:5000 registry:2` and use `localhost:9990`.
-
+    - Enable the Google Container Registry api [here](https://pantheon.corp.google.com/apis/library/containerregistry.googleapis.com).
+  - If you're not using a GCP project then set `JIB_INTEGRATION_TESTING_LOCATION` to a specific registry for testing. (For example, you can run `docker run -d -p 9990:5000 registry:2` to set up a local registry and set the variable to `localhost:9990`.)
+  
 You will also need Docker installed with the daemon running. Note that the
 integration tests will create local registries on ports 5000 and 6000.
 


### PR DESCRIPTION
Includes additional steps to follow if a user is using a GCP project to run integration tests. 