### PR TITLE
Fixes running select integration tests from intellij

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,8 @@ following environment variables:
 You will also need Docker installed with the daemon running. Note that the
 integration tests will create local registries on ports 5000 and 6000.
 
+To run select integration tests, use `--tests=<testPattern>`, see [gradle docs](https://docs.gradle.org/current/javadoc/org/gradle/api/tasks/testing/TestFilter.html) for `testPattern` examples.
+
 # Development Tips
 
 ## Configuring Eclipse

--- a/build.gradle
+++ b/build.gradle
@@ -224,7 +224,6 @@ subprojects {
     systemProperty '_JIB_DISABLE_USER_AGENT', true
   }
 
-  integrationTest.dependsOn test
 
   task integrationTestJar(type: Jar) {
     from sourceSets.integrationTest.output.classesDirs
@@ -237,6 +236,13 @@ subprojects {
 
   artifacts {
     integrationTests integrationTestJar
+  }
+
+  integrationTest {
+    testLogging {
+      showStandardStreams = true
+      exceptionFormat = 'full'
+    }
   }
   /* INTEGRATION TESTS */
 

--- a/jib-build-plan/scripts/prepare_release.sh
+++ b/jib-build-plan/scripts/prepare_release.sh
@@ -39,8 +39,8 @@ if [[ $(git status -uno --porcelain) ]]; then
   Die 'There are uncommitted changes.'
 fi
 
-# Runs integration tests.
-./gradlew :jib-build-plan:integrationTest --info --stacktrace
+# Runs checks and integration tests.
+./gradlew :jib-build-plan:check :jib-build-plan:integrationTest --info --stacktrace
 
 # Checks out a new branch for this version release (eg. 1.5.7).
 BRANCH=build_plan_release_v${VERSION}

--- a/jib-core/scripts/prepare_release.sh
+++ b/jib-core/scripts/prepare_release.sh
@@ -39,8 +39,8 @@ if [[ $(git status -uno --porcelain) ]]; then
   Die 'There are uncommitted changes.'
 fi
 
-# Runs integration tests.
-./gradlew :jib-core:integrationTest --info --stacktrace
+# Runs checks and integration tests.
+./gradlew :jib-core:check :jib-core:integrationTest --info --stacktrace
 
 # Checks out a new branch for this version release (eg. 1.5.7).
 BRANCH=core_release_v${VERSION}

--- a/jib-gradle-plugin-extension-api/scripts/prepare_release.sh
+++ b/jib-gradle-plugin-extension-api/scripts/prepare_release.sh
@@ -39,8 +39,8 @@ if [[ $(git status -uno --porcelain) ]]; then
   Die 'There are uncommitted changes.'
 fi
 
-# Runs integration tests.
-./gradlew :jib-gradle-plugin-extension-api:integrationTest --info --stacktrace
+# Runs checks and integration tests.
+./gradlew :jib-gradle-plugin-extension-api:check :jib-gradle-plugin-extension-api:integrationTest --info --stacktrace
 
 # Checks out a new branch for this version release (eg. 1.5.7).
 BRANCH=gradle_extension_release_v${VERSION}

--- a/jib-gradle-plugin/scripts/prepare_release.sh
+++ b/jib-gradle-plugin/scripts/prepare_release.sh
@@ -39,8 +39,8 @@ if [[ $(git status -uno --porcelain) ]]; then
     Die 'There are uncommitted changes.'
 fi
 
-# Runs integration tests.
-./gradlew jib-gradle-plugin:integrationTest --info --stacktrace
+# Runs checks and integration tests.
+./gradlew jib-gradle-plugin:check jib-gradle-plugin:integrationTest --info --stacktrace
 
 # Checks out a new branch for this version release (eg. 1.5.7).
 BRANCH=gradle_release_v${VERSION}

--- a/jib-maven-plugin-extension-api/scripts/prepare_release.sh
+++ b/jib-maven-plugin-extension-api/scripts/prepare_release.sh
@@ -39,8 +39,8 @@ if [[ $(git status -uno --porcelain) ]]; then
   Die 'There are uncommitted changes.'
 fi
 
-# Runs integration tests.
-./gradlew :jib-maven-plugin-extension-api:integrationTest --info --stacktrace
+# Runs checks integration tests.
+./gradlew :jib-maven-plugin-extension-api:check :jib-maven-plugin-extension-api:integrationTest --info --stacktrace
 
 # Checks out a new branch for this version release (eg. 1.5.7).
 BRANCH=maven_extension_release_v${VERSION}

--- a/jib-maven-plugin/scripts/prepare_release.sh
+++ b/jib-maven-plugin/scripts/prepare_release.sh
@@ -39,8 +39,8 @@ if [[ $(git status -uno --porcelain) ]]; then
     Die 'There are uncommitted changes.'
 fi
 
-# Runs integration tests.
-./gradlew jib-maven-plugin:integrationTest --info --stacktrace
+# Runs checks integration tests.
+./gradlew jib-maven-plugin:check jib-maven-plugin:integrationTest --info --stacktrace
 
 # Checks out a new branch for this version release (eg. 1.5.7).
 BRANCH=maven_release_v${VERSION}

--- a/jib-plugins-extension-common/scripts/prepare_release.sh
+++ b/jib-plugins-extension-common/scripts/prepare_release.sh
@@ -39,8 +39,8 @@ if [[ $(git status -uno --porcelain) ]]; then
   Die 'There are uncommitted changes.'
 fi
 
-# Runs integration tests.
-./gradlew :jib-plugins-extension-common:integrationTest --info --stacktrace
+# Runs checks and integration tests.
+./gradlew :jib-plugins-extension-common:check :jib-plugins-extension-common:integrationTest --info --stacktrace
 
 # Checks out a new branch for this version release (eg. 1.5.7).
 BRANCH=extension_common_release_v${VERSION}


### PR DESCRIPTION
The intellij test runner has some issues with tests that are run
if integrationTest depends on test. Remove that dependency and
this fixes the issue.

Also adds some additional logging output and update release scripts
