### PR TITLE
Fix to handle integration test failure caused by #2739

### DIFF
--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/empty/build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/empty/build.gradle
@@ -26,5 +26,5 @@ jib {
 
 def additionalTag = System.getProperty("_ADDITIONAL_TAG")
 if (additionalTag != null && !additionalTag.isEmpty()) {
-  jib.to.tags = [System.getProperty("_ADDITIONAL_TAG")] as Set
+  jib.to.tags = [System.getProperty("_ADDITIONAL_TAG")]
 }

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/empty/build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/empty/build.gradle
@@ -26,5 +26,5 @@ jib {
 
 def additionalTag = System.getProperty("_ADDITIONAL_TAG")
 if (additionalTag != null && !additionalTag.isEmpty()) {
-  jib.to.tags = [System.getProperty("_ADDITIONAL_TAG")]
+  jib.to.tags = [System.getProperty("_ADDITIONAL_TAG")] as Set
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TargetImageParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TargetImageParameters.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.gradle;
 import com.google.cloud.tools.jib.plugins.common.ConfigurationPropertyValidator;
 import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.common.collect.ImmutableSet;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -74,6 +75,10 @@ public class TargetImageParameters {
               System.getProperty(PropertyNames.TO_TAGS)));
     }
     return tags.get();
+  }
+
+  public void setTags(List<String> tags) {
+    this.tags.set(tags);
   }
 
   public void setTags(Set<String> tags) {


### PR DESCRIPTION
Specifically, [this](https://github.com/GoogleContainerTools/jib/blob/faff19bd59737e10db4425e47b7e6c9904e83833/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/EmptyProjectIntegrationTest.java#L76) integration test was failing. This PR serves as a follow-up to #2739. 

