### PR TITLE
Rename RegistryClient.checkimage() to RegistryClient.checkManifest()

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestCheckerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestCheckerIntegrationTest.java
@@ -49,7 +49,7 @@ public class ManifestCheckerIntegrationTest {
     registryClient.doPullBearerAuth();
 
     Optional<ManifestAndDigest<ManifestTemplate>> manifestDescriptor =
-        registryClient.checkImage(KNOWN_MANIFEST);
+        registryClient.checkManifest(KNOWN_MANIFEST);
 
     assertTrue(manifestDescriptor.isPresent());
     assertEquals(KNOWN_MANIFEST, manifestDescriptor.get().getDigest().toString());
@@ -64,7 +64,7 @@ public class ManifestCheckerIntegrationTest {
     registryClient.doPullBearerAuth();
 
     Optional<ManifestAndDigest<ManifestTemplate>> manifestDescriptor =
-        registryClient.checkImage(UNKNOWN_MANIFEST);
+        registryClient.checkManifest(UNKNOWN_MANIFEST);
 
     assertEquals(Optional.empty(), manifestDescriptor);
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/CheckImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/CheckImageStep.java
@@ -83,7 +83,7 @@ class CheckImageStep implements Callable<Optional<ManifestAndDigest<ManifestTemp
         return Optional.empty();
       }
 
-      return registryClient.checkImage(manifestDigest.toString());
+      return registryClient.checkManifest(manifestDigest.toString());
     }
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -368,15 +368,15 @@ public class RegistryClient {
   }
 
   /**
-   * Check if an image is on the registry.
+   * Check if a manifest referred to by a tag or digest exists on the registry.
    *
    * @param imageQualifier the tag or digest to check for
-   * @return the {@link ManifestAndDigest} of the image if the image exists on the registry, or
-   *     {@link Optional#empty()} otherwise
+   * @return the manifest and its digest referred to by the tag or digest if the manifest exists on
+   *     the registry, or {@link Optional#empty()} otherwise
    * @throws IOException if communicating with the endpoint fails
    * @throws RegistryException if communicating with the endpoint fails
    */
-  public Optional<ManifestAndDigest<ManifestTemplate>> checkImage(String imageQualifier)
+  public Optional<ManifestAndDigest<ManifestTemplate>> checkManifest(String imageQualifier)
       throws IOException, RegistryException {
     ManifestChecker<ManifestTemplate> manifestChecker =
         new ManifestChecker<>(
@@ -404,7 +404,7 @@ public class RegistryClient {
     return callRegistryEndpoint(manifestPuller);
   }
 
-  public ManifestAndDigest<?> pullManifest(String imageQualifier)
+  public ManifestAndDigest<ManifestTemplate> pullManifest(String imageQualifier)
       throws IOException, RegistryException {
     return pullManifest(imageQualifier, ManifestTemplate.class);
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -368,11 +368,12 @@ public class RegistryClient {
   }
 
   /**
-   * Check if a manifest referred to by a tag or digest exists on the registry.
+   * Check if a manifest referred to by {@code imageQualifier} (tag or digest) exists on the
+   * registry.
    *
    * @param imageQualifier the tag or digest to check for
-   * @return the manifest and its digest referred to by the tag or digest if the manifest exists on
-   *     the registry, or {@link Optional#empty()} otherwise
+   * @return the {@link ManifestAndDigest} referred to by {@code imageQualifier} if the manifest
+   *     exists on the registry, or {@link Optional#empty()} otherwise
    * @throws IOException if communicating with the endpoint fails
    * @throws RegistryException if communicating with the endpoint fails
    */


### PR DESCRIPTION
The method pulls the manifest referred to by a tag or digest (if exists). The pulled manifest can also be a manifest list instead of an image manifest, so renaming it to `checkManifest()`.