### PR TITLE
Add ability to run single integration test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ following environment variables:
 You will also need Docker installed with the daemon running. Note that the
 integration tests will create local registries on ports 5000 and 6000.
 
+To run select integration tests, use `-DonlyIT=<testPattern>`, see [gradle docs](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/testing/TestFilter.html) for `testPattern` examples.
+
 # Development Tips
 
 ## Configuring Eclipse

--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,17 @@ subprojects {
     systemProperty '_JIB_DISABLE_USER_AGENT', true
   }
 
-  integrationTest.dependsOn test
+  // shortcut to run select integration tests and ignore all other tests
+  if (project.hasProperty("onlyIT")) {
+    integrationTest {
+      filter {
+        includeTestsMatching project.getProperty("onlyIT")
+      }
+    }
+  } else {
+    integrationTest.dependsOn test
+  }
+
 
   task integrationTestJar(type: Jar) {
     from sourceSets.integrationTest.output.classesDirs


### PR DESCRIPTION
For some reason [stackoverflow](https://stackoverflow.com/questions/18061774/run-single-integration-test-with-gradle) doesn't seem to work (except my new answer). So update our integration test helper so we can run a single integration test locally.

I think we might be able to use `--test` if we radically reorganize our project, but I don't see that happening yet (like if integration tests go into a new project).