### PR TITLE
Single Platform Specification Support

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -593,6 +593,11 @@ public class JibContainerBuilder {
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(
                 buildContext.getEventHandlers(), containerizer.getDescription())) {
+
+      if (buildContext.getContainerConfiguration().getPlatforms().size() != 1) {
+        throw new UnsupportedOperationException(
+            "multi-platform specification is not yet supported");
+      }
       logSources(buildContext.getEventHandlers());
 
       BuildResult buildResult = containerizer.run(buildContext);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainerBuilder.java
@@ -596,7 +596,7 @@ public class JibContainerBuilder {
 
       if (buildContext.getContainerConfiguration().getPlatforms().size() != 1) {
         throw new UnsupportedOperationException(
-            "multi-platform specification is not yet supported");
+            "multi-platform image building is not yet supported");
       }
       logSources(buildContext.getEventHandlers());
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
@@ -38,6 +38,7 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Consumer;
 import org.hamcrest.CoreMatchers;
@@ -361,5 +362,24 @@ public class JibContainerBuilderTest {
     ContainerBuildPlan convertedPlan = containerBuilder.toContainerBuildPlan();
     Assert.assertEquals(
         ImmutableSet.of(new Platform("testArchitecture", "testOS")), convertedPlan.getPlatforms());
+  }
+
+  @Test
+  public void testContainerize_multiPlatforms()
+      throws InvalidImageReferenceException, CacheDirectoryCreationException, InterruptedException,
+          RegistryException, IOException, ExecutionException {
+    try {
+      ImageConfiguration imageConfiguration =
+          ImageConfiguration.builder(ImageReference.parse("base/image")).build();
+      new JibContainerBuilder(imageConfiguration, spyBuildContextBuilder)
+          .setPlatforms(
+              ImmutableSet.of(
+                  new Platform("testArchitecture", "testOS"),
+                  new Platform("testArchitecture1", "testOS2")))
+          .containerize(Containerizer.to(RegistryImage.named("target/image")));
+      Assert.fail();
+    } catch (UnsupportedOperationException ex) {
+      Assert.assertEquals("multi-platform image building is not yet supported", ex.getMessage());
+    }
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
@@ -368,15 +368,15 @@ public class JibContainerBuilderTest {
   public void testContainerize_multiPlatformsList()
       throws InvalidImageReferenceException, CacheDirectoryCreationException, InterruptedException,
           RegistryException, IOException, ExecutionException {
+    ImageConfiguration imageConfiguration =
+        ImageConfiguration.builder(ImageReference.parse("base/image")).build();
+    JibContainerBuilder containerBuilder =
+        new JibContainerBuilder(imageConfiguration, spyBuildContextBuilder)
+            .setPlatforms(
+                ImmutableSet.of(new Platform("arch1", "os1"), new Platform("arch2", "os2")));
+    Containerizer containerizer = Containerizer.to(RegistryImage.named("target/image"));
     try {
-      ImageConfiguration imageConfiguration =
-          ImageConfiguration.builder(ImageReference.parse("base/image")).build();
-      new JibContainerBuilder(imageConfiguration, spyBuildContextBuilder)
-          .setPlatforms(
-              ImmutableSet.of(
-                  new Platform("testArchitecture", "testOS"),
-                  new Platform("testArchitecture1", "testOS2")))
-          .containerize(Containerizer.to(RegistryImage.named("target/image")));
+      containerBuilder.containerize(containerizer);
       Assert.fail();
     } catch (UnsupportedOperationException ex) {
       Assert.assertEquals("multi-platform image building is not yet supported", ex.getMessage());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
@@ -365,7 +365,7 @@ public class JibContainerBuilderTest {
   }
 
   @Test
-  public void testContainerize_multiPlatforms()
+  public void testContainerize_multiPlatformsList()
       throws InvalidImageReferenceException, CacheDirectoryCreationException, InterruptedException,
           RegistryException, IOException, ExecutionException {
     try {


### PR DESCRIPTION
This PR restricts Jib to support a single platform specification only .
Jib will throw an error if a user specifies more than one platform .