### PR TITLE
Check configured platforms for single image building

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -111,6 +111,8 @@ public class LocalBaseImageSteps {
         Optional<LocalImage> cachedImage =
             getCachedDockerImage(buildContext.getBaseImageLayersCache(), dockerImageDetails);
         if (cachedImage.isPresent()) {
+          PlatformChecker.checkManifestPlatform(
+              buildContext, cachedImage.get().configurationTemplate);
           return cachedImage.get();
         }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -125,11 +125,14 @@ public class LocalBaseImageSteps {
           dockerClient.save(imageReference, tarPath, throttledProgressReporter);
         }
 
-        return cacheDockerImageTar(
-            buildContext,
-            tarPath,
-            progressEventDispatcher.newChildProducer(),
-            tempDirectoryProvider);
+        LocalImage localImage =
+            cacheDockerImageTar(
+                buildContext,
+                tarPath,
+                progressEventDispatcher.newChildProducer(),
+                tempDirectoryProvider);
+        PlatformChecker.checkManifestPlatform(buildContext, localImage.configurationTemplate);
+        return localImage;
       }
     };
   }
@@ -139,9 +142,13 @@ public class LocalBaseImageSteps {
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
       Path tarPath,
       TempDirectoryProvider tempDirectoryProvider) {
-    return () ->
-        cacheDockerImageTar(
-            buildContext, tarPath, progressEventDispatcherFactory, tempDirectoryProvider);
+    return () -> {
+      LocalImage localImage =
+          cacheDockerImageTar(
+              buildContext, tarPath, progressEventDispatcherFactory, tempDirectoryProvider);
+      PlatformChecker.checkManifestPlatform(buildContext, localImage.configurationTemplate);
+      return localImage;
+    };
   }
 
   static Callable<ImagesAndRegistryClient> returnImageAndRegistryClientStep(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PlatformChecker.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PlatformChecker.java
@@ -46,7 +46,8 @@ public class PlatformChecker {
 
     if (platforms.size() != 1) {
       eventHandlers.dispatch(
-          LogEvent.warn("platforms configured, but '" + baseImageName + "' is not a manifest list"));
+          LogEvent.warn(
+              "platforms configured, but '" + baseImageName + "' is not a manifest list"));
     } else {
       Platform platform = platforms.iterator().next();
       if (!platform.getArchitecture().equals(containerConfig.getArchitecture())

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PlatformChecker.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PlatformChecker.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.builder.steps;
 
-import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.api.buildplan.Platform;
 import com.google.cloud.tools.jib.configuration.BuildContext;
@@ -37,13 +36,17 @@ public class PlatformChecker {
   static void checkManifestPlatform(
       BuildContext buildContext, ContainerConfigurationTemplate containerConfig) {
     EventHandlers eventHandlers = buildContext.getEventHandlers();
-    ImageReference baseImage = buildContext.getBaseImageConfiguration().getImage();
+    String baseImageName =
+        buildContext.getBaseImageConfiguration().getTarPath().isPresent()
+            ? buildContext.getBaseImageConfiguration().getTarPath().get().toString()
+            : buildContext.getBaseImageConfiguration().getImage().toString();
+
     Set<Platform> platforms = buildContext.getContainerConfiguration().getPlatforms();
     Verify.verify(!platforms.isEmpty());
 
     if (platforms.size() != 1) {
       eventHandlers.dispatch(
-          LogEvent.warn("platforms configured, but '" + baseImage + "' is not a manifest list"));
+          LogEvent.warn("platforms configured, but '" + baseImageName + "' is not a manifest list"));
     } else {
       Platform platform = platforms.iterator().next();
       if (!platform.getArchitecture().equals(containerConfig.getArchitecture())
@@ -63,7 +66,7 @@ public class PlatformChecker {
                       platform.getOs(),
                       containerConfig.getArchitecture(),
                       containerConfig.getOs(),
-                      baseImage)));
+                      baseImageName)));
         }
       }
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PlatformChecker.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PlatformChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 20120 Google LLC.
+ * Copyright 2020 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PlatformChecker.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PlatformChecker.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 20120 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.builder.steps;
+
+import com.google.cloud.tools.jib.api.ImageReference;
+import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.api.buildplan.Platform;
+import com.google.cloud.tools.jib.configuration.BuildContext;
+import com.google.cloud.tools.jib.event.EventHandlers;
+import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
+import com.google.common.base.Verify;
+import java.util.Set;
+
+/** Provides helper methods to check platforms. */
+public class PlatformChecker {
+
+  /**
+   * Assuming the base image is not a manifest list, checks and warns misconfigured platforms.
+   *
+   * @param buildContext the {@link BuildContext}
+   * @param containerConfig container configuration JSON of the base image
+   */
+  static void checkManifestPlatform(
+      BuildContext buildContext, ContainerConfigurationTemplate containerConfig) {
+    EventHandlers eventHandlers = buildContext.getEventHandlers();
+    ImageReference baseImage = buildContext.getBaseImageConfiguration().getImage();
+    Set<Platform> platforms = buildContext.getContainerConfiguration().getPlatforms();
+    Verify.verify(!platforms.isEmpty());
+
+    if (platforms.size() != 1) {
+      eventHandlers.dispatch(
+          LogEvent.warn("platforms configured, but '" + baseImage + "' is not a manifest list"));
+    } else {
+      Platform platform = platforms.iterator().next();
+      if (!platform.getArchitecture().equals(containerConfig.getArchitecture())
+          || !platform.getOs().equals(containerConfig.getOs())) {
+
+        // Unfortunately, "platforms" has amd64/linux by default even if the user didn't explicitly
+        // configure it. Skip reporting to suppress false alarm.
+        if (!(platform.getArchitecture().equals("amd64") && platform.getOs().equals("linux"))) {
+          String warning =
+              "the configured platform (%s/%s) doesn't match the platform (%s/%s) of the base "
+                  + "image (%s)";
+          eventHandlers.dispatch(
+              LogEvent.warn(
+                  String.format(
+                      warning,
+                      platform.getArchitecture(),
+                      platform.getOs(),
+                      containerConfig.getArchitecture(),
+                      containerConfig.getOs(),
+                      baseImage)));
+        }
+      }
+    }
+  }
+}

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -380,10 +380,14 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
         return Collections.singletonList(
             JsonToImageTranslator.toImage((V21ManifestTemplate) manifest));
       }
+
+      ContainerConfigurationTemplate containerConfig =
+          Verify.verifyNotNull(manifestsAndConfigs.get(0).getConfig());
+      PlatformChecker.checkManifestPlatform(buildContext, containerConfig);
+
       return Collections.singletonList(
           JsonToImageTranslator.toImage(
-              (BuildableManifestTemplate) Verify.verifyNotNull(manifest),
-              Verify.verifyNotNull(manifestsAndConfigs.get(0).getConfig())));
+              (BuildableManifestTemplate) Verify.verifyNotNull(manifest), containerConfig));
     }
 
     // Manifest list cached. Identify matching platforms and check if all of them are cached.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -233,6 +233,7 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
       BuildableManifestTemplate imageManifest = (BuildableManifestTemplate) manifestTemplate;
       ContainerConfigurationTemplate containerConfig =
           pullContainerConfigJson(manifestAndDigest, registryClient, progressEventDispatcher);
+      PlatformChecker.checkManifestPlatform(buildContext, containerConfig);
       cache.writeMetadata(baseImageConfig.getImage(), imageManifest, containerConfig);
       return Collections.singletonList(
           JsonToImageTranslator.toImage(imageManifest, containerConfig));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PlatformCheckerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PlatformCheckerTest.java
@@ -109,6 +109,8 @@ public class PlatformCheckerTest {
     PlatformChecker.checkManifestPlatform(buildContext, new ContainerConfigurationTemplate());
 
     Mockito.verify(eventHandlers)
-        .dispatch(LogEvent.warn("platforms configured, but '/foo/bar.tar' is not a manifest list"));
+        .dispatch(
+            LogEvent.warn(
+                "platforms configured, but '" + tar.toString() + "' is not a manifest list"));
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PlatformCheckerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PlatformCheckerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.builder.steps;
+
+import com.google.cloud.tools.jib.api.ImageReference;
+import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.api.buildplan.Platform;
+import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
+import com.google.cloud.tools.jib.configuration.BuildContext;
+import com.google.cloud.tools.jib.configuration.ContainerConfiguration;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
+import com.google.cloud.tools.jib.event.EventHandlers;
+import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
+import com.google.cloud.tools.jib.registry.RegistryClient;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Tests for {@link PlatformChecker}. */
+@RunWith(MockitoJUnitRunner.class)
+public class PlatformCheckerTest {
+
+  @Mock private ProgressEventDispatcher.Factory progressDispatcherFactory;
+  @Mock private BuildContext buildContext;
+  @Mock private RegistryClient registryClient;
+  @Mock private ImageConfiguration imageConfiguration;
+  @Mock private ContainerConfiguration containerConfig;
+  @Mock private EventHandlers eventHandlers;
+
+  @Before
+  public void setUp() {
+    Mockito.when(buildContext.getBaseImageConfiguration())
+        .thenReturn(ImageConfiguration.builder(ImageReference.scratch()).build());
+    Mockito.when(buildContext.getEventHandlers()).thenReturn(eventHandlers);
+    Mockito.when(buildContext.getContainerConfiguration()).thenReturn(containerConfig);
+  }
+
+  @Test
+  public void testCheckManifestPlatform_mismatch() {
+    Mockito.when(containerConfig.getPlatforms())
+        .thenReturn(ImmutableSet.of(new Platform("configured arch", "configured OS")));
+
+    ContainerConfigurationTemplate containerConfigJson = new ContainerConfigurationTemplate();
+    containerConfigJson.setArchitecture("actual arch");
+    containerConfigJson.setOs("actual OS");
+
+    PlatformChecker.checkManifestPlatform(buildContext, containerConfigJson);
+
+    Mockito.verify(eventHandlers)
+        .dispatch(
+            LogEvent.warn(
+                "the configured platform (configured arch/configured OS) doesn't match the "
+                    + "platform (actual arch/actual OS) of the base image (scratch)"));
+  }
+
+  @Test
+  public void testCheckManifestPlatform_noWarningIfDefaultAmd64Linux() {
+    Mockito.when(containerConfig.getPlatforms())
+        .thenReturn(ImmutableSet.of(new Platform("amd64", "linux")));
+
+    ContainerConfigurationTemplate containerConfigJson = new ContainerConfigurationTemplate();
+    containerConfigJson.setArchitecture("actual arch");
+    containerConfigJson.setOs("actual OS");
+
+    PlatformChecker.checkManifestPlatform(buildContext, containerConfigJson);
+
+    Mockito.verifyNoInteractions(eventHandlers);
+  }
+
+  @Test
+  public void testCheckManifestPlatform_multiplePlatformsConfigured() {
+    Mockito.when(containerConfig.getPlatforms())
+        .thenReturn(ImmutableSet.of(new Platform("amd64", "linux"), new Platform("arch", "os")));
+
+    PlatformChecker.checkManifestPlatform(buildContext, new ContainerConfigurationTemplate());
+
+    Mockito.verify(eventHandlers)
+        .dispatch(LogEvent.warn("platforms configured, but 'scratch' is not a manifest list"));
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PlatformCheckerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PlatformCheckerTest.java
@@ -27,6 +27,8 @@ import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
 import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.common.collect.ImmutableSet;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -94,5 +96,19 @@ public class PlatformCheckerTest {
 
     Mockito.verify(eventHandlers)
         .dispatch(LogEvent.warn("platforms configured, but 'scratch' is not a manifest list"));
+  }
+
+  @Test
+  public void testCheckManifestPlatform_tarBaseImage() {
+    Path tar = Paths.get("/foo/bar.tar");
+    Mockito.when(buildContext.getBaseImageConfiguration())
+        .thenReturn(ImageConfiguration.builder(ImageReference.scratch()).setTarPath(tar).build());
+    Mockito.when(containerConfig.getPlatforms())
+        .thenReturn(ImmutableSet.of(new Platform("amd64", "linux"), new Platform("arch", "os")));
+
+    PlatformChecker.checkManifestPlatform(buildContext, new ContainerConfigurationTemplate());
+
+    Mockito.verify(eventHandlers)
+        .dispatch(LogEvent.warn("platforms configured, but '/foo/bar.tar' is not a manifest list"));
   }
 }


### PR DESCRIPTION
Fixes #2746. Fixes #2745.

When the base image is not a manifest list (including a local Docker and tar image), logs a warning in the follow cases.
1. Multiple platforms are configured.
2. The configured platform doesn't match the actual platform, unless the "configured" platform is `amd64/linux`.

About 2): Currently we cannot distinguish between explicitly configured `amd64/linux` and the implicit `amd64/linux` default when omitted, so unfortunately sometimes we need to suppress logging even if the platforms don't match.