### PR TITLE
Fix multi-platform integration test caused by Jib version info in container config

### DIFF
--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-multiplatform-build.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-multiplatform-build.xml
@@ -40,18 +40,18 @@
         <artifactId>jib-maven-plugin</artifactId>
         <version>${jib-maven-plugin.version}</version>
         <configuration>
-           <from>
-        <image>busybox@sha256:4f47c01fa91355af2865ac10fef5bf6ec9c7f42ad2321377c21e844427972977</image>
-	  <platforms>
-	    <platform>
-	       <architecture>arm64</architecture>
-	       <os>linux</os>
-	    </platform>
-	    <platform>
-	       <architecture>amd64</architecture>
-	       <os>linux</os>
-	    </platform>
-	   </platforms>
+          <from>
+            <image>busybox@sha256:4f47c01fa91355af2865ac10fef5bf6ec9c7f42ad2321377c21e844427972977</image>
+            <platforms>
+              <platform>
+                <architecture>arm64</architecture>
+                <os>linux</os>
+              </platform>
+              <platform>
+                <architecture>amd64</architecture>
+                <os>linux</os>
+              </platform>
+            </platforms>
           </from>
           <to>
             <image>${_TARGET_IMAGE}</image>


### PR DESCRIPTION
Fixes the integration test failure after bumping the Jib version. The cause was the change in the `created_by` value in the container config.

```
  "history": [
    {
      "created": "2020-07-27T23:41:26.054263591Z",
      "created_by": "/bin/sh -c #(nop) ADD file:b30c8ba7ffe694c4cd200cdcfc75a57a099c28f5cc97c74b6e5c0cf2bfcc5962 in / "
    },
    {
      "created": "2020-07-27T23:41:26.640971697Z",
      "created_by": "/bin/sh -c #(nop)  CMD [\"sh\"]",
      "empty_layer": true
    },
    {
      "created": "1970-01-01T00:00:00Z",
      "author": "Jib",
      "created_by": "jib-maven-plugin:2.6.1-SNAPSHOT",
      "comment": "dependencies"
    },
```