### PR TITLE
Read a buildfile and convert it into a JibContainerBuilder

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
@@ -43,9 +43,10 @@ public class BuildFiles {
    */
   public static JibContainerBuilder toJibContainerBuilder(Path buildFilePath)
       throws InvalidImageReferenceException, IOException {
-    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+    ObjectMapper yamlObjectMapper = new ObjectMapper(new YAMLFactory());
     BuildFileSpec buildFile =
-        om.readValue(Files.newBufferedReader(buildFilePath, Charsets.UTF_8), BuildFileSpec.class);
+        yamlObjectMapper.readValue(
+            Files.newBufferedReader(buildFilePath, Charsets.UTF_8), BuildFileSpec.class);
     Path projectRoot = buildFilePath.toAbsolutePath().getParent();
 
     JibContainerBuilder containerBuilder;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.cli.buildfile;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
+import com.google.cloud.tools.jib.api.Jib;
+import com.google.cloud.tools.jib.api.JibContainerBuilder;
+import com.google.cloud.tools.jib.api.buildplan.Platform;
+import com.google.common.base.Charsets;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+
+/** Class to convert BuildFiles to build container representations. */
+public class BuildFiles {
+
+  /**
+   * Read a buildfile from disk and generate a JibContainerBuilder instance. All parsing of files
+   * considers the directory the buildfile is located in as the working directory.
+   *
+   * @param buildFilePath a file containing the build definition
+   * @return a {@link JibContainerBuilder} generated from the contents of {@code buildFilePath}
+   * @throws IOException if an I/O error occurs opening the file, or an error occurs while
+   *     traversing files on the filesystem
+   * @throws InvalidImageReferenceException if the baseImage reference can not be parsed
+   */
+  public static JibContainerBuilder toJibContainerBuilder(Path buildFilePath)
+      throws InvalidImageReferenceException, IOException {
+    ObjectMapper om = new ObjectMapper(new YAMLFactory());
+    BuildFileSpec buildFile =
+        om.readValue(Files.newBufferedReader(buildFilePath, Charsets.UTF_8), BuildFileSpec.class);
+    Path projectRoot = buildFilePath.toAbsolutePath().getParent();
+
+    JibContainerBuilder containerBuilder;
+    if (buildFile.getFrom().isPresent()) {
+      BaseImageSpec from = buildFile.getFrom().get();
+      containerBuilder = Jib.from(buildFile.getFrom().get().getImage());
+      if (!from.getPlatforms().isEmpty()) {
+        containerBuilder.setPlatforms(
+            from.getPlatforms()
+                .stream()
+                .map(
+                    platformSpec ->
+                        new Platform(platformSpec.getArchitecture(), platformSpec.getOs()))
+                .collect(Collectors.toSet()));
+      }
+    } else {
+      containerBuilder = Jib.fromScratch();
+    }
+
+    buildFile.getCreationTime().ifPresent(containerBuilder::setCreationTime);
+    buildFile.getFormat().ifPresent(containerBuilder::setFormat);
+    containerBuilder.setEnvironment(buildFile.getEnvironment());
+    containerBuilder.setLabels(buildFile.getLabels());
+    containerBuilder.setVolumes(buildFile.getVolumes());
+    containerBuilder.setExposedPorts(buildFile.getExposedPorts());
+    buildFile.getUser().ifPresent(containerBuilder::setUser);
+    buildFile.getWorkingDirectory().ifPresent(containerBuilder::setWorkingDirectory);
+    buildFile.getEntrypoint().ifPresent(containerBuilder::setEntrypoint);
+    buildFile.getCmd().ifPresent(containerBuilder::setProgramArguments);
+
+    if (buildFile.getLayers().isPresent()) {
+      containerBuilder.setFileEntriesLayers(
+          Layers.toLayers(projectRoot, buildFile.getLayers().get()));
+    }
+    return containerBuilder;
+  }
+}

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
@@ -23,6 +23,7 @@ import com.google.cloud.tools.jib.api.Jib;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.buildplan.Platform;
 import com.google.common.base.Charsets;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -44,15 +45,16 @@ public class BuildFiles {
   public static JibContainerBuilder toJibContainerBuilder(Path buildFilePath)
       throws InvalidImageReferenceException, IOException {
     ObjectMapper yamlObjectMapper = new ObjectMapper(new YAMLFactory());
-    BuildFileSpec buildFile =
-        yamlObjectMapper.readValue(
-            Files.newBufferedReader(buildFilePath, Charsets.UTF_8), BuildFileSpec.class);
+    BuildFileSpec buildFile;
+    try (BufferedReader reader = Files.newBufferedReader(buildFilePath, Charsets.UTF_8)) {
+      buildFile = yamlObjectMapper.readValue(reader, BuildFileSpec.class);
+    }
     Path projectRoot = buildFilePath.toAbsolutePath().getParent();
 
     JibContainerBuilder containerBuilder;
     if (buildFile.getFrom().isPresent()) {
       BaseImageSpec from = buildFile.getFrom().get();
-      containerBuilder = Jib.from(buildFile.getFrom().get().getImage());
+      containerBuilder = Jib.from(from.getImage());
       if (!from.getPlatforms().isEmpty()) {
         containerBuilder.setPlatforms(
             from.getPlatforms()

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Layers.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Layers.java
@@ -47,8 +47,8 @@ class Layers {
    * @return a {@link List} of {@link LayerObject} to use as part of a buildplan
    * @throws IOException if traversing a directory fails
    */
-  static List<LayerObject> toLayers(Path buildRoot, LayersSpec layersSpec) throws IOException {
-    List<LayerObject> layers = new ArrayList<>();
+  static List<FileEntriesLayer> toLayers(Path buildRoot, LayersSpec layersSpec) throws IOException {
+    List<FileEntriesLayer> layers = new ArrayList<>();
 
     FilePropertiesStack filePropertiesStack = new FilePropertiesStack();
     // base properties

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Layers.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Layers.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.jib.cli.buildfile;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.FileEntry;
-import com.google.cloud.tools.jib.api.buildplan.LayerObject;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.nio.file.FileSystems;
@@ -44,7 +43,7 @@ class Layers {
    * @param buildRoot the directory to resolve relative paths, usually the directory where the build
    *     config file is located
    * @param layersSpec a layersSpec containing configuration for all layers
-   * @return a {@link List} of {@link LayerObject} to use as part of a buildplan
+   * @return a {@link List} of {@link FileEntriesLayer} to use as part of a jib container build
    * @throws IOException if traversing a directory fails
    */
   static List<FileEntriesLayer> toLayers(Path buildRoot, LayersSpec layersSpec) throws IOException {

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
@@ -42,7 +42,7 @@ import org.junit.rules.TemporaryFolder;
 
 public class BuildFilesTest {
 
-  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+  @Rule public final TemporaryFolder tmp = new TemporaryFolder();
 
   @Test
   public void testToJibContainerBuilder_allProperties()
@@ -76,7 +76,6 @@ public class BuildFilesTest {
     Assert.assertEquals("scripts", resolvedLayer.getName());
     Assert.assertEquals(
         FileEntriesLayer.builder()
-            .setName("scripts")
             .addEntry(
                 projectRoot.resolve("project/script.sh"), AbsoluteUnixPath.get("/home/script.sh"))
             .build()

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.cli.buildfile;
+
+import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
+import com.google.cloud.tools.jib.api.JibContainerBuilder;
+import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.api.buildplan.ContainerBuildPlan;
+import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
+import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
+import com.google.cloud.tools.jib.api.buildplan.LayerObject;
+import com.google.cloud.tools.jib.api.buildplan.Platform;
+import com.google.cloud.tools.jib.api.buildplan.Port;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class BuildFilesTest {
+
+  @Rule public TemporaryFolder tmp = new TemporaryFolder();
+
+  @Test
+  public void testToJibContainerBuilder_allProperties()
+      throws URISyntaxException, IOException, InvalidImageReferenceException {
+    URL resource = Resources.getResource("buildfiles/projects/allProperties/jib.yaml");
+    JibContainerBuilder jibContainerBuilder =
+        BuildFiles.toJibContainerBuilder(Paths.get(resource.toURI()));
+    Path projectRoot = Paths.get(resource.toURI()).getParent();
+
+    ContainerBuildPlan resolved = jibContainerBuilder.toContainerBuildPlan();
+    Assert.assertEquals("ubuntu", resolved.getBaseImage());
+    Assert.assertEquals(Instant.ofEpochMilli(2000), resolved.getCreationTime());
+    Assert.assertEquals(ImageFormat.OCI, resolved.getFormat());
+    Assert.assertEquals(
+        ImmutableSet.of(new Platform("arm", "linux"), new Platform("amd64", "darwin")),
+        resolved.getPlatforms());
+    Assert.assertEquals(ImmutableMap.of("KEY1", "v1", "KEY2", "v2"), resolved.getEnvironment());
+    Assert.assertEquals(
+        ImmutableSet.of(AbsoluteUnixPath.get("/volume1"), AbsoluteUnixPath.get("/volume2")),
+        resolved.getVolumes());
+    Assert.assertEquals(ImmutableMap.of("label1", "l1", "label2", "l2"), resolved.getLabels());
+    Assert.assertEquals(
+        ImmutableSet.of(Port.udp(123), Port.tcp(456), Port.tcp(789)), resolved.getExposedPorts());
+    Assert.assertEquals("customUser", resolved.getUser());
+    Assert.assertEquals(AbsoluteUnixPath.get("/home"), resolved.getWorkingDirectory());
+    Assert.assertEquals(ImmutableList.of("sh", "script.sh"), resolved.getEntrypoint());
+    Assert.assertEquals(ImmutableList.of("--param", "param"), resolved.getCmd());
+
+    Assert.assertEquals(1, resolved.getLayers().size());
+    FileEntriesLayer resolvedLayer = (FileEntriesLayer) resolved.getLayers().get(0);
+    Assert.assertEquals("scripts", resolvedLayer.getName());
+    Assert.assertEquals(
+        FileEntriesLayer.builder()
+            .setName("scripts")
+            .addEntry(
+                projectRoot.resolve("project/script.sh"), AbsoluteUnixPath.get("/home/script.sh"))
+            .build()
+            .getEntries(),
+        resolvedLayer.getEntries());
+    Assert.assertEquals(LayerObject.Type.FILE_ENTRIES, resolvedLayer.getType());
+  }
+
+  @Test
+  public void testToJibContainerBuilder_requiredProperties()
+      throws URISyntaxException, IOException, InvalidImageReferenceException {
+    URL resource = Resources.getResource("buildfiles/projects/allDefaults/jib.yaml");
+    JibContainerBuilder jibContainerBuilder =
+        BuildFiles.toJibContainerBuilder(Paths.get(resource.toURI()));
+
+    ContainerBuildPlan resolved = jibContainerBuilder.toContainerBuildPlan();
+    Assert.assertEquals("scratch", resolved.getBaseImage());
+    Assert.assertEquals(ImmutableSet.of(new Platform("amd64", "linux")), resolved.getPlatforms());
+    Assert.assertEquals(Instant.EPOCH, resolved.getCreationTime());
+    Assert.assertEquals(ImageFormat.Docker, resolved.getFormat());
+    Assert.assertTrue(resolved.getEnvironment().isEmpty());
+    Assert.assertTrue(resolved.getLabels().isEmpty());
+    Assert.assertTrue(resolved.getVolumes().isEmpty());
+    Assert.assertTrue(resolved.getExposedPorts().isEmpty());
+    Assert.assertNull(resolved.getUser());
+    Assert.assertNull(resolved.getWorkingDirectory());
+    Assert.assertNull(resolved.getEntrypoint());
+    Assert.assertTrue(resolved.getLayers().isEmpty());
+  }
+}

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/LayersTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/LayersTest.java
@@ -22,7 +22,6 @@ import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.FileEntry;
 import com.google.cloud.tools.jib.api.buildplan.FilePermissions;
-import com.google.cloud.tools.jib.api.buildplan.LayerObject;
 import com.google.common.base.Charsets;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
@@ -32,11 +31,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -48,7 +44,7 @@ public class LayersTest {
   public static List<FileEntriesLayer> parseLayers(Path testDir, int expectedLayerCount)
       throws IOException {
     Path layersSpecYaml = testDir.resolve("layers.yaml");
-    List<LayerObject> layers =
+    List<FileEntriesLayer> layers =
         Layers.toLayers(
             layersSpecYaml.getParent(),
             new ObjectMapper(new YAMLFactory())
@@ -56,12 +52,7 @@ public class LayersTest {
                     Files.newBufferedReader(layersSpecYaml, Charsets.UTF_8), LayersSpec.class));
 
     Assert.assertEquals(expectedLayerCount, layers.size());
-    List<FileEntriesLayer> fileEntriesLayers = new ArrayList<>(expectedLayerCount);
-    for (LayerObject layerObject : layers) {
-      MatcherAssert.assertThat(layerObject, CoreMatchers.instanceOf(FileEntriesLayer.class));
-      fileEntriesLayers.add((FileEntriesLayer) layerObject);
-    }
-    return fileEntriesLayers;
+    return layers;
   }
 
   private static Path getLayersTestRoot(String testName) throws URISyntaxException {

--- a/jib-cli/src/test/resources/buildfiles/projects/allDefaults/jib.yaml
+++ b/jib-cli/src/test/resources/buildfiles/projects/allDefaults/jib.yaml
@@ -1,0 +1,3 @@
+apiVersion: jib/v1alpha1
+kind: BuildFile
+

--- a/jib-cli/src/test/resources/buildfiles/projects/allProperties/jib.yaml
+++ b/jib-cli/src/test/resources/buildfiles/projects/allProperties/jib.yaml
@@ -9,14 +9,6 @@ from:
   platforms:
     - architecture: "arm"
       os: "linux"
-      os.version: "a"
-      os.features:
-        - "b1"
-        - "b2"
-      variant: "c"
-      features:
-        - "d1"
-        - "d2"
     - architecture: "amd64"
       os: "darwin"
 

--- a/jib-cli/src/test/resources/buildfiles/projects/allProperties/jib.yaml
+++ b/jib-cli/src/test/resources/buildfiles/projects/allProperties/jib.yaml
@@ -1,0 +1,58 @@
+# this buildfile doesn't necessarily work, just useful for testing parsing and translation
+apiVersion: jib/v1alpha1
+kind: BuildFile
+
+# "FROM" with detail for manifest lists or multiple architectures
+from:
+  image: "ubuntu"
+  # optional: if missing, then defaults to `linux/amd64`
+  platforms:
+    - architecture: "arm"
+      os: "linux"
+      os.version: "a"
+      os.features:
+        - "b1"
+        - "b2"
+      variant: "c"
+      features:
+        - "d1"
+        - "d2"
+    - architecture: "amd64"
+      os: "darwin"
+
+# potentially simple form of "FROM" (based on ability to define schema)
+# from: "gcr.io/distroless/java:8"
+
+creationTime: 2000 # millis since epoch or iso8601 creation time
+format: OCI # Docker or OCI
+
+environment:
+  "KEY1": "v1"
+  "KEY2": "v2"
+labels:
+  "label1": "l1"
+  "label2": "l2"
+volumes:
+  - "/volume1"
+  - "/volume2"
+
+exposedPorts:
+  - "123/udp"
+  - "456"
+  - "789/tcp"
+
+user: "customUser"
+workingDirectory: "/home"
+entrypoint:
+  - "sh"
+  - "script.sh"
+cmd:
+  - "--param"
+  - "param"
+
+layers:
+  entries:
+    - name: "scripts"
+      files:
+        - src: "project/script.sh"
+          dest: "/home/script.sh"

--- a/jib-cli/src/test/resources/buildfiles/projects/allProperties/project/script.sh
+++ b/jib-cli/src/test/resources/buildfiles/projects/allProperties/project/script.sh
@@ -1,0 +1,2 @@
+env
+echo "string from file"


### PR DESCRIPTION
Reads a buildfile from file and converts it into a JibContainerBuilder, this will be used by the CLI to then generate a container.

Requires #2763 