### PR TITLE
Fix child progress dispatcher factory

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -404,7 +404,8 @@ public class StepsRunner {
               Map<Future<Image>, Image> builtImagesAndBaseImages = new HashMap<>();
               for (Map.Entry<Image, List<Future<PreparedLayer>>> entry :
                   results.baseImagesAndLayers.get().entrySet()) {
-                Factory progressDispatcherFactory = progressDispatcher.newChildProducer();
+                ProgressEventDispatcher.Factory progressDispatcherFactory =
+                    progressDispatcher.newChildProducer();
                 Future<Image> builtImage =
                     executorService.submit(
                         () ->

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -305,6 +305,8 @@ public class StepsRunner {
   }
 
   private void obtainBaseImageLayers(boolean layersRequiredLocally) {
+    ProgressEventDispatcher.Factory childProgressDispatcherFactory =
+        Verify.verifyNotNull(rootProgressDispatcher).newChildProducer();
 
     results.baseImagesAndLayers =
         executorService.submit(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -399,7 +399,7 @@ public class StepsRunner {
               // auto-close it wit the current implementation.)
               ProgressEventDispatcher progressDispatcher =
                   childProgressDispatcherFactory.create(
-                      "scheduling building images", results.baseImagesAndLayers.get().size());
+                      "scheduling building manifests", results.baseImagesAndLayers.get().size());
 
               Map<Future<Image>, Image> builtImagesAndBaseImages = new HashMap<>();
               for (Map.Entry<Image, List<Future<PreparedLayer>>> entry :
@@ -436,7 +436,7 @@ public class StepsRunner {
               ProgressEventDispatcher progressDispatcher =
                   childProgressDispatcherFactory.create(
                       "scheduling pushing container configurations",
-                      results.builtImagesAndBaseImages.get().keySet().size());
+                      results.builtImagesAndBaseImages.get().size());
 
               Map<Future<Image>, Future<BlobDescriptor>> pushResults = new HashMap<>();
               for (Future<Image> builtImage : results.builtImagesAndBaseImages.get().keySet()) {
@@ -506,8 +506,8 @@ public class StepsRunner {
               // auto-close it wit the current implementation.)
               ProgressEventDispatcher progressDispatcher =
                   childProgressDispatcherFactory.create(
-                      "scheduling pushing images",
-                      results.builtImagesAndBaseImages.get().keySet().size());
+                      "scheduling pushing manifests",
+                      results.builtImagesAndBaseImages.get().size());
 
               realizeFutures(results.applicationLayerPushResults.get());
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -510,32 +510,6 @@ public class StepsRunner {
         });
   }
 
-  private void buildManifestList() {
-    ProgressEventDispatcher.Factory childProgressDispatcherFactory =
-        Verify.verifyNotNull(rootProgressDispatcher).newChildProducer();
-
-    results.manifestList =
-        executorService.submit(
-            () -> {
-              //              if (results.builtImagesAndBaseImages.get().size() == 1) return
-              // results.buildResults;
-
-              List<Future<Image>> builtImages = new ArrayList<>();
-              builtImages.addAll(
-                  results.builtImagesAndContainerConfigurationPushResults.get().keySet());
-              List<Future<BlobDescriptor>> containerConfigPushResults = new ArrayList<>();
-              containerConfigPushResults.addAll(
-                  results.builtImagesAndContainerConfigurationPushResults.get().values());
-
-              return new BuildManifestListStep(
-                      buildContext,
-                      childProgressDispatcherFactory,
-                      realizeFutures(builtImages),
-                      realizeFutures(containerConfigPushResults))
-                  .call();
-            });
-  }
-
   private void loadDocker(DockerClient dockerClient) {
     ProgressEventDispatcher.Factory childProgressDispatcherFactory =
         Verify.verifyNotNull(rootProgressDispatcher).newChildProducer();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -28,7 +28,6 @@ import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
 import com.google.cloud.tools.jib.global.JibSystemProperties;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.json.ManifestTemplate;
-import com.google.cloud.tools.jib.image.json.V22ManifestListTemplate;
 import com.google.cloud.tools.jib.registry.ManifestAndDigest;
 import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.common.base.Preconditions;
@@ -81,7 +80,6 @@ public class StepsRunner {
     private Future<List<Future<BuildResult>>> buildResults = failedFuture();
     private Future<Optional<ManifestAndDigest<ManifestTemplate>>> manifestCheckResult =
         failedFuture();
-    private Future<V22ManifestListTemplate> manifestList = failedFuture();
   }
 
   /**
@@ -189,7 +187,6 @@ public class StepsRunner {
     stepsToRun.add(this::pushContainerConfigurations);
     stepsToRun.add(this::checkImageInTargetRegistry);
     stepsToRun.add(this::pushImages);
-    stepsToRun.add(this::buildManifestList);
     return this;
   }
 


### PR DESCRIPTION
This PR fixes the `java.lang.IllegalStateException` resulting from the multiple use of a single progress dispatcher factory.