### PR TITLE
Post release 2.5.1-gradle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,8 +125,8 @@ To use a local build of the `jib-gradle-plugin`:
   1. Modify your test project's `build.gradle` to use the snapshot version
         ```groovy
         plugins {
-          // id 'com.google.cloud.tools.jib' version '2.5.0'
-          id 'com.google.cloud.tools.jib' version '2.5.1-SNAPSHOT'
+          // id 'com.google.cloud.tools.jib' version '2.5.1'
+          id 'com.google.cloud.tools.jib' version '2.5.2-SNAPSHOT'
         }
 
         ```

--- a/examples/helloworld/build.gradle
+++ b/examples/helloworld/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'com.google.cloud.tools.jib' version '2.5.0'
+  id 'com.google.cloud.tools.jib' version '2.5.1'
 }
 
 sourceCompatibility = 1.8

--- a/examples/java-agent/build.gradle
+++ b/examples/java-agent/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'com.google.cloud.tools.jib' version '2.5.0'
+  id 'com.google.cloud.tools.jib' version '2.5.1'
   id 'de.undercouch.download' version '4.0.0'
   id "com.gorylenko.gradle-git-properties" version "2.2.0"
 }

--- a/examples/micronaut/build.gradle
+++ b/examples/micronaut/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "groovy"
     id "com.github.johnrengelman.shadow" version "5.2.0"
     id "application"
-    id 'com.google.cloud.tools.jib' version '2.5.0'
+    id 'com.google.cloud.tools.jib' version '2.5.1'
 }
 
 version "0.1"

--- a/examples/multi-module/build.gradle
+++ b/examples/multi-module/build.gradle
@@ -2,5 +2,5 @@
 plugins {
   id 'org.springframework.boot' version '2.0.3.RELEASE' apply false
   id 'io.spring.dependency-management' version '1.0.6.RELEASE' apply false
-  id 'com.google.cloud.tools.jib' version '2.5.0' apply false
+  id 'com.google.cloud.tools.jib' version '2.5.1' apply false
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'idea'
     id 'org.springframework.boot' version '2.1.6.RELEASE'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
-    id 'com.google.cloud.tools.jib' version '2.5.0'
+    id 'com.google.cloud.tools.jib' version '2.5.1'
 }
 
 repositories {

--- a/examples/vertx/build.gradle
+++ b/examples/vertx/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'io.vertx.vertx-plugin' version '0.1.0'
-    id 'com.google.cloud.tools.jib' version '2.5.0'
+    id 'com.google.cloud.tools.jib' version '2.5.1'
 }
 
 repositories {

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -15,10 +15,15 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Fixed `NullPointerException` during input validation (in Java 9+) when configuring Jib parameters using certain immutable collections (such as `List.of()`). ([#2702](https://github.com/GoogleContainerTools/jib/issues/2702))
-- Fixed an issue that configuring `jib.from.platforms` was always additive to the default `amd64/linux` platform. ([#2783](https://github.com/GoogleContainerTools/jib/issues/2783))
 - Fixed authentication failure with Azure Container Registry when using ["tokens"](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-repository-scoped-permissions). ([#2784](https://github.com/GoogleContainerTools/jib/issues/2784))
 - Improved authentication flow for base image registry. ([#2134](https://github.com/GoogleContainerTools/jib/issues/2134))
 - Throw `IllegalArgumentException` with an error message instead of throwing a `NullPointerException` when `jib.to.tags` is set to a collection containing a `null` value. ([#2760](https://github.com/GoogleContainerTools/jib/issues/2760))
+
+## 2.5.1
+
+### Fixed
+
+- Fixed an issue that configuring `jib.from.platforms` was always additive to the default `amd64/linux` platform. ([#2783](https://github.com/GoogleContainerTools/jib/issues/2783))
 
 ## 2.5.0
 

--- a/jib-gradle-plugin/README.md
+++ b/jib-gradle-plugin/README.md
@@ -48,7 +48,7 @@ In your Gradle Java project, add the plugin to your `build.gradle`:
 
 ```groovy
 plugins {
-  id 'com.google.cloud.tools.jib' version '2.5.0'
+  id 'com.google.cloud.tools.jib' version '2.5.1'
 }
 ```
 

--- a/jib-gradle-plugin/gradle.properties
+++ b/jib-gradle-plugin/gradle.properties
@@ -1,1 +1,1 @@
-version = 2.5.1-SNAPSHOT
+version = 2.5.2-SNAPSHOT


### PR DESCRIPTION
Update docs, actual release is not from master
See: https://github.com/GoogleContainerTools/jib/pull/2794