### PR TITLE
Don't wrongly assume Spring Boot isn't configured when empty <configuration>

### DIFF
--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -9,11 +9,13 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed the regression introduced in 2.5.1 that caused Jib to containerize a Spring Boot fat JAR instead of a normal thin JAR when `<containerizingMode>packaged` is set and the Spring Boot Maven plugin does not have a `<configuration>` block. ([#2693](https://github.com/GoogleContainerTools/jib/pull/2693))
+
 ## 2.5.1
 
 ### Fixed
 
-- Fixed `NullPointerException` when the Spring Boot Maven plugin does not have a `<configuration>` block. ([#2687](https://github.com/GoogleContainerTools/jib/issues/2687))
+- Fixed `NullPointerException` when `<containerizingMode>packaged` is set the Spring Boot Maven plugin does not have a `<configuration>` block. ([#2687](https://github.com/GoogleContainerTools/jib/issues/2687))
 
 ## 2.5.0
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -566,9 +566,12 @@ public class MavenProjectProperties implements ProjectProperties {
       for (PluginExecution execution : springBootPlugin.getExecutions()) {
         if (execution.getGoals().contains("repackage")) {
           Xpp3Dom configuration = (Xpp3Dom) execution.getConfiguration();
+          if (configuration == null) {
+            return Optional.of(new Xpp3Dom("configuration"));
+          }
 
           boolean skip = Boolean.parseBoolean(getChildValue(configuration, "skip").orElse("false"));
-          return skip ? Optional.empty() : Optional.ofNullable(configuration);
+          return skip ? Optional.empty() : Optional.of(configuration);
         }
       }
     }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -788,7 +788,8 @@ public class MavenProjectPropertiesTest {
     Mockito.when(mockPluginExecution.getGoals()).thenReturn(Arrays.asList("repackage"));
     Mockito.when(mockPluginExecution.getConfiguration()).thenReturn(null);
     Assert.assertEquals(
-        Optional.empty(), mavenProjectProperties.getSpringBootRepackageConfiguration());
+        Optional.of(new Xpp3Dom("configuration")),
+        mavenProjectProperties.getSpringBootRepackageConfiguration());
   }
 
   @Test


### PR DESCRIPTION
Fixes #2692.

Reverts the fix of #2688, which only avoided NPE but wrongly assumed Spring Boot isn't configured by returning `Optional.empty()`. Instead, this PR returns an empty `Xpp3Dom` to signal that Spring Boot is configured.

Note that we do have a [Spring Boot integration test](https://github.com/GoogleContainerTools/jib/blob/74dd7a6263c0ca2e4aaab4f96578f9c19ecda5dd/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java#L702) for checking if we accidentally containerize a fat JAR. However, as mentioned [here](https://github.com/GoogleContainerTools/jib/issues/2687#issuecomment-671365684), this doesn't seem reproducible with a default setup. To hit both #2687 and #2692, it may be a multi-module Spring Boot setup (although I can't conclusively confirm this).