### PR TITLE
Preserve trailing slash metadata

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/CopySpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/CopySpec.java
@@ -45,6 +45,8 @@ import javax.annotation.Nullable;
 public class CopySpec {
   private final Path src;
   private final AbsoluteUnixPath dest;
+  // extra metadata to determine if the target can be considered a file
+  private final boolean destEndsWithSlash;
 
   @Nullable private final FilePropertiesSpec properties;
   private final List<String> excludes;
@@ -70,6 +72,7 @@ public class CopySpec {
     Validator.checkNotEmpty(dest, "dest");
     this.src = Paths.get(src);
     this.dest = AbsoluteUnixPath.get(dest);
+    this.destEndsWithSlash = dest.endsWith("/");
     this.excludes = (excludes == null) ? ImmutableList.of() : excludes;
     this.includes = (includes == null) ? ImmutableList.of() : includes;
     this.properties = properties;
@@ -81,6 +84,10 @@ public class CopySpec {
 
   public AbsoluteUnixPath getDest() {
     return dest;
+  }
+
+  public boolean isDestEndsWithSlash() {
+    return destEndsWithSlash;
   }
 
   public List<String> getExcludes() {

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/CopySpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/CopySpecTest.java
@@ -80,6 +80,24 @@ public class CopySpecTest {
   }
 
   @Test
+  public void testCopySpec_destEndsWithSlash() throws JsonProcessingException {
+    String data = "src: target/classes\n" + "dest: /app/classes/";
+
+    CopySpec parsed = mapper.readValue(data, CopySpec.class);
+    Assert.assertEquals(AbsoluteUnixPath.get("/app/classes"), parsed.getDest());
+    Assert.assertTrue(parsed.isDestEndsWithSlash());
+  }
+
+  @Test
+  public void testCopySpec_destDoesNotEndWithSlash() throws JsonProcessingException {
+    String data = "src: target/classes\n" + "dest: /app/classes";
+
+    CopySpec parsed = mapper.readValue(data, CopySpec.class);
+    Assert.assertEquals(AbsoluteUnixPath.get("/app/classes"), parsed.getDest());
+    Assert.assertFalse(parsed.isDestEndsWithSlash());
+  }
+
+  @Test
   public void testCopySpec_srcNotNull() {
     String data = "src: null\n" + "dest: /app/classes\n";
 


### PR DESCRIPTION
Preserve trailing slash information in `dest` property. This should not be done in `AbsoluteUnixPath` because that is agnostic to the filesystem. It merely contains a list of paths. Preserve the information here and use within the `jib-cli` project.