### PR TITLE
Adding functionality to push base image layers and push container config to the registry

### DIFF
--- a/jib-build-plan/CHANGELOG.md
+++ b/jib-build-plan/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+### Changed
+
+- Replaced `BiFunction` usage in `FileEntriesLayer` with `FilePermissionsProvider`, `ModificationTimeProvider` and `OwnershipProvider`. ([#2638](https://github.com/GoogleContainerTools/jib/issues/2638))
+
+### Fixed
+
+## 0.3.1
+
+### Added
+
 - Added `Platform` class representing an image platform. ([#2584](https://github.com/GoogleContainerTools/jib/pull/2584))
 - Added `get/setPlatforms()` and `addPlatform()` to `ContainerBuildPlan` for setting and getting image platforms. ([#2584](https://github.com/GoogleContainerTools/jib/pull/2584))
 
@@ -14,7 +24,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed the critical bug that the default `Platform` in `ContainerBuildPlan` has OS and architecture values switched with each other. ([#2597](https://github.com/GoogleContainerTools/jib/pull/2597)
+- Fixed the critical bug that the default `Platform` in `ContainerBuildPlan` has OS and architecture values switched with each other. ([#2597](https://github.com/GoogleContainerTools/jib/pull/2597))
 
 ## 0.2.0
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -393,17 +393,17 @@ public class StepsRunner {
         executorService.submit(
             () -> {
               Map<Future<Image>, Future<BlobDescriptor>> pushResults = new HashMap<>();
-              for (Future<Image> buildImage : results.builtImages.get()) {
-                Future<BlobDescriptor> containerConfigurationPushResult =
+              for (Future<Image> builtImage : results.builtImages.get()) {
+                Future<BlobDescriptor> configPushResult =
                     executorService.submit(
                         () ->
                             new PushContainerConfigurationStep(
                                     buildContext,
                                     childProgressDispatcherFactory,
                                     results.targetRegistryClient.get(),
-                                    buildImage.get())
+                                    builtImage.get())
                                 .call());
-                pushResults.put(buildImage, containerConfigurationPushResult);
+                pushResults.put(builtImage, configPushResult);
               }
               return pushResults;
             });

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -73,8 +73,8 @@ public class StepsRunner {
     private Future<RegistryClient> targetRegistryClient = failedFuture();
     private Future<List<List<Future<BlobDescriptor>>>> baseImageLayerPushResults = failedFuture();
     private Future<List<Future<BlobDescriptor>>> applicationLayerPushResults = failedFuture();
-    private Future<Map<Image, Future<BlobDescriptor>>> containerConfigurationPushResults =
-        failedFuture();
+    private Future<Map<Image, Future<BlobDescriptor>>>
+        builtImagesAndContainerConfigurationPushResults = failedFuture();
     private Future<BuildResult> buildResult = failedFuture();
     private Future<Optional<ManifestAndDigest<ManifestTemplate>>> manifestCheckResult =
         failedFuture();
@@ -389,7 +389,7 @@ public class StepsRunner {
     ProgressEventDispatcher.Factory childProgressDispatcherFactory =
         Verify.verifyNotNull(rootProgressDispatcher).newChildProducer();
 
-    results.containerConfigurationPushResults =
+    results.builtImagesAndContainerConfigurationPushResults =
         executorService.submit(
             () -> {
               Map<Image, Future<BlobDescriptor>> containerConfigurationPushResults =
@@ -439,7 +439,7 @@ public class StepsRunner {
                         results.targetRegistryClient.get(),
                         Verify.verifyNotNull(
                                 results
-                                    .containerConfigurationPushResults
+                                    .builtImagesAndContainerConfigurationPushResults
                                     .get()
                                     .get(results.builtImages.get().get(0).get()))
                             .get(),
@@ -465,7 +465,7 @@ public class StepsRunner {
                           results.targetRegistryClient.get(),
                           Verify.verifyNotNull(
                                   results
-                                      .containerConfigurationPushResults
+                                      .builtImagesAndContainerConfigurationPushResults
                                       .get()
                                       .get(results.builtImages.get().get(0).get()))
                               .get(),
@@ -477,7 +477,7 @@ public class StepsRunner {
                       results.manifestCheckResult.get().get().getDigest(),
                       Verify.verifyNotNull(
                               results
-                                  .containerConfigurationPushResults
+                                  .builtImagesAndContainerConfigurationPushResults
                                   .get()
                                   .get(results.builtImages.get().get(0).get()))
                           .get()

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -71,9 +71,10 @@ public class StepsRunner {
     @Nullable private List<Future<PreparedLayer>> applicationLayers;
     private Future<List<Future<Image>>> builtImages = failedFuture();
     private Future<RegistryClient> targetRegistryClient = failedFuture();
-    private Future<List<Future<BlobDescriptor>>> baseImageLayerPushResults = failedFuture();
+    private Future<List<List<Future<BlobDescriptor>>>> baseImageLayerPushResults = failedFuture();
     private Future<List<Future<BlobDescriptor>>> applicationLayerPushResults = failedFuture();
-    private Future<BlobDescriptor> containerConfigurationPushResult = failedFuture();
+    private Future<Map<Image, Future<BlobDescriptor>>> containerConfigurationPushResults =
+        failedFuture();
     private Future<BuildResult> buildResult = failedFuture();
     private Future<Optional<ManifestAndDigest<ManifestTemplate>>> manifestCheckResult =
         failedFuture();
@@ -332,17 +333,21 @@ public class StepsRunner {
 
     results.baseImageLayerPushResults =
         executorService.submit(
-            () ->
-                scheduleCallables(
-                    PushLayerStep.makeList(
-                        buildContext,
-                        childProgressDispatcherFactory,
-                        results.targetRegistryClient.get(),
-                        Verify.verifyNotNull(
-                            results
-                                .baseImagesAndLayers
-                                .get()
-                                .get(results.baseImagesAndRegistryClient.get().images.get(0))))));
+            () -> {
+              List<List<Future<BlobDescriptor>>> baseImageLayerPushResults = new ArrayList<>();
+              for (List<Future<PreparedLayer>> baseImageLayers :
+                  results.baseImagesAndLayers.get().values()) {
+                List<Future<BlobDescriptor>> baseImageLayerPushResult =
+                    scheduleCallables(
+                        PushLayerStep.makeList(
+                            buildContext,
+                            childProgressDispatcherFactory,
+                            results.targetRegistryClient.get(),
+                            Verify.verifyNotNull(baseImageLayers)));
+                baseImageLayerPushResults.add(baseImageLayerPushResult);
+              }
+              return baseImageLayerPushResults;
+            });
   }
 
   private void buildAndCacheApplicationLayers() {
@@ -384,15 +389,26 @@ public class StepsRunner {
     ProgressEventDispatcher.Factory childProgressDispatcherFactory =
         Verify.verifyNotNull(rootProgressDispatcher).newChildProducer();
 
-    results.containerConfigurationPushResult =
+    results.containerConfigurationPushResults =
         executorService.submit(
-            () ->
-                new PushContainerConfigurationStep(
-                        buildContext,
-                        childProgressDispatcherFactory,
-                        results.targetRegistryClient.get(),
-                        results.builtImages.get().get(0).get())
-                    .call());
+            () -> {
+              Map<Image, Future<BlobDescriptor>> containerConfigurationPushResults =
+                  new HashMap<>();
+              for (Future<Image> builtImage : results.builtImages.get()) {
+                Future<BlobDescriptor> containerConfigurationPushResult =
+                    executorService.submit(
+                        () ->
+                            new PushContainerConfigurationStep(
+                                    buildContext,
+                                    childProgressDispatcherFactory,
+                                    results.targetRegistryClient.get(),
+                                    builtImage.get())
+                                .call());
+                containerConfigurationPushResults.put(
+                    builtImage.get(), containerConfigurationPushResult);
+              }
+              return containerConfigurationPushResults;
+            });
   }
 
   private void pushApplicationLayers() {
@@ -421,7 +437,12 @@ public class StepsRunner {
                         buildContext,
                         childProgressDispatcherFactory,
                         results.targetRegistryClient.get(),
-                        results.containerConfigurationPushResult.get(),
+                        Verify.verifyNotNull(
+                                results
+                                    .containerConfigurationPushResults
+                                    .get()
+                                    .get(results.builtImages.get().get(0).get()))
+                            .get(),
                         results.builtImages.get().get(0).get())
                     .call());
   }
@@ -433,7 +454,7 @@ public class StepsRunner {
     results.buildResult =
         executorService.submit(
             () -> {
-              realizeFutures(results.baseImageLayerPushResults.get());
+              realizeFutures(results.baseImageLayerPushResults.get().get(0));
               realizeFutures(results.applicationLayerPushResults.get());
 
               List<Future<BuildResult>> manifestPushResults =
@@ -442,14 +463,25 @@ public class StepsRunner {
                           buildContext,
                           childProgressDispatcherFactory,
                           results.targetRegistryClient.get(),
-                          results.containerConfigurationPushResult.get(),
+                          Verify.verifyNotNull(
+                                  results
+                                      .containerConfigurationPushResults
+                                      .get()
+                                      .get(results.builtImages.get().get(0).get()))
+                              .get(),
                           results.builtImages.get().get(0).get(),
                           results.manifestCheckResult.get().isPresent()));
               realizeFutures(manifestPushResults);
               return manifestPushResults.isEmpty()
                   ? new BuildResult(
                       results.manifestCheckResult.get().get().getDigest(),
-                      results.containerConfigurationPushResult.get().getDigest())
+                      Verify.verifyNotNull(
+                              results
+                                  .containerConfigurationPushResults
+                                  .get()
+                                  .get(results.builtImages.get().get(0).get()))
+                          .get()
+                          .getDigest())
                   // Manifest pushers return the same BuildResult.
                   : manifestPushResults.get(0).get();
             });


### PR DESCRIPTION
1. This PR pushes multiple container config JSONs: loops through the built images and schedules multiple pushes in `pushContainerConfiguration()`. Note care has been taken to not block scheduling threads while looping by using the `Future<Image> ` as the key in the resulting `pushResults` map.
2.This PR also pushes multiple baseImageLayers: loops through the `results.baseImagesAndLayers.get()` and schedules multiple pushes in `pushBaseImageLayers()`. Note  the resulting results from the pushes are being stored in a list for now but in the next PR we will update the resulting `pushResults` list into a map so as to track the `builtImage/baseImageLayers` key-pair values.
