### PR TITLE
obtainBaseImageLayers for multiple images

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -304,7 +304,7 @@ public class StepsRunner {
     results.baseImagesAndLayers =
         executorService.submit(
             () -> {
-              Map<Image, List<Future<PreparedLayer>>> baseImageAndLayers = new HashMap<>();
+              Map<Image, List<Future<PreparedLayer>>> baseImagesAndLayers = new HashMap<>();
               for (Image image : results.baseImagesAndRegistryClient.get().images) {
                 List<Future<PreparedLayer>> layers =
                     scheduleCallables(
@@ -320,9 +320,9 @@ public class StepsRunner {
                                 image,
                                 results.baseImagesAndRegistryClient.get().registryClient,
                                 results.targetRegistryClient.get()));
-                baseImageAndLayers.put(image, layers);
+                baseImagesAndLayers.put(image, layers);
               }
-              return baseImageAndLayers;
+              return baseImagesAndLayers;
             });
   }
 


### PR DESCRIPTION
This is a draft PR for design review
Stylistics changes are still in progress
This PR adds the ability for Jib to pull and store baseImagelayers for multiple images
