### PR TITLE
Update FAQ and plugin reference docs about selecting base image platform from a manifest list

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -469,7 +469,7 @@ To inspect the image that is produced from the build using Docker, you can use c
 
 ### How do I specify a platform in the manifest list (or OCI index) of a base image?
 
-Jib 2.5.0 added an _incubating feature_ that provides limited support for selecting a base image with the describe platform from a manifest list. For example,
+Jib 2.5.0 added an _incubating feature_ that provides limited support for selecting a base image with the desired platform from a manifest list. For example,
 
 ```xml
   <from>

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -469,18 +469,46 @@ To inspect the image that is produced from the build using Docker, you can use c
 
 ### How do I specify a platform in the manifest list (or OCI index) of a base image?
 
-By design, if the target image reference is a [manifest list](https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list), Jib will always select an image for the platform `amd64/linux`. If you need to specify a different image from a manifest list you must specify the digest for the platform you are targeting.
+Jib 2.5.0 added an _incubating feature_ that provides limited support for selecting a base image with the describe platform from a manifest list. For example,
 
-To view a manifest, [enable experimental docker CLI](https://docs.docker.com/engine/reference/commandline/cli/#experimental-features) features and then run the [manifest inspect](https://docs.docker.com/engine/reference/commandline/manifest_inspect/) command.
+```xml
+  <from>
+    <image>... image reference to a manifest list ...</image>
+    <platforms>
+      <platform>
+        <architecture>arm64</architecture>
+        <os>linux</os>
+      </platform>
+    </platforms>
+  </from>
+```
+
+```gradle
+jib.from {
+  image = '... image reference to a manifest list ...'
+  platforms {
+    platform {
+      architecture = 'arm64'
+      os = 'linux'
+    }
+  }
+}
+```
+
+The default platform is "amd64/linux" if not specified, whose behavior is backward-compatible.
+
+As an incubating feature, there are certain limitations:
+- OCI image indices are not supported (as opposed to Docker manifest lists).
+- Supports specifying only one platform.
+- Only `architecture` and `os` are supported. If there are multiple base images with given architecture and os, the first image will be selected.
+
+Make sure to specify a manifest _list_ in `<from><image>` (whether by a tag name or a digest (`@sha256:...`)). For troubleshooting, you may want to check what platforms a manifest list contains. To view a manifest, [enable experimental docker CLI](https://docs.docker.com/engine/reference/commandline/cli/#experimental-features) features and then run the [manifest inspect](https://docs.docker.com/engine/reference/commandline/manifest_inspect/) command.
+
 ```
 $ docker manifest inspect openjdk:8
