### PR TITLE
Fix NullPointerException during preconditions validation for Java 9+

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -122,7 +122,8 @@ public class ContainerConfiguration {
         this.programArguments = null;
       } else {
         Preconditions.checkArgument(
-            !programArguments.stream().anyMatch(Objects::isNull), "program arguments list contains null elements");
+            !programArguments.stream().anyMatch(Objects::isNull),
+            "program arguments list contains null elements");
         this.programArguments = ImmutableList.copyOf(programArguments);
       }
       return this;
@@ -201,7 +202,8 @@ public class ContainerConfiguration {
       if (volumes == null) {
         this.volumes = null;
       } else {
-        Preconditions.checkArgument(!volumes.stream().anyMatch(Objects::isNull), "volumes list contains null elements");
+        Preconditions.checkArgument(
+            !volumes.stream().anyMatch(Objects::isNull), "volumes list contains null elements");
         this.volumes = new HashSet<>(volumes);
       }
       return this;
@@ -262,7 +264,7 @@ public class ContainerConfiguration {
         this.entrypoint = null;
       } else {
         Preconditions.checkArgument(
-                !entrypoint.stream().anyMatch(Objects::isNull), "entrypoint contains null elements");
+            !entrypoint.stream().anyMatch(Objects::isNull), "entrypoint contains null elements");
         this.entrypoint = ImmutableList.copyOf(entrypoint);
       }
       return this;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -122,7 +122,7 @@ public class ContainerConfiguration {
         this.programArguments = null;
       } else {
         Preconditions.checkArgument(
-            !programArguments.contains(null), "program arguments list contains null elements");
+            !programArguments.stream().anyMatch(Objects::isNull), "program arguments list contains null elements");
         this.programArguments = ImmutableList.copyOf(programArguments);
       }
       return this;
@@ -201,7 +201,7 @@ public class ContainerConfiguration {
       if (volumes == null) {
         this.volumes = null;
       } else {
-        Preconditions.checkArgument(!volumes.contains(null), "volumes list contains null elements");
+        Preconditions.checkArgument(!volumes.stream().anyMatch(Objects::isNull), "volumes list contains null elements");
         this.volumes = new HashSet<>(volumes);
       }
       return this;
@@ -262,7 +262,7 @@ public class ContainerConfiguration {
         this.entrypoint = null;
       } else {
         Preconditions.checkArgument(
-            !entrypoint.contains(null), "entrypoint contains null elements");
+                !entrypoint.stream().anyMatch(Objects::isNull), "entrypoint contains null elements");
         this.entrypoint = ImmutableList.copyOf(entrypoint);
       }
       return this;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -174,7 +174,7 @@ public class ContainerConfiguration {
         this.exposedPorts = null;
       } else {
         Preconditions.checkArgument(
-            !exposedPorts.contains(null), "ports list contains null elements");
+            !exposedPorts.stream().anyMatch(Objects::isNull), "ports list contains null elements");
         this.exposedPorts = new HashSet<>(exposedPorts);
       }
       return this;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -122,7 +122,7 @@ public class ContainerConfiguration {
         this.programArguments = null;
       } else {
         Preconditions.checkArgument(
-            !programArguments.stream().anyMatch(Objects::isNull),
+            programArguments.stream().allMatch(Objects::nonNull),
             "program arguments list contains null elements");
         this.programArguments = ImmutableList.copyOf(programArguments);
       }
@@ -174,7 +174,7 @@ public class ContainerConfiguration {
         this.exposedPorts = null;
       } else {
         Preconditions.checkArgument(
-            !exposedPorts.stream().anyMatch(Objects::isNull), "ports list contains null elements");
+            exposedPorts.stream().allMatch(Objects::nonNull), "ports list contains null elements");
         this.exposedPorts = new HashSet<>(exposedPorts);
       }
       return this;
@@ -203,7 +203,7 @@ public class ContainerConfiguration {
         this.volumes = null;
       } else {
         Preconditions.checkArgument(
-            !volumes.stream().anyMatch(Objects::isNull), "volumes list contains null elements");
+            volumes.stream().allMatch(Objects::nonNull), "volumes list contains null elements");
         this.volumes = new HashSet<>(volumes);
       }
       return this;
@@ -264,7 +264,7 @@ public class ContainerConfiguration {
         this.entrypoint = null;
       } else {
         Preconditions.checkArgument(
-            !entrypoint.stream().anyMatch(Objects::isNull), "entrypoint contains null elements");
+            entrypoint.stream().allMatch(Objects::nonNull), "entrypoint contains null elements");
         this.entrypoint = ImmutableList.copyOf(entrypoint);
       }
       return this;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
@@ -99,7 +99,7 @@ public class DockerHealthCheck {
   public static DockerHealthCheck.Builder fromCommand(List<String> command) {
     Preconditions.checkArgument(command.size() > 0, "command must not be empty");
     Preconditions.checkArgument(
-        !command.stream().anyMatch(Objects::isNull), "command must not contain null elements");
+        command.stream().allMatch(Objects::nonNull), "command must not contain null elements");
     return new Builder(ImmutableList.copyOf(command));
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.time.Duration;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -97,7 +98,7 @@ public class DockerHealthCheck {
    */
   public static DockerHealthCheck.Builder fromCommand(List<String> command) {
     Preconditions.checkArgument(command.size() > 0, "command must not be empty");
-    Preconditions.checkArgument(!command.contains(null), "command must not contain null elements");
+    Preconditions.checkArgument(!command.stream().anyMatch(Objects::isNull), "command must not contain null elements");
     return new Builder(ImmutableList.copyOf(command));
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
@@ -98,7 +98,8 @@ public class DockerHealthCheck {
    */
   public static DockerHealthCheck.Builder fromCommand(List<String> command) {
     Preconditions.checkArgument(command.size() > 0, "command must not be empty");
-    Preconditions.checkArgument(!command.stream().anyMatch(Objects::isNull), "command must not contain null elements");
+    Preconditions.checkArgument(
+        !command.stream().anyMatch(Objects::isNull), "command must not contain null elements");
     return new Builder(ImmutableList.copyOf(command));
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
 
@@ -46,7 +47,7 @@ public class ImageConfiguration {
      */
     public Builder setCredentialRetrievers(List<CredentialRetriever> credentialRetrievers) {
       Preconditions.checkArgument(
-          !credentialRetrievers.contains(null), "credential retriever list contains null elements");
+          !credentialRetrievers.stream().anyMatch(Objects::isNull), "credential retriever list contains null elements");
       this.credentialRetrievers = ImmutableList.copyOf(credentialRetrievers);
       return this;
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
@@ -47,7 +47,8 @@ public class ImageConfiguration {
      */
     public Builder setCredentialRetrievers(List<CredentialRetriever> credentialRetrievers) {
       Preconditions.checkArgument(
-          !credentialRetrievers.stream().anyMatch(Objects::isNull), "credential retriever list contains null elements");
+          !credentialRetrievers.stream().anyMatch(Objects::isNull),
+          "credential retriever list contains null elements");
       this.credentialRetrievers = ImmutableList.copyOf(credentialRetrievers);
       return this;
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ImageConfiguration.java
@@ -47,7 +47,7 @@ public class ImageConfiguration {
      */
     public Builder setCredentialRetrievers(List<CredentialRetriever> credentialRetrievers) {
       Preconditions.checkArgument(
-          !credentialRetrievers.stream().anyMatch(Objects::isNull),
+          credentialRetrievers.stream().allMatch(Objects::nonNull),
           "credential retriever list contains null elements");
       this.credentialRetrievers = ImmutableList.copyOf(credentialRetrievers);
       return this;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
@@ -29,6 +29,7 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
@@ -29,7 +29,6 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
-
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
In Java 9+,  passing in `null` to ImmutableCollection#contains results in a NullPointerException. This PR uses a workaround to manually check for null values in an immutablecollection instead of calling .contains(). 

Since ImmutableCollection#contains in Java8 accepts null (https://guava.dev/releases/23.0/api/docs/com/google/common/collect/ImmutableList.html#contains-java.lang.Object-), this issue can't be reproduced in Java 8. 

Fixes #2702
