### PR TITLE
Add defaults to FilePropertiesStack

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesStack.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesStack.java
@@ -86,15 +86,7 @@ class FilePropertiesStack {
       group = properties.getGroup().orElse(group);
     }
     // ownership calculations
-    if (group == null && user == null) {
-      ownership = "";
-    } else if (group == null && /* Nullaway */ user != null) {
-      ownership = user;
-    } else if (user == null) {
-      ownership = ":" + group;
-    } else {
-      ownership = user + ":" + group;
-    }
+    ownership = (user != null ? user : "") + (group != null ? ":" + group : "");
   }
 
   public FilePermissions getFilePermissions() {

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesStack.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesStack.java
@@ -23,7 +23,6 @@ import com.google.common.base.Preconditions;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import javax.annotation.Nullable;
 
 /**
  * A class that keeps track of permissions for various stacking file permissions settings in {@link
@@ -98,22 +97,18 @@ class FilePropertiesStack {
     }
   }
 
-  @Nullable
   public FilePermissions getFilePermissions() {
     return filePermissions;
   }
 
-  @Nullable
   public FilePermissions getDirectoryPermissions() {
     return directoryPermissions;
   }
 
-  @Nullable
   public Instant getModificationTime() {
     return modificationTime;
   }
 
-  @Nullable
   public String getOwnership() {
     return ownership;
   }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesStackTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesStackTest.java
@@ -24,6 +24,17 @@ import org.junit.Test;
 public class FilePropertiesStackTest {
 
   @Test
+  public void testDefaults() {
+    FilePropertiesStack testStack = new FilePropertiesStack();
+
+    Assert.assertEquals(FilePermissions.fromOctalString("644"), testStack.getFilePermissions());
+    Assert.assertEquals(
+        FilePermissions.fromOctalString("755"), testStack.getDirectoryPermissions());
+    Assert.assertEquals("", testStack.getOwnership());
+    Assert.assertEquals(Instant.ofEpochSecond(1), testStack.getModificationTime());
+  }
+
+  @Test
   public void testPush_simple() {
     FilePropertiesStack testStack = new FilePropertiesStack();
 
@@ -74,10 +85,11 @@ public class FilePropertiesStackTest {
     testStack.push(new FilePropertiesSpec("111", "111", "1", "1", "1"));
     testStack.pop();
 
-    Assert.assertNull(testStack.getFilePermissions());
-    Assert.assertNull(testStack.getDirectoryPermissions());
-    Assert.assertNull(testStack.getModificationTime());
-    Assert.assertNull(testStack.getOwnership());
+    Assert.assertEquals(FilePermissions.fromOctalString("644"), testStack.getFilePermissions());
+    Assert.assertEquals(
+        FilePermissions.fromOctalString("755"), testStack.getDirectoryPermissions());
+    Assert.assertEquals("", testStack.getOwnership());
+    Assert.assertEquals(Instant.ofEpochSecond(1), testStack.getModificationTime());
   }
 
   @Test
@@ -137,6 +149,6 @@ public class FilePropertiesStackTest {
     FilePropertiesStack testStack = new FilePropertiesStack();
     testStack.push(new FilePropertiesSpec(null, null, null, null, null));
 
-    Assert.assertNull(testStack.getOwnership());
+    Assert.assertEquals("", testStack.getOwnership());
   }
 }


### PR DESCRIPTION
The way we use `FileEntriesLayer.addEntry` requires non-null values to be entered. So work with defaults directly here, so we can always pass all properties to that method instead of complicated logic to determine based on null values which `addEntry` to call.