-```
-
-You can then inspect the output for the specific image you want (in this example an image for the platform `arm64/linux`)
-```java
 {         
    ...
-   // This whole BLOB itself is a manifest list.
+   // This confirms that openjdk:8 points to a manifest list.
    "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
    "manifests": [
       {
@@ -497,8 +525,6 @@ You can then inspect the output for the specific image you want (in this example
    ]
 }
 ```
-
-You then use the digest for the target platform you desire in your `jib.to.image` in the form `"opendjdk@sha256:1fbd49e3fc5e53154fa93cad15f211112d899a6b0c5dc1e8661d6eb6c18b30a6"` or if you wish to preserve the tag for documentation purposes, you can also use the form `"opendjdk:8@sha256:1fbd49e3fc5e53154fa93cad15f211112d899a6b0c5dc1e8661d6eb6c18b30a6"`.
 
 ## Build Problems
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -500,7 +500,7 @@ The default platform is "amd64/linux" if not specified, whose behavior is backwa
 As an incubating feature, there are certain limitations:
 - OCI image indices are not supported (as opposed to Docker manifest lists).
 - Supports specifying only one platform.
-- Only `architecture` and `os` are supported. If there are multiple base images with given architecture and os, the first image will be selected.
+- Only `architecture` and `os` are supported. If the base image manifest list contains multiple images with the given architecture and os, the first image will be selected.
 
 Make sure to specify a manifest _list_ in `<from><image>` (whether by a tag name or a digest (`@sha256:...`)). For troubleshooting, you may want to check what platforms a manifest list contains. To view a manifest, [enable experimental docker CLI](https://docs.docker.com/engine/reference/commandline/cli/#experimental-features) features and then run the [manifest inspect](https://docs.docker.com/engine/reference/commandline/manifest_inspect/) command.
 

--- a/jib-gradle-plugin/README.md
+++ b/jib-gradle-plugin/README.md
@@ -206,7 +206,7 @@ Property | Type | Default | Description
 Property | Type | Default | Description
 --- | --- | --- | ---
 `image` | `String` | *Required* | The image reference for the target image. This can also be specified via the `--image` command line option.
-`auth` | [`auth`](#auth-closure) | *None* | Specify credentials directly (alternative to `credHelper`).
+`auth` | [`auth`](#auth-closure) | *None* | Specifies credentials directly (alternative to `credHelper`).
 `credHelper` | `String` | *None* | Specifies a credential helper that can authenticate pushing the target image. This parameter can either be configured as an absolute path to the credential helper executable or as a credential helper suffix (following `docker-credential-`).
 `tags` | `List<String>` | *None* | Additional tags to push to.
 

--- a/jib-gradle-plugin/README.md
+++ b/jib-gradle-plugin/README.md
@@ -197,8 +197,9 @@ Field | Type | Default | Description
 Property | Type | Default | Description
 --- | --- | --- | ---
 `image` | `String` | `gcr.io/distroless/java` | The image reference for the base image. The source type can be specified using a [special type prefix](#setting-the-base-image).
-`auth` | [`auth`](#auth-closure) | *None* | Specify credentials directly (alternative to `credHelper`).
+`auth` | [`auth`](#auth-closure) | *None* | Specifies credentials directly (alternative to `credHelper`).
 `credHelper` | `String` | *None* | Specifies a credential helper that can authenticate pulling the base image. This parameter can either be configured as an absolute path to the credential helper executable or as a credential helper suffix (following `docker-credential-`).
+`platforms` | [`platforms`](#platforms-closure) | See [`platforms`](#platforms-closure) | _Incubating feature_: Configures platforms of base images to select from a manifest list.
 
 <a name="to-closure"></a>`to` is a closure with the following properties:
 
@@ -215,6 +216,15 @@ Property | Type
 --- | ---
 `username` | `String`
 `password` | `String`
+
+<a name="platforms-closure"></a>`platforms` can configure multiple `platform` closures.  Each individual `platform` has the following properties:
+
+Property | Type | Default | Description
+--- | --- | --- | ---
+`architecture` | `String` | `amd64` | The architecture of a base image to select from a manifest list.
+`os` | `String` | `linux` | The OS of a base image to select from a manifest list.
+
+See [How do I specify a platform in the manifest list (or OCI index) of a base image?](../docs/faq.md#how-do-i-specify-a-platform-in-the-manifest-list-or-oci-index-of-a-base-image) for examples.
 
 <a name="container-closure"></a>`container` is a closure with the following properties:
 

--- a/jib-maven-plugin/README.md
+++ b/jib-maven-plugin/README.md
@@ -245,6 +245,7 @@ Property | Type | Default | Description
 `image` | string | `gcr.io/distroless/java` | The image reference for the base image. The source type can be specified using a [special type prefix](#setting-the-base-image).
 `auth` | [`auth`](#auth-object) | *None* | Specify credentials directly (alternative to `credHelper`).
 `credHelper` | string | *None* | Specifies a credential helper that can authenticate pulling the base image. This parameter can either be configured as an absolute path to the credential helper executable or as a credential helper suffix (following `docker-credential-`).
+`platforms` | list | See [`platform`](#platform-object) | _Incubating feature_: Configures platforms of base images to select from a manifest list.
 
 <a name="to-object"></a>`to` is an object with the following properties:
 
@@ -261,6 +262,15 @@ Property | Type
 --- | ---
 `username` | string
 `password` | string
+
+<a name="platform-object"></a>`platform` is an object with the following properties:
+
+Property | Type | Default | Description
+--- | --- | --- | ---
+`architecture` | string | `amd64` | The architecture of a base image to select from a manifest list.
+`os` | string | `linux` | The OS of a base image to select from a manifest list.
+
+See [How do I specify a platform in the manifest list (or OCI index) of a base image?](../docs/faq.md#how-do-i-specify-a-platform-in-the-manifest-list-or-oci-index-of-a-base-image) for examples.
 
 <a name="container-object"></a>`container` is an object with the following properties:
 

--- a/jib-maven-plugin/README.md
+++ b/jib-maven-plugin/README.md
@@ -243,7 +243,7 @@ Field | Type | Default | Description
 Property | Type | Default | Description
 --- | --- | --- | ---
 `image` | string | `gcr.io/distroless/java` | The image reference for the base image. The source type can be specified using a [special type prefix](#setting-the-base-image).
-`auth` | [`auth`](#auth-object) | *None* | Specify credentials directly (alternative to `credHelper`).
+`auth` | [`auth`](#auth-object) | *None* | Specifies credentials directly (alternative to `credHelper`).
 `credHelper` | string | *None* | Specifies a credential helper that can authenticate pulling the base image. This parameter can either be configured as an absolute path to the credential helper executable or as a credential helper suffix (following `docker-credential-`).
 `platforms` | list | See [`platform`](#platform-object) | _Incubating feature_: Configures platforms of base images to select from a manifest list.
 
@@ -252,7 +252,7 @@ Property | Type | Default | Description
 Property | Type | Default | Description
 --- | --- | --- | ---
 `image` | string | *Required* | The image reference for the target image. This can also be specified via the `-Dimage` command line option.
-`auth` | [`auth`](#auth-object) | *None* | Specify credentials directly (alternative to `credHelper`).
+`auth` | [`auth`](#auth-object) | *None* | Specifies credentials directly (alternative to `credHelper`).
 `credHelper` | string | *None* | Specifies a credential helper that can authenticate pushing the target image. This parameter can either be configured as an absolute path to the credential helper executable or as a credential helper suffix (following `docker-credential-`).
 `tags` | list | *None* | Additional tags to push to.
 


### PR DESCRIPTION
Should be merge only after releasing Jib 2.5.0.

The FAQ needs to be correct and helpful, as we show the link to the FAQ in our Jib error message if Jib was unable to find a matching platform. @louismurerwa