### PR TITLE
Remove PlatformSpec unsupported parameters for now

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
@@ -36,11 +36,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *   - aes
  * }</pre>
  */
+// TODO: reintroduce platform details when ready
+// TODO: revert https://github.com/GoogleContainerTools/jib/pull/2763
 public class PlatformSpec {
   private final String architecture;
   private final String os;
-  // TODO: reintroduce platform details when ready
-  // TODO: revert https://github.com/GoogleContainerTools/jib/pull/2763
 
   /**
    * Constructor for use by jackson to populate this object.

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
@@ -18,10 +18,6 @@ package com.google.cloud.tools.jib.cli.buildfile;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
-import java.util.List;
-import java.util.Optional;
-import javax.annotation.Nullable;
 
 /**
  * A yaml block for specifying platforms.
@@ -43,41 +39,22 @@ import javax.annotation.Nullable;
 public class PlatformSpec {
   private final String architecture;
   private final String os;
-  @Nullable private final String osVersion;
-  private final List<String> osFeatures;
-  @Nullable private final String variant;
-  private final List<String> features;
+  // TODO: reintroduce platform details
 
   /**
    * Constructor for use by jackson to populate this object.
    *
    * @param architecture the target cpu architecture
    * @param os the target operating system
-   * @param variant the cpu variant
-   * @param features a list of cpu features
-   * @param osVersion the operating system version
-   * @param osFeatures a list of operating system features
    */
   @JsonCreator
   public PlatformSpec(
       @JsonProperty(value = "architecture", required = true) String architecture,
-      @JsonProperty(value = "os", required = true) String os,
-      @JsonProperty("os.version") String osVersion,
-      @JsonProperty("os.features") List<String> osFeatures,
-      @JsonProperty("variant") String variant,
-      @JsonProperty("features") List<String> features) {
+      @JsonProperty(value = "os", required = true) String os) {
     Validator.checkNotNullAndNotEmpty(architecture, "architecture");
     Validator.checkNotNullAndNotEmpty(os, "os");
-    Validator.checkNullOrNotEmpty(osVersion, "os.version");
-    Validator.checkNullOrNonNullNonEmptyEntries(osFeatures, "os.features");
-    Validator.checkNullOrNotEmpty(variant, "variant");
-    Validator.checkNullOrNonNullNonEmptyEntries(features, "features");
     this.architecture = architecture;
     this.os = os;
-    this.osVersion = osVersion;
-    this.osFeatures = (osFeatures == null) ? ImmutableList.of() : osFeatures;
-    this.variant = variant;
-    this.features = (features == null) ? ImmutableList.of() : features;
   }
 
   public String getArchitecture() {
@@ -86,21 +63,5 @@ public class PlatformSpec {
 
   public String getOs() {
     return os;
-  }
-
-  public Optional<String> getOsVersion() {
-    return Optional.ofNullable(osVersion);
-  }
-
-  public List<String> getOsFeatures() {
-    return osFeatures;
-  }
-
-  public Optional<String> getVariant() {
-    return Optional.ofNullable(variant);
-  }
-
-  public List<String> getFeatures() {
-    return features;
   }
 }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpec.java
@@ -39,7 +39,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class PlatformSpec {
   private final String architecture;
   private final String os;
-  // TODO: reintroduce platform details
+  // TODO: reintroduce platform details when ready
+  // TODO: revert https://github.com/GoogleContainerTools/jib/pull/2763
 
   /**
    * Constructor for use by jackson to populate this object.

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/PlatformSpecTest.java
@@ -19,15 +19,10 @@ package com.google.cloud.tools.jib.cli.buildfile;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.common.collect.ImmutableList;
-import java.util.Arrays;
-import java.util.Collection;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 
 /** Tests for {@link PlatformSpec}. */
 public class PlatformSpecTest {
@@ -36,24 +31,11 @@ public class PlatformSpecTest {
 
   @Test
   public void testPlatformSpec_full() throws JsonProcessingException {
-    String data =
-        "architecture: amd64\n"
-            + "os: linux\n"
-            + "os.version: 1.0.0\n"
-            + "os.features:\n"
-            + "  - headless\n"
-            + "variant: amd64v10\n"
-            + "features:\n"
-            + "  - sse4\n"
-            + "  - aes\n";
+    String data = "architecture: amd64\n" + "os: linux\n";
 
     PlatformSpec parsed = mapper.readValue(data, PlatformSpec.class);
     Assert.assertEquals("amd64", parsed.getArchitecture());
     Assert.assertEquals("linux", parsed.getOs());
-    Assert.assertEquals("1.0.0", parsed.getOsVersion().get());
-    Assert.assertEquals(ImmutableList.of("headless"), parsed.getOsFeatures());
-    Assert.assertEquals("amd64v10", parsed.getVariant().get());
-    Assert.assertEquals(ImmutableList.of("sse4", "aes"), parsed.getFeatures());
   }
 
   @Test
@@ -133,101 +115,6 @@ public class PlatformSpecTest {
       MatcherAssert.assertThat(
           jpe.getMessage(),
           CoreMatchers.containsString("Property 'architecture' cannot be an empty string"));
-    }
-  }
-
-  @Test
-  public void testPlatformSpec_nullCollections() throws JsonProcessingException {
-    String data = "architecture: amd64\n" + "os: linux\n";
-
-    PlatformSpec parsed = mapper.readValue(data, PlatformSpec.class);
-    Assert.assertEquals(ImmutableList.of(), parsed.getOsFeatures());
-    Assert.assertEquals(ImmutableList.of(), parsed.getFeatures());
-  }
-
-  @RunWith(Parameterized.class)
-  public static class OptionalStringTests {
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-      return Arrays.asList(new Object[][] {{"os.version"}, {"variant"}});
-    }
-
-    @Parameterized.Parameter public String fieldName;
-
-    @Test
-    public void testPlatformSpec_noEmptyValues() {
-      String data = "architecture: ignored\n" + "os: ignored\n" + fieldName + ": ' '";
-
-      try {
-        mapper.readValue(data, PlatformSpec.class);
-        Assert.fail();
-      } catch (JsonProcessingException ex) {
-        Assert.assertEquals(
-            "Property '" + fieldName + "' cannot be an empty string", ex.getCause().getMessage());
-      }
-    }
-
-    @Test
-    public void testPlatformSpec_nullOkay() throws JsonProcessingException {
-      String data = "architecture: ignored\n" + "os: ignored\n" + fieldName + ": null";
-
-      mapper.readValue(data, PlatformSpec.class);
-      // pass
-    }
-  }
-
-  @RunWith(Parameterized.class)
-  public static class OptionalStringCollectionTests {
-
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-      return Arrays.asList(new Object[][] {{"os.features"}, {"features"}});
-    }
-
-    @Parameterized.Parameter public String fieldName;
-
-    @Test
-    public void testPlatformSpec_noNullEntries() {
-      String data = "architecture: ignored\n" + "os: ignored\n" + fieldName + ": ['first', null]";
-
-      try {
-        mapper.readValue(data, PlatformSpec.class);
-        Assert.fail();
-      } catch (JsonProcessingException ex) {
-        Assert.assertEquals(
-            "Property '" + fieldName + "' cannot contain null entries", ex.getCause().getMessage());
-      }
-    }
-
-    @Test
-    public void testPlatformSpec_noEmptyEntries() {
-      String data = "architecture: ignored\n" + "os: ignored\n" + fieldName + ": ['first', '  ']";
-
-      try {
-        mapper.readValue(data, PlatformSpec.class);
-        Assert.fail();
-      } catch (JsonProcessingException ex) {
-        Assert.assertEquals(
-            "Property '" + fieldName + "' cannot contain empty strings",
-            ex.getCause().getMessage());
-      }
-    }
-
-    @Test
-    public void testPlatformSpec_emptyOkay() throws JsonProcessingException {
-      String data = "architecture: ignored\n" + "os: ignored\n" + fieldName + ": []";
-
-      mapper.readValue(data, PlatformSpec.class);
-      // pass
-    }
-
-    @Test
-    public void testPlatformSpec_nullOkay() throws JsonProcessingException {
-      String data = "architecture: ignored\n" + "os: ignored\n" + fieldName + ": null";
-
-      mapper.readValue(data, PlatformSpec.class);
-      // pass
     }
   }
 }


### PR DESCRIPTION
Since jib-core doesn't supported advanced platform spec options yet, remove these and reintroduce them later.