### PR TITLE
Add more validations after yaml is serialized

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/ArchiveLayerSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/ArchiveLayerSpec.java
@@ -57,8 +57,9 @@ public class ArchiveLayerSpec implements LayerSpec {
       @JsonProperty(value = "name", required = true) String name,
       @JsonProperty(value = "archive", required = true) String archive,
       @JsonProperty("mediaType") String mediaType) {
-    Validator.checkNotEmpty(name, "name");
-    Validator.checkNotEmpty(archive, "archive");
+    Validator.checkNotNullAndNotEmpty(name, "name");
+    Validator.checkNotNullAndNotEmpty(archive, "archive");
+    Validator.checkNullOrNotEmpty(mediaType, "mediaType");
     this.name = name;
     this.archive = Paths.get(archive);
     this.mediaType = mediaType;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpec.java
@@ -48,7 +48,7 @@ public class BaseImageSpec {
       @JsonProperty(value = "image", required = true) String image,
       @JsonProperty("platforms") List<PlatformSpec> platforms) {
     Validator.checkNotNullAndNotEmpty(image, "image");
-    Validator.checkNonNullEntriesIfExists(platforms, "platforms");
+    Validator.checkNullOrNonNullEntries(platforms, "platforms");
     this.image = image;
     this.platforms = platforms == null ? ImmutableList.of() : platforms;
   }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpec.java
@@ -47,7 +47,8 @@ public class BaseImageSpec {
   public BaseImageSpec(
       @JsonProperty(value = "image", required = true) String image,
       @JsonProperty("platforms") List<PlatformSpec> platforms) {
-    Validator.checkNotEmpty(image, "image");
+    Validator.checkNotNullAndNotEmpty(image, "image");
+    Validator.checkNonNullEntriesIfExists(platforms, "platforms");
     this.image = image;
     this.platforms = platforms == null ? ImmutableList.of() : platforms;
   }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
@@ -127,14 +127,14 @@ public class BuildFileSpec {
 
     Validator.checkNullOrNotEmpty(creationTime, "creationTime");
     Validator.checkNullOrNotEmpty(format, "format");
-    Validator.checkNonNullNonEmptyEntriesIfExists(environment, "environment");
-    Validator.checkNonNullNonEmptyEntriesIfExists(labels, "labels");
-    Validator.checkNonNullNonEmptyEntriesIfExists(volumes, "volumes");
-    Validator.checkNonNullNonEmptyEntriesIfExists(exposedPorts, "exposedPorts");
+    Validator.checkNullOrNonNullNonEmptyEntries(environment, "environment");
+    Validator.checkNullOrNonNullNonEmptyEntries(labels, "labels");
+    Validator.checkNullOrNonNullNonEmptyEntries(volumes, "volumes");
+    Validator.checkNullOrNonNullNonEmptyEntries(exposedPorts, "exposedPorts");
     Validator.checkNullOrNotEmpty(user, "user");
     Validator.checkNullOrNotEmpty(workingDirectory, "workingDirectory");
-    Validator.checkNonNullNonEmptyEntriesIfExists(entrypoint, "entrypoint");
-    Validator.checkNonNullNonEmptyEntriesIfExists(cmd, "cmd");
+    Validator.checkNullOrNonNullNonEmptyEntries(entrypoint, "entrypoint");
+    Validator.checkNullOrNonNullNonEmptyEntries(cmd, "cmd");
 
     this.apiVersion = apiVersion;
     Preconditions.checkArgument(

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
@@ -121,8 +121,21 @@ public class BuildFileSpec {
       @JsonProperty("entrypoint") List<String> entrypoint,
       @JsonProperty("cmd") List<String> cmd,
       @JsonProperty("layers") LayersSpec layers) {
-    Validator.checkNotEmpty(apiVersion, "apiVersion");
+
+    Validator.checkNotNullAndNotEmpty(apiVersion, "apiVersion");
     Validator.checkEquals(kind, "kind", "BuildFile");
+
+    Validator.checkNullOrNotEmpty(creationTime, "creationTime");
+    Validator.checkNullOrNotEmpty(format, "format");
+    Validator.checkNonNullNonEmptyEntriesIfExists(environment, "environment");
+    Validator.checkNonNullNonEmptyEntriesIfExists(labels, "labels");
+    Validator.checkNonNullNonEmptyEntriesIfExists(volumes, "volumes");
+    Validator.checkNonNullNonEmptyEntriesIfExists(exposedPorts, "exposedPorts");
+    Validator.checkNullOrNotEmpty(user, "user");
+    Validator.checkNullOrNotEmpty(workingDirectory, "workingDirectory");
+    Validator.checkNonNullNonEmptyEntriesIfExists(entrypoint, "entrypoint");
+    Validator.checkNonNullNonEmptyEntriesIfExists(cmd, "cmd");
+
     this.apiVersion = apiVersion;
     Preconditions.checkArgument(
         "BuildFile".equals(kind), "Field 'kind' must be BuildFile but is " + kind);

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/CopySpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/CopySpec.java
@@ -66,8 +66,10 @@ public class CopySpec {
       @JsonProperty("includes") List<String> includes,
       @JsonProperty("excludes") List<String> excludes,
       @JsonProperty("properties") FilePropertiesSpec properties) {
-    Validator.checkNotEmpty(src, "src");
-    Validator.checkNotEmpty(dest, "dest");
+    Validator.checkNotNullAndNotEmpty(src, "src");
+    Validator.checkNotNullAndNotEmpty(dest, "dest");
+    Validator.checkNonNullNonEmptyEntriesIfExists(includes, "includes");
+    Validator.checkNonNullNonEmptyEntriesIfExists(excludes, "excludes");
     this.src = Paths.get(src);
     this.dest = AbsoluteUnixPath.get(dest);
     this.excludes = (excludes == null) ? ImmutableList.of() : excludes;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/CopySpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/CopySpec.java
@@ -68,8 +68,8 @@ public class CopySpec {
       @JsonProperty("properties") FilePropertiesSpec properties) {
     Validator.checkNotNullAndNotEmpty(src, "src");
     Validator.checkNotNullAndNotEmpty(dest, "dest");
-    Validator.checkNonNullNonEmptyEntriesIfExists(includes, "includes");
-    Validator.checkNonNullNonEmptyEntriesIfExists(excludes, "excludes");
+    Validator.checkNullOrNonNullNonEmptyEntries(includes, "includes");
+    Validator.checkNullOrNonNullNonEmptyEntries(excludes, "excludes");
     this.src = Paths.get(src);
     this.dest = AbsoluteUnixPath.get(dest);
     this.excludes = (excludes == null) ? ImmutableList.of() : excludes;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FileLayerSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FileLayerSpec.java
@@ -56,8 +56,8 @@ public class FileLayerSpec implements LayerSpec {
       @JsonProperty(value = "name", required = true) String name,
       @JsonProperty(value = "files", required = true) List<CopySpec> files,
       @JsonProperty("properties") FilePropertiesSpec properties) {
-    Validator.checkNotEmpty(name, "name");
-    Validator.checkNotEmpty(files, "files");
+    Validator.checkNotNullAndNotEmpty(name, "name");
+    Validator.checkNotNullAndNotEmpty(files, "files");
     this.name = name;
     this.properties = properties;
     this.files = files;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesSpec.java
@@ -59,6 +59,11 @@ public class FilePropertiesSpec {
       @JsonProperty("user") String user,
       @JsonProperty("group") String group,
       @JsonProperty("timestamp") String timestamp) {
+    Validator.checkNullOrNotEmpty(filePermissions, "filePermissions");
+    Validator.checkNullOrNotEmpty(directoryPermissions, "directoryPermissions");
+    Validator.checkNullOrNotEmpty(user, "user");
+    Validator.checkNullOrNotEmpty(group, "group");
+    Validator.checkNullOrNotEmpty(timestamp, "timestamp");
     this.filePermissions =
         filePermissions == null ? null : FilePermissions.fromOctalString(filePermissions);
     this.directoryPermissions =

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/LayersSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/LayersSpec.java
@@ -48,7 +48,7 @@ public class LayersSpec {
   public LayersSpec(
       @JsonProperty(value = "entries", required = true) List<LayerSpec> entries,
       @JsonProperty("properties") FilePropertiesSpec properties) {
-    Validator.checkNotEmpty(entries, "entries");
+    Validator.checkNotNullAndNotEmpty(entries, "entries");
     this.entries = entries;
     this.properties = properties;
   }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
@@ -69,9 +69,9 @@ public class PlatformSpec {
     Validator.checkNotNullAndNotEmpty(architecture, "architecture");
     Validator.checkNotNullAndNotEmpty(os, "os");
     Validator.checkNullOrNotEmpty(osVersion, "os.version");
-    Validator.checkNonNullNonEmptyEntriesIfExists(osFeatures, "os.features");
+    Validator.checkNullOrNonNullNonEmptyEntries(osFeatures, "os.features");
     Validator.checkNullOrNotEmpty(variant, "variant");
-    Validator.checkNonNullNonEmptyEntriesIfExists(features, "features");
+    Validator.checkNullOrNonNullNonEmptyEntries(features, "features");
     this.architecture = architecture;
     this.os = os;
     this.osVersion = osVersion;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
@@ -66,8 +66,12 @@ public class PlatformSpec {
       @JsonProperty("os.features") List<String> osFeatures,
       @JsonProperty("variant") String variant,
       @JsonProperty("features") List<String> features) {
-    Validator.checkNotEmpty(architecture, "architecture");
-    Validator.checkNotEmpty(os, "os");
+    Validator.checkNotNullAndNotEmpty(architecture, "architecture");
+    Validator.checkNotNullAndNotEmpty(os, "os");
+    Validator.checkNullOrNotEmpty(osVersion, "os.version");
+    Validator.checkNonNullNonEmptyEntriesIfExists(osFeatures, "os.features");
+    Validator.checkNullOrNotEmpty(variant, "variant");
+    Validator.checkNonNullNonEmptyEntriesIfExists(features, "features");
     this.architecture = architecture;
     this.os = os;
     this.osVersion = osVersion;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Validator.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Validator.java
@@ -81,7 +81,7 @@ public class Validator {
    */
   public static void checkNullOrNonNullNonEmptyEntries(
       @Nullable Collection<String> values, String propertyName) {
-    if (values == null || values.isEmpty()) {
+    if (values == null) {
       // pass
       return;
     }
@@ -103,7 +103,7 @@ public class Validator {
    */
   public static void checkNullOrNonNullNonEmptyEntries(
       @Nullable Map<String, String> values, String propertyName) {
-    if (values == null || values.isEmpty()) {
+    if (values == null) {
       // pass
       return;
     }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Validator.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Validator.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.cli.buildfile;
 
 import com.google.common.base.Preconditions;
 import java.util.Collection;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -27,35 +28,116 @@ import javax.annotation.Nullable;
 public class Validator {
 
   /**
-   * Checks if string is null, empty or only whitespace.
+   * Checks if string is non null and non empty.
    *
    * @param value the string in question
    * @param propertyName the equivalent 'yaml' property name
    * @throws NullPointerException if {@code value} is null
    * @throws IllegalArgumentException if {@code value} is empty or only whitespace
    */
-  public static void checkNotEmpty(@Nullable String value, String propertyName) {
+  public static void checkNotNullAndNotEmpty(@Nullable String value, String propertyName) {
     Preconditions.checkNotNull(value, "Property '" + propertyName + "' cannot be null");
     Preconditions.checkArgument(
         !value.trim().isEmpty(), "Property '" + propertyName + "' cannot be empty");
   }
 
   /**
-   * Checks if a collection is null or empty.
+   * Checks if string is null or non empty.
+   *
+   * @param value the string in question
+   * @param propertyName the equivalent 'yaml' property name
+   * @throws IllegalArgumentException if {@code value} is empty or only whitespace
+   */
+  public static void checkNullOrNotEmpty(@Nullable String value, String propertyName) {
+    if (value == null) {
+      // pass
+      return;
+    }
+    Preconditions.checkArgument(
+        !value.trim().isEmpty(), "Property '" + propertyName + "' cannot be empty");
+  }
+
+  /**
+   * Checks if a collection is not null and not empty.
    *
    * @param value the string in question
    * @param propertyName the equivalent 'yaml' property name
    * @throws NullPointerException if {@code value} is null
    * @throws IllegalArgumentException if {@code value} is empty
    */
-  public static void checkNotEmpty(@Nullable Collection<?> value, String propertyName) {
+  public static void checkNotNullAndNotEmpty(@Nullable Collection<?> value, String propertyName) {
     Preconditions.checkNotNull(value, "Property '" + propertyName + "' cannot be null");
     Preconditions.checkArgument(
         !value.isEmpty(), "Property '" + propertyName + "' cannot be an empty collection");
   }
 
   /**
-   * Checks if string is what is expected.
+   * Check if a collection is either null, empty or contains only non-null, non-empty values.
+   *
+   * @param values the collection in question
+   * @param propertyName the equivalent 'yaml' property name
+   * @throws IllegalArgumentException if {@code value} is empty or only whitespace
+   */
+  public static void checkNonNullNonEmptyEntriesIfExists(
+      @Nullable Collection<String> values, String propertyName) {
+    if (values == null || values.isEmpty()) {
+      // pass
+      return;
+    }
+    for (String value : values) {
+      Preconditions.checkNotNull(
+          value, "Property '" + propertyName + "' cannot contain null entries");
+      Preconditions.checkArgument(
+          !value.trim().isEmpty(), "Property '" + propertyName + "' cannot contain empty entries");
+    }
+  }
+
+  /**
+   * Check if a map is either null, empty or contains only non-null, non-empty keys and values.
+   *
+   * @param values the collection in question
+   * @param propertyName the equivalent 'yaml' property name
+   * @throws IllegalArgumentException if {@code value} is empty or only whitespace
+   */
+  public static void checkNonNullNonEmptyEntriesIfExists(
+      @Nullable Map<String, String> values, String propertyName) {
+    if (values == null || values.isEmpty()) {
+      // pass
+      return;
+    }
+    for (String key : values.keySet()) {
+      Preconditions.checkNotNull(key, "Property '" + propertyName + "' cannot contain null keys");
+      Preconditions.checkArgument(
+          !key.trim().isEmpty(), "Property '" + propertyName + "' cannot contain empty keys");
+      String value = values.get(key);
+      Preconditions.checkNotNull(
+          value, "Property '" + propertyName + "' cannot contain null values");
+      Preconditions.checkArgument(
+          !value.trim().isEmpty(), "Property '" + propertyName + "' cannot contain empty values");
+    }
+  }
+
+  /**
+   * Check if a collection is either null, empty or contains only non-null values.
+   *
+   * @param values the collection in question
+   * @param propertyName the equivalent 'yaml' property name
+   * @throws IllegalArgumentException if {@code value} is empty or only whitespace
+   */
+  public static void checkNonNullEntriesIfExists(
+      @Nullable Collection<?> values, String propertyName) {
+    if (values == null || values.isEmpty()) {
+      // pass
+      return;
+    }
+    for (Object value : values) {
+      Preconditions.checkNotNull(
+          value, "Property '" + propertyName + "' cannot contain null entries");
+    }
+  }
+
+  /**
+   * Checks if string is equal to the expected string.
    *
    * @param value the string in question
    * @param propertyName the equivalent 'yaml' property name

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Validator.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Validator.java
@@ -38,7 +38,7 @@ public class Validator {
   public static void checkNotNullAndNotEmpty(@Nullable String value, String propertyName) {
     Preconditions.checkNotNull(value, "Property '" + propertyName + "' cannot be null");
     Preconditions.checkArgument(
-        !value.trim().isEmpty(), "Property '" + propertyName + "' cannot be empty");
+        !value.trim().isEmpty(), "Property '" + propertyName + "' cannot be an empty string");
   }
 
   /**
@@ -54,7 +54,7 @@ public class Validator {
       return;
     }
     Preconditions.checkArgument(
-        !value.trim().isEmpty(), "Property '" + propertyName + "' cannot be empty");
+        !value.trim().isEmpty(), "Property '" + propertyName + "' cannot be an empty string");
   }
 
   /**
@@ -76,9 +76,10 @@ public class Validator {
    *
    * @param values the collection in question
    * @param propertyName the equivalent 'yaml' property name
-   * @throws IllegalArgumentException if {@code value} is empty or only whitespace
+   * @throws IllegalArgumentException if {@code values} contains empty entries
+   * @throws NullPointerException if {@code values} contains null entries
    */
-  public static void checkNonNullNonEmptyEntriesIfExists(
+  public static void checkNullOrNonNullNonEmptyEntries(
       @Nullable Collection<String> values, String propertyName) {
     if (values == null || values.isEmpty()) {
       // pass
@@ -88,7 +89,7 @@ public class Validator {
       Preconditions.checkNotNull(
           value, "Property '" + propertyName + "' cannot contain null entries");
       Preconditions.checkArgument(
-          !value.trim().isEmpty(), "Property '" + propertyName + "' cannot contain empty entries");
+          !value.trim().isEmpty(), "Property '" + propertyName + "' cannot contain empty strings");
     }
   }
 
@@ -97,23 +98,26 @@ public class Validator {
    *
    * @param values the collection in question
    * @param propertyName the equivalent 'yaml' property name
-   * @throws IllegalArgumentException if {@code value} is empty or only whitespace
+   * @throws IllegalArgumentException if {@code values} contains empty keys or values
+   * @throws NullPointerException if {@code values} contains null keys or values
    */
-  public static void checkNonNullNonEmptyEntriesIfExists(
+  public static void checkNullOrNonNullNonEmptyEntries(
       @Nullable Map<String, String> values, String propertyName) {
     if (values == null || values.isEmpty()) {
       // pass
       return;
     }
-    for (String key : values.keySet()) {
-      Preconditions.checkNotNull(key, "Property '" + propertyName + "' cannot contain null keys");
-      Preconditions.checkArgument(
-          !key.trim().isEmpty(), "Property '" + propertyName + "' cannot contain empty keys");
-      String value = values.get(key);
+    for (Map.Entry<String, String> entry : values.entrySet()) {
       Preconditions.checkNotNull(
-          value, "Property '" + propertyName + "' cannot contain null values");
+          entry.getKey(), "Property '" + propertyName + "' cannot contain null keys");
       Preconditions.checkArgument(
-          !value.trim().isEmpty(), "Property '" + propertyName + "' cannot contain empty values");
+          !entry.getKey().trim().isEmpty(),
+          "Property '" + propertyName + "' cannot contain empty string keys");
+      Preconditions.checkNotNull(
+          entry.getValue(), "Property '" + propertyName + "' cannot contain null values");
+      Preconditions.checkArgument(
+          !entry.getValue().trim().isEmpty(),
+          "Property '" + propertyName + "' cannot contain empty string values");
     }
   }
 
@@ -122,11 +126,11 @@ public class Validator {
    *
    * @param values the collection in question
    * @param propertyName the equivalent 'yaml' property name
-   * @throws IllegalArgumentException if {@code value} is empty or only whitespace
+   * @throws NullPointerException if {@code values} contains null entries
    */
-  public static void checkNonNullEntriesIfExists(
+  public static void checkNullOrNonNullEntries(
       @Nullable Collection<?> values, String propertyName) {
-    if (values == null || values.isEmpty()) {
+    if (values == null) {
       // pass
       return;
     }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ArchiveLayerSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ArchiveLayerSpecTest.java
@@ -120,4 +120,17 @@ public class ArchiveLayerSpecTest {
           jpe.getMessage(), CoreMatchers.containsString("Property 'archive' cannot be empty"));
     }
   }
+
+  @Test
+  public void testArchiveLayerSpec_mediaTypeNonEmpty() {
+    String data = "name: layer name\n" + "archive: out/archive.tgz\n" + "mediaType: ' '";
+
+    try {
+      mapper.readValue(data, ArchiveLayerSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(), CoreMatchers.containsString("Property 'mediaType' cannot be empty"));
+    }
+  }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ArchiveLayerSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ArchiveLayerSpecTest.java
@@ -76,7 +76,8 @@ public class ArchiveLayerSpecTest {
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
-          jpe.getMessage(), CoreMatchers.containsString("Property 'name' cannot be empty"));
+          jpe.getMessage(),
+          CoreMatchers.containsString("Property 'name' cannot be an empty string"));
     }
   }
 
@@ -117,7 +118,8 @@ public class ArchiveLayerSpecTest {
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
-          jpe.getMessage(), CoreMatchers.containsString("Property 'archive' cannot be empty"));
+          jpe.getMessage(),
+          CoreMatchers.containsString("Property 'archive' cannot be an empty string"));
     }
   }
 
@@ -130,7 +132,8 @@ public class ArchiveLayerSpecTest {
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
-          jpe.getMessage(), CoreMatchers.containsString("Property 'mediaType' cannot be empty"));
+          jpe.getMessage(),
+          CoreMatchers.containsString("Property 'mediaType' cannot be an empty string"));
     }
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpecTest.java
@@ -98,4 +98,18 @@ public class BaseImageSpecTest {
     BaseImageSpec baseImageSpec = mapper.readValue(data, BaseImageSpec.class);
     Assert.assertEquals(ImmutableList.of(), baseImageSpec.getPlatforms());
   }
+
+  @Test
+  public void testBaseImageSpec_platformsNoNullEntries() {
+    String data = "image: gcr.io/example/jib\n" + "platforms: [null]\n";
+
+    try {
+      mapper.readValue(data, BaseImageSpec.class);
+      Assert.fail();
+    } catch (JsonProcessingException jpe) {
+      MatcherAssert.assertThat(
+          jpe.getMessage(),
+          CoreMatchers.containsString("Property 'platforms' cannot contain null entries"));
+    }
+  }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BaseImageSpecTest.java
@@ -87,7 +87,8 @@ public class BaseImageSpecTest {
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
-          jpe.getMessage(), CoreMatchers.containsString("Property 'image' cannot be empty"));
+          jpe.getMessage(),
+          CoreMatchers.containsString("Property 'image' cannot be an empty string"));
     }
   }
 

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpecTest.java
@@ -127,7 +127,8 @@ public class BuildFileSpecTest {
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
-          jpe.getMessage(), CoreMatchers.containsString("Property 'apiVersion' cannot be empty"));
+          jpe.getMessage(),
+          CoreMatchers.containsString("Property 'apiVersion' cannot be an empty string"));
     }
   }
 
@@ -218,7 +219,7 @@ public class BuildFileSpecTest {
         Assert.fail();
       } catch (JsonProcessingException ex) {
         Assert.assertEquals(
-            "Property '" + fieldName + "' cannot contain empty entries",
+            "Property '" + fieldName + "' cannot contain empty strings",
             ex.getCause().getMessage());
       }
     }
@@ -260,7 +261,7 @@ public class BuildFileSpecTest {
         Assert.fail();
       } catch (JsonProcessingException ex) {
         Assert.assertEquals(
-            "Property '" + fieldName + "' cannot be empty", ex.getCause().getMessage());
+            "Property '" + fieldName + "' cannot be an empty string", ex.getCause().getMessage());
       }
     }
 
@@ -320,7 +321,8 @@ public class BuildFileSpecTest {
         Assert.fail();
       } catch (JsonProcessingException ex) {
         Assert.assertEquals(
-            "Property '" + fieldName + "' cannot contain empty values", ex.getCause().getMessage());
+            "Property '" + fieldName + "' cannot contain empty string values",
+            ex.getCause().getMessage());
       }
     }
 
@@ -334,7 +336,8 @@ public class BuildFileSpecTest {
         Assert.fail();
       } catch (JsonProcessingException ex) {
         Assert.assertEquals(
-            "Property '" + fieldName + "' cannot contain empty keys", ex.getCause().getMessage());
+            "Property '" + fieldName + "' cannot contain empty string keys",
+            ex.getCause().getMessage());
       }
     }
 

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpecTest.java
@@ -27,10 +27,14 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 /** Tests for {@link BuildFileSpec}. */
 public class BuildFileSpecTest {
@@ -179,5 +183,175 @@ public class BuildFileSpecTest {
     // entrypoint and cmd CAN be not present
     Assert.assertFalse(parsed.getEntrypoint().isPresent());
     Assert.assertFalse(parsed.getCmd().isPresent());
+  }
+
+  @RunWith(Parameterized.class)
+  public static class OptionalStringCollectionTests {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+      return Arrays.asList(new Object[][] {{"volumes"}, {"exposedPorts"}, {"entrypoint"}, {"cmd"}});
+    }
+
+    @Parameterized.Parameter public String fieldName;
+
+    @Test
+    public void testBuildFileSpec_noNullEntries() {
+      String data =
+          "apiVersion: v1alpha1\n" + "kind: BuildFile\n" + fieldName + ": ['first', null]";
+
+      try {
+        mapper.readValue(data, BuildFileSpec.class);
+        Assert.fail();
+      } catch (JsonProcessingException ex) {
+        Assert.assertEquals(
+            "Property '" + fieldName + "' cannot contain null entries", ex.getCause().getMessage());
+      }
+    }
+
+    @Test
+    public void testBuildFileSpec_noEmptyEntries() {
+      String data = "apiVersion: v1alpha1\n" + "kind: BuildFile\n" + fieldName + ": ['first', ' ']";
+
+      try {
+        mapper.readValue(data, BuildFileSpec.class);
+        Assert.fail();
+      } catch (JsonProcessingException ex) {
+        Assert.assertEquals(
+            "Property '" + fieldName + "' cannot contain empty entries",
+            ex.getCause().getMessage());
+      }
+    }
+
+    @Test
+    public void testBuildFileSpec_emptyOkay() throws JsonProcessingException {
+      String data = "apiVersion: v1alpha1\n" + "kind: BuildFile\n" + fieldName + ": []";
+
+      mapper.readValue(data, BuildFileSpec.class);
+      // pass
+    }
+
+    @Test
+    public void testBuildFileSpec_nullOkay() throws JsonProcessingException {
+      String data = "apiVersion: v1alpha1\n" + "kind: BuildFile\n" + fieldName + ": null";
+
+      mapper.readValue(data, BuildFileSpec.class);
+      // pass
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class OptionalStringTests {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+      return Arrays.asList(
+          new Object[][] {{"creationTime"}, {"format"}, {"user"}, {"workingDirectory"}});
+    }
+
+    @Parameterized.Parameter public String fieldName;
+
+    @Test
+    public void testBuildFileSpec_noEmptyValues() {
+      String data = "apiVersion: v1alpha1\n" + "kind: BuildFile\n" + fieldName + ": ' '";
+
+      try {
+        mapper.readValue(data, BuildFileSpec.class);
+        Assert.fail();
+      } catch (JsonProcessingException ex) {
+        Assert.assertEquals(
+            "Property '" + fieldName + "' cannot be empty", ex.getCause().getMessage());
+      }
+    }
+
+    @Test
+    public void testBuildFileSpec_nullOkay() throws JsonProcessingException {
+      String data = "apiVersion: v1alpha1\n" + "kind: BuildFile\n" + fieldName + ": null";
+
+      mapper.readValue(data, BuildFileSpec.class);
+      // pass
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class OptionalStringMapTests {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+      return Arrays.asList(new Object[][] {{"environment"}, {"labels"}});
+    }
+
+    @Parameterized.Parameter public String fieldName;
+
+    @Test
+    public void testBuildFileSpec_noNullValues() {
+      String data =
+          "apiVersion: v1alpha1\n" + "kind: BuildFile\n" + fieldName + ":\n" + "  key: null";
+
+      try {
+        mapper.readValue(data, BuildFileSpec.class);
+        Assert.fail();
+      } catch (JsonProcessingException ex) {
+        Assert.assertEquals(
+            "Property '" + fieldName + "' cannot contain null values", ex.getCause().getMessage());
+      }
+    }
+
+    /**
+     * A quirk of our parser is that "null" keys are parsed as strings and not null, this test just
+     * formalizes that behavior.
+     */
+    @Test
+    public void testBuildFileSpec_yamlNullKeysPass() throws JsonProcessingException {
+      String data =
+          "apiVersion: v1alpha1\n" + "kind: BuildFile\n" + fieldName + ":\n" + "  null: value";
+
+      mapper.readValue(data, BuildFileSpec.class);
+      // pass
+    }
+
+    @Test
+    public void testBuildFileSpec_noEmptyValues() {
+      String data =
+          "apiVersion: v1alpha1\n" + "kind: BuildFile\n" + fieldName + ":\n" + "  key: ' '";
+
+      try {
+        mapper.readValue(data, BuildFileSpec.class);
+        Assert.fail();
+      } catch (JsonProcessingException ex) {
+        Assert.assertEquals(
+            "Property '" + fieldName + "' cannot contain empty values", ex.getCause().getMessage());
+      }
+    }
+
+    @Test
+    public void testBuildFileSpec_noEmptyKeys() {
+      String data =
+          "apiVersion: v1alpha1\n" + "kind: BuildFile\n" + fieldName + ":\n" + "  ' ': value";
+
+      try {
+        mapper.readValue(data, BuildFileSpec.class);
+        Assert.fail();
+      } catch (JsonProcessingException ex) {
+        Assert.assertEquals(
+            "Property '" + fieldName + "' cannot contain empty keys", ex.getCause().getMessage());
+      }
+    }
+
+    @Test
+    public void testBuildFileSpec_emptyOkay() throws JsonProcessingException {
+      String data = "apiVersion: v1alpha1\n" + "kind: BuildFile\n" + fieldName + ": {}";
+
+      mapper.readValue(data, BuildFileSpec.class);
+      // pass
+    }
+
+    @Test
+    public void testBuildFileSpec_nullOkay() throws JsonProcessingException {
+      String data = "apiVersion: v1alpha1\n" + "kind: BuildFile\n" + fieldName + ": null";
+
+      mapper.readValue(data, BuildFileSpec.class);
+      // pass
+    }
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/CopySpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/CopySpecTest.java
@@ -23,10 +23,14 @@ import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 /** Tests for {@link CopySpec}. */
 public class CopySpecTest {
@@ -138,5 +142,61 @@ public class CopySpecTest {
     CopySpec parsed = mapper.readValue(data, CopySpec.class);
     Assert.assertEquals(ImmutableList.of(), parsed.getIncludes());
     Assert.assertEquals(ImmutableList.of(), parsed.getExcludes());
+  }
+
+  @RunWith(Parameterized.class)
+  public static class OptionalStringCollectionTests {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+      return Arrays.asList(new Object[][] {{"includes"}, {"excludes"}});
+    }
+
+    @Parameterized.Parameter public String fieldName;
+
+    @Test
+    public void testCopySpec_noNullEntries() {
+      String data =
+          "src: target/classes\n" + "dest: /app/classes\n" + fieldName + ": ['first', null]";
+
+      try {
+        mapper.readValue(data, CopySpec.class);
+        Assert.fail();
+      } catch (JsonProcessingException ex) {
+        Assert.assertEquals(
+            "Property '" + fieldName + "' cannot contain null entries", ex.getCause().getMessage());
+      }
+    }
+
+    @Test
+    public void testCopySpec_noEmptyEntries() {
+      String data =
+          "src: target/classes\n" + "dest: /app/classes\n" + fieldName + ": ['first', ' ']";
+
+      try {
+        mapper.readValue(data, CopySpec.class);
+        Assert.fail();
+      } catch (JsonProcessingException ex) {
+        Assert.assertEquals(
+            "Property '" + fieldName + "' cannot contain empty entries",
+            ex.getCause().getMessage());
+      }
+    }
+
+    @Test
+    public void testCopySpec_emptyOkay() throws JsonProcessingException {
+      String data = "src: target/classes\n" + "dest: /app/classes\n" + fieldName + ": []";
+
+      mapper.readValue(data, CopySpec.class);
+      // pass
+    }
+
+    @Test
+    public void testCopySpec_nullOkay() throws JsonProcessingException {
+      String data = "src: target/classes\n" + "dest: /app/classes\n" + fieldName + ": null";
+
+      mapper.readValue(data, CopySpec.class);
+      // pass
+    }
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/CopySpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/CopySpecTest.java
@@ -105,7 +105,8 @@ public class CopySpecTest {
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
-          jpe.getMessage(), CoreMatchers.containsString("Property 'src' cannot be empty"));
+          jpe.getMessage(),
+          CoreMatchers.containsString("Property 'src' cannot be an empty string"));
     }
   }
 
@@ -131,7 +132,8 @@ public class CopySpecTest {
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
-          jpe.getMessage(), CoreMatchers.containsString("Property 'dest' cannot be empty"));
+          jpe.getMessage(),
+          CoreMatchers.containsString("Property 'dest' cannot be an empty string"));
     }
   }
 
@@ -178,7 +180,7 @@ public class CopySpecTest {
         Assert.fail();
       } catch (JsonProcessingException ex) {
         Assert.assertEquals(
-            "Property '" + fieldName + "' cannot contain empty entries",
+            "Property '" + fieldName + "' cannot contain empty strings",
             ex.getCause().getMessage());
       }
     }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/FileLayerSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/FileLayerSpecTest.java
@@ -84,7 +84,8 @@ public class FileLayerSpecTest {
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
-          jpe.getMessage(), CoreMatchers.containsString("Property 'name' cannot be empty"));
+          jpe.getMessage(),
+          CoreMatchers.containsString("Property 'name' cannot be an empty string"));
     }
   }
 

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesSpecTest.java
@@ -138,7 +138,7 @@ public class FilePropertiesSpecTest {
         Assert.fail();
       } catch (JsonProcessingException ex) {
         Assert.assertEquals(
-            "Property '" + fieldName + "' cannot be empty", ex.getCause().getMessage());
+            "Property '" + fieldName + "' cannot be an empty string", ex.getCause().getMessage());
       }
     }
 

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpecTest.java
@@ -20,10 +20,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.Collection;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 /** Tests for {@link PlatformSpec}. */
 public class PlatformSpecTest {
@@ -138,5 +142,91 @@ public class PlatformSpecTest {
     PlatformSpec parsed = mapper.readValue(data, PlatformSpec.class);
     Assert.assertEquals(ImmutableList.of(), parsed.getOsFeatures());
     Assert.assertEquals(ImmutableList.of(), parsed.getFeatures());
+  }
+
+  @RunWith(Parameterized.class)
+  public static class OptionalStringTests {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+      return Arrays.asList(new Object[][] {{"os.version"}, {"variant"}});
+    }
+
+    @Parameterized.Parameter public String fieldName;
+
+    @Test
+    public void testPlatformSpec_noEmptyValues() {
+      String data = "architecture: ignored\n" + "os: ignored\n" + fieldName + ": ' '";
+
+      try {
+        mapper.readValue(data, PlatformSpec.class);
+        Assert.fail();
+      } catch (JsonProcessingException ex) {
+        Assert.assertEquals(
+            "Property '" + fieldName + "' cannot be empty", ex.getCause().getMessage());
+      }
+    }
+
+    @Test
+    public void testPlatformSpec_nullOkay() throws JsonProcessingException {
+      String data = "architecture: ignored\n" + "os: ignored\n" + fieldName + ": null";
+
+      mapper.readValue(data, PlatformSpec.class);
+      // pass
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class OptionalStringCollectionTests {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+      return Arrays.asList(new Object[][] {{"os.features"}, {"features"}});
+    }
+
+    @Parameterized.Parameter public String fieldName;
+
+    @Test
+    public void testPlatformSpec_noNullEntries() {
+      String data = "architecture: ignored\n" + "os: ignored\n" + fieldName + ": ['first', null]";
+
+      try {
+        mapper.readValue(data, PlatformSpec.class);
+        Assert.fail();
+      } catch (JsonProcessingException ex) {
+        Assert.assertEquals(
+            "Property '" + fieldName + "' cannot contain null entries", ex.getCause().getMessage());
+      }
+    }
+
+    @Test
+    public void testPlatformSpec_noEmptyEntries() {
+      String data = "architecture: ignored\n" + "os: ignored\n" + fieldName + ": ['first', '  ']";
+
+      try {
+        mapper.readValue(data, PlatformSpec.class);
+        Assert.fail();
+      } catch (JsonProcessingException ex) {
+        Assert.assertEquals(
+            "Property '" + fieldName + "' cannot contain empty entries",
+            ex.getCause().getMessage());
+      }
+    }
+
+    @Test
+    public void testPlatformSpec_emptyOkay() throws JsonProcessingException {
+      String data = "architecture: ignored\n" + "os: ignored\n" + fieldName + ": []";
+
+      mapper.readValue(data, PlatformSpec.class);
+      // pass
+    }
+
+    @Test
+    public void testPlatformSpec_nullOkay() throws JsonProcessingException {
+      String data = "architecture: ignored\n" + "os: ignored\n" + fieldName + ": null";
+
+      mapper.readValue(data, PlatformSpec.class);
+      // pass
+    }
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpecTest.java
@@ -91,7 +91,7 @@ public class PlatformSpecTest {
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
-          jpe.getMessage(), CoreMatchers.containsString("Property 'os' cannot be empty"));
+          jpe.getMessage(), CoreMatchers.containsString("Property 'os' cannot be an empty string"));
     }
   }
 
@@ -131,7 +131,8 @@ public class PlatformSpecTest {
       Assert.fail();
     } catch (JsonProcessingException jpe) {
       MatcherAssert.assertThat(
-          jpe.getMessage(), CoreMatchers.containsString("Property 'architecture' cannot be empty"));
+          jpe.getMessage(),
+          CoreMatchers.containsString("Property 'architecture' cannot be an empty string"));
     }
   }
 
@@ -163,7 +164,7 @@ public class PlatformSpecTest {
         Assert.fail();
       } catch (JsonProcessingException ex) {
         Assert.assertEquals(
-            "Property '" + fieldName + "' cannot be empty", ex.getCause().getMessage());
+            "Property '" + fieldName + "' cannot be an empty string", ex.getCause().getMessage());
       }
     }
 
@@ -208,7 +209,7 @@ public class PlatformSpecTest {
         Assert.fail();
       } catch (JsonProcessingException ex) {
         Assert.assertEquals(
-            "Property '" + fieldName + "' cannot contain empty entries",
+            "Property '" + fieldName + "' cannot contain empty strings",
             ex.getCause().getMessage());
       }
     }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ValidatorTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ValidatorTest.java
@@ -51,7 +51,7 @@ public class ValidatorTest {
       Validator.checkNotNullAndNotEmpty("  ", "test");
       Assert.fail();
     } catch (IllegalArgumentException iae) {
-      Assert.assertEquals("Property 'test' cannot be empty", iae.getMessage());
+      Assert.assertEquals("Property 'test' cannot be an empty string", iae.getMessage());
     }
   }
 
@@ -71,7 +71,7 @@ public class ValidatorTest {
       Validator.checkNullOrNotEmpty("   ", "test");
       Assert.fail();
     } catch (IllegalArgumentException iae) {
-      Assert.assertEquals("Property 'test' cannot be empty", iae.getMessage());
+      Assert.assertEquals("Property 'test' cannot be an empty string", iae.getMessage());
     }
   }
 
@@ -102,28 +102,28 @@ public class ValidatorTest {
   }
 
   @Test
-  public void testCheckNonNullNonEmptyEntriesIfExists_nullMapPass() {
-    Validator.checkNonNullNonEmptyEntriesIfExists((Map<String, String>) null, "test");
+  public void testCheckNullOrNonNullNonEmptyEntries_nullMapPass() {
+    Validator.checkNullOrNonNullNonEmptyEntries((Map<String, String>) null, "test");
     // pass
   }
 
   @Test
-  public void testCheckNonNullNonEmptyEntriesIfExists_emptyMapPass() {
-    Validator.checkNonNullNonEmptyEntriesIfExists(ImmutableMap.of(), "test");
+  public void testCheckNullOrNonNullNonEmptyEntries_emptyMapPass() {
+    Validator.checkNullOrNonNullNonEmptyEntries(ImmutableMap.of(), "test");
     // pass
   }
 
   @Test
-  public void testCheckNonNullNonEmptyEntriesIfExists_mapWithValuesPass() {
-    Validator.checkNonNullNonEmptyEntriesIfExists(
+  public void testCheckNullOrNonNullNonEmptyEntries_mapWithValuesPass() {
+    Validator.checkNullOrNonNullNonEmptyEntries(
         ImmutableMap.of("key1", "val1", "key2", "val2"), "test");
     // pass
   }
 
   @Test
-  public void testCheckNonNullNonEmptyEntriesIfExists_mapNullKeyFail() {
+  public void testCheckNullOrNonNullNonEmptyEntries_mapNullKeyFail() {
     try {
-      Validator.checkNonNullNonEmptyEntriesIfExists(Collections.singletonMap(null, "val1"), "test");
+      Validator.checkNullOrNonNullNonEmptyEntries(Collections.singletonMap(null, "val1"), "test");
       Assert.fail();
     } catch (NullPointerException npe) {
       Assert.assertEquals("Property 'test' cannot contain null keys", npe.getMessage());
@@ -131,19 +131,19 @@ public class ValidatorTest {
   }
 
   @Test
-  public void testCheckNonNullNonEmptyEntriesIfExists_mapEmptyKeyFail() {
+  public void testCheckNullOrNonNullNonEmptyEntries_mapEmptyKeyFail() {
     try {
-      Validator.checkNonNullNonEmptyEntriesIfExists(Collections.singletonMap(" ", "val1"), "test");
+      Validator.checkNullOrNonNullNonEmptyEntries(Collections.singletonMap(" ", "val1"), "test");
       Assert.fail();
     } catch (IllegalArgumentException iae) {
-      Assert.assertEquals("Property 'test' cannot contain empty keys", iae.getMessage());
+      Assert.assertEquals("Property 'test' cannot contain empty string keys", iae.getMessage());
     }
   }
 
   @Test
-  public void testCheckNonNullNonEmptyEntriesIfExists_mapNullValueFail() {
+  public void testCheckNullOrNonNullNonEmptyEntries_mapNullValueFail() {
     try {
-      Validator.checkNonNullNonEmptyEntriesIfExists(Collections.singletonMap("key1", null), "test");
+      Validator.checkNullOrNonNullNonEmptyEntries(Collections.singletonMap("key1", null), "test");
       Assert.fail();
     } catch (NullPointerException npe) {
       Assert.assertEquals("Property 'test' cannot contain null values", npe.getMessage());
@@ -151,37 +151,37 @@ public class ValidatorTest {
   }
 
   @Test
-  public void testCheckNonNullNonEmptyEntriesIfExists_mapEmptyValueFail() {
+  public void testCheckNullOrNonNullNonEmptyEntries_mapEmptyValueFail() {
     try {
-      Validator.checkNonNullNonEmptyEntriesIfExists(Collections.singletonMap("key1", " "), "test");
+      Validator.checkNullOrNonNullNonEmptyEntries(Collections.singletonMap("key1", " "), "test");
       Assert.fail();
     } catch (IllegalArgumentException iae) {
-      Assert.assertEquals("Property 'test' cannot contain empty values", iae.getMessage());
+      Assert.assertEquals("Property 'test' cannot contain empty string values", iae.getMessage());
     }
   }
 
   @Test
-  public void testCheckNonNullNonEmptyEntriesIfExists_nullPass() {
-    Validator.checkNonNullNonEmptyEntriesIfExists((List<String>) null, "test");
+  public void testCheckNullOrNonNullNonEmptyEntries_nullPass() {
+    Validator.checkNullOrNonNullNonEmptyEntries((List<String>) null, "test");
     // pass
   }
 
   @Test
-  public void testCheckNonNullNonEmptyEntriesIfExists_emptyPass() {
-    Validator.checkNonNullNonEmptyEntriesIfExists(ImmutableList.of(), "test");
+  public void testCheckNullOrNonNullNonEmptyEntries_emptyPass() {
+    Validator.checkNullOrNonNullNonEmptyEntries(ImmutableList.of(), "test");
     // pass
   }
 
   @Test
-  public void testCheckNonNullNonEmptyEntriesIfExists_valuesPass() {
-    Validator.checkNonNullNonEmptyEntriesIfExists(ImmutableList.of("first", "second"), "test");
+  public void testCheckNullNonNullNonEmptyEntries_valuesPass() {
+    Validator.checkNullOrNonNullNonEmptyEntries(ImmutableList.of("first", "second"), "test");
     // pass
   }
 
   @Test
-  public void testCheckNonNullNonEmptyEntriesIfExists_nullValueFail() {
+  public void testCheckNullNonNullNonEmptyEntries_nullValueFail() {
     try {
-      Validator.checkNonNullNonEmptyEntriesIfExists(Arrays.asList("first", null), "test");
+      Validator.checkNullOrNonNullNonEmptyEntries(Arrays.asList("first", null), "test");
       Assert.fail();
     } catch (NullPointerException npe) {
       Assert.assertEquals("Property 'test' cannot contain null entries", npe.getMessage());
@@ -189,37 +189,37 @@ public class ValidatorTest {
   }
 
   @Test
-  public void testCheckNonNullNonEmptyEntriesIfExists_emptyValueFail() {
+  public void testCheckNullOrNonNullNonEmptyEntries_emptyValueFail() {
     try {
-      Validator.checkNonNullNonEmptyEntriesIfExists(ImmutableList.of("first", "  "), "test");
+      Validator.checkNullOrNonNullNonEmptyEntries(ImmutableList.of("first", "  "), "test");
       Assert.fail();
     } catch (IllegalArgumentException iae) {
-      Assert.assertEquals("Property 'test' cannot contain empty entries", iae.getMessage());
+      Assert.assertEquals("Property 'test' cannot contain empty strings", iae.getMessage());
     }
   }
 
   @Test
-  public void testCheckNonNullEntriesIfExists_nullPass() {
-    Validator.checkNonNullEntriesIfExists(null, "test");
+  public void testCheckNullOrNonNullEntries_nullPass() {
+    Validator.checkNullOrNonNullEntries(null, "test");
     // pass
   }
 
   @Test
-  public void testCheckNonNullEntriesIfExists_emptyPass() {
-    Validator.checkNonNullEntriesIfExists(ImmutableList.of(), "test");
+  public void testCheckNullOrNonNullEntries_emptyPass() {
+    Validator.checkNullOrNonNullEntries(ImmutableList.of(), "test");
     // pass
   }
 
   @Test
-  public void testCheckNonNullEntriesIfExists_valuesPass() {
-    Validator.checkNonNullEntriesIfExists(ImmutableList.of(new Object(), new Object()), "test");
+  public void testCheckNullOrNonNullEntries_valuesPass() {
+    Validator.checkNullOrNonNullEntries(ImmutableList.of(new Object(), new Object()), "test");
     // pass
   }
 
   @Test
-  public void testCheckNonNullEntriesIfExists_nullFail() {
+  public void testCheckNullOrNonNullEntries_nullFail() {
     try {
-      Validator.checkNonNullEntriesIfExists(Arrays.asList(new Object(), null), "test");
+      Validator.checkNullOrNonNullEntries(Arrays.asList(new Object(), null), "test");
       Assert.fail();
     } catch (NullPointerException npe) {
       Assert.assertEquals("Property 'test' cannot contain null entries", npe.getMessage());

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ValidatorTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/ValidatorTest.java
@@ -17,7 +17,12 @@
 package com.google.cloud.tools.jib.cli.buildfile;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -25,15 +30,15 @@ import org.junit.Test;
 public class ValidatorTest {
 
   @Test
-  public void testCheckNotEmpty_stringPass() {
-    Validator.checkNotEmpty("value", "ignored");
+  public void testCheckNotNullAndNotEmpty_stringPass() {
+    Validator.checkNotNullAndNotEmpty("value", "ignored");
     // pass
   }
 
   @Test
-  public void testCheckNotEmpty_stringFailNull() {
+  public void testCheckNotNullAndNotEmpty_stringFailNull() {
     try {
-      Validator.checkNotEmpty((String) null, "test");
+      Validator.checkNotNullAndNotEmpty((String) null, "test");
       Assert.fail();
     } catch (NullPointerException npe) {
       Assert.assertEquals("Property 'test' cannot be null", npe.getMessage());
@@ -41,9 +46,29 @@ public class ValidatorTest {
   }
 
   @Test
-  public void testCheckNotEmpty_stringFailEmpty() {
+  public void testCheckNotNullAndNotEmpty_stringFailEmpty() {
     try {
-      Validator.checkNotEmpty("  ", "test");
+      Validator.checkNotNullAndNotEmpty("  ", "test");
+      Assert.fail();
+    } catch (IllegalArgumentException iae) {
+      Assert.assertEquals("Property 'test' cannot be empty", iae.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckNullOrNotEmpty_valuePass() {
+    Validator.checkNullOrNotEmpty("value", "test");
+  }
+
+  @Test
+  public void testCheckNullOrNotEmpty_nullPass() {
+    Validator.checkNullOrNotEmpty(null, "test");
+  }
+
+  @Test
+  public void testCheckNullOrNotEmpty_fail() {
+    try {
+      Validator.checkNullOrNotEmpty("   ", "test");
       Assert.fail();
     } catch (IllegalArgumentException iae) {
       Assert.assertEquals("Property 'test' cannot be empty", iae.getMessage());
@@ -52,14 +77,14 @@ public class ValidatorTest {
 
   @Test
   public void testCheckNotEmpty_collectionPass() {
-    Validator.checkNotEmpty(ImmutableList.of("value"), "ignored");
+    Validator.checkNotNullAndNotEmpty(ImmutableList.of("value"), "ignored");
     // pass
   }
 
   @Test
   public void testCheckNotEmpty_collectionFailNull() {
     try {
-      Validator.checkNotEmpty((Collection<?>) null, "test");
+      Validator.checkNotNullAndNotEmpty((Collection<?>) null, "test");
       Assert.fail();
     } catch (NullPointerException npe) {
       Assert.assertEquals("Property 'test' cannot be null", npe.getMessage());
@@ -69,11 +94,137 @@ public class ValidatorTest {
   @Test
   public void testCheckNotEmpty_collectionFailEmpty() {
     try {
-      Validator.checkNotEmpty(ImmutableList.of(), "test");
+      Validator.checkNotNullAndNotEmpty(ImmutableList.of(), "test");
       Assert.fail();
     } catch (IllegalArgumentException iae) {
       Assert.assertEquals("Property 'test' cannot be an empty collection", iae.getMessage());
     }
+  }
+
+  @Test
+  public void testCheckNonNullNonEmptyEntriesIfExists_nullMapPass() {
+    Validator.checkNonNullNonEmptyEntriesIfExists((Map<String, String>) null, "test");
+    // pass
+  }
+
+  @Test
+  public void testCheckNonNullNonEmptyEntriesIfExists_emptyMapPass() {
+    Validator.checkNonNullNonEmptyEntriesIfExists(ImmutableMap.of(), "test");
+    // pass
+  }
+
+  @Test
+  public void testCheckNonNullNonEmptyEntriesIfExists_mapWithValuesPass() {
+    Validator.checkNonNullNonEmptyEntriesIfExists(
+        ImmutableMap.of("key1", "val1", "key2", "val2"), "test");
+    // pass
+  }
+
+  @Test
+  public void testCheckNonNullNonEmptyEntriesIfExists_mapNullKeyFail() {
+    try {
+      Validator.checkNonNullNonEmptyEntriesIfExists(Collections.singletonMap(null, "val1"), "test");
+      Assert.fail();
+    } catch (NullPointerException npe) {
+      Assert.assertEquals("Property 'test' cannot contain null keys", npe.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckNonNullNonEmptyEntriesIfExists_mapEmptyKeyFail() {
+    try {
+      Validator.checkNonNullNonEmptyEntriesIfExists(Collections.singletonMap(" ", "val1"), "test");
+      Assert.fail();
+    } catch (IllegalArgumentException iae) {
+      Assert.assertEquals("Property 'test' cannot contain empty keys", iae.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckNonNullNonEmptyEntriesIfExists_mapNullValueFail() {
+    try {
+      Validator.checkNonNullNonEmptyEntriesIfExists(Collections.singletonMap("key1", null), "test");
+      Assert.fail();
+    } catch (NullPointerException npe) {
+      Assert.assertEquals("Property 'test' cannot contain null values", npe.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckNonNullNonEmptyEntriesIfExists_mapEmptyValueFail() {
+    try {
+      Validator.checkNonNullNonEmptyEntriesIfExists(Collections.singletonMap("key1", " "), "test");
+      Assert.fail();
+    } catch (IllegalArgumentException iae) {
+      Assert.assertEquals("Property 'test' cannot contain empty values", iae.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckNonNullNonEmptyEntriesIfExists_nullPass() {
+    Validator.checkNonNullNonEmptyEntriesIfExists((List<String>) null, "test");
+    // pass
+  }
+
+  @Test
+  public void testCheckNonNullNonEmptyEntriesIfExists_emptyPass() {
+    Validator.checkNonNullNonEmptyEntriesIfExists(ImmutableList.of(), "test");
+    // pass
+  }
+
+  @Test
+  public void testCheckNonNullNonEmptyEntriesIfExists_valuesPass() {
+    Validator.checkNonNullNonEmptyEntriesIfExists(ImmutableList.of("first", "second"), "test");
+    // pass
+  }
+
+  @Test
+  public void testCheckNonNullNonEmptyEntriesIfExists_nullValueFail() {
+    try {
+      Validator.checkNonNullNonEmptyEntriesIfExists(Arrays.asList("first", null), "test");
+      Assert.fail();
+    } catch (NullPointerException npe) {
+      Assert.assertEquals("Property 'test' cannot contain null entries", npe.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckNonNullNonEmptyEntriesIfExists_emptyValueFail() {
+    try {
+      Validator.checkNonNullNonEmptyEntriesIfExists(ImmutableList.of("first", "  "), "test");
+      Assert.fail();
+    } catch (IllegalArgumentException iae) {
+      Assert.assertEquals("Property 'test' cannot contain empty entries", iae.getMessage());
+    }
+  }
+
+  @Test
+  public void testCheckNonNullEntriesIfExists_nullPass() {
+    Validator.checkNonNullEntriesIfExists(null, "test");
+    // pass
+  }
+
+  @Test
+  public void testCheckNonNullEntriesIfExists_emptyPass() {
+    Validator.checkNonNullEntriesIfExists(ImmutableList.of(), "test");
+    // pass
+  }
+
+  @Test
+  public void testCheckNonNullEntriesIfExists_valuesPass() {
+    Validator.checkNonNullEntriesIfExists(ImmutableList.of(new Object(), new Object()), "test");
+    // pass
+  }
+
+  @Test
+  public void testCheckNonNullEntriesIfExists_nullFail() {
+    try {
+      Validator.checkNonNullEntriesIfExists(Arrays.asList(new Object(), null), "test");
+      Assert.fail();
+    } catch (NullPointerException npe) {
+      Assert.assertEquals("Property 'test' cannot contain null entries", npe.getMessage());
+    }
+    // pass
   }
 
   @Test


### PR DESCRIPTION
- Added validation for all our optional parameters
- Added new parameterized tests
- Found out yaml parses converts `null` to string if used as a map key

part of #2570 