### PR TITLE
Fix platform configuration in Gradle plugin

### DIFF
--- a/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlan.java
+++ b/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlan.java
@@ -39,8 +39,7 @@ public class ContainerBuildPlan {
     private Instant creationTime = Instant.EPOCH;
     private ImageFormat format = ImageFormat.Docker;
 
-    // note that a LinkedHashSet instead of HashSet has been used so as to preserve the platform
-    // order
+    // LinkedHashSet to preserve the order
     private Set<Platform> platforms =
         new LinkedHashSet<>(Collections.singleton(new Platform("amd64", "linux")));
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -47,8 +47,7 @@ public class ContainerConfiguration {
      */
     private static final Instant DEFAULT_CREATION_TIME = Instant.EPOCH;
 
-    // note that a LinkedHashSet instead of HashSet has been used so as to preserve the platform
-    // order
+    // LinkedHashSet to preserve the order
     private Set<Platform> platforms =
         new LinkedHashSet<>(Collections.singleton(new Platform("amd64", "linux")));
     private Instant creationTime = DEFAULT_CREATION_TIME;

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed `NullPointerException` during input validation (in Java 9+) when configuring Jib parameters using certain immutable collections (such as `List.of()`). ([#2702](https://github.com/GoogleContainerTools/jib/issues/2702))
+- Fixed an issue that configuring `jib.from.platforms` was always additive to the default `amd64/linux` platform. ([#2783](https://github.com/GoogleContainerTools/jib/issues/2783))
 
 ## 2.5.0
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
@@ -49,17 +49,18 @@ public class BaseImageParameters {
   @Nested
   @Optional
   public ListProperty<PlatformParameters> getPlatforms() {
-    if (platforms.get().isEmpty()) {
-      PlatformParameters amd64Linux = new PlatformParameters();
-      amd64Linux.setArchitecture("amd64");
-      amd64Linux.setOs("linux");
-
-      ListProperty<PlatformParameters> platforms =
-          objectFactory.listProperty(PlatformParameters.class);
-      platforms.add(amd64Linux);
+    if (!platforms.get().isEmpty()) {
       return platforms;
     }
-    return platforms;
+
+    PlatformParameters amd64Linux = new PlatformParameters();
+    amd64Linux.setArchitecture("amd64");
+    amd64Linux.setOs("linux");
+
+    ListProperty<PlatformParameters> defaultPlatforms =
+        objectFactory.listProperty(PlatformParameters.class);
+    defaultPlatforms.add(amd64Linux);
+    return defaultPlatforms;
   }
 
   public void platforms(Action<? super PlatformParametersSpec> action) {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
@@ -41,29 +41,24 @@ public class BaseImageParameters {
   public BaseImageParameters(ObjectFactory objectFactory) {
     this.objectFactory = objectFactory;
     auth = objectFactory.newInstance(AuthParameters.class, "from.auth");
-    platforms = objectFactory.listProperty(PlatformParameters.class).empty();
+    platforms = objectFactory.listProperty(PlatformParameters.class);
     platformParametersSpec =
         objectFactory.newInstance(PlatformParametersSpec.class, objectFactory, platforms);
+
+    PlatformParameters amd64Linux = new PlatformParameters();
+    amd64Linux.setArchitecture("amd64");
+    amd64Linux.setOs("linux");
+    platforms.add(amd64Linux);
   }
 
   @Nested
   @Optional
   public ListProperty<PlatformParameters> getPlatforms() {
-    if (!platforms.get().isEmpty()) {
-      return platforms;
-    }
-
-    PlatformParameters amd64Linux = new PlatformParameters();
-    amd64Linux.setArchitecture("amd64");
-    amd64Linux.setOs("linux");
-
-    ListProperty<PlatformParameters> defaultPlatforms =
-        objectFactory.listProperty(PlatformParameters.class);
-    defaultPlatforms.add(amd64Linux);
-    return defaultPlatforms;
+    return platforms;
   }
 
   public void platforms(Action<? super PlatformParametersSpec> action) {
+    platforms.empty();
     action.execute(platformParametersSpec);
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
@@ -35,22 +35,30 @@ public class BaseImageParameters {
   private final PlatformParametersSpec platformParametersSpec;
   private final ListProperty<PlatformParameters> platforms;
 
+  private final ObjectFactory objectFactory;
+
   @Inject
   public BaseImageParameters(ObjectFactory objectFactory) {
+    this.objectFactory = objectFactory;
     auth = objectFactory.newInstance(AuthParameters.class, "from.auth");
     platforms = objectFactory.listProperty(PlatformParameters.class).empty();
     platformParametersSpec =
         objectFactory.newInstance(PlatformParametersSpec.class, objectFactory, platforms);
-
-    PlatformParameters platform = new PlatformParameters();
-    platform.setOs("linux");
-    platform.setArchitecture("amd64");
-    platforms.add(platform);
   }
 
   @Nested
   @Optional
   public ListProperty<PlatformParameters> getPlatforms() {
+    if (platforms.get().isEmpty()) {
+      PlatformParameters amd64Linux = new PlatformParameters();
+      amd64Linux.setArchitecture("amd64");
+      amd64Linux.setOs("linux");
+
+      ListProperty<PlatformParameters> platforms =
+          objectFactory.listProperty(PlatformParameters.class);
+      platforms.add(amd64Linux);
+      return platforms;
+    }
     return platforms;
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
@@ -35,11 +35,8 @@ public class BaseImageParameters {
   private final PlatformParametersSpec platformParametersSpec;
   private final ListProperty<PlatformParameters> platforms;
 
-  private final ObjectFactory objectFactory;
-
   @Inject
   public BaseImageParameters(ObjectFactory objectFactory) {
-    this.objectFactory = objectFactory;
     auth = objectFactory.newInstance(AuthParameters.class, "from.auth");
     platforms = objectFactory.listProperty(PlatformParameters.class);
     platformParametersSpec =

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -62,11 +62,6 @@ public class JibExtensionTest {
     Assert.assertEquals("amd64", defaultPlatforms.get(0).getArchitecture());
     Assert.assertEquals("linux", defaultPlatforms.get(0).getOs());
 
-    // Ensures calling getPlatforms() again doesn't increase the resulting list.
-    List<PlatformParameters> defaultPlatformsAgain =
-        testJibExtension.getFrom().getPlatforms().get();
-    Assert.assertEquals(1, defaultPlatformsAgain.size());
-
     testJibExtension.from(
         from -> {
           from.setImage("some image");

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -56,17 +57,45 @@ public class JibExtensionTest {
     Assert.assertNull(testJibExtension.getFrom().getImage());
     Assert.assertNull(testJibExtension.getFrom().getCredHelper());
 
+    List<PlatformParameters> defaultPlatforms = testJibExtension.getFrom().getPlatforms().get();
+    Assert.assertEquals(1, defaultPlatforms.size());
+    Assert.assertEquals("amd64", defaultPlatforms.get(0).getArchitecture());
+    Assert.assertEquals("linux", defaultPlatforms.get(0).getOs());
+
+    // Ensures calling getPlatforms() again doesn't increase the resulting list.
+    List<PlatformParameters> defaultPlatformsAgain =
+        testJibExtension.getFrom().getPlatforms().get();
+    Assert.assertEquals(1, defaultPlatformsAgain.size());
+
     testJibExtension.from(
         from -> {
           from.setImage("some image");
           from.setCredHelper("some cred helper");
           from.auth(auth -> auth.setUsername("some username"));
           from.auth(auth -> auth.setPassword("some password"));
+          from.platforms(
+              platformSpec -> {
+                platformSpec.platform(
+                    platform -> {
+                      platform.setArchitecture("arm");
+                      platform.setOs("windows");
+                    });
+              });
         });
     Assert.assertEquals("some image", testJibExtension.getFrom().getImage());
     Assert.assertEquals("some cred helper", testJibExtension.getFrom().getCredHelper());
     Assert.assertEquals("some username", testJibExtension.getFrom().getAuth().getUsername());
     Assert.assertEquals("some password", testJibExtension.getFrom().getAuth().getPassword());
+
+    List<PlatformParameters> platforms = testJibExtension.getFrom().getPlatforms().get();
+    Assert.assertEquals(1, platforms.size());
+    Assert.assertEquals("arm", platforms.get(0).getArchitecture());
+    Assert.assertEquals("windows", platforms.get(0).getOs());
+  }
+
+  @Test
+  public void testFromPlatforms() {
+    List<PlatformParameters> list = testJibExtension.getFrom().getPlatforms().get();
   }
 
   @Test

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -94,11 +94,6 @@ public class JibExtensionTest {
   }
 
   @Test
-  public void testFromPlatforms() {
-    List<PlatformParameters> list = testJibExtension.getFrom().getPlatforms().get();
-  }
-
-  @Test
   public void testTo() {
     Assert.assertNull(testJibExtension.getTo().getImage());
     Assert.assertNull(testJibExtension.getTo().getCredHelper());


### PR DESCRIPTION
Fixes #2781.

We started with the default amd64/linux, and we were always adding new platforms.