### PR TITLE
Allow DefaultCredentialRetrievers to accept multiple user defined helpers

### DIFF
--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
@@ -82,7 +82,7 @@ public class DefaultCredentialRetrievers {
 
   @Nullable private CredentialRetriever knownCredentialRetriever;
   @Nullable private CredentialRetriever inferredCredentialRetriever;
-  @Nullable private String credentialHelper;
+  private final List<String> credentialHelpers = new ArrayList<>();
   private final Properties systemProperties;
   private final Map<String, String> environment;
 
@@ -124,15 +124,15 @@ public class DefaultCredentialRetrievers {
   }
 
   /**
-   * Sets the known credential helper. May either be a path to a credential helper executable, or a
+   * Adds a known credential helper. May either be a path to a credential helper executable, or a
    * credential helper suffix (following {@code docker-credential-}).
    *
    * @param credentialHelper the path to a credential helper, or a credential helper suffix
    *     (following {@code docker-credential-}).
    * @return this
    */
-  public DefaultCredentialRetrievers setCredentialHelper(@Nullable String credentialHelper) {
-    this.credentialHelper = credentialHelper;
+  public DefaultCredentialRetrievers addCredentialHelper(String credentialHelper) {
+    credentialHelpers.add(credentialHelper);
     return this;
   }
 
@@ -148,7 +148,7 @@ public class DefaultCredentialRetrievers {
     if (knownCredentialRetriever != null) {
       credentialRetrievers.add(knownCredentialRetriever);
     }
-    if (credentialHelper != null) {
+    for (String credentialHelper : credentialHelpers) {
       // If credential helper contains file separator, treat as path; otherwise treat as suffix
       if (credentialHelper.contains(FileSystems.getDefault().getSeparator())) {
         if (!Files.exists(Paths.get(credentialHelper))) {

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -860,7 +860,9 @@ public class PluginConfigurationProcessor {
       }
     }
 
-    defaultCredentialRetrievers.setCredentialHelper(credHelper);
+    if (credHelper != null) {
+      defaultCredentialRetrievers.addCredentialHelper(credHelper);
+    }
     defaultCredentialRetrievers.asList().forEach(registryImage::addCredentialRetriever);
   }
 

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrieversTest.java
@@ -156,7 +156,7 @@ public class DefaultCredentialRetrieversTest {
         new DefaultCredentialRetrievers(mockCredentialRetrieverFactory, properties, environment)
             .setKnownCredential(knownCredential, "credentialSource")
             .setInferredCredential(inferredCredential, "inferredCredentialSource")
-            .setCredentialHelper("credentialHelperSuffix")
+            .addCredentialHelper("credentialHelperSuffix")
             .asList();
     Assert.assertEquals(
         Arrays.asList(
@@ -188,7 +188,7 @@ public class DefaultCredentialRetrieversTest {
     Path fakeCredentialHelperPath = temporaryFolder.newFile("fake-credHelper").toPath();
     DefaultCredentialRetrievers defaultCredentialRetrievers =
         new DefaultCredentialRetrievers(mockCredentialRetrieverFactory, properties, environment)
-            .setCredentialHelper(fakeCredentialHelperPath.toString());
+            .addCredentialHelper(fakeCredentialHelperPath.toString());
 
     List<CredentialRetriever> credentialRetrievers = defaultCredentialRetrievers.asList();
     Assert.assertEquals(
@@ -278,7 +278,7 @@ public class DefaultCredentialRetrieversTest {
 
     DefaultCredentialRetrievers credentialRetrievers =
         new DefaultCredentialRetrievers(mockCredentialRetrieverFactory, properties, environment)
-            .setCredentialHelper(pathWithoutCmd.toString());
+            .addCredentialHelper(pathWithoutCmd.toString());
     try {
       credentialRetrievers.asList();
       Assert.fail("shouldn't check .cmd suffix on non-Windows");
@@ -291,7 +291,7 @@ public class DefaultCredentialRetrieversTest {
     properties.setProperty("os.name", "winDOWs");
     List<CredentialRetriever> retrieverList =
         new DefaultCredentialRetrievers(mockCredentialRetrieverFactory, properties, environment)
-            .setCredentialHelper(pathWithoutCmd.toString())
+            .addCredentialHelper(pathWithoutCmd.toString())
             .asList();
 
     Assert.assertEquals(
@@ -319,7 +319,7 @@ public class DefaultCredentialRetrieversTest {
 
     DefaultCredentialRetrievers credentialRetrievers =
         new DefaultCredentialRetrievers(mockCredentialRetrieverFactory, properties, environment)
-            .setCredentialHelper(pathWithoutExe.toString());
+            .addCredentialHelper(pathWithoutExe.toString());
     try {
       credentialRetrievers.asList();
       Assert.fail("shouldn't check .exe suffix on non-Windows");
@@ -332,7 +332,7 @@ public class DefaultCredentialRetrieversTest {
     properties.setProperty("os.name", "winDOWs");
     List<CredentialRetriever> retrieverList =
         new DefaultCredentialRetrievers(mockCredentialRetrieverFactory, properties, environment)
-            .setCredentialHelper(pathWithoutExe.toString())
+            .addCredentialHelper(pathWithoutExe.toString())
             .asList();
 
     Assert.assertEquals(
@@ -350,5 +350,19 @@ public class DefaultCredentialRetrieversTest {
             mockWellKnownCredentialHelpersCredentialRetriever,
             mockApplicationDefaultCredentialRetriever),
         retrieverList);
+  }
+
+  @Test
+  public void testCredentialHelper_addMultipleCredentialHelpers() throws IOException {
+    new DefaultCredentialRetrievers(mockCredentialRetrieverFactory, properties, environment)
+        .setKnownCredential(knownCredential, "credentialSource")
+        .setInferredCredential(inferredCredential, "inferredCredentialSource")
+        .addCredentialHelper("credentialHelperSuffix")
+        .addCredentialHelper("credentialHelperSuffix2")
+        .asList();
+    Mockito.verify(mockCredentialRetrieverFactory)
+        .dockerCredentialHelper("docker-credential-credentialHelperSuffix");
+    Mockito.verify(mockCredentialRetrieverFactory)
+        .dockerCredentialHelper("docker-credential-credentialHelperSuffix2");
   }
 }


### PR DESCRIPTION
This will allow it to work with params that can be specified multiple times like `--credential-helper` on the cli