### PR TITLE
Optimize authentication for base image

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
 - Fixed `NullPointerException` to return a helpful message when a server does not provide any message in certain error cases (400 Bad Request, 404 Not Found, and 405 Method Not Allowed). ([#2532](https://github.com/GoogleContainerTools/jib/issues/2532))
 - Now supports sending client certificate (for example, via the `javax.net.ssl.keyStore` and `javax.net.ssl.keyStorePassword` system properties) and thus enabling mutual TLS authentication. ([#2585](https://github.com/GoogleContainerTools/jib/issues/2585), [#2226](https://github.com/GoogleContainerTools/jib/issues/2226))
 - Fixed `NullPointerException` during input validation (in Java 9+) when configuring Jib parameters using certain immutable collections (such as `List.of()`). ([#2702](https://github.com/GoogleContainerTools/jib/issues/2702))
+- Fixed authentication failure with Azure Container Registry when using ["tokens"](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions). ([#2784](https://github.com/GoogleContainerTools/jib/issues/2784))
+- Improved authentication flow for base image registry. ([#2134](https://github.com/GoogleContainerTools/jib/issues/2134))
 
 ## 0.15.0
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -128,7 +128,10 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
             progressEventDispatcherFactory.create("pulling base image manifest", 2);
         TimerEventDispatcher ignored1 = new TimerEventDispatcher(eventHandlers, DESCRIPTION)) {
 
-      // First, try with no credentials.
+      // First, try with no credentials. This works with public GCR images (but not Docker Hub).
+      // TODO: investigate if we should just pass credentials up front. However, this involves
+      // some risk. https://github.com/GoogleContainerTools/jib/pull/2200#discussion_r359069026
+      // contains some related discussions.
       RegistryClient noAuthRegistryClient =
           buildContext.newBaseImageRegistryClientFactory().newRegistryClient();
       try {
@@ -140,40 +143,43 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
             LogEvent.lifecycle(
                 "The base image requires auth. Trying again for " + imageReference + "..."));
 
-        Credential registryCredential =
+        Credential credential =
             RegistryCredentialRetriever.getBaseImageCredential(buildContext).orElse(null);
-
         RegistryClient registryClient =
             buildContext
                 .newBaseImageRegistryClientFactory()
-                .setCredential(registryCredential)
+                .setCredential(credential)
                 .newRegistryClient();
 
-        try {
-          // TODO: refactor the code (https://github.com/GoogleContainerTools/jib/pull/2202)
-          if (registryCredential == null || registryCredential.isOAuth2RefreshToken()) {
-            throw ex;
-          }
-
-          eventHandlers.dispatch(LogEvent.debug("Trying basic auth for " + imageReference + "..."));
-          registryClient.configureBasicAuth();
+        String wwwAuthenticate = ex.getHttpResponseException().getHeaders().getAuthenticate();
+        if (wwwAuthenticate != null) {
+          eventHandlers.dispatch(
+              LogEvent.debug("WWW-Authenticate for " + imageReference + ": " + wwwAuthenticate));
+          registryClient.authPullByWwwAuthenticate(wwwAuthenticate);
           return new ImagesAndRegistryClient(
               pullBaseImages(registryClient, progressEventDispatcher), registryClient);
 
-        } catch (RegistryUnauthorizedException registryUnauthorizedException) {
-          // The registry requires us to authenticate using the Docker Token Authentication.
-          // See https://docs.docker.com/registry/spec/auth/token
-          eventHandlers.dispatch(
-              LogEvent.debug("Trying bearer auth for " + imageReference + "..."));
-          if (registryClient.doPullBearerAuth()) {
-            return new ImagesAndRegistryClient(
-                pullBaseImages(registryClient, progressEventDispatcher), registryClient);
+        } else {
+          // Not getting WWW-Authenticate is unexpected in practice, and we may just blame the
+          // server and fail. However, to keep some old behavior, try a few things as a last resort.
+          // TODO: consider removing this fallback branch.
+          if (credential != null && !credential.isOAuth2RefreshToken()) {
+            eventHandlers.dispatch(
+                LogEvent.debug("Trying basic auth as fallback for " + imageReference + "..."));
+            registryClient.configureBasicAuth();
+            try {
+              return new ImagesAndRegistryClient(
+                  pullBaseImages(registryClient, progressEventDispatcher), registryClient);
+            } catch (RegistryUnauthorizedException ignored) {
+              // Fall back to try bearer auth.
+            }
           }
+
           eventHandlers.dispatch(
-              LogEvent.error(
-                  "The registry asked for basic authentication, but the registry had refused basic "
-                      + "authentication previously"));
-          throw registryUnauthorizedException;
+              LogEvent.debug("Trying bearer auth as fallback for " + imageReference + "..."));
+          registryClient.doPullBearerAuth();
+          return new ImagesAndRegistryClient(
+              pullBaseImages(registryClient, progressEventDispatcher), registryClient);
         }
       }
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -383,7 +383,6 @@ public class RegistryClient {
    *
    * @param wwwAuthenticate {@code WWW-Authenticate} HTTP header value from a server response
    *     specifying a required authentication method
-   * @return true if bearer authentication succeeded or basic authentication configured
    * @throws RegistryException if communicating with the endpoint fails
    * @throws RegistryAuthenticationFailedException if authentication fails
    * @throws RegistryCredentialsNotSentException if authentication failed and credentials were not

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -325,15 +325,26 @@ public class RegistryClient {
       return false; // server returned "WWW-Authenticate: Basic ..."
     }
 
-    initialBearerAuthenticator.set(authenticator.get());
+    doBearerAuth(readOnlyBearerAuth, authenticator.get());
+    return true;
+  }
+
+  private void doBearerAuth(boolean readOnlyBearerAuth, RegistryAuthenticator authenticator)
+      throws RegistryException {
+    initialBearerAuthenticator.set(authenticator);
     if (readOnlyBearerAuth) {
-      authorization.set(authenticator.get().authenticatePull(credential));
+      authorization.set(authenticator.authenticatePull(credential));
     } else {
-      authorization.set(authenticator.get().authenticatePush(credential));
+      authorization.set(authenticator.authenticatePush(credential));
     }
     this.readOnlyBearerAuth = readOnlyBearerAuth;
-    eventHandlers.dispatch(LogEvent.debug("bearer auth succeeded for " + image));
-    return true;
+
+    eventHandlers.dispatch(
+        LogEvent.debug(
+            "bearer auth succeeded for "
+                + registryEndpointRequestProperties.getServerUrl()
+                + "/"
+                + registryEndpointRequestProperties.getImageName()));
   }
 
   private Authorization refreshBearerAuth(@Nullable String wwwAuthenticate)
@@ -364,6 +375,28 @@ public class RegistryClient {
       return Verify.verifyNotNull(initialBearerAuthenticator.get()).authenticatePull(credential);
     }
     return Verify.verifyNotNull(initialBearerAuthenticator.get()).authenticatePush(credential);
+  }
+
+  /**
+   * Configure basic authentication or attempts bearer authentication for pulling based on the
+   * specified authentication method in a server response.
+   *
+   * @param wwwAuthenticate {@code WWW-Authenticate} HTTP header value from a server response
+   *     specifying a required authentication method
+   * @return true if bearer authentication succeeded or basic authentication configured
+   * @throws RegistryException if communicating with the endpoint fails
+   * @throws RegistryAuthenticationFailedException if authentication fails
+   * @throws RegistryCredentialsNotSentException if authentication failed and credentials were not
+   */
+  public void authPullByWwwAuthenticate(String wwwAuthenticate) throws RegistryException {
+    Optional<RegistryAuthenticator> authenticator =
+        RegistryAuthenticator.fromAuthenticationMethod(
+            wwwAuthenticate, registryEndpointRequestProperties, getUserAgent(), httpClient);
+    if (authenticator.isPresent()) {
+      doBearerAuth(true, authenticator.get());
+    } else if (credential != null && !credential.isOAuth2RefreshToken()) {
+      configureBasicAuth();
+    }
   }
 
   /**

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file.
 
 - Fixed `NullPointerException` during input validation (in Java 9+) when configuring Jib parameters using certain immutable collections (such as `List.of()`). ([#2702](https://github.com/GoogleContainerTools/jib/issues/2702))
 - Fixed an issue that configuring `jib.from.platforms` was always additive to the default `amd64/linux` platform. ([#2783](https://github.com/GoogleContainerTools/jib/issues/2783))
+- Fixed authentication failure with Azure Container Registry when using ["tokens"](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions). ([#2784](https://github.com/GoogleContainerTools/jib/issues/2784))
+- Improved authentication flow for base image registry. ([#2134](https://github.com/GoogleContainerTools/jib/issues/2134))
 
 ## 2.5.0
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -11,6 +11,9 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fixed authentication failure with Azure Container Registry when using ["tokens"](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions). ([#2784](https://github.com/GoogleContainerTools/jib/issues/2784))
+- Improved authentication flow for base image registry. ([#2134](https://github.com/GoogleContainerTools/jib/issues/2134))
+
 ## 2.5.2
 
 ### Fixed


### PR DESCRIPTION
Fixes #2784. Fixes #2134.

After we try to pull a base image manifest without sending credentials, we either attempt bearer auth or basic auth based on the `WWW-Authenticate` HTTP header value in a 401 unauthorized response. I have been thinking for a very long time even before filing #2134 this is the most ideal and optimized flow. I believe every sane registry implementation that throws 401 on a manifest request will send `WWW-Authenticate`.

However, since auth is the most frictional part, I didn't want to make a drastic change. So when the server doesn't return `WWW-Authenticate` (I don't expect this to happen), we do some fallback operations. First, we just blindly send credentials via basic auth, and if that fails again with 401, we attempt bearer auth for the last moment. This fallback is basically identical to the current auth flow.