### PR TITLE
Handle OCI manifest and index with no mediaType

### DIFF
--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPullerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/ManifestPullerTest.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.hash.Digests;
 import com.google.cloud.tools.jib.http.Response;
 import com.google.cloud.tools.jib.image.json.ManifestTemplate;
+import com.google.cloud.tools.jib.image.json.OciIndexTemplate;
 import com.google.cloud.tools.jib.image.json.OciManifestTemplate;
 import com.google.cloud.tools.jib.image.json.UnknownManifestFormatException;
 import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
@@ -204,6 +205,69 @@ public class ManifestPullerTest {
     } catch (UnknownManifestFormatException ex) {
       Assert.assertEquals("Unknown schemaVersion: 0 - only 1 and 2 are supported", ex.getMessage());
     }
+  }
+
+  @Test
+  public void testHandleResponse_ociIndexWithNoMediaType()
+      throws IOException, UnknownManifestFormatException {
+    String ociManifestJson =
+        "{\n"
+            + "  \"schemaVersion\": 2,\n"
+            + "  \"manifests\": [\n"
+            + "    {\n"
+            + "      \"mediaType\": \"application/vnd.oci.image.manifest.v1+json\",\n"
+            + "      \"size\": 7143,\n"
+            + "      \"digest\": \"sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f\"\n"
+            + "    }\n"
+            + "  ]\n"
+            + "}";
+    Mockito.when(mockResponse.getBody()).thenReturn(stringToInputStreamUtf8(ociManifestJson));
+
+    ManifestTemplate manifest =
+        new ManifestPuller<>(
+                fakeRegistryEndpointRequestProperties, "test-image-tag", ManifestTemplate.class)
+            .handleResponse(mockResponse)
+            .getManifest();
+
+    MatcherAssert.assertThat(manifest, CoreMatchers.instanceOf(OciIndexTemplate.class));
+    OciIndexTemplate ociIndex = (OciIndexTemplate) manifest;
+
+    Assert.assertEquals("application/vnd.oci.image.index.v1+json", manifest.getManifestMediaType());
+    Assert.assertEquals(1, ociIndex.getManifests().size());
+    Assert.assertEquals(
+        "e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+        ociIndex.getManifests().get(0).getDigest().getHash());
+  }
+
+  @Test
+  public void testHandleResponse_ociManfiestWithNoMediaType()
+      throws IOException, UnknownManifestFormatException {
+    String ociManifestJson =
+        "{\n"
+            + "  \"schemaVersion\": 2,\n"
+            + "  \"config\": {\n"
+            + "    \"mediaType\": \"application/vnd.oci.image.config.v1+json\",\n"
+            + "    \"size\": 7023,\n"
+            + "    \"digest\": \"sha256:b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7\"\n"
+            + "  },\n"
+            + "  \"layers\": []\n"
+            + "}";
+    Mockito.when(mockResponse.getBody()).thenReturn(stringToInputStreamUtf8(ociManifestJson));
+
+    ManifestTemplate manifest =
+        new ManifestPuller<>(
+                fakeRegistryEndpointRequestProperties, "test-image-tag", ManifestTemplate.class)
+            .handleResponse(mockResponse)
+            .getManifest();
+
+    MatcherAssert.assertThat(manifest, CoreMatchers.instanceOf(OciManifestTemplate.class));
+    OciManifestTemplate ociManifest = (OciManifestTemplate) manifest;
+
+    Assert.assertEquals(
+        "application/vnd.oci.image.manifest.v1+json", manifest.getManifestMediaType());
+    Assert.assertEquals(
+        "b5b2b2c507a0944348e0303114d8d93aaaa081732b86451d9bce1f432a537bc7",
+        ociManifest.getContainerConfiguration().getDigest().getHash());
   }
 
   @Test


### PR DESCRIPTION
Fixes #2819.

As explained in #2819, the Docker spec requires `mediaType` in a manifest or manifest list. OTOH, the OCI spec doesn't require it. Therefore, if `mediaType` is not present (when schema 2), assume it's OCI.

And `manifests` and `config` are required in an OCI manifest or index, respectively.