### PR TITLE
Add templating to jib-cli

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,6 +65,7 @@ subprojects {
     MAVEN_EXTENSION: 'com.google.cloud.tools:jib-maven-plugin-extension-api:0.4.0',
 
     COMMONS_COMPRESS: 'org.apache.commons:commons-compress:1.20',
+    COMMONS_TEXT: 'org.apache.commons:commons-text:1.9',
     JACKSON_DATABIND: 'com.fasterxml.jackson.core:jackson-databind:2.11.2',
     JACKSON_DATAFORMAT_YAML: 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.2',
     ASM: 'org.ow2.asm:asm:8.0.1',

--- a/jib-cli/build.gradle
+++ b/jib-cli/build.gradle
@@ -16,6 +16,7 @@ application {
 
 dependencies {
   implementation project(':jib-core')
+  implementation dependencyStrings.COMMONS_TEXT
   implementation dependencyStrings.JACKSON_DATAFORMAT_YAML
   implementation dependencyStrings.JACKSON_DATABIND
   implementation dependencyStrings.GUAVA

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
@@ -23,32 +23,45 @@ import com.google.cloud.tools.jib.api.Jib;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.buildplan.Platform;
 import com.google.common.base.Charsets;
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.commons.text.StringSubstitutor;
+import org.apache.commons.text.io.StringSubstitutorReader;
 
 /** Class to convert BuildFiles to build container representations. */
 public class BuildFiles {
+
+  /** Read a build file from disk and apply templating parameters. */
+  private static BuildFileSpec toBuildFileSpec(
+      Path buildFilePath, Map<String, String> templateParameters) throws IOException {
+    ObjectMapper yamlObjectMapper = new ObjectMapper(new YAMLFactory());
+    StringSubstitutor templater =
+        new StringSubstitutor(templateParameters).setEnableUndefinedVariableException(true);
+    try (StringSubstitutorReader reader =
+        new StringSubstitutorReader(
+            Files.newBufferedReader(buildFilePath, Charsets.UTF_8), templater)) {
+      return yamlObjectMapper.readValue(reader, BuildFileSpec.class);
+    }
+  }
 
   /**
    * Read a buildfile from disk and generate a JibContainerBuilder instance. All parsing of files
    * considers the directory the buildfile is located in as the working directory.
    *
    * @param buildFilePath a file containing the build definition
+   * @param templateParameters a map of templating variables to apply on the file before parsing
    * @return a {@link JibContainerBuilder} generated from the contents of {@code buildFilePath}
    * @throws IOException if an I/O error occurs opening the file, or an error occurs while
    *     traversing files on the filesystem
    * @throws InvalidImageReferenceException if the baseImage reference can not be parsed
    */
-  public static JibContainerBuilder toJibContainerBuilder(Path buildFilePath)
+  public static JibContainerBuilder toJibContainerBuilder(
+      Path buildFilePath, Map<String, String> templateParameters)
       throws InvalidImageReferenceException, IOException {
-    ObjectMapper yamlObjectMapper = new ObjectMapper(new YAMLFactory());
-    BuildFileSpec buildFile;
-    try (BufferedReader reader = Files.newBufferedReader(buildFilePath, Charsets.UTF_8)) {
-      buildFile = yamlObjectMapper.readValue(reader, BuildFileSpec.class);
-    }
+    BuildFileSpec buildFile = toBuildFileSpec(buildFilePath, templateParameters);
     Path projectRoot = buildFilePath.toAbsolutePath().getParent();
 
     JibContainerBuilder containerBuilder;

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
@@ -157,7 +157,8 @@ public class BuildFilesTest {
 
     JibContainerBuilder jibContainerBuilder =
         BuildFiles.toJibContainerBuilder(
-            Paths.get(resource.toURI()), ImmutableMap.of("replace\nthis", "creationTime: 1234"));
+            Paths.get(resource.toURI()),
+            ImmutableMap.of("replace" + System.lineSeparator() + "this", "creationTime: 1234"));
     ContainerBuildPlan resolved = jibContainerBuilder.toContainerBuildPlan();
     Assert.assertEquals(Instant.ofEpochMilli(1234), resolved.getCreationTime());
   }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
@@ -35,6 +35,9 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
+import java.util.Map;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,7 +52,7 @@ public class BuildFilesTest {
       throws URISyntaxException, IOException, InvalidImageReferenceException {
     URL resource = Resources.getResource("buildfiles/projects/allProperties/jib.yaml");
     JibContainerBuilder jibContainerBuilder =
-        BuildFiles.toJibContainerBuilder(Paths.get(resource.toURI()));
+        BuildFiles.toJibContainerBuilder(Paths.get(resource.toURI()), ImmutableMap.of());
     Path projectRoot = Paths.get(resource.toURI()).getParent();
 
     ContainerBuildPlan resolved = jibContainerBuilder.toContainerBuildPlan();
@@ -89,7 +92,7 @@ public class BuildFilesTest {
       throws URISyntaxException, IOException, InvalidImageReferenceException {
     URL resource = Resources.getResource("buildfiles/projects/allDefaults/jib.yaml");
     JibContainerBuilder jibContainerBuilder =
-        BuildFiles.toJibContainerBuilder(Paths.get(resource.toURI()));
+        BuildFiles.toJibContainerBuilder(Paths.get(resource.toURI()), ImmutableMap.of());
 
     ContainerBuildPlan resolved = jibContainerBuilder.toContainerBuildPlan();
     Assert.assertEquals("scratch", resolved.getBaseImage());
@@ -104,5 +107,58 @@ public class BuildFilesTest {
     Assert.assertNull(resolved.getWorkingDirectory());
     Assert.assertNull(resolved.getEntrypoint());
     Assert.assertTrue(resolved.getLayers().isEmpty());
+  }
+
+  @Test
+  public void testToBuildFileSpec_withTemplating()
+      throws URISyntaxException, InvalidImageReferenceException, IOException {
+    URL resource = Resources.getResource("buildfiles/projects/templating/valid.yaml");
+
+    JibContainerBuilder jibContainerBuilder =
+        BuildFiles.toJibContainerBuilder(
+            Paths.get(resource.toURI()),
+            ImmutableMap.of(
+                "unused", "ignored", // keys that are defined but not used do not throw an error
+                "key", "templateKey",
+                "value", "templateValue",
+                "repeated", "repeatedValue"));
+
+    ContainerBuildPlan resolved = jibContainerBuilder.toContainerBuildPlan();
+    Map<String, String> expectedLabels =
+        ImmutableMap.<String, String>builder()
+            .put("templateKey", "templateValue")
+            .put("label1", "repeatedValue")
+            .put("label2", "repeatedValue")
+            .put("label3", "${escaped}")
+            .put("label4", "free$")
+            .put("unmatched", "${")
+            .build();
+    Assert.assertEquals(expectedLabels, resolved.getLabels());
+  }
+
+  @Test
+  public void testToBuildFileSpec_failWithMissingTemplateVariable()
+      throws URISyntaxException, InvalidImageReferenceException, IOException {
+    URL resource = Resources.getResource("buildfiles/projects/templating/missingVar.yaml");
+
+    try {
+      BuildFiles.toJibContainerBuilder(Paths.get(resource.toURI()), ImmutableMap.of());
+      Assert.fail();
+    } catch (IllegalArgumentException iae) {
+      MatcherAssert.assertThat(
+          iae.getMessage(), CoreMatchers.startsWith("Cannot resolve variable 'missingVar'"));
+    }
+  }
+
+  @Test
+  public void testToBuildFileSpec_templateMultiLineBehavior()
+      throws URISyntaxException, InvalidImageReferenceException, IOException {
+    URL resource = Resources.getResource("buildfiles/projects/templating/multiLine.yaml");
+
+    JibContainerBuilder jibContainerBuilder =
+        BuildFiles.toJibContainerBuilder(
+            Paths.get(resource.toURI()), ImmutableMap.of("replace\nthis", "creationTime: 1234"));
+    ContainerBuildPlan resolved = jibContainerBuilder.toContainerBuildPlan();
+    Assert.assertEquals(Instant.ofEpochMilli(1234), resolved.getCreationTime());
   }
 }

--- a/jib-cli/src/test/resources/buildfiles/projects/templating/missingVar.yaml
+++ b/jib-cli/src/test/resources/buildfiles/projects/templating/missingVar.yaml
@@ -1,0 +1,5 @@
+apiVersion: jib/v1alpha1
+kind: BuildFile
+
+labels:
+  "label1": "${missingVar}"

--- a/jib-cli/src/test/resources/buildfiles/projects/templating/multiLine.yaml
+++ b/jib-cli/src/test/resources/buildfiles/projects/templating/multiLine.yaml
@@ -1,0 +1,5 @@
+apiVersion: jib/v1alpha1
+kind: BuildFile
+
+${replace
+this}

--- a/jib-cli/src/test/resources/buildfiles/projects/templating/valid.yaml
+++ b/jib-cli/src/test/resources/buildfiles/projects/templating/valid.yaml
@@ -1,0 +1,10 @@
+apiVersion: jib/v1alpha1
+kind: BuildFile
+
+labels:
+  "${key}": "${value}"
+  "label1": "${repeated}"
+  "label2": "${repeated}"
+  "label3": "$${escaped}"
+  "label4": "free$"
+  "unmatched": "${"


### PR DESCRIPTION
Allow templating in cli buildfiles

Expected usage:
```
$ jib build -Pkey=value
```
will replace any instances of `${key}` with `value' in the raw build file. This means the user can technically replace whole sections of the buildfile.