### PR TITLE
Add to/from credential helper

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/JibCli.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/JibCli.java
@@ -148,42 +148,33 @@ public class JibCli {
   @SuppressWarnings("NullAway.Init") // initialized by picocli
   private boolean sendCredentialsOverHttp;
 
-  @Option(
-      names = {"--credential-helper"},
-      paramLabel = "<credential-helper>",
-      description =
-          "Add a credential helper, either a path to the helper, or a suffix for an executable named `docker-credential-<suffix>` (repeatable)")
-  private List<String> credentialHelpers = new ArrayList<>();
-
   @ArgGroup(exclusive = true)
-  @SuppressWarnings("NullAway.Init") // initialized by picocli
-  private UsernamePassword usernamePassword;
+  @SuppressWarnings("NullAway.Init")
+  private Credentials credentials;
 
-  private static class UsernamePassword {
-    @ArgGroup(exclusive = false)
+  private static class Credentials {
+    @Option(
+        names = {"--credential-helper"},
+        paramLabel = "<credential-helper>",
+        description =
+            "credential helper for communicating with both target and base image registries, either a path to the helper, or a suffix for an executable named `docker-credential-<suffix>`")
     @SuppressWarnings("NullAway.Init") // initialized by picocli
-    SingleUsernamePassword single;
-
-    @ArgGroup(exclusive = false)
-    @SuppressWarnings("NullAway.Init") // initialized by picocli
-    MultiUsernamePassword multi;
-  }
-
-  private static class MultiUsernamePassword {
-    @ArgGroup(exclusive = false)
-    @SuppressWarnings("NullAway.Init") // initialized by picocli
-    ToUsernamePassword to;
+    private String credentialHelper;
 
     @ArgGroup(exclusive = false)
     @SuppressWarnings("NullAway.Init") // initialized by picocli
-    FromUsernamePassword from;
+    private SingleUsernamePassword usernamePassword;
+
+    @ArgGroup(exclusive = false)
+    @SuppressWarnings("NullAway.Init")
+    private SeparateCredentials separate;
   }
 
   private static class SingleUsernamePassword {
     @Option(
         names = "--username",
         required = true,
-        description = "username for communicating with target/base image registry")
+        description = "username for communicating with both target and base image registries")
     @SuppressWarnings("NullAway.Init") // initialized by picocli
     String username;
 
@@ -192,9 +183,47 @@ public class JibCli {
         arity = "0..1",
         required = true,
         interactive = true,
-        description = "password for communicating with target/base image registry")
+        description = "password for communicating with both target and base image registries")
     @SuppressWarnings("NullAway.Init") // initialized by picocli
     String password;
+  }
+
+  private static class SeparateCredentials {
+    @ArgGroup
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    private ToCredentials to;
+
+    @ArgGroup
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    private FromCredentials from;
+  }
+
+  private static class ToCredentials {
+    @Option(
+        names = {"--to-credential-helper"},
+        paramLabel = "<credential-helper>",
+        description =
+            "credential helper for communicating with target registry, either a path to the helper, or a suffix for an executable named `docker-credential-<suffix>`")
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    private String credentialHelper;
+
+    @ArgGroup(exclusive = false)
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    private ToUsernamePassword usernamePassword;
+  }
+
+  private static class FromCredentials {
+    @Option(
+        names = {"--from-credential-helper"},
+        paramLabel = "<credential-helper>",
+        description =
+            "credential helper for communicating with base image registry, either a path to the helper, or a suffix for an executable named `docker-credential-<suffix>`")
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    private String credentialHelper;
+
+    @ArgGroup(exclusive = false)
+    @SuppressWarnings("NullAway.Init") // initialized by picocli
+    private FromUsernamePassword usernamePassword;
   }
 
   private static class ToUsernamePassword {
@@ -295,8 +324,49 @@ public class JibCli {
     return sendCredentialsOverHttp;
   }
 
-  public List<String> getCredentialHelpers() {
-    return credentialHelpers;
+  /**
+   * Returns the user configured credential helper for any registry during the build, this can be
+   * interpreted as a path or a string.
+   *
+   * @return a Optional string reference to the credential helper
+   */
+  public Optional<String> getCredentialHelper() {
+    if (credentials != null && credentials.credentialHelper != null) {
+      return Optional.of(credentials.credentialHelper);
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the user configured credential helper for the target image registry, this can be
+   * interpreted as a path or a string.
+   *
+   * @return a Optional string reference to the credential helper
+   */
+  public Optional<String> getToCredentialHelper() {
+    if (credentials != null
+        && credentials.separate != null
+        && credentials.separate.to != null
+        && credentials.separate.to.credentialHelper != null) {
+      return Optional.of(credentials.separate.to.credentialHelper);
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the user configured credential helper for the base image registry, this can be
+   * interpreted as a path or a string.
+   *
+   * @return a Optional string reference to the credential helper
+   */
+  public Optional<String> getFromCredentialHelper() {
+    if (credentials != null
+        && credentials.separate != null
+        && credentials.separate.from != null
+        && credentials.separate.from.credentialHelper != null) {
+      return Optional.of(credentials.separate.from.credentialHelper);
+    }
+    return Optional.empty();
   }
 
   public boolean isHttpTrace() {
@@ -317,11 +387,12 @@ public class JibCli {
    * @return an optional Credential
    */
   public Optional<Credential> getUsernamePassword() {
-    if (usernamePassword != null && usernamePassword.single != null) {
-      Verify.verifyNotNull(usernamePassword.single.username);
-      Verify.verifyNotNull(usernamePassword.single.password);
+    if (credentials != null && credentials.usernamePassword != null) {
+      Verify.verifyNotNull(credentials.usernamePassword.username);
+      Verify.verifyNotNull(credentials.usernamePassword.password);
       return Optional.of(
-          Credential.from(usernamePassword.single.username, usernamePassword.single.password));
+          Credential.from(
+              credentials.usernamePassword.username, credentials.usernamePassword.password));
     }
     return Optional.empty();
   }
@@ -333,13 +404,16 @@ public class JibCli {
    * @return a optional Credential
    */
   public Optional<Credential> getToUsernamePassword() {
-    if (usernamePassword != null
-        && usernamePassword.multi != null
-        && usernamePassword.multi.to != null) {
-      Verify.verifyNotNull(usernamePassword.multi.to.username);
-      Verify.verifyNotNull(usernamePassword.multi.to.password);
+    if (credentials != null
+        && credentials.separate != null
+        && credentials.separate.to != null
+        && credentials.separate.to.usernamePassword != null) {
+      Verify.verifyNotNull(credentials.separate.to.usernamePassword.username);
+      Verify.verifyNotNull(credentials.separate.to.usernamePassword.password);
       return Optional.of(
-          Credential.from(usernamePassword.multi.to.username, usernamePassword.multi.to.password));
+          Credential.from(
+              credentials.separate.to.usernamePassword.username,
+              credentials.separate.to.usernamePassword.password));
     }
     return Optional.empty();
   }
@@ -351,14 +425,16 @@ public class JibCli {
    * @return a optional Credential
    */
   public Optional<Credential> getFromUsernamePassword() {
-    if (usernamePassword != null
-        && usernamePassword.multi != null
-        && usernamePassword.multi.from != null) {
-      Verify.verifyNotNull(usernamePassword.multi.from.username);
-      Verify.verifyNotNull(usernamePassword.multi.from.password);
+    if (credentials != null
+        && credentials.separate != null
+        && credentials.separate.from != null
+        && credentials.separate.from.usernamePassword != null) {
+      Verify.verifyNotNull(credentials.separate.from.usernamePassword.username);
+      Verify.verifyNotNull(credentials.separate.from.usernamePassword.password);
       return Optional.of(
           Credential.from(
-              usernamePassword.multi.from.username, usernamePassword.multi.from.password));
+              credentials.separate.from.usernamePassword.username,
+              credentials.separate.from.usernamePassword.password));
     }
     return Optional.empty();
   }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/JibCliTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/JibCliTest.java
@@ -395,20 +395,15 @@ public class JibCliTest {
 
     @Test
     public void testParse_usernameWithoutPassword() {
-      try {
-        CommandLine.populateCommand(new JibCli(), ArrayUtils.addAll(requiredArgs, authArgs));
-      } catch (CommandLine.MaxValuesExceededException error) {
-        System.out.println("goose");
-      } catch (Exception ex) {
-        // do nothing
-      }
       MutuallyExclusiveArgsException meae =
           assertThrows(
               MutuallyExclusiveArgsException.class,
               () ->
                   CommandLine.populateCommand(
                       new JibCli(), ArrayUtils.addAll(requiredArgs, authArgs)));
-      assertThat(meae.getMessage()).startsWith("Error: ");
+      assertThat(meae)
+          .hasMessageThat()
+          .containsMatch("^Error: (--credential-helper|\\[--username)");
     }
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/JibCliTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/JibCliTest.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableMap;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collection;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -51,7 +52,9 @@ public class JibCliTest {
     assertThat(jibCli.getUsernamePassword()).isEmpty();
     assertThat(jibCli.getToUsernamePassword()).isEmpty();
     assertThat(jibCli.getFromUsernamePassword()).isEmpty();
-    assertThat(jibCli.getCredentialHelpers()).isEmpty();
+    assertThat(jibCli.getCredentialHelper()).isEmpty();
+    assertThat(jibCli.getToCredentialHelper()).isEmpty();
+    assertThat(jibCli.getFromCredentialHelper()).isEmpty();
     assertThat(jibCli.getBuildFile()).isEqualTo(Paths.get("./jib.yaml"));
     assertThat(jibCli.getContextRoot()).isEqualTo(Paths.get("."));
     assertThat(jibCli.getAdditionalTags()).isEmpty();
@@ -81,7 +84,9 @@ public class JibCliTest {
     assertThat(jibCli.getUsernamePassword()).isEmpty();
     assertThat(jibCli.getToUsernamePassword()).isEmpty();
     assertThat(jibCli.getFromUsernamePassword()).isEmpty();
-    assertThat(jibCli.getCredentialHelpers()).isEmpty();
+    assertThat(jibCli.getCredentialHelper()).isEmpty();
+    assertThat(jibCli.getToCredentialHelper()).isEmpty();
+    assertThat(jibCli.getFromCredentialHelper()).isEmpty();
     assertThat(jibCli.getBuildFile()).isEqualTo(Paths.get("test-build-file"));
     assertThat(jibCli.getContextRoot()).isEqualTo(Paths.get("test-context"));
     assertThat(jibCli.getAdditionalTags()).isEmpty();
@@ -100,6 +105,8 @@ public class JibCliTest {
 
   @Test
   public void testParse_longFormParams() {
+    // this test does not check credential helpers, scroll down for specialized credential helper
+    // tests
     JibCli jibCli =
         CommandLine.populateCommand(
             new JibCli(),
@@ -108,8 +115,6 @@ public class JibCliTest {
             "--build-file=test-build-file",
             "--parameter=param1=value1",
             "--parameter=param2=value2",
-            "--credential-helper=helper1",
-            "--credential-helper=helper2",
             "--additional-tags=tag1,tag2,tag3",
             "--allow-insecure-registries",
             "--send-credentials-over-http",
@@ -124,7 +129,9 @@ public class JibCliTest {
     assertThat(jibCli.getUsernamePassword()).isEmpty();
     assertThat(jibCli.getToUsernamePassword()).isEmpty();
     assertThat(jibCli.getFromUsernamePassword()).isEmpty();
-    assertThat(jibCli.getCredentialHelpers()).isEqualTo(ImmutableList.of("helper1", "helper2"));
+    assertThat(jibCli.getCredentialHelper()).isEmpty();
+    assertThat(jibCli.getToCredentialHelper()).isEmpty();
+    assertThat(jibCli.getFromCredentialHelper()).isEmpty();
     assertThat(jibCli.getBuildFile()).isEqualTo(Paths.get("test-build-file"));
     assertThat(jibCli.getContextRoot()).isEqualTo(Paths.get("test-context"));
     assertThat(jibCli.getAdditionalTags()).isEqualTo(ImmutableList.of("tag1", "tag2", "tag3"));
@@ -151,17 +158,59 @@ public class JibCliTest {
   }
 
   @Test
+  public void testParse_credentialHelper() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(), "--target=test-image-ref", "--credential-helper=test-cred-helper");
+
+    assertThat(jibCli.getCredentialHelper()).hasValue("test-cred-helper");
+    assertThat(jibCli.getToCredentialHelper()).isEmpty();
+    assertThat(jibCli.getFromCredentialHelper()).isEmpty();
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
+    assertThat(jibCli.getToUsernamePassword()).isEmpty();
+    assertThat(jibCli.getFromUsernamePassword()).isEmpty();
+  }
+
+  @Test
+  public void testParse_toCredentialHelper() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(), "--target=test-image-ref", "--to-credential-helper=test-cred-helper");
+
+    assertThat(jibCli.getCredentialHelper()).isEmpty();
+    assertThat(jibCli.getToCredentialHelper()).hasValue("test-cred-helper");
+    assertThat(jibCli.getFromCredentialHelper()).isEmpty();
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
+    assertThat(jibCli.getToUsernamePassword()).isEmpty();
+    assertThat(jibCli.getFromUsernamePassword()).isEmpty();
+  }
+
+  @Test
+  public void testParse_fromCredentialHelper() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(), "--target=test-image-ref", "--from-credential-helper=test-cred-helper");
+
+    assertThat(jibCli.getCredentialHelper()).isEmpty();
+    assertThat(jibCli.getToCredentialHelper()).isEmpty();
+    assertThat(jibCli.getFromCredentialHelper()).hasValue("test-cred-helper");
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
+    assertThat(jibCli.getToUsernamePassword()).isEmpty();
+    assertThat(jibCli.getFromUsernamePassword()).isEmpty();
+  }
+
+  @Test
   public void testParse_usernamePassword() {
     JibCli jibCli =
         CommandLine.populateCommand(
             new JibCli(),
-            "--target",
-            "test-image-ref",
-            "--username",
-            "test-username",
-            "--password",
-            "test-password");
+            "--target=test-image-ref",
+            "--username=test-username",
+            "--password=test-password");
 
+    assertThat(jibCli.getCredentialHelper()).isEmpty();
+    assertThat(jibCli.getToCredentialHelper()).isEmpty();
+    assertThat(jibCli.getFromCredentialHelper()).isEmpty();
     assertThat(jibCli.getUsernamePassword())
         .hasValue(Credential.from("test-username", "test-password"));
     assertThat(jibCli.getToUsernamePassword()).isEmpty();
@@ -173,17 +222,17 @@ public class JibCliTest {
     JibCli jibCli =
         CommandLine.populateCommand(
             new JibCli(),
-            "--target",
-            "test-image-ref",
-            "--to-username",
-            "test-username",
-            "--to-password",
-            "test-password");
+            "--target=test-image-ref",
+            "--to-username=test-username",
+            "--to-password=test-password");
 
+    assertThat(jibCli.getCredentialHelper()).isEmpty();
+    assertThat(jibCli.getToCredentialHelper()).isEmpty();
+    assertThat(jibCli.getFromCredentialHelper()).isEmpty();
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
     assertThat(jibCli.getToUsernamePassword())
         .hasValue(Credential.from("test-username", "test-password"));
     assertThat(jibCli.getFromUsernamePassword()).isEmpty();
-    assertThat(jibCli.getUsernamePassword()).isEmpty();
   }
 
   @Test
@@ -191,17 +240,17 @@ public class JibCliTest {
     JibCli jibCli =
         CommandLine.populateCommand(
             new JibCli(),
-            "--target",
-            "test-image-ref",
-            "--from-username",
-            "test-username",
-            "--from-password",
-            "test-password");
+            "--target=test-image-ref",
+            "--from-username=test-username",
+            "--from-password=test-password");
 
+    assertThat(jibCli.getCredentialHelper()).isEmpty();
+    assertThat(jibCli.getToCredentialHelper()).isEmpty();
+    assertThat(jibCli.getFromCredentialHelper()).isEmpty();
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
+    assertThat(jibCli.getToUsernamePassword()).isEmpty();
     assertThat(jibCli.getFromUsernamePassword())
         .hasValue(Credential.from("test-username", "test-password"));
-    assertThat(jibCli.getToUsernamePassword()).isEmpty();
-    assertThat(jibCli.getUsernamePassword()).isEmpty();
   }
 
   @Test
@@ -209,22 +258,75 @@ public class JibCliTest {
     JibCli jibCli =
         CommandLine.populateCommand(
             new JibCli(),
-            "--target",
-            "test-image-ref",
-            "--to-username",
-            "test-username-1",
-            "--to-password",
-            "test-password-1",
-            "--from-username",
-            "test-username-2",
-            "--from-password",
-            "test-password-2");
+            "--target=test-image-ref",
+            "--to-username=test-username-1",
+            "--to-password=test-password-1",
+            "--from-username=test-username-2",
+            "--from-password=test-password-2");
 
+    assertThat(jibCli.getCredentialHelper()).isEmpty();
+    assertThat(jibCli.getToCredentialHelper()).isEmpty();
+    assertThat(jibCli.getFromCredentialHelper()).isEmpty();
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
     assertThat(jibCli.getToUsernamePassword())
         .hasValue(Credential.from("test-username-1", "test-password-1"));
     assertThat(jibCli.getFromUsernamePassword())
         .hasValue(Credential.from("test-username-2", "test-password-2"));
+  }
+
+  @Test
+  public void testParse_toAndFromCredentialHelper() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(),
+            "--target=test-image-ref",
+            "--to-credential-helper=to-test-helper",
+            "--from-credential-helper=from-test-helper");
+
+    assertThat(jibCli.getCredentialHelper()).isEmpty();
+    assertThat(jibCli.getToCredentialHelper()).hasValue("to-test-helper");
+    assertThat(jibCli.getFromCredentialHelper()).hasValue("from-test-helper");
     assertThat(jibCli.getUsernamePassword()).isEmpty();
+    assertThat(jibCli.getToUsernamePassword()).isEmpty();
+    assertThat(jibCli.getFromUsernamePassword()).isEmpty();
+  }
+
+  @Test
+  public void testParse_toUsernamePasswordAndFromCredentialHelper() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(),
+            "--target=test-image-ref",
+            "--to-username=test-username",
+            "--to-password=test-password",
+            "--from-credential-helper=test-cred-helper");
+
+    assertThat(jibCli.getCredentialHelper()).isEmpty();
+    assertThat(jibCli.getToCredentialHelper()).isEmpty();
+    assertThat(jibCli.getFromCredentialHelper()).hasValue("test-cred-helper");
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
+    assertThat(jibCli.getToUsernamePassword())
+        .hasValue(Credential.from("test-username", "test-password"));
+    assertThat(jibCli.getFromUsernamePassword()).isEmpty();
+  }
+
+  @Test
+  public void testParse_toCredentialHelperAndFromUsernamePassword() {
+    JibCli jibCli =
+        CommandLine.populateCommand(
+            new JibCli(),
+            "--target=test-image-ref",
+            "--to-credential-helper=test-cred-helper",
+            "--from-username=test-username",
+            "--from-password=test-password");
+
+    assertThat(jibCli.getCredentialHelper()).isEmpty();
+    assertThat(jibCli.getToCredentialHelper()).hasValue("test-cred-helper");
+    assertThat(jibCli.getFromCredentialHelper()).isEmpty();
+    assertThat(jibCli.getUsernamePassword()).isEmpty();
+    assertThat(jibCli.getToUsernamePassword()).isEmpty();
+    assertThat(jibCli.getFromUsernamePassword())
+        .hasValue(Credential.from("test-username", "test-password"));
   }
 
   @RunWith(Parameterized.class)
@@ -271,43 +373,42 @@ public class JibCliTest {
   }
 
   @RunWith(Parameterized.class)
-  public static class UsernamePasswordNotAllowedWithToAndFrom {
-    @Parameterized.Parameters(name = "{0},{1}")
-    public static Collection<Object[]> data() {
+  public static class IncompatibleCredentialCombos {
+    @Parameterized.Parameters
+    public static Collection<String[][]> data() {
       return Arrays.asList(
-          new Object[][] {
-            {"--to-username", "--to-password"},
-            {"--from-username", "--from-password"}
+          new String[][][] {
+            {{"--credential-helper=x", "--to-credential-helper=x"}},
+            {{"--credential-helper=x", "--from-credential-helper=x"}},
+            {{"--credential-helper=x", "--username=x", "--password=x"}},
+            {{"--credential-helper=x", "--from-username=x", "--from-password=x"}},
+            {{"--credential-helper=x", "--to-username=x", "--to-password=x"}},
+            {{"--username=x", "--password=x", "--from-username=x", "--from-password=x"}},
+            {{"--username=x", "--password=x", "--to-username=x", "--to-password=x"}},
+            {{"--username=x", "--password=x", "--to-credential-helper=x"}},
+            {{"--username=x", "--password=x", "--from-credential-helper=x"}},
           });
     }
 
-    @Parameterized.Parameter(0)
-    public String usernameField;
-
-    @Parameterized.Parameter(1)
-    public String passwordField;
+    @Parameterized.Parameter public String[] authArgs;
+    private final String[] requiredArgs = new String[] {"--target=ignored"};
 
     @Test
     public void testParse_usernameWithoutPassword() {
+      try {
+        CommandLine.populateCommand(new JibCli(), ArrayUtils.addAll(requiredArgs, authArgs));
+      } catch (CommandLine.MaxValuesExceededException error) {
+        System.out.println("goose");
+      } catch (Exception ex) {
+        // do nothing
+      }
       MutuallyExclusiveArgsException meae =
           assertThrows(
               MutuallyExclusiveArgsException.class,
               () ->
                   CommandLine.populateCommand(
-                      new JibCli(),
-                      "--target",
-                      "test-image-ref",
-                      "--username",
-                      "test-username",
-                      "--password",
-                      "test-password",
-                      usernameField,
-                      "test-username",
-                      passwordField,
-                      "test-password"));
-      assertThat(meae.getMessage())
-          .isEqualTo(
-              "Error: [--username=<username> --password[=<password>]] and [[--to-username=<username> --to-password[=<password>]] [--from-username=<username> --from-password[=<password>]]] are mutually exclusive (specify only one)");
+                      new JibCli(), ArrayUtils.addAll(requiredArgs, authArgs)));
+      assertThat(meae.getMessage()).startsWith("Error: ");
     }
   }
 }


### PR DESCRIPTION
Implementation of #2831 

Adds option to specify credential helper specifically for target image or base image registries.

There is a way to separate out complex parameter logic like this into a separate class and then include it as a mixin. Maybe that'll help reduce some of the clutter in the future. Just dropping in here for information Mixin: https://picocli.info/apidocs/picocli/CommandLine.Mixin.html