### PR TITLE
Build Command for building from cli

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Build.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Build.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.cli.cli2;
+
+import com.google.cloud.tools.jib.api.Containerizer;
+import com.google.cloud.tools.jib.api.JibContainerBuilder;
+import com.google.cloud.tools.jib.cli.buildfile.BuildFiles;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+    name = "build",
+    showAtFileInUsageHelp = true,
+    description = "Build a container")
+public class Build implements Callable<Integer> {
+  @CommandLine.ParentCommand
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  protected JibCli globalOptions;
+
+  @Override
+  public Integer call() {
+    globalOptions.validate();
+
+    try {
+      Containerizer containerizer = Containerizers.from(globalOptions);
+      JibContainerBuilder containerBuilder =
+          BuildFiles.toJibContainerBuilder(
+              globalOptions.getContextRoot(),
+              globalOptions.getBuildFile(),
+              globalOptions.getTemplateParameters());
+
+      containerBuilder.containerize(containerizer);
+    } catch (Exception ex) {
+      if (globalOptions.isStacktrace()) {
+        ex.printStackTrace();
+      }
+      System.err.println(ex.getMessage());
+      return 1;
+    }
+    return 0;
+  }
+}

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Containerizers.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Containerizers.java
@@ -89,7 +89,7 @@ public class Containerizers {
     return Containerizer.to(registryImage);
   }
 
-  static void applyConfiguration(Containerizer containerizer, JibCli buildOptions) {
+  private static void applyConfiguration(Containerizer containerizer, JibCli buildOptions) {
     containerizer.setToolName(VersionInfo.TOOL_NAME);
     containerizer.setToolVersion(VersionInfo.getVersionSimple());
 
@@ -109,7 +109,7 @@ public class Containerizers {
     buildOptions.getAdditionalTags().forEach(containerizer::withAdditionalTag);
   }
 
-  static void applyHandlers(Containerizer containerizer, ConsoleLogger consoleLogger) {
+  private static void applyHandlers(Containerizer containerizer, ConsoleLogger consoleLogger) {
     containerizer
         .addEventHandler(
             LogEvent.class,

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Containerizers.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Containerizers.java
@@ -63,7 +63,7 @@ public class Containerizers {
     return containerizer;
   }
 
-  static Containerizer create(JibCli buildOptions, ConsoleLogger logger)
+  private static Containerizer create(JibCli buildOptions, ConsoleLogger logger)
       throws InvalidImageReferenceException, FileNotFoundException {
     String imageSpec = buildOptions.getTargetImage();
     if (imageSpec.startsWith(DOCKER_DAEMON_IMAGE_PREFIX)) {
@@ -106,9 +106,7 @@ public class Containerizers {
     buildOptions.getBaseImageCache().ifPresent(containerizer::setBaseImageLayersCache);
     buildOptions.getApplicationCache().ifPresent(containerizer::setApplicationLayersCache);
 
-    for (String tag : buildOptions.getAdditionalTags()) {
-      containerizer.withAdditionalTag(tag);
-    }
+    buildOptions.getAdditionalTags().forEach(containerizer::withAdditionalTag);
   }
 
   static void applyHandlers(Containerizer containerizer, ConsoleLogger consoleLogger) {

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Containerizers.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Containerizers.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.cli.cli2;
+
+import static com.google.cloud.tools.jib.api.Jib.DOCKER_DAEMON_IMAGE_PREFIX;
+import static com.google.cloud.tools.jib.api.Jib.REGISTRY_IMAGE_PREFIX;
+import static com.google.cloud.tools.jib.api.Jib.TAR_IMAGE_PREFIX;
+
+import com.google.cloud.tools.jib.api.Containerizer;
+import com.google.cloud.tools.jib.api.DockerDaemonImage;
+import com.google.cloud.tools.jib.api.ImageReference;
+import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
+import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.api.RegistryImage;
+import com.google.cloud.tools.jib.api.TarImage;
+import com.google.cloud.tools.jib.cli.cli2.logging.CliLogger;
+import com.google.cloud.tools.jib.event.events.ProgressEvent;
+import com.google.cloud.tools.jib.event.progress.ProgressEventHandler;
+import com.google.cloud.tools.jib.frontend.CredentialRetrieverFactory;
+import com.google.cloud.tools.jib.global.JibSystemProperties;
+import com.google.cloud.tools.jib.plugins.common.DefaultCredentialRetrievers;
+import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
+import com.google.cloud.tools.jib.plugins.common.logging.ProgressDisplayGenerator;
+import java.io.FileNotFoundException;
+import java.nio.file.Paths;
+import java.util.List;
+
+/** Helper class for creating Containerizers from JibCli specifications. */
+public class Containerizers {
+
+  /**
+   * Create a Containerizer from a jibcli command line specification.
+   *
+   * @param buildOptions JibCli options
+   * @return a populated Containerizer
+   * @throws InvalidImageReferenceException if the image reference could not be parsed
+   * @throws FileNotFoundException if a credential helper file is not found
+   */
+  public static Containerizer from(JibCli buildOptions)
+      throws InvalidImageReferenceException, FileNotFoundException {
+    ConsoleLogger logger =
+        CliLogger.newLogger(buildOptions.getVerbosity(), buildOptions.getConsoleOutput());
+
+    Containerizer containerizer = create(buildOptions, logger);
+
+    applyHandlers(containerizer, logger);
+    applyConfiguration(containerizer, buildOptions);
+
+    return containerizer;
+  }
+
+  static Containerizer create(JibCli buildOptions, ConsoleLogger logger)
+      throws InvalidImageReferenceException, FileNotFoundException {
+    String imageSpec = buildOptions.getTargetImage();
+    if (imageSpec.startsWith(DOCKER_DAEMON_IMAGE_PREFIX)) {
+      // TODO: allow setting docker env and docker executable (along with path/env)
+      return Containerizer.to(
+          DockerDaemonImage.named(imageSpec.replaceFirst(DOCKER_DAEMON_IMAGE_PREFIX, "")));
+    }
+    if (imageSpec.startsWith(TAR_IMAGE_PREFIX)) {
+      return Containerizer.to(
+          TarImage.at(Paths.get(imageSpec.replaceFirst(TAR_IMAGE_PREFIX, "")))
+              .named(buildOptions.getName()));
+    }
+    ImageReference imageReference =
+        ImageReference.parse(imageSpec.replaceFirst(REGISTRY_IMAGE_PREFIX, ""));
+    RegistryImage registryImage = RegistryImage.named(imageReference);
+    DefaultCredentialRetrievers defaultCredentialRetrievers =
+        DefaultCredentialRetrievers.init(
+            CredentialRetrieverFactory.forImage(
+                imageReference,
+                logEvent -> logger.log(logEvent.getLevel(), logEvent.getMessage())));
+    Credentials.getToCredentialRetrievers(buildOptions, defaultCredentialRetrievers)
+        .forEach(registryImage::addCredentialRetriever);
+    return Containerizer.to(registryImage);
+  }
+
+  static void applyConfiguration(Containerizer containerizer, JibCli buildOptions) {
+    containerizer.setToolName(VersionInfo.TOOL_NAME);
+    containerizer.setToolVersion(VersionInfo.getVersionSimple());
+
+    // TODO: it's strange that we use system properties to set these
+    // TODO: perhaps we should expose these as configuration options on the containerizer
+    if (buildOptions.isSendCredentialsOverHttp()) {
+      System.setProperty(JibSystemProperties.SEND_CREDENTIALS_OVER_HTTP, Boolean.TRUE.toString());
+    }
+    if (buildOptions.isSerialize()) {
+      System.setProperty(JibSystemProperties.SERIALIZE, Boolean.TRUE.toString());
+    }
+
+    containerizer.setAllowInsecureRegistries(buildOptions.isAllowInsecureRegistries());
+    buildOptions.getBaseImageCache().ifPresent(containerizer::setBaseImageLayersCache);
+    buildOptions.getApplicationCache().ifPresent(containerizer::setApplicationLayersCache);
+
+    for (String tag : buildOptions.getAdditionalTags()) {
+      containerizer.withAdditionalTag(tag);
+    }
+  }
+
+  static void applyHandlers(Containerizer containerizer, ConsoleLogger consoleLogger) {
+    containerizer
+        .addEventHandler(
+            LogEvent.class,
+            logEvent -> consoleLogger.log(logEvent.getLevel(), logEvent.getMessage()))
+        .addEventHandler(
+            ProgressEvent.class,
+            new ProgressEventHandler(
+                update -> {
+                  List<String> footer =
+                      ProgressDisplayGenerator.generateProgressDisplay(
+                          update.getProgress(), update.getUnfinishedLeafTasks());
+                  footer.add("");
+                  consoleLogger.setFooter(footer);
+                }));
+  }
+}

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/JibCli.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/JibCli.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.jib.cli.cli2;
 
+import static com.google.cloud.tools.jib.api.Jib.TAR_IMAGE_PREFIX;
+
 import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.cli.cli2.logging.ConsoleOutput;
 import com.google.cloud.tools.jib.cli.cli2.logging.Verbosity;
@@ -36,8 +38,13 @@ import picocli.CommandLine.Option;
     mixinStandardHelpOptions = true,
     showAtFileInUsageHelp = true,
     synopsisSubcommandLabel = "COMMAND",
-    description = "A tool for creating container images")
+    description = "A tool for creating container images",
+    subcommands = {Build.class})
 public class JibCli {
+
+  @CommandLine.Spec
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  private CommandLine.Model.CommandSpec spec;
 
   @Option(
       names = "--verbosity",
@@ -447,5 +454,14 @@ public class JibCli {
   public static void main(String[] args) {
     int exitCode = new CommandLine(new JibCli()).execute(args);
     System.exit(exitCode);
+  }
+
+  /** Validates parameters defined in this class that could not be done declaratively. */
+  public void validate() {
+    if (targetImage.startsWith(TAR_IMAGE_PREFIX) && name == null) {
+      throw new CommandLine.ParameterException(
+          spec.commandLine(),
+          "Missing option: --name must be specified when using --target=tar://....");
+    }
   }
 }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/logging/CliLogger.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/logging/CliLogger.java
@@ -42,10 +42,10 @@ public class CliLogger {
   @VisibleForTesting
   static ConsoleLogger newLogger(
       CliLogger cliLogger, boolean isRichConsole, SingleThreadedExecutor executor) {
+    // rich logger will use an explicit progress event handler
     ConsoleLoggerBuilder builder =
         isRichConsole
-            ? ConsoleLoggerBuilder.rich(
-                executor, true) // rich logger will use an explicit progress handler
+            ? ConsoleLoggerBuilder.rich(executor, true)
             : ConsoleLoggerBuilder.plain(executor).progress(cliLogger::lifecycle);
     builder.error(cliLogger::error);
     builder.warn(cliLogger::warn);

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/api/ContainerizerTestProxy.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/api/ContainerizerTestProxy.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.api;
+
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
+import java.nio.file.Path;
+import java.util.Set;
+
+/**
+ * A simple test proxy to access the innards of Containerizer which are otherwise package private.
+ */
+public class ContainerizerTestProxy {
+
+  private final Containerizer containerizer;
+
+  public ContainerizerTestProxy(Containerizer containerizer) {
+    this.containerizer = containerizer;
+  }
+
+  public boolean getAllowInsecureRegistries() {
+    return containerizer.getAllowInsecureRegistries();
+  }
+
+  public boolean isOfflineMode() {
+    return containerizer.isOfflineMode();
+  }
+
+  public String getToolName() {
+    return containerizer.getToolName();
+  }
+
+  public String getToolVersion() {
+    return containerizer.getToolVersion();
+  }
+
+  public boolean getAlwaysCacheBaseImage() {
+    return containerizer.getAlwaysCacheBaseImage();
+  }
+
+  public String getDescription() {
+    return containerizer.getDescription();
+  }
+
+  public ImageConfiguration getImageConfiguration() {
+    return containerizer.getImageConfiguration();
+  }
+
+  public Path getBaseImageLayersCacheDirectory() {
+    return containerizer.getBaseImageLayersCacheDirectory();
+  }
+
+  public Path getApplicationsLayersCacheDirectory() throws CacheDirectoryCreationException {
+    return containerizer.getApplicationLayersCacheDirectory();
+  }
+
+  public Set<String> getAdditionalTags() {
+    return containerizer.getAdditionalTags();
+  }
+}

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/ContainerizersTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/ContainerizersTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.cli.cli2;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
+
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
+import com.google.cloud.tools.jib.api.Containerizer;
+import com.google.cloud.tools.jib.api.ContainerizerTestProxy;
+import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
+import com.google.cloud.tools.jib.global.JibSystemProperties;
+import com.google.common.collect.ImmutableSet;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.TemporaryFolder;
+import picocli.CommandLine;
+
+public class ContainerizersTest {
+
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+  // Containerizers will add system properties based on cli properties
+  @Rule
+  public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+  @Test
+  public void testApplyConfiguration_defaults()
+      throws InvalidImageReferenceException, FileNotFoundException {
+    JibCli buildOptions = CommandLine.populateCommand(new JibCli(), "-t", "test-image-ref");
+
+    ContainerizerTestProxy containerizer =
+        new ContainerizerTestProxy(Containerizers.from(buildOptions));
+
+    assertThat(Boolean.getBoolean(JibSystemProperties.SEND_CREDENTIALS_OVER_HTTP)).isFalse();
+    assertThat(Boolean.getBoolean(JibSystemProperties.SERIALIZE)).isFalse();
+    assertThat(containerizer.getToolName()).isEqualTo(VersionInfo.TOOL_NAME);
+    assertThat(containerizer.getToolVersion()).isEqualTo(VersionInfo.getVersionSimple());
+    assertThat(Boolean.getBoolean("sendCredentialsOverHttp")).isFalse();
+    assertThat(containerizer.getAllowInsecureRegistries()).isFalse();
+    assertThat(containerizer.getBaseImageLayersCacheDirectory())
+        .isEqualTo(Containerizer.DEFAULT_BASE_CACHE_DIRECTORY);
+    // it's a little hard to test applicationLayersCacheDirectory defaults here, so intentionally
+    // skipped
+    assertThat(containerizer.getAdditionalTags()).isEqualTo(ImmutableSet.of());
+  }
+
+  @Test
+  public void testApplyConfiguration_withValues()
+      throws InvalidImageReferenceException, CacheDirectoryCreationException,
+          FileNotFoundException {
+    JibCli buildOptions =
+        CommandLine.populateCommand(
+            new JibCli(),
+            "-t=test-image-ref",
+            "--send-credentials-over-http",
+            "--allow-insecure-registries",
+            "--base-image-cache=./bi-cache",
+            "--application-cache=./app-cache",
+            "--additional-tags=tag1,tag2",
+            "--serialize");
+
+    ContainerizerTestProxy containerizer =
+        new ContainerizerTestProxy(Containerizers.from(buildOptions));
+
+    assertThat(Boolean.getBoolean(JibSystemProperties.SEND_CREDENTIALS_OVER_HTTP)).isTrue();
+    assertThat(Boolean.getBoolean(JibSystemProperties.SERIALIZE)).isTrue();
+    assertThat(containerizer.getAllowInsecureRegistries()).isTrue();
+    assertThat(containerizer.getBaseImageLayersCacheDirectory()).isEqualTo(Paths.get("./bi-cache"));
+    assertThat(containerizer.getApplicationsLayersCacheDirectory())
+        .isEqualTo(Paths.get("./app-cache"));
+    assertThat(containerizer.getAdditionalTags()).isEqualTo(ImmutableSet.of("tag1", "tag2"));
+  }
+
+  @Test
+  public void testFrom_dockerDaemonImage()
+      throws InvalidImageReferenceException, FileNotFoundException {
+    JibCli buildOptions =
+        CommandLine.populateCommand(new JibCli(), "-t", "docker://gcr.io/test/test-image-ref");
+    ContainerizerTestProxy containerizer =
+        new ContainerizerTestProxy(Containerizers.from(buildOptions));
+
+    assertThat(containerizer.getDescription()).isEqualTo("Building image to Docker daemon");
+    ImageConfiguration config = containerizer.getImageConfiguration();
+
+    assertThat(config.getCredentialRetrievers()).isEmpty();
+    assertThat(config.getDockerClient()).isEmpty();
+    assertThat(config.getImage().toString()).isEqualTo("gcr.io/test/test-image-ref");
+    assertThat(config.getTarPath()).isEmpty();
+  }
+
+  @Test
+  public void testFrom_tarImage() throws InvalidImageReferenceException, IOException {
+    Path tarPath = temporaryFolder.getRoot().toPath().resolve("test-tar.tar");
+    JibCli buildOptions =
+        CommandLine.populateCommand(
+            new JibCli(),
+            "-t",
+            "tar://" + tarPath.toAbsolutePath(),
+            "--name",
+            "gcr.io/test/test-image-ref");
+    ContainerizerTestProxy containerizer =
+        new ContainerizerTestProxy(Containerizers.from(buildOptions));
+
+    assertThat(containerizer.getDescription()).isEqualTo("Building image tarball");
+    ImageConfiguration config = containerizer.getImageConfiguration();
+
+    assertThat(config.getCredentialRetrievers()).isEmpty();
+    assertThat(config.getDockerClient()).isEmpty();
+    assertThat(config.getImage().toString()).isEqualTo("gcr.io/test/test-image-ref");
+    assertThat(config.getTarPath()).isEmpty(); // weird, but the way jib currently works
+  }
+
+  @Test
+  public void testFrom_registryImage() throws InvalidImageReferenceException, IOException {
+    JibCli buildOptions =
+        CommandLine.populateCommand(new JibCli(), "-t", "registry://gcr.io/test/test-image-ref");
+    ContainerizerTestProxy containerizer =
+        new ContainerizerTestProxy(Containerizers.from(buildOptions));
+
+    // description from Containerizer.java
+    assertThat(containerizer.getDescription()).isEqualTo("Building and pushing image");
+    ImageConfiguration config = containerizer.getImageConfiguration();
+
+    assertThat(config.getCredentialRetrievers()).isNotEmpty();
+    assertThat(config.getDockerClient()).isEmpty();
+    assertThat(config.getImage().toString()).isEqualTo("gcr.io/test/test-image-ref");
+    assertThat(config.getTarPath()).isEmpty();
+  }
+}

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/JibCliTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/JibCliTest.java
@@ -391,4 +391,24 @@ public class JibCliTest {
         .hasMessageThat()
         .containsMatch("^Error: (--(from-|to-)?credential-helper|\\[--username)");
   }
+
+  @Test
+  public void testValidate_nameMissingFail() {
+    JibCli jibCli = CommandLine.populateCommand(new JibCli(), "--target=tar://sometar.tar");
+
+    CommandLine.ParameterException pex =
+        assertThrows(CommandLine.ParameterException.class, jibCli::validate);
+    assertThat(pex.getMessage())
+        .isEqualTo("Missing option: --name must be specified when using --target=tar://....");
+  }
+
+  @Test
+  public void testValidate_pass() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(), "--target=tar://sometar.tar", "--name=test.io/test/test");
+
+    jibCli.validate();
+    // pass
+  }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
@@ -29,10 +29,8 @@ public class JibSystemProperties {
 
   @VisibleForTesting static final String CROSS_REPOSITORY_BLOB_MOUNTS = "jib.blobMounts";
 
-  @VisibleForTesting
   public static final String SEND_CREDENTIALS_OVER_HTTP = "sendCredentialsOverHttp";
-
-  private static final String SERIALIZE = "jib.serialize";
+  public static final String SERIALIZE = "jib.serialize";
 
   private static final String DISABLE_USER_AGENT = "_JIB_DISABLE_USER_AGENT";
 

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
@@ -73,7 +73,8 @@ public class DefaultCredentialRetrievers {
    *     CredentialRetriever}s
    * @return a new {@link DefaultCredentialRetrievers}
    */
-  static DefaultCredentialRetrievers init(CredentialRetrieverFactory credentialRetrieverFactory) {
+  public static DefaultCredentialRetrievers init(
+      CredentialRetrieverFactory credentialRetrieverFactory) {
     return new DefaultCredentialRetrievers(
         credentialRetrieverFactory, System.getProperties(), System.getenv());
   }


### PR DESCRIPTION
Convert cli options to a containerizer, create a build with default logging.
The logging probably still needs configuration (like allow `--console=plain`) or something.

Requires ~~#2811~~  ~~#2817~~ 