### PR TITLE
Add (new) Jib Cli parameters in base command class.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ subprojects {
 
     //test
     TRUTH: 'com.google.truth:truth:1.0.1',
+    TRUTH8: 'com.google.truth.extensions:truth-java8-extension:1.0.1', // should match TRUTH version
     JUNIT: 'junit:junit:4.13.1',
     MAVEN_TESTING_HARNESS: 'org.apache.maven.plugin-testing:maven-plugin-testing-harness:3.3.0',
     MAVEN_VERIFIER: 'org.apache.maven.shared:maven-verifier:1.7.2',

--- a/jib-cli/build.gradle
+++ b/jib-cli/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 
   testImplementation dependencyStrings.JUNIT
   testImplementation dependencyStrings.TRUTH
+  testImplementation dependencyStrings.TRUTH8
   testImplementation dependencyStrings.MOCKITO_CORE
   testImplementation dependencyStrings.SLF4J_API
   testImplementation dependencyStrings.SYSTEM_RULES

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/JibCli.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/JibCli.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.cli.cli2;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import picocli.CommandLine;
+import picocli.CommandLine.ArgGroup;
+import picocli.CommandLine.Option;
+
+@CommandLine.Command(
+    name = "jib",
+    versionProvider = VersionInfo.class,
+    showAtFileInUsageHelp = true,
+    synopsisSubcommandLabel = "COMMAND",
+    description = "A tool for creating container images")
+public class JibCli {
+  @Option(
+      names = {"-v", "--version"},
+      versionHelp = true,
+      description = "display version info")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  boolean versionInfoRequested;
+
+  @Option(
+      names = {"-h", "--help"},
+      usageHelp = true,
+      description = "display this help message")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  boolean usageHelpRequested;
+
+  @Option(
+      names = "--verbosity",
+      paramLabel = "<level>",
+      defaultValue = "lifecycle",
+      description = "set logging verbosity (error, warn, lifecycle (default), info, debug)")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  String verbosity;
+
+  @Option(names = "--stacktrace", description = "display stacktrace on failures")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  boolean stacktrace;
+
+  // Build Configuration
+  @Option(
+      names = {"-t", "--target"},
+      required = true,
+      paramLabel = "<target-image>",
+      description =
+          "The destination image reference or jib style url,%nexamples:%n gcr.io/project/image,%n registry://image-ref,%n docker://image,%n tar://path")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  String targetImage;
+
+  @Option(
+      names = {"-c", "--context"},
+      defaultValue = ".",
+      paramLabel = "<project-root>",
+      description = "The context root directory of the build (ex: path/to/my/build/things)")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  Path contextRoot;
+
+  @Option(
+      names = {"-b", "--build-file"},
+      paramLabel = "<build-file>",
+      description = "The path to the build file (ex: path/to/other-jib.yaml)")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  Path buildFile;
+
+  @Option(
+      names = {"-p", "--parameter"},
+      paramLabel = "<name>=<value>",
+      description =
+          "templating parameter to inject into build file, replace $${<name>} with <value> (repeatable)")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  Map<String, String> templateParameters = new HashMap<String, String>();
+
+  @Option(
+      names = "--tags",
+      paramLabel = "<tag>",
+      split = ",",
+      description = "Additional tags for target image")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  List<String> tags = new ArrayList<String>();
+
+  @Option(
+      names = "--base-image-cache",
+      paramLabel = "<cache-directory>",
+      description = "A path to a base image cache")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  Path baseImageCache;
+
+  @Option(
+      names = "--application-cache",
+      paramLabel = "<cache-directory>",
+      description = "A path to an application cache")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  Path applicationCache;
+
+  // Auth/Security
+  @Option(
+      names = "--allow-insecure-registries",
+      description = "Allow jib to communicate with registries over https")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  boolean allowInsecureRegistries;
+
+  @Option(
+      names = "--send-credentials-over-http",
+      description = "Allow jib to communicate with registries over https")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  boolean sendCredentialsOverHttp;
+
+  @Option(
+      names = {"--credential-helper"},
+      paramLabel = "<credential-helper>",
+      description =
+          "Add a credential helper, either a path to the helper, or a suffix for an executable named `docker-credential-<suffix>` (repeatable)")
+  List<String> credentialHelpers = new ArrayList<>();
+
+  @ArgGroup(exclusive = true)
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  UsernamePassword usernamePassword;
+
+  static class UsernamePassword {
+    @ArgGroup(exclusive = false)
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    SingleUsernamePassword single;
+
+    @ArgGroup(exclusive = false)
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    MultiUsernamePassword multi;
+  }
+
+  static class MultiUsernamePassword {
+    @ArgGroup(exclusive = false)
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    ToUsernamePassword to;
+
+    @ArgGroup(exclusive = false)
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    FromUsernamePassword from;
+  }
+
+  static class SingleUsernamePassword {
+    @Option(
+        names = "--username",
+        required = true,
+        description = "username for communicating with target/base image registry")
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    String username;
+
+    @Option(
+        names = "--password",
+        arity = "0..1",
+        required = true,
+        interactive = true,
+        description = "password for communicating with target/base image registry")
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    String password;
+  }
+
+  static class ToUsernamePassword {
+    @Option(
+        names = "--to-username",
+        required = true,
+        description = "username for communicating with target image registry")
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    String username;
+
+    @Option(
+        names = "--to-password",
+        arity = "0..1",
+        interactive = true,
+        required = true,
+        description = "password for communicating with target image registry")
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    String password;
+  }
+
+  static class FromUsernamePassword {
+    @Option(
+        names = "--from-username",
+        required = true,
+        description = "username for communicating with base image registry")
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    String username;
+
+    @Option(
+        names = "--from-password",
+        arity = "0..1",
+        required = true,
+        interactive = true,
+        description = "password for communicating with base image registry")
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    String password;
+  }
+
+  /**
+   * The magic starts here.
+   *
+   * @param args the command-line arguments
+   */
+  public static void main(String[] args) {
+    int exitCode = new CommandLine(new JibCli()).execute(args);
+    System.exit(exitCode);
+  }
+}

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/JibCli.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/JibCli.java
@@ -101,12 +101,12 @@ public class JibCli {
   private Map<String, String> templateParameters = new HashMap<String, String>();
 
   @Option(
-      names = "--tags",
+      names = "--additional-tags",
       paramLabel = "<tag>",
       split = ",",
       description = "Additional tags for target image")
   @SuppressWarnings("NullAway.Init") // initialized by picocli
-  private List<String> tags = new ArrayList<String>();
+  private List<String> additionalTags = new ArrayList<String>();
 
   @Option(
       names = "--base-image-cache",
@@ -125,13 +125,13 @@ public class JibCli {
   // Auth/Security
   @Option(
       names = "--allow-insecure-registries",
-      description = "Allow jib to communicate with registries over https")
+      description = "Allow jib to communicate with registries over http (insecure)")
   @SuppressWarnings("NullAway.Init") // initialized by picocli
   private boolean allowInsecureRegistries;
 
   @Option(
       names = "--send-credentials-over-http",
-      description = "Allow jib to communicate with registries over https")
+      description = "Allow jib to send credentials over http (very insecure)")
   @SuppressWarnings("NullAway.Init") // initialized by picocli
   private boolean sendCredentialsOverHttp;
 
@@ -256,9 +256,9 @@ public class JibCli {
     return templateParameters;
   }
 
-  public List<String> getTags() {
-    Verify.verifyNotNull(tags);
-    return tags;
+  public List<String> getAdditionalTags() {
+    Verify.verifyNotNull(additionalTags);
+    return additionalTags;
   }
 
   public Optional<Path> getBaseImageCache() {
@@ -296,7 +296,7 @@ public class JibCli {
   /**
    * If configured, returns a {@link Credential} created from user configured username/password.
    *
-   * @return a optional Credential
+   * @return an optional Credential
    */
   public Optional<Credential> getUsernamePassword() {
     if (usernamePassword != null && usernamePassword.single != null) {

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/VersionInfo.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/VersionInfo.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.cli.cli2;
+
+import picocli.CommandLine;
+
+public class VersionInfo implements CommandLine.IVersionProvider {
+  public static final String TOOL_NAME = "jib-cli";
+
+  @Override
+  public String[] getVersion() throws Exception {
+    return new String[] {getVersionSimple()};
+  }
+
+  public static String getVersionSimple() {
+    return "preview";
+  }
+}

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/JibCliTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/JibCliTest.java
@@ -17,8 +17,10 @@
 package com.google.cloud.tools.jib.cli.cli2;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 import static org.junit.Assert.fail;
 
+import com.google.cloud.tools.jib.api.Credential;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.nio.file.Paths;
@@ -44,19 +46,23 @@ public class JibCliTest {
   public void testParse_defaults() {
     JibCli jibCli = CommandLine.populateCommand(new JibCli(), "-t", "test-image-ref");
 
-    assertThat(jibCli.targetImage).isEqualTo("test-image-ref");
-    assertThat(jibCli.usernamePassword).isNull();
-    assertThat(jibCli.credentialHelpers).isEmpty();
-    assertThat((Object) jibCli.buildFile).isNull();
-    assertThat((Object) jibCli.contextRoot).isEqualTo(Paths.get("."));
-    assertThat(jibCli.tags).isEmpty();
-    assertThat(jibCli.templateParameters).isEmpty();
-    assertThat((Object) jibCli.applicationCache).isNull();
-    assertThat((Object) jibCli.baseImageCache).isNull();
-    assertThat(jibCli.allowInsecureRegistries).isFalse();
-    assertThat(jibCli.sendCredentialsOverHttp).isFalse();
-    assertThat(jibCli.verbosity).isEqualTo("lifecycle");
-    assertThat(jibCli.stacktrace).isFalse();
+    assertThat(jibCli.getTargetImage()).isEqualTo("test-image-ref");
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
+    assertThat(jibCli.getToUsernamePassword()).isEmpty();
+    assertThat(jibCli.getFromUsernamePassword()).isEmpty();
+    assertThat(jibCli.getCredentialHelpers()).isEmpty();
+    assertThat(jibCli.getBuildFile()).isEqualTo(Paths.get("./jib.yaml"));
+    assertThat(jibCli.getContextRoot()).isEqualTo(Paths.get("."));
+    assertThat(jibCli.getTags()).isEmpty();
+    assertThat(jibCli.getTemplateParameters()).isEmpty();
+    assertThat(jibCli.getApplicationCache()).isEmpty();
+    assertThat(jibCli.getBaseImageCache()).isEmpty();
+    assertThat(jibCli.isAllowInsecureRegistries()).isFalse();
+    assertThat(jibCli.isSendCredentialsOverHttp()).isFalse();
+    assertThat(jibCli.getVerbosity()).isEqualTo("lifecycle");
+    assertThat(jibCli.isStacktrace()).isFalse();
+    assertThat(jibCli.isHttpTrace()).isFalse();
+    assertThat(jibCli.isSerialize()).isFalse();
   }
 
   @Test
@@ -75,20 +81,25 @@ public class JibCliTest {
             "-p",
             "param2=value2");
 
-    assertThat(jibCli.targetImage).isEqualTo("test-image-ref");
-    assertThat(jibCli.usernamePassword).isNull();
-    assertThat(jibCli.credentialHelpers).isEmpty();
-    assertThat((Object) jibCli.buildFile).isEqualTo(Paths.get("test-build-file"));
-    assertThat((Object) jibCli.contextRoot).isEqualTo(Paths.get("test-context"));
-    assertThat(jibCli.tags).isEmpty();
-    assertThat(jibCli.templateParameters)
+    assertThat(jibCli.getTargetImage()).isEqualTo("test-image-ref");
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
+    assertThat(jibCli.getToUsernamePassword()).isEmpty();
+    assertThat(jibCli.getFromUsernamePassword()).isEmpty();
+    assertThat(jibCli.getCredentialHelpers()).isEmpty();
+    assertThat(jibCli.getBuildFile()).isEqualTo(Paths.get("test-build-file"));
+    assertThat(jibCli.getContextRoot()).isEqualTo(Paths.get("test-context"));
+    assertThat(jibCli.getTags()).isEmpty();
+    assertThat(jibCli.getTemplateParameters())
         .isEqualTo(ImmutableMap.of("param1", "value1", "param2", "value2"));
-    assertThat((Object) jibCli.applicationCache).isNull();
-    assertThat((Object) jibCli.baseImageCache).isNull();
-    assertThat(jibCli.allowInsecureRegistries).isFalse();
-    assertThat(jibCli.sendCredentialsOverHttp).isFalse();
-    assertThat(jibCli.verbosity).isEqualTo("lifecycle");
-    assertThat(jibCli.stacktrace).isFalse();
+    assertThat(jibCli.getApplicationCache()).isEmpty();
+    assertThat(jibCli.getBaseImageCache()).isEmpty();
+    assertThat(jibCli.isAllowInsecureRegistries()).isFalse();
+    assertThat(jibCli.isSendCredentialsOverHttp()).isFalse();
+    assertThat(jibCli.getVerbosity()).isEqualTo("lifecycle");
+    assertThat(jibCli.isStacktrace()).isFalse();
+    assertThat(jibCli.isStacktrace()).isFalse();
+    assertThat(jibCli.isHttpTrace()).isFalse();
+    assertThat(jibCli.isSerialize()).isFalse();
   }
 
   @Test
@@ -120,22 +131,38 @@ public class JibCliTest {
             "test-base-image-cache",
             "--verbosity",
             "info",
-            "--stacktrace");
+            "--stacktrace",
+            "--http-trace",
+            "--serialize");
 
-    assertThat(jibCli.targetImage).isEqualTo("test-image-ref");
-    assertThat(jibCli.usernamePassword).isNull();
-    assertThat(jibCli.credentialHelpers).isEqualTo(ImmutableList.of("helper1", "helper2"));
-    assertThat((Object) jibCli.buildFile).isEqualTo(Paths.get("test-build-file"));
-    assertThat((Object) jibCli.contextRoot).isEqualTo(Paths.get("test-context"));
-    assertThat(jibCli.tags).isEqualTo(ImmutableList.of("tag1", "tag2", "tag3"));
-    assertThat(jibCli.templateParameters)
+    assertThat(jibCli.getTargetImage()).isEqualTo("test-image-ref");
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
+    assertThat(jibCli.getToUsernamePassword()).isEmpty();
+    assertThat(jibCli.getFromUsernamePassword()).isEmpty();
+    assertThat(jibCli.getCredentialHelpers()).isEqualTo(ImmutableList.of("helper1", "helper2"));
+    assertThat(jibCli.getBuildFile()).isEqualTo(Paths.get("test-build-file"));
+    assertThat(jibCli.getContextRoot()).isEqualTo(Paths.get("test-context"));
+    assertThat(jibCli.getTags()).isEqualTo(ImmutableList.of("tag1", "tag2", "tag3"));
+    assertThat(jibCli.getTemplateParameters())
         .isEqualTo(ImmutableMap.of("param1", "value1", "param2", "value2"));
-    assertThat((Object) jibCli.applicationCache).isEqualTo(Paths.get("test-application-cache"));
-    assertThat((Object) jibCli.baseImageCache).isEqualTo(Paths.get("test-base-image-cache"));
-    assertThat(jibCli.allowInsecureRegistries).isTrue();
-    assertThat(jibCli.sendCredentialsOverHttp).isTrue();
-    assertThat(jibCli.verbosity).isEqualTo("info");
-    assertThat(jibCli.stacktrace).isTrue();
+    assertThat(jibCli.getApplicationCache()).hasValue(Paths.get("test-application-cache"));
+    assertThat(jibCli.getBaseImageCache()).hasValue(Paths.get("test-base-image-cache"));
+    assertThat(jibCli.isAllowInsecureRegistries()).isTrue();
+    assertThat(jibCli.isSendCredentialsOverHttp()).isTrue();
+    assertThat(jibCli.getVerbosity()).isEqualTo("info");
+    assertThat(jibCli.isStacktrace()).isTrue();
+    assertThat(jibCli.isHttpTrace()).isTrue();
+    assertThat(jibCli.isSerialize()).isTrue();
+  }
+
+  @Test
+  public void testParse_buildFileDefaultForContext() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(), "--target", "test-image-ref", "--context", "test-context");
+
+    assertThat(jibCli.getBuildFile()).isEqualTo(Paths.get("test-context/jib.yaml"));
+    assertThat(jibCli.getContextRoot()).isEqualTo(Paths.get("test-context"));
   }
 
   @Test
@@ -150,9 +177,10 @@ public class JibCliTest {
             "--password",
             "test-password");
 
-    assertThat(jibCli.usernamePassword.single.username).isEqualTo("test-username");
-    assertThat(jibCli.usernamePassword.single.password).isEqualTo("test-password");
-    assertThat(jibCli.usernamePassword.multi).isNull();
+    assertThat(jibCli.getUsernamePassword())
+        .hasValue(Credential.from("test-username", "test-password"));
+    assertThat(jibCli.getToUsernamePassword()).isEmpty();
+    assertThat(jibCli.getFromUsernamePassword()).isEmpty();
   }
 
   @Test
@@ -167,10 +195,10 @@ public class JibCliTest {
             "--to-password",
             "test-password");
 
-    assertThat(jibCli.usernamePassword.multi.to.username).isEqualTo("test-username");
-    assertThat(jibCli.usernamePassword.multi.to.password).isEqualTo("test-password");
-    assertThat(jibCli.usernamePassword.multi.from).isNull();
-    assertThat(jibCli.usernamePassword.single).isNull();
+    assertThat(jibCli.getToUsernamePassword())
+        .hasValue(Credential.from("test-username", "test-password"));
+    assertThat(jibCli.getFromUsernamePassword()).isEmpty();
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
   }
 
   @Test
@@ -185,10 +213,10 @@ public class JibCliTest {
             "--from-password",
             "test-password");
 
-    assertThat(jibCli.usernamePassword.multi.from.username).isEqualTo("test-username");
-    assertThat(jibCli.usernamePassword.multi.from.password).isEqualTo("test-password");
-    assertThat(jibCli.usernamePassword.multi.to).isNull();
-    assertThat(jibCli.usernamePassword.single).isNull();
+    assertThat(jibCli.getFromUsernamePassword())
+        .hasValue(Credential.from("test-username", "test-password"));
+    assertThat(jibCli.getToUsernamePassword()).isEmpty();
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
   }
 
   @Test
@@ -207,11 +235,11 @@ public class JibCliTest {
             "--from-password",
             "test-password-2");
 
-    assertThat(jibCli.usernamePassword.multi.to.username).isEqualTo("test-username-1");
-    assertThat(jibCli.usernamePassword.multi.to.password).isEqualTo("test-password-1");
-    assertThat(jibCli.usernamePassword.multi.from.username).isEqualTo("test-username-2");
-    assertThat(jibCli.usernamePassword.multi.from.password).isEqualTo("test-password-2");
-    assertThat(jibCli.usernamePassword.single).isNull();
+    assertThat(jibCli.getToUsernamePassword())
+        .hasValue(Credential.from("test-username-1", "test-password-1"));
+    assertThat(jibCli.getFromUsernamePassword())
+        .hasValue(Credential.from("test-username-2", "test-password-2"));
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
   }
 
   @RunWith(Parameterized.class)

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/JibCliTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/JibCliTest.java
@@ -1,0 +1,300 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.cli.cli2;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import picocli.CommandLine;
+
+public class JibCliTest {
+  @Test
+  public void testParse_missingRequiredParams() {
+    try {
+      CommandLine.populateCommand(new JibCli(), "");
+      fail();
+    } catch (CommandLine.MissingParameterException mpe) {
+      assertThat(mpe.getMessage()).isEqualTo("Missing required option: '--target=<target-image>'");
+    }
+  }
+
+  @Test
+  public void testParse_defaults() {
+    JibCli jibCli = CommandLine.populateCommand(new JibCli(), "-t", "test-image-ref");
+
+    assertThat(jibCli.targetImage).isEqualTo("test-image-ref");
+    assertThat(jibCli.usernamePassword).isNull();
+    assertThat(jibCli.credentialHelpers).isEmpty();
+    assertThat((Object) jibCli.buildFile).isNull();
+    assertThat((Object) jibCli.contextRoot).isEqualTo(Paths.get("."));
+    assertThat(jibCli.tags).isEmpty();
+    assertThat(jibCli.templateParameters).isEmpty();
+    assertThat((Object) jibCli.applicationCache).isNull();
+    assertThat((Object) jibCli.baseImageCache).isNull();
+    assertThat(jibCli.allowInsecureRegistries).isFalse();
+    assertThat(jibCli.sendCredentialsOverHttp).isFalse();
+    assertThat(jibCli.verbosity).isEqualTo("lifecycle");
+    assertThat(jibCli.stacktrace).isFalse();
+  }
+
+  @Test
+  public void testParse_shortFormParams() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(),
+            "-t",
+            "test-image-ref",
+            "-c",
+            "test-context",
+            "-b",
+            "test-build-file",
+            "-p",
+            "param1=value1",
+            "-p",
+            "param2=value2");
+
+    assertThat(jibCli.targetImage).isEqualTo("test-image-ref");
+    assertThat(jibCli.usernamePassword).isNull();
+    assertThat(jibCli.credentialHelpers).isEmpty();
+    assertThat((Object) jibCli.buildFile).isEqualTo(Paths.get("test-build-file"));
+    assertThat((Object) jibCli.contextRoot).isEqualTo(Paths.get("test-context"));
+    assertThat(jibCli.tags).isEmpty();
+    assertThat(jibCli.templateParameters)
+        .isEqualTo(ImmutableMap.of("param1", "value1", "param2", "value2"));
+    assertThat((Object) jibCli.applicationCache).isNull();
+    assertThat((Object) jibCli.baseImageCache).isNull();
+    assertThat(jibCli.allowInsecureRegistries).isFalse();
+    assertThat(jibCli.sendCredentialsOverHttp).isFalse();
+    assertThat(jibCli.verbosity).isEqualTo("lifecycle");
+    assertThat(jibCli.stacktrace).isFalse();
+  }
+
+  @Test
+  public void testParse_longFormParams() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(),
+            "--target",
+            "test-image-ref",
+            "--context",
+            "test-context",
+            "--build-file",
+            "test-build-file",
+            "--parameter",
+            "param1=value1",
+            "--parameter",
+            "param2=value2",
+            "--credential-helper",
+            "helper1",
+            "--credential-helper",
+            "helper2",
+            "--tags",
+            "tag1,tag2,tag3",
+            "--allow-insecure-registries",
+            "--send-credentials-over-http",
+            "--application-cache",
+            "test-application-cache",
+            "--base-image-cache",
+            "test-base-image-cache",
+            "--verbosity",
+            "info",
+            "--stacktrace");
+
+    assertThat(jibCli.targetImage).isEqualTo("test-image-ref");
+    assertThat(jibCli.usernamePassword).isNull();
+    assertThat(jibCli.credentialHelpers).isEqualTo(ImmutableList.of("helper1", "helper2"));
+    assertThat((Object) jibCli.buildFile).isEqualTo(Paths.get("test-build-file"));
+    assertThat((Object) jibCli.contextRoot).isEqualTo(Paths.get("test-context"));
+    assertThat(jibCli.tags).isEqualTo(ImmutableList.of("tag1", "tag2", "tag3"));
+    assertThat(jibCli.templateParameters)
+        .isEqualTo(ImmutableMap.of("param1", "value1", "param2", "value2"));
+    assertThat((Object) jibCli.applicationCache).isEqualTo(Paths.get("test-application-cache"));
+    assertThat((Object) jibCli.baseImageCache).isEqualTo(Paths.get("test-base-image-cache"));
+    assertThat(jibCli.allowInsecureRegistries).isTrue();
+    assertThat(jibCli.sendCredentialsOverHttp).isTrue();
+    assertThat(jibCli.verbosity).isEqualTo("info");
+    assertThat(jibCli.stacktrace).isTrue();
+  }
+
+  @Test
+  public void testParse_usernamePassword() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(),
+            "--target",
+            "test-image-ref",
+            "--username",
+            "test-username",
+            "--password",
+            "test-password");
+
+    assertThat(jibCli.usernamePassword.single.username).isEqualTo("test-username");
+    assertThat(jibCli.usernamePassword.single.password).isEqualTo("test-password");
+    assertThat(jibCli.usernamePassword.multi).isNull();
+  }
+
+  @Test
+  public void testParse_toUsernamePassword() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(),
+            "--target",
+            "test-image-ref",
+            "--to-username",
+            "test-username",
+            "--to-password",
+            "test-password");
+
+    assertThat(jibCli.usernamePassword.multi.to.username).isEqualTo("test-username");
+    assertThat(jibCli.usernamePassword.multi.to.password).isEqualTo("test-password");
+    assertThat(jibCli.usernamePassword.multi.from).isNull();
+    assertThat(jibCli.usernamePassword.single).isNull();
+  }
+
+  @Test
+  public void testParse_fromUsernamePassword() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(),
+            "--target",
+            "test-image-ref",
+            "--from-username",
+            "test-username",
+            "--from-password",
+            "test-password");
+
+    assertThat(jibCli.usernamePassword.multi.from.username).isEqualTo("test-username");
+    assertThat(jibCli.usernamePassword.multi.from.password).isEqualTo("test-password");
+    assertThat(jibCli.usernamePassword.multi.to).isNull();
+    assertThat(jibCli.usernamePassword.single).isNull();
+  }
+
+  @Test
+  public void testParse_toAndFromUsernamePassword() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(),
+            "--target",
+            "test-image-ref",
+            "--to-username",
+            "test-username-1",
+            "--to-password",
+            "test-password-1",
+            "--from-username",
+            "test-username-2",
+            "--from-password",
+            "test-password-2");
+
+    assertThat(jibCli.usernamePassword.multi.to.username).isEqualTo("test-username-1");
+    assertThat(jibCli.usernamePassword.multi.to.password).isEqualTo("test-password-1");
+    assertThat(jibCli.usernamePassword.multi.from.username).isEqualTo("test-username-2");
+    assertThat(jibCli.usernamePassword.multi.from.password).isEqualTo("test-password-2");
+    assertThat(jibCli.usernamePassword.single).isNull();
+  }
+
+  @RunWith(Parameterized.class)
+  public static class UsernamePasswordBothRequired {
+    @Parameterized.Parameters(name = "{0},{1}")
+    public static Collection<Object[]> data() {
+      return Arrays.asList(
+          new Object[][] {
+            {"--username", "--password"},
+            {"--to-username", "--to-password"},
+            {"--from-username", "--from-password"}
+          });
+    }
+
+    @Parameterized.Parameter(0)
+    public String usernameField;
+
+    @Parameterized.Parameter(1)
+    public String passwordField;
+
+    @Test
+    public void testParse_usernameWithoutPassword() {
+      try {
+        CommandLine.populateCommand(
+            new JibCli(), "--target", "test-image-ref", usernameField, "test-username");
+        fail();
+      } catch (CommandLine.MissingParameterException mpe) {
+        assertThat(mpe.getMessage())
+            .isEqualTo("Error: Missing required argument(s): " + passwordField);
+      }
+    }
+
+    @Test
+    public void testParse_passwordWithoutUsername() {
+      try {
+        CommandLine.populateCommand(
+            new JibCli(), "--target", "test-image-ref", passwordField, "test-password");
+        fail();
+      } catch (CommandLine.MissingParameterException mpe) {
+        assertThat(mpe.getMessage())
+            .isEqualTo("Error: Missing required argument(s): " + usernameField + "=<username>");
+      }
+    }
+  }
+
+  @RunWith(Parameterized.class)
+  public static class UsernamePasswordNotAllowedWithToAndFrom {
+    @Parameterized.Parameters(name = "{0},{1}")
+    public static Collection<Object[]> data() {
+      return Arrays.asList(
+          new Object[][] {
+            {"--to-username", "--to-password"},
+            {"--from-username", "--from-password"}
+          });
+    }
+
+    @Parameterized.Parameter(0)
+    public String usernameField;
+
+    @Parameterized.Parameter(1)
+    public String passwordField;
+
+    @Test
+    public void testParse_usernameWithoutPassword() {
+      try {
+        CommandLine.populateCommand(
+            new JibCli(),
+            "--target",
+            "test-image-ref",
+            "--username",
+            "test-username",
+            "--password",
+            "test-password",
+            usernameField,
+            "test-username",
+            passwordField,
+            "test-password");
+        fail();
+      } catch (CommandLine.MutuallyExclusiveArgsException mpe) {
+        assertThat(mpe.getMessage())
+            .isEqualTo(
+                "Error: [--username=<username> --password[=<password>]] and [[--to-username=<username> --to-password[=<password>]] [--from-username=<username> --from-password[=<password>]]] are mutually exclusive (specify only one)");
+      }
+    }
+  }
+}


### PR DESCRIPTION
Initial implementation of #2787 

does not execute anything

Here's what the help text looks like:
```
Usage: jib [-hV] [--allow-insecure-registries] [--send-credentials-over-http]
           [--application-cache=<cache-directory>] [-b=<build-file>]
           [--base-image-cache=<cache-directory>] [-c=<project-root>]
           [--name=<image-reference>] -t=<target-image> [--verbosity=<level>]
           [--credential-helper=<credential-helper>]... [-p=<name>=<value>]...
           [--tags=<tag>[,<tag>...]]... [[--username=<username> --password
           [=<password>]] | [[--to-username=<username> --to-password
           [=<password>]] [--from-username=<username> --from-password
           [=<password>]]]] [@<filename>...]
A tool for creating container images
      [@<filename>...]      One or more argument files containing options.
      --allow-insecure-registries
                            Allow jib to communicate with registries over https
      --application-cache=<cache-directory>
                            A path to an application cache
  -b, --build-file=<build-file>
                            The path to the build file (ex: path/to/other-jib.
                              yaml)
      --base-image-cache=<cache-directory>
                            A path to a base image cache
  -c, --context=<project-root>
                            The context root directory of the build (ex:
                              path/to/my/build/things)
      --credential-helper=<credential-helper>
                            Add a credential helper, either a path to the
                              helper, or a suffix for an executable named
                              `docker-credential-<suffix>` (repeatable)
      --from-password[=<password>]
                            password for communicating with base image registry
      --from-username=<username>
                            username for communicating with base image registry
  -h, --help                Show this help message and exit.
      --name=<image-reference>
                            The image reference to inject into the tar
                              configuration (required when using --target tar:
                              //...)
  -p, --parameter=<name>=<value>
                            templating parameter to inject into build file,
                              replace ${<name>} with <value> (repeatable)
      --password[=<password>]
                            password for communicating with target/base image
                              registry
      --send-credentials-over-http
                            Allow jib to communicate with registries over https
  -t, --target=<target-image>
                            The destination image reference or jib style url,
                            examples:
                             gcr.io/project/image,
                             registry://image-ref,
                             docker://image,
                             tar://path
      --tags=<tag>[,<tag>...]
                            Additional tags for target image
      --to-password[=<password>]
                            password for communicating with target image
                              registry
      --to-username=<username>
                            username for communicating with target image
                              registry
      --username=<username> username for communicating with target/base image
                              registry
  -V, --version             Print version information and exit.
      --verbosity=<level>   set logging verbosity (error, warn, lifecycle
                              (default), info, debug)
```
