### PR TITLE
2.5.1 gradle cherrypick release (do not merge)

### DIFF
--- a/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlan.java
+++ b/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlan.java
@@ -39,8 +39,7 @@ public class ContainerBuildPlan {
     private Instant creationTime = Instant.EPOCH;
     private ImageFormat format = ImageFormat.Docker;
 
-    // note that a LinkedHashSet instead of HashSet has been used so as to preserve the platform
-    // order
+    // LinkedHashSet to preserve the order
     private Set<Platform> platforms =
         new LinkedHashSet<>(Collections.singleton(new Platform("amd64", "linux")));
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -47,8 +47,7 @@ public class ContainerConfiguration {
      */
     private static final Instant DEFAULT_CREATION_TIME = Instant.EPOCH;
 
-    // note that a LinkedHashSet instead of HashSet has been used so as to preserve the platform
-    // order
+    // LinkedHashSet to preserve the order
     private Set<Platform> platforms =
         new LinkedHashSet<>(Collections.singleton(new Platform("amd64", "linux")));
     private Instant creationTime = DEFAULT_CREATION_TIME;

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -3,24 +3,14 @@ All notable changes to this project will be documented in this file.
 
 ## [unreleased]
 
-### Added
-
-- Added lazy evaluation for `jib.to.image` and `jib.to.tags` using Gradle Property and Provider. ([#2727](https://github.com/GoogleContainerTools/jib/issues/2727))
-
-### Changed
-
-- Previous locally cached base image manifests will be ignored, as the caching mechanism changed to enable multi-platform image building. ([#2730](https://github.com/GoogleContainerTools/jib/pull/2730), [#2711](https://github.com/GoogleContainerTools/jib/pull/2711))
-
 ### Fixed
 
-- Fixed `NullPointerException` during input validation (in Java 9+) when configuring Jib parameters using certain immutable collections (such as `List.of()`). ([#2702](https://github.com/GoogleContainerTools/jib/issues/2702))
 - Fixed an issue that configuring `jib.from.platforms` was always additive to the default `amd64/linux` platform. ([#2783](https://github.com/GoogleContainerTools/jib/issues/2783))
 
 ## 2.5.0
 
 ### Added
 
->>>>>>> 212cc8a3 (Fix platform configuration in Gradle plugin (#2783))
 - Also tries `.exe` file extension for credential helpers on Windows. ([#2527](https://github.com/GoogleContainerTools/jib/issues/2527))
 - New system property `jib.skipExistingImages` (false by default) to skip pushing images (manifests) if the image already exists in the registry. ([#2360](https://github.com/GoogleContainerTools/jib/issues/2360)
 - _Incubating feature_: can now configure desired platform (architecture and OS) to select the matching manifest from a Docker manifest list. Currently supports building only one image. OCI image indices are not supported. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added lazy evaluation for `jib.to.image` and `jib.to.tags` using Gradle Property and Provider. ([#2727](https://github.com/GoogleContainerTools/jib/issues/2727))
+
+### Changed
+
+- Previous locally cached base image manifests will be ignored, as the caching mechanism changed to enable multi-platform image building. ([#2730](https://github.com/GoogleContainerTools/jib/pull/2730), [#2711](https://github.com/GoogleContainerTools/jib/pull/2711))
+
+### Fixed
+
+- Fixed `NullPointerException` during input validation (in Java 9+) when configuring Jib parameters using certain immutable collections (such as `List.of()`). ([#2702](https://github.com/GoogleContainerTools/jib/issues/2702))
+- Fixed an issue that configuring `jib.from.platforms` was always additive to the default `amd64/linux` platform. ([#2783](https://github.com/GoogleContainerTools/jib/issues/2783))
+
+## 2.5.0
+
+### Added
+
+>>>>>>> 212cc8a3 (Fix platform configuration in Gradle plugin (#2783))
 - Also tries `.exe` file extension for credential helpers on Windows. ([#2527](https://github.com/GoogleContainerTools/jib/issues/2527))
 - New system property `jib.skipExistingImages` (false by default) to skip pushing images (manifests) if the image already exists in the registry. ([#2360](https://github.com/GoogleContainerTools/jib/issues/2360)
 - _Incubating feature_: can now configure desired platform (architecture and OS) to select the matching manifest from a Docker manifest list. Currently supports building only one image. OCI image indices are not supported. ([#1567](https://github.com/GoogleContainerTools/jib/issues/1567))

--- a/jib-gradle-plugin/gradle.properties
+++ b/jib-gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-version = 2.5.0
+version = 2.5.1

--- a/jib-gradle-plugin/gradle.properties
+++ b/jib-gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-version = 2.4.1-SNAPSHOT
+version = 2.5.0

--- a/jib-gradle-plugin/scripts/release.sh
+++ b/jib-gradle-plugin/scripts/release.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 
 set -o errexit
-set -o xtrace
 
 readonly PUBLISH_KEY=$(cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_key")
 readonly PUBLISH_SECRET=$(cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secret")
+
+set -o xtrace
 
 gcloud components install docker-credential-gcr
 
@@ -20,6 +21,11 @@ docker kill $(docker ps --all --quiet) || true
 export readonly JIB_INTEGRATION_TESTING_PROJECT=jib-integration-testing
 
 cd github/jib
+
+echo "gradle publish"
+
+# turn of command tracing when dealing with secrets
+set +o xtrace
 
 ./gradlew :jib-gradle-plugin:publishPlugins \
   -Pgradle.publish.key="${PUBLISH_KEY}" \

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -361,7 +361,7 @@ public class SingleProjectIntegrationTest {
     Assert.assertEquals(output, new Command("docker", "run", "--rm", id).run());
 
     JibRunHelper.assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);
-    assertWorkingDirectory("", targetImage);
+    assertWorkingDirectory("/", targetImage);
   }
 
   @Test
@@ -370,7 +370,7 @@ public class SingleProjectIntegrationTest {
     Instant beforeBuild = Instant.now();
     buildAndRunComplex(targetImage, "testuser", "testpassword", localRegistry1);
     JibRunHelper.assertSimpleCreationTimeIsAfter(beforeBuild, targetImage);
-    assertWorkingDirectory("", targetImage);
+    assertWorkingDirectory("/", targetImage);
   }
 
   @Test

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
@@ -38,14 +38,14 @@ public class BaseImageParameters {
   @Inject
   public BaseImageParameters(ObjectFactory objectFactory) {
     auth = objectFactory.newInstance(AuthParameters.class, "from.auth");
-    platforms = objectFactory.listProperty(PlatformParameters.class).empty();
+    platforms = objectFactory.listProperty(PlatformParameters.class);
     platformParametersSpec =
         objectFactory.newInstance(PlatformParametersSpec.class, objectFactory, platforms);
 
-    PlatformParameters platform = new PlatformParameters();
-    platform.setOs("linux");
-    platform.setArchitecture("amd64");
-    platforms.add(platform);
+    PlatformParameters amd64Linux = new PlatformParameters();
+    amd64Linux.setArchitecture("amd64");
+    amd64Linux.setOs("linux");
+    platforms.add(amd64Linux);
   }
 
   @Nested
@@ -55,6 +55,7 @@ public class BaseImageParameters {
   }
 
   public void platforms(Action<? super PlatformParametersSpec> action) {
+    platforms.empty();
     action.execute(platformParametersSpec);
   }
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -25,6 +25,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -56,17 +57,35 @@ public class JibExtensionTest {
     Assert.assertNull(testJibExtension.getFrom().getImage());
     Assert.assertNull(testJibExtension.getFrom().getCredHelper());
 
+    List<PlatformParameters> defaultPlatforms = testJibExtension.getFrom().getPlatforms().get();
+    Assert.assertEquals(1, defaultPlatforms.size());
+    Assert.assertEquals("amd64", defaultPlatforms.get(0).getArchitecture());
+    Assert.assertEquals("linux", defaultPlatforms.get(0).getOs());
+
     testJibExtension.from(
         from -> {
           from.setImage("some image");
           from.setCredHelper("some cred helper");
           from.auth(auth -> auth.setUsername("some username"));
           from.auth(auth -> auth.setPassword("some password"));
+          from.platforms(
+              platformSpec -> {
+                platformSpec.platform(
+                    platform -> {
+                      platform.setArchitecture("arm");
+                      platform.setOs("windows");
+                    });
+              });
         });
     Assert.assertEquals("some image", testJibExtension.getFrom().getImage());
     Assert.assertEquals("some cred helper", testJibExtension.getFrom().getCredHelper());
     Assert.assertEquals("some username", testJibExtension.getFrom().getAuth().getUsername());
     Assert.assertEquals("some password", testJibExtension.getFrom().getAuth().getPassword());
+
+    List<PlatformParameters> platforms = testJibExtension.getFrom().getPlatforms().get();
+    Assert.assertEquals(1, platforms.size());
+    Assert.assertEquals("arm", platforms.get(0).getArchitecture());
+    Assert.assertEquals("windows", platforms.get(0).getOs());
   }
 
   @Test

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -505,7 +505,7 @@ public class BuildImageMojoIntegrationTest {
     Assert.assertEquals(
         "", buildAndRun(emptyTestProject.getProjectRoot(), targetImage, "pom.xml", false));
     assertCreationTimeEpoch(targetImage);
-    assertWorkingDirectory("", targetImage);
+    assertWorkingDirectory("/", targetImage);
   }
 
   @Test
@@ -571,7 +571,7 @@ public class BuildImageMojoIntegrationTest {
     Assert.assertEquals(output, new Command("docker", "run", "--rm", id).run());
 
     assertCreationTimeIsAfter(before, targetImage);
-    assertWorkingDirectory("", targetImage);
+    assertWorkingDirectory("/", targetImage);
     assertEntrypoint(
         "[java -Xms512m -Xdebug -cp /other:/app/resources:/app/classes:/app/libs/* "
             + "com.test.HelloWorld]",
@@ -604,7 +604,7 @@ public class BuildImageMojoIntegrationTest {
             + "-Xms512m\n-Xdebug\nenvvalue1\nenvvalue2\n",
         buildAndRunComplex(
             targetImage, "testuser", "testpassword", localRegistry1, "pom-complex.xml"));
-    assertWorkingDirectory("", targetImage);
+    assertWorkingDirectory("/", targetImage);
   }
 
   @Test
@@ -621,7 +621,7 @@ public class BuildImageMojoIntegrationTest {
             "testpassword2",
             localRegistry2,
             "pom-complex-properties.xml"));
-    assertWorkingDirectory("", targetImage);
+    assertWorkingDirectory("/", targetImage);
   }
 
   @Test


### PR DESCRIPTION
Cherry pick release (do not merge).
Cherry picked: #2783, #2792 
Tagged: https://github.com/GoogleContainerTools/jib/releases/tag/v2.5.1-gradle