### PR TITLE
Fix build error with "packaged" containerizingMode when Spring Boot defines <finalName>

### DIFF
--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Fixed `NullPointerException` when the `"auths":` section in `~/.docker/config.json` has an entry with no `"auth":` field. ([#2535](https://github.com/GoogleContainerTools/jib/issues/2535))
 - Fixed `NullPointerException` to return a helpful message when a server does not provide any message in certain error cases (400 Bad Request, 404 Not Found, and 405 Method Not Allowed). ([#2532](https://github.com/GoogleContainerTools/jib/issues/2532))
 - Now supports sending client certificate (for example, via the `javax.net.ssl.keyStore` and `javax.net.ssl.keyStorePassword` system properties) and thus enabling mutual TLS authentication. ([#2585](https://github.com/GoogleContainerTools/jib/issues/2585), [#2226](https://github.com/GoogleContainerTools/jib/issues/2226))
+- Fixed build failure with `<containerizingMode>packaged` in Spring Boot projects where Jib assumed a wrong JAR path when `<finalName>` or `<classifier>` is configured in Spring Boot. ([#2565](https://github.com/GoogleContainerTools/jib/issues/2565))
 
 ## 2.4.0
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -513,6 +513,7 @@ public class MavenProjectProperties implements ProjectProperties {
           if (directoryString.isPresent()) {
             outputDirectory = project.getBasedir().toPath().resolve(directoryString.get());
           }
+          break;
         }
       }
     }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -955,6 +955,58 @@ public class MavenProjectPropertiesTest {
   }
 
   @Test
+  public void testGetJarArtifact_originalJarIfSpringBoot_differentFinalNames() throws IOException {
+    Path buildDirectory = temporaryFolder.newFolder("target").toPath();
+    Files.createFile(buildDirectory.resolve("helloworld-1.jar"));
+    Mockito.when(mockMavenProject.getBasedir()).thenReturn(temporaryFolder.getRoot());
+    Mockito.when(mockBuild.getDirectory()).thenReturn(buildDirectory.toString());
+    Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
+
+    Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
+    Mockito.when(mockPluginExecution.getId()).thenReturn("default-jar");
+    Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
+    addXpp3DomChild(pluginConfiguration, "outputDirectory", "target");
+
+    Xpp3Dom bootPluginConfiguration = setUpSpringBootFatJar();
+    addXpp3DomChild(bootPluginConfiguration, "finalName", "boot-helloworld-1");
+
+    Assert.assertEquals(
+        buildDirectory.resolve("helloworld-1.jar"), mavenProjectProperties.getJarArtifact());
+
+    mavenProjectProperties.waitForLoggingThread();
+    Mockito.verify(mockLog)
+        .info("Spring Boot repackaging (fat JAR) detected; using the original JAR");
+  }
+
+  @Test
+  public void testGetJarArtifact_originalJarIfSpringBoot_differentClassifier() throws IOException {
+    Path buildDirectory = temporaryFolder.newFolder("target").toPath();
+    Files.createFile(buildDirectory.resolve("helloworld-1.jar"));
+    Mockito.when(mockMavenProject.getBasedir()).thenReturn(temporaryFolder.getRoot());
+    Mockito.when(mockBuild.getDirectory()).thenReturn(buildDirectory.toString());
+    Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
+
+    Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
+        .thenReturn(mockPlugin);
+    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
+    Mockito.when(mockPluginExecution.getId()).thenReturn("default-jar");
+    Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
+    addXpp3DomChild(pluginConfiguration, "outputDirectory", "target");
+
+    Xpp3Dom bootPluginConfiguration = setUpSpringBootFatJar();
+    addXpp3DomChild(bootPluginConfiguration, "classifier", "boot-class");
+
+    Assert.assertEquals(
+        buildDirectory.resolve("helloworld-1.jar"), mavenProjectProperties.getJarArtifact());
+
+    mavenProjectProperties.waitForLoggingThread();
+    Mockito.verify(mockLog)
+        .info("Spring Boot repackaging (fat JAR) detected; using the original JAR");
+  }
+
+  @Test
   public void testGetJarArtifact_originalJarCopiedIfSpringBoot_sameDirectory() throws IOException {
     Path buildDirectory = temporaryFolder.newFolder("target").toPath();
     Files.createFile(buildDirectory.resolve("helloworld-1.jar.original"));
@@ -976,32 +1028,6 @@ public class MavenProjectPropertiesTest {
     Assert.assertEquals(
         tempDirectory.resolve("helloworld-1.original.jar"),
         mavenProjectProperties.getJarArtifact());
-
-    mavenProjectProperties.waitForLoggingThread();
-    Mockito.verify(mockLog)
-        .info("Spring Boot repackaging (fat JAR) detected; using the original JAR");
-  }
-
-  @Test
-  public void testGetJarArtifact_originalJarIfSpringBoot_differentFinalNames() throws IOException {
-    Path buildDirectory = temporaryFolder.newFolder("target").toPath();
-    Files.createFile(buildDirectory.resolve("helloworld-1.jar"));
-    Mockito.when(mockMavenProject.getBasedir()).thenReturn(temporaryFolder.getRoot());
-    Mockito.when(mockBuild.getDirectory()).thenReturn(buildDirectory.toString());
-    Mockito.when(mockBuild.getFinalName()).thenReturn("helloworld-1");
-
-    Mockito.when(mockMavenProject.getPlugin("org.apache.maven.plugins:maven-jar-plugin"))
-        .thenReturn(mockPlugin);
-    Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
-    Mockito.when(mockPluginExecution.getId()).thenReturn("default-jar");
-    Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
-    addXpp3DomChild(pluginConfiguration, "outputDirectory", "target");
-
-    Xpp3Dom bootPluginConfiguration = setUpSpringBootFatJar();
-    addXpp3DomChild(bootPluginConfiguration, "finalName", "boot-helloworld-1");
-
-    Assert.assertEquals(
-        buildDirectory.resolve("helloworld-1.jar"), mavenProjectProperties.getJarArtifact());
 
     mavenProjectProperties.waitForLoggingThread();
     Mockito.verify(mockLog)

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -775,56 +775,65 @@ public class MavenProjectPropertiesTest {
   }
 
   @Test
-  public void testJarRepackagedBySpringBoot_pluginNotApplied() {
-    Assert.assertFalse(mavenProjectProperties.jarRepackagedBySpringBoot());
+  public void testGetSpringBootRepackageConfiguration_pluginNotApplied() {
+    Assert.assertEquals(
+        Optional.empty(), mavenProjectProperties.getSpringBootRepackageConfiguration());
   }
 
   @Test
-  public void testJarRepackagedBySpringBoot_noExecutions() {
+  public void testGetSpringBootRepackageConfiguration_noExecutions() {
     Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
         .thenReturn(mockPlugin);
     Mockito.when(mockPlugin.getExecutions()).thenReturn(Collections.emptyList());
-    Assert.assertFalse(mavenProjectProperties.jarRepackagedBySpringBoot());
+    Assert.assertEquals(
+        Optional.empty(), mavenProjectProperties.getSpringBootRepackageConfiguration());
   }
 
   @Test
-  public void testJarRepackagedBySpringBoot_noRepackageGoal() {
+  public void testGetSpringBootRepackageConfiguration_noRepackageGoal() {
     Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
         .thenReturn(mockPlugin);
     Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
     Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("goal", "foo", "bar"));
-    Assert.assertFalse(mavenProjectProperties.jarRepackagedBySpringBoot());
+    Assert.assertEquals(
+        Optional.empty(), mavenProjectProperties.getSpringBootRepackageConfiguration());
   }
 
   @Test
-  public void testJarRepackagedBySpringBoot_repackageGoal() {
+  public void testGetSpringBootRepackageConfiguration_repackageGoal() {
     Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
         .thenReturn(mockPlugin);
     Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
     Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("goal", "repackage"));
-    Assert.assertTrue(mavenProjectProperties.jarRepackagedBySpringBoot());
+    Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
+    Assert.assertEquals(
+        Optional.of(pluginConfiguration),
+        mavenProjectProperties.getSpringBootRepackageConfiguration());
   }
 
   @Test
-  public void testJarRepackagedBySpringBoot_skipped() {
+  public void testGetSpringBootRepackageConfiguration_skipped() {
     Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
         .thenReturn(mockPlugin);
     Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
     Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("repackage"));
     Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
     addXpp3DomChild(pluginConfiguration, "skip", "true");
-    Assert.assertFalse(mavenProjectProperties.jarRepackagedBySpringBoot());
+    Assert.assertEquals(
+        Optional.empty(), mavenProjectProperties.getSpringBootRepackageConfiguration());
   }
 
   @Test
-  public void testJarRepackagedBySpringBoot_skipNotTrue() {
+  public void testGetSpringBootRepackageConfiguration_skipNotTrue() {
     Mockito.when(mockMavenProject.getPlugin("org.springframework.boot:spring-boot-maven-plugin"))
         .thenReturn(mockPlugin);
     Mockito.when(mockPlugin.getExecutions()).thenReturn(Arrays.asList(mockPluginExecution));
     Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("repackage"));
     Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(pluginConfiguration);
     addXpp3DomChild(pluginConfiguration, "skip", null);
-    Assert.assertTrue(mavenProjectProperties.jarRepackagedBySpringBoot());
+    Assert.assertEquals(
+        Optional.of(pluginConfiguration),
+        mavenProjectProperties.getSpringBootRepackageConfiguration());
   }
 
   @Test
@@ -1061,5 +1070,6 @@ public class MavenProjectPropertiesTest {
         .thenReturn(plugin);
     Mockito.when(plugin.getExecutions()).thenReturn(Arrays.asList(execution));
     Mockito.when(execution.getGoals()).thenReturn(Arrays.asList("repackage"));
+    Mockito.when(execution.getConfiguration()).thenReturn(pluginConfiguration);
   }
 }


### PR DESCRIPTION
Fixes #2565.

Spring Boot renames the original thin JAR only when it is replacing JAR with its repackaged fat JAR. If Spring Boot defines `<finalName>`, it doesn't rename the JAR as the fat JAR name doesn't clash with the original JAR. In this case, we were incorrectly assuming that Spring Boot renamed the original JAR with the `.jar.original` suffix.

I also discovered that we were not comparing `<classifier>`.