### PR TITLE
Add ability to specify root context directory when parsing buildfile

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
@@ -51,6 +51,7 @@ public class BuildFiles {
    * Read a buildfile from disk and generate a JibContainerBuilder instance. All parsing of files
    * considers the directory the buildfile is located in as the working directory.
    *
+   * @param projectRoot the root context directory of this build
    * @param buildFilePath a file containing the build definition
    * @param templateParameters a map of templating variables to apply on the file before parsing
    * @return a {@link JibContainerBuilder} generated from the contents of {@code buildFilePath}
@@ -59,10 +60,9 @@ public class BuildFiles {
    * @throws InvalidImageReferenceException if the baseImage reference can not be parsed
    */
   public static JibContainerBuilder toJibContainerBuilder(
-      Path buildFilePath, Map<String, String> templateParameters)
+      Path projectRoot, Path buildFilePath, Map<String, String> templateParameters)
       throws InvalidImageReferenceException, IOException {
     BuildFileSpec buildFile = toBuildFileSpec(buildFilePath, templateParameters);
-    Path projectRoot = buildFilePath.toAbsolutePath().getParent();
 
     JibContainerBuilder containerBuilder;
     if (buildFile.getFrom().isPresent()) {

--- a/jib-cli/src/test/resources/buildfiles/projects/allProperties/altYamls/alt-jib.yaml
+++ b/jib-cli/src/test/resources/buildfiles/projects/allProperties/altYamls/alt-jib.yaml
@@ -1,0 +1,50 @@
+# this buildfile doesn't necessarily work, just useful for testing parsing and translation
+apiVersion: jib/v1alpha1
+kind: BuildFile
+
+# "FROM" with detail for manifest lists or multiple architectures
+from:
+  image: "ubuntu"
+  # optional: if missing, then defaults to `linux/amd64`
+  platforms:
+    - architecture: "arm"
+      os: "linux"
+    - architecture: "amd64"
+      os: "darwin"
+
+# potentially simple form of "FROM" (based on ability to define schema)
+# from: "gcr.io/distroless/java:8"
+
+creationTime: 2000 # millis since epoch or iso8601 creation time
+format: OCI # Docker or OCI
+
+environment:
+  "KEY1": "v1"
+  "KEY2": "v2"
+labels:
+  "label1": "l1"
+  "label2": "l2"
+volumes:
+  - "/volume1"
+  - "/volume2"
+
+exposedPorts:
+  - "123/udp"
+  - "456"
+  - "789/tcp"
+
+user: "customUser"
+workingDirectory: "/home"
+entrypoint:
+  - "sh"
+  - "script.sh"
+cmd:
+  - "--param"
+  - "param"
+
+layers:
+  entries:
+    - name: "scripts"
+      files:
+        - src: "project/script.sh"
+          dest: "/home/script.sh"


### PR DESCRIPTION
Allows the cli to follow a docker style
```
$ jib build my/project/root -b some/build/file/somewhere.yaml
```