### PR TITLE
Check if cached manifest matches configured platform

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - New system property `jib.skipExistingImages` (false by default) to skip pushing images (manifests) if the image already exists in the registry. ([#2360](https://github.com/GoogleContainerTools/jib/issues/2360)
-- _Incubating feature_: can now configure desired platform (architecture and OS) to select the matching manifest from a Docker manifest list or an OCI image index for a base image. Currently supports building only one image. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
+- _Incubating feature_: can now configure desired platform (architecture and OS) to select the matching manifest from a Docker manifest list for a base image. Currently supports building only one image. OCI image indices are not supported. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
 
 ### Changed
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - New system property `jib.skipExistingImages` (false by default) to skip pushing images (manifests) if the image already exists in the registry. ([#2360](https://github.com/GoogleContainerTools/jib/issues/2360)
+- _Incubating feature_: selecting a manifest by platform (architecture and OS) from a manifest list (image index in OCI terms) for a base image. Currently supports building only one image. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
 
 ### Changed
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - New system property `jib.skipExistingImages` (false by default) to skip pushing images (manifests) if the image already exists in the registry. ([#2360](https://github.com/GoogleContainerTools/jib/issues/2360)
-- _Incubating feature_: selecting a manifest by platform (architecture and OS) from a manifest list (image index in OCI terms) for a base image. Currently supports building only one image. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
+- _Incubating feature_: can now configure desired platform (architecture and OS) to select the matching manifest from a Docker manifest list or an OCI image index for a base image. Currently supports building only one image. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
 
 ### Changed
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
@@ -147,7 +147,7 @@ public class PullBaseImageStepTest {
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(manifestAndConfig));
     Mockito.when(buildContext.isOffline()).thenReturn(true);
     Mockito.when(containerConfig.getPlatforms())
-        .thenReturn(ImmutableSet.of(new Platform("foo arch", "bar OS")));
+        .thenReturn(ImmutableSet.of(new Platform("testArch", "testOS")));
 
     try {
       pullBaseImageStep.call();
@@ -172,7 +172,7 @@ public class PullBaseImageStepTest {
     Mockito.when(imageConfiguration.getImage()).thenReturn(imageReference);
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(manifestAndConfig));
     Mockito.when(containerConfig.getPlatforms())
-        .thenReturn(ImmutableSet.of(new Platform("foo arch", "bar OS")));
+        .thenReturn(ImmutableSet.of(new Platform("testArch", "testOS")));
 
     try {
       pullBaseImageStep.call();

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,7 +7,18 @@ All notable changes to this project will be documented in this file.
 
 - Also tries `.exe` file extension for credential helpers on Windows. ([#2527](https://github.com/GoogleContainerTools/jib/issues/2527))
 - New system property `jib.skipExistingImages` (false by default) to skip pushing images (manifests) if the image already exists in the registry. ([#2360](https://github.com/GoogleContainerTools/jib/issues/2360)
-- _Incubating feature_: selecting a manifest by platform (architecture and OS) from a manifest list (image index in OCI terms) for a base image. Currently supports building only one image. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
+- _Incubating feature_: can now configure desired platform (architecture and OS) to select the matching manifest from a Docker manifest list or an OCI image index for a base image. Currently supports building only one image. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
+   ```gradle
+   jib.from {
+     image = '... image reference to a manifest list ...'
+     platforms {
+       platform {
+         architecture = 'arm64'
+         os = 'linux'
+       }
+     }
+   }
+   ```
 
 ### Changed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Also tries `.exe` file extension for credential helpers on Windows. ([#2527](https://github.com/GoogleContainerTools/jib/issues/2527))
 - New system property `jib.skipExistingImages` (false by default) to skip pushing images (manifests) if the image already exists in the registry. ([#2360](https://github.com/GoogleContainerTools/jib/issues/2360)
-- _Incubating feature_: can now configure desired platform (architecture and OS) to select the matching manifest from a Docker manifest list or an OCI image index for a base image. Currently supports building only one image. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
+- _Incubating feature_: can now configure desired platform (architecture and OS) to select the matching manifest from a Docker manifest list. Currently supports building only one image. OCI image indices are not supported. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
    ```gradle
    jib.from {
      image = '... image reference to a manifest list ...'

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Also tries `.exe` file extension for credential helpers on Windows. ([#2527](https://github.com/GoogleContainerTools/jib/issues/2527))
 - New system property `jib.skipExistingImages` (false by default) to skip pushing images (manifests) if the image already exists in the registry. ([#2360](https://github.com/GoogleContainerTools/jib/issues/2360)
+- _Incubating feature_: selecting a manifest by platform (architecture and OS) from a manifest list (image index in OCI terms) for a base image. Currently supports building only one image. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
 
 ### Changed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Also tries `.exe` file extension for credential helpers on Windows. ([#2527](https://github.com/GoogleContainerTools/jib/issues/2527))
 - New system property `jib.skipExistingImages` (false by default) to skip pushing images (manifests) if the image already exists in the registry. ([#2360](https://github.com/GoogleContainerTools/jib/issues/2360)
+- _Incubating feature_: selecting a manifest by platform (architecture and OS) from a manifest list (image index in OCI terms) for a base image. Currently supports building only one image. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
 
 ### Changed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Also tries `.exe` file extension for credential helpers on Windows. ([#2527](https://github.com/GoogleContainerTools/jib/issues/2527))
 - New system property `jib.skipExistingImages` (false by default) to skip pushing images (manifests) if the image already exists in the registry. ([#2360](https://github.com/GoogleContainerTools/jib/issues/2360)
-- _Incubating feature_: can now configure desired platform (architecture and OS) to select the matching manifest from a Docker manifest list or an OCI image index for a base image. Currently supports building only one image. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
+- _Incubating feature_: can now configure desired platform (architecture and OS) to select the matching manifest from a Docker manifest list for a base image. Currently supports building only one image. OCI image indices are not supported. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
     ```xml
       <from>
         <image>... image reference to a manifest list ...</image>

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,7 +7,18 @@ All notable changes to this project will be documented in this file.
 
 - Also tries `.exe` file extension for credential helpers on Windows. ([#2527](https://github.com/GoogleContainerTools/jib/issues/2527))
 - New system property `jib.skipExistingImages` (false by default) to skip pushing images (manifests) if the image already exists in the registry. ([#2360](https://github.com/GoogleContainerTools/jib/issues/2360)
-- _Incubating feature_: selecting a manifest by platform (architecture and OS) from a manifest list (image index in OCI terms) for a base image. Currently supports building only one image. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
+- _Incubating feature_: can now configure desired platform (architecture and OS) to select the matching manifest from a Docker manifest list or an OCI image index for a base image. Currently supports building only one image. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))
+    ```xml
+      <from>
+        <image>... image reference to a manifest list ...</image>
+        <platforms>
+          <platform>
+            <architecture>arm64</architecture>
+            <os>linux</os>
+          </platform>
+        </platforms>
+      </from>
+    ```
 
 ### Changed
 


### PR DESCRIPTION
- Added a guard for #2655. Basically checks if a previously cached manifest doesn't match the configured platform. If so, raise an error with an actionable message.

- Updates CHANGELOG in jib-core, jib-maven-plugin, and jib-gradle-plugin.

- Also, there was a warning that `pullBaseImages` sometimes returns a mutable list and other times immutable, so I've addressed it by always returning an immutable list.
   ```
   .../jib/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java:217: warning:
   [MixedMutabilityReturnType]
   This method returns both mutable and immutable collections or maps from different paths. This may be confusing for users of the method.
     private List<Image> pullBaseImages(
   ```

In the meantime, I will continue to do some actual end-to-end tests.