### PR TITLE
Prepare JSON template classes for new manifest cache design

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -38,7 +38,7 @@ import com.google.cloud.tools.jib.image.json.BadContainerConfigurationFormatExce
 import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
 import com.google.cloud.tools.jib.image.json.JsonToImageTranslator;
-import com.google.cloud.tools.jib.image.json.ManifestAndConfig;
+import com.google.cloud.tools.jib.image.json.ManifestAndConfigTemplate;
 import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.UnknownManifestFormatException;
 import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
@@ -49,6 +49,7 @@ import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.cloud.tools.jib.registry.credentials.CredentialRetrievalException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.Collections;
@@ -364,7 +365,7 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
       throws IOException, CacheCorruptedException, BadContainerConfigurationFormatException,
           LayerCountMismatchException {
     ImageReference baseImage = buildContext.getBaseImageConfiguration().getImage();
-    Optional<ManifestAndConfig> metadata =
+    Optional<ManifestAndConfigTemplate> metadata =
         buildContext.getBaseImageLayersCache().retrieveMetadata(baseImage);
     if (!metadata.isPresent()) {
       return Optional.empty();
@@ -376,9 +377,10 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
     }
 
     ContainerConfigurationTemplate configurationTemplate =
-        metadata.get().getConfig().orElseThrow(IllegalStateException::new);
+        Verify.verifyNotNull(metadata.get().getConfig());
     return Optional.of(
         JsonToImageTranslator.toImage(
-            (BuildableManifestTemplate) manifestTemplate, configurationTemplate));
+            (BuildableManifestTemplate) Verify.verifyNotNull(manifestTemplate),
+            configurationTemplate));
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
@@ -23,7 +23,7 @@ import com.google.cloud.tools.jib.api.buildplan.FileEntry;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
-import com.google.cloud.tools.jib.image.json.ManifestAndConfig;
+import com.google.cloud.tools.jib.image.json.ManifestAndConfigTemplate;
 import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -163,7 +163,7 @@ public class Cache {
    * @throws IOException if an I/O exception occurs
    * @throws CacheCorruptedException if the cache is corrupted
    */
-  public Optional<ManifestAndConfig> retrieveMetadata(ImageReference imageReference)
+  public Optional<ManifestAndConfigTemplate> retrieveMetadata(ImageReference imageReference)
       throws IOException, CacheCorruptedException {
     return cacheStorageReader.retrieveMetadata(imageReference);
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
@@ -23,7 +23,7 @@ import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.blob.Blobs;
 import com.google.cloud.tools.jib.filesystem.LockFile;
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
-import com.google.cloud.tools.jib.image.json.ManifestAndConfig;
+import com.google.cloud.tools.jib.image.json.ManifestAndConfigTemplate;
 import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.OciManifestTemplate;
 import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
@@ -84,7 +84,7 @@ class CacheStorageReader {
    * @throws IOException if an I/O exception occurs
    * @throws CacheCorruptedException if the cache is corrupted
    */
-  Optional<ManifestAndConfig> retrieveMetadata(ImageReference imageReference)
+  Optional<ManifestAndConfigTemplate> retrieveMetadata(ImageReference imageReference)
       throws IOException, CacheCorruptedException {
     Path imageDirectory = cacheStorageFiles.getImageDirectory(imageReference);
     Path manifestPath = imageDirectory.resolve("manifest.json");
@@ -110,7 +110,7 @@ class CacheStorageReader {
 
       if (schemaVersion == 1) {
         return Optional.of(
-            new ManifestAndConfig(
+            new ManifestAndConfigTemplate(
                 JsonTemplateMapper.readJsonFromFile(manifestPath, V21ManifestTemplate.class),
                 null));
       }
@@ -139,7 +139,7 @@ class CacheStorageReader {
         ContainerConfigurationTemplate config =
             JsonTemplateMapper.readJsonFromFile(configPath, ContainerConfigurationTemplate.class);
 
-        return Optional.of(new ManifestAndConfig(manifestTemplate, config));
+        return Optional.of(new ManifestAndConfigTemplate(manifestTemplate, config));
       }
       throw new CacheCorruptedException(
           cacheStorageFiles.getCacheDirectory(),

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
@@ -59,6 +59,7 @@ public interface BuildableManifestTemplate extends ManifestTemplate {
     }
 
     /** Necessary for Jackson to create from JSON. */
+    @SuppressWarnings("unused")
     private ContentDescriptorTemplate() {}
 
     @VisibleForTesting

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ImageMetadataTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ImageMetadataTemplate.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.image.json;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.cloud.tools.jib.json.JsonTemplate;
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+/** A bundle of an image manifest list, manifests, and container configurations. */
+public class ImageMetadataTemplate implements JsonTemplate {
+
+  @JsonTypeInfo(
+      use = JsonTypeInfo.Id.CLASS,
+      include = JsonTypeInfo.As.PROPERTY,
+      property = "@class")
+  @JsonSubTypes({
+    @JsonSubTypes.Type(value = OciIndexTemplate.class),
+    @JsonSubTypes.Type(value = V22ManifestListTemplate.class),
+  })
+  @Nullable
+  private ManifestTemplate manifestList;
+
+  private List<ManifestAndConfigTemplate> manifestsAndConfigs = new ArrayList<>();
+
+  @SuppressWarnings("unused")
+  private ImageMetadataTemplate() {}
+
+  public ImageMetadataTemplate(
+      @Nullable ManifestTemplate manifestList,
+      List<ManifestAndConfigTemplate> manifestsAndConfigs) {
+    this.manifestList = manifestList;
+    this.manifestsAndConfigs = manifestsAndConfigs;
+  }
+
+  @Nullable
+  public ManifestTemplate getManifestList() {
+    return manifestList;
+  }
+
+  public List<ManifestAndConfigTemplate> getManifestsAndConfigs() {
+    return manifestsAndConfigs;
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ManifestAndConfigTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ManifestAndConfigTemplate.java
@@ -16,16 +16,32 @@
 
 package com.google.cloud.tools.jib.image.json;
 
-import java.util.Optional;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.google.cloud.tools.jib.json.JsonTemplate;
 import javax.annotation.Nullable;
 
 /** Stores a manifest and container config. */
-public class ManifestAndConfig {
+public class ManifestAndConfigTemplate implements JsonTemplate {
 
-  private final ManifestTemplate manifest;
-  @Nullable private final ContainerConfigurationTemplate config;
+  @JsonTypeInfo(
+      use = JsonTypeInfo.Id.CLASS,
+      include = JsonTypeInfo.As.PROPERTY,
+      property = "@class")
+  @JsonSubTypes({
+    @JsonSubTypes.Type(value = OciManifestTemplate.class),
+    @JsonSubTypes.Type(value = V21ManifestTemplate.class),
+    @JsonSubTypes.Type(value = V22ManifestTemplate.class),
+  })
+  @Nullable
+  private ManifestTemplate manifest;
 
-  public ManifestAndConfig(
+  @Nullable private ContainerConfigurationTemplate config;
+
+  @SuppressWarnings("unused")
+  private ManifestAndConfigTemplate() {}
+
+  public ManifestAndConfigTemplate(
       ManifestTemplate manifest, @Nullable ContainerConfigurationTemplate config) {
     this.manifest = manifest;
     this.config = config;
@@ -36,6 +52,7 @@ public class ManifestAndConfig {
    *
    * @return the manifest
    */
+  @Nullable
   public ManifestTemplate getManifest() {
     return manifest;
   }
@@ -45,7 +62,8 @@ public class ManifestAndConfig {
    *
    * @return the container configuration
    */
-  public Optional<ContainerConfigurationTemplate> getConfig() {
-    return Optional.ofNullable(config);
+  @Nullable
+  public ContainerConfigurationTemplate getConfig() {
+    return config;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ManifestTemplate.java
@@ -19,7 +19,7 @@ package com.google.cloud.tools.jib.image.json;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.cloud.tools.jib.json.JsonTemplate;
 
-/** Parent class for image manifest JSON templates. */
+/** Parent class for image manifest and manifest list JSON templates. */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public interface ManifestTemplate extends JsonTemplate {
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/OciIndexTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/OciIndexTemplate.java
@@ -17,7 +17,6 @@
 package com.google.cloud.tools.jib.image.json;
 
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
-import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
@@ -47,13 +46,17 @@ import java.util.List;
  * @see <a href="https://github.com/opencontainers/image-spec/blob/master/image-index.md">OCI Image
  *     Index Specification</a>
  */
-public class OciIndexTemplate implements JsonTemplate {
+public class OciIndexTemplate implements ManifestTemplate {
 
-  @SuppressWarnings("unused")
   private final int schemaVersion = 2;
 
   private final List<BuildableManifestTemplate.ContentDescriptorTemplate> manifests =
       new ArrayList<>();
+
+  @Override
+  public int getSchemaVersion() {
+    return schemaVersion;
+  }
 
   /**
    * Adds a manifest reference with the given {@link BlobDescriptor}.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AbstractManifestPuller.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/AbstractManifestPuller.java
@@ -136,7 +136,7 @@ abstract class AbstractManifestPuller<T extends ManifestTemplate, R>
 
     int schemaVersion = node.get("schemaVersion").asInt(-1);
     if (schemaVersion == -1) {
-      throw new UnknownManifestFormatException("`schemaVersion` field is not an integer");
+      throw new UnknownManifestFormatException("'schemaVersion' field is not an integer");
     }
 
     if (schemaVersion == 1) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
@@ -94,6 +94,7 @@ public class DockerConfigTemplate implements JsonTemplate {
     this.auths = ImmutableMap.copyOf(auths);
   }
 
+  @SuppressWarnings("unused")
   private DockerConfigTemplate() {
     auths = new HashMap<>();
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/json/ErrorEntryTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/json/ErrorEntryTemplate.java
@@ -33,6 +33,7 @@ public class ErrorEntryTemplate implements JsonTemplate {
   }
 
   /** Necessary for Jackson to create from JSON. */
+  @SuppressWarnings("unused")
   private ErrorEntryTemplate() {}
 
   @Nullable

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
@@ -33,7 +33,7 @@ import com.google.cloud.tools.jib.image.LayerCountMismatchException;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.cloud.tools.jib.image.json.BadContainerConfigurationFormatException;
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
-import com.google.cloud.tools.jib.image.json.ManifestAndConfig;
+import com.google.cloud.tools.jib.image.json.ManifestAndConfigTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestListTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
@@ -57,8 +57,8 @@ public class PullBaseImageStepTest {
 
   private final ContainerConfigurationTemplate containerConfigJson =
       new ContainerConfigurationTemplate();
-  private final ManifestAndConfig manifestAndConfig =
-      new ManifestAndConfig(new V22ManifestTemplate(), containerConfigJson);
+  private final ManifestAndConfigTemplate manifestAndConfig =
+      new ManifestAndConfigTemplate(new V22ManifestTemplate(), containerConfigJson);
 
   @Mock private ProgressEventDispatcher.Factory progressDispatcherFactory;
   @Mock private BuildContext buildContext;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageReaderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageReaderTest.java
@@ -159,8 +159,8 @@ public class CacheStorageReaderTest {
         cacheStorageReader
             .retrieveMetadata(ImageReference.of("test", "image", "tag"))
             .get()
-            .getConfig()
-            .get();
+            .getConfig();
+    Assert.assertNotNull(configurationTemplate);
     Assert.assertEquals("wasm", configurationTemplate.getArchitecture());
     Assert.assertEquals("js", configurationTemplate.getOs());
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPullerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPullerTest.java
@@ -189,7 +189,7 @@ public class ManifestPullerTest {
       Assert.fail("A non-integer schemaVersion should throw an error");
 
     } catch (UnknownManifestFormatException ex) {
-      Assert.assertEquals("`schemaVersion` field is not an integer", ex.getMessage());
+      Assert.assertEquals("'schemaVersion' field is not an integer", ex.getMessage());
     }
   }
 


### PR DESCRIPTION
1. Renaming `ManifestAndConfig` to `ManifestAndConfigTemplate`.
   - The class is a simple pair of manifest and config. In the new design, it will be used as a JSON template for de-/serialization.
   - As a JSON template, converted `Optional<>` to `@Nullable`.

1. New class: `ImageMetadataTemplate`.
   - Holds
      1. a manifest list (if not Docker schema 1). Can be null (when a base image reference is not a manifest list).
      2. a list of manifest+config pairs (`List<ManifestAndConfigTemplate>`).
   For example,
   ```
   {
     "manifestList": {  # manifest list content
       "@class": "com.google.cloud.tools.jib.image.json.V22ManifestListTemplate",
       "manifests": [ { ... }, { ... }, { ... }, ... ]
     },

     "manifestsAndConfigs": [
       {
         "manifest": {
           "@class": "com.google.cloud.tools.jib.image.json.V22ManifestTemplate",
           "schemaVersion": 2,
           "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
           "config": { ... }
           ...
         },
         "config": { ... }
       },
       { ... },
       ...
     ]
   ```

1. `OciImageIndex` now inherits `ManifestTemplate` (previously `JsonTemplate`). This is to have a slightly more specialized class as a common super class of `OciImageIndex` and `V22ManifestListTemplate`.
   - Note currently `ManfiestTemplate` is also a super class of `OciManifestTemplate`, `V21ManifestTemplate` and `V22ManifestTemplate`. It does make sense to consider all of these manifest list classes and manifest classes as `ManifestTemplate`.

@louismurerwa