### PR TITLE
Add credentials for `from` image in BuildFile

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
@@ -16,16 +16,32 @@
 
 package com.google.cloud.tools.jib.cli.buildfile;
 
+import static com.google.cloud.tools.jib.api.Jib.DOCKER_DAEMON_IMAGE_PREFIX;
+import static com.google.cloud.tools.jib.api.Jib.REGISTRY_IMAGE_PREFIX;
+import static com.google.cloud.tools.jib.api.Jib.TAR_IMAGE_PREFIX;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.google.cloud.tools.jib.api.DockerDaemonImage;
+import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.Jib;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
+import com.google.cloud.tools.jib.api.RegistryImage;
+import com.google.cloud.tools.jib.api.TarImage;
 import com.google.cloud.tools.jib.api.buildplan.Platform;
+import com.google.cloud.tools.jib.cli.cli2.Credentials;
+import com.google.cloud.tools.jib.cli.cli2.JibCli;
+import com.google.cloud.tools.jib.frontend.CredentialRetrieverFactory;
+import com.google.cloud.tools.jib.plugins.common.DefaultCredentialRetrievers;
+import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.commons.text.StringSubstitutor;
@@ -53,33 +69,22 @@ public class BuildFiles {
    *
    * @param projectRoot the root context directory of this build
    * @param buildFilePath a file containing the build definition
-   * @param templateParameters a map of templating variables to apply on the file before parsing
+   * @param buildOptions the build configuration from the command line
+   * @param logger a logger to inject into various objects that do logging
    * @return a {@link JibContainerBuilder} generated from the contents of {@code buildFilePath}
    * @throws IOException if an I/O error occurs opening the file, or an error occurs while
    *     traversing files on the filesystem
    * @throws InvalidImageReferenceException if the baseImage reference can not be parsed
    */
   public static JibContainerBuilder toJibContainerBuilder(
-      Path projectRoot, Path buildFilePath, Map<String, String> templateParameters)
+      Path projectRoot, Path buildFilePath, JibCli buildOptions, ConsoleLogger logger)
       throws InvalidImageReferenceException, IOException {
-    BuildFileSpec buildFile = toBuildFileSpec(buildFilePath, templateParameters);
+    BuildFileSpec buildFile = toBuildFileSpec(buildFilePath, buildOptions.getTemplateParameters());
 
-    JibContainerBuilder containerBuilder;
-    if (buildFile.getFrom().isPresent()) {
-      BaseImageSpec from = buildFile.getFrom().get();
-      containerBuilder = Jib.from(from.getImage());
-      if (!from.getPlatforms().isEmpty()) {
-        containerBuilder.setPlatforms(
-            from.getPlatforms()
-                .stream()
-                .map(
-                    platformSpec ->
-                        new Platform(platformSpec.getArchitecture(), platformSpec.getOs()))
-                .collect(Collectors.toSet()));
-      }
-    } else {
-      containerBuilder = Jib.fromScratch();
-    }
+    JibContainerBuilder containerBuilder =
+        buildFile.getFrom().isPresent()
+            ? createJibContainerBuilder(buildFile.getFrom().get(), buildOptions, logger)
+            : Jib.fromScratch();
 
     buildFile.getCreationTime().ifPresent(containerBuilder::setCreationTime);
     buildFile.getFormat().ifPresent(containerBuilder::setFormat);
@@ -95,6 +100,44 @@ public class BuildFiles {
     if (buildFile.getLayers().isPresent()) {
       containerBuilder.setFileEntriesLayers(
           Layers.toLayers(projectRoot, buildFile.getLayers().get()));
+    }
+    return containerBuilder;
+  }
+
+  @VisibleForTesting
+  // TODO: add testing, need to do via intergration tests as there's no good way to extract out that
+  //   the base image was populated as the user intended currently.
+  static JibContainerBuilder createJibContainerBuilder(
+      BaseImageSpec from, JibCli buildOptions, ConsoleLogger logger)
+      throws InvalidImageReferenceException, FileNotFoundException {
+    String baseImageReference = from.getImage();
+    if (baseImageReference.startsWith(DOCKER_DAEMON_IMAGE_PREFIX)) {
+      return Jib.from(
+          DockerDaemonImage.named(baseImageReference.replaceFirst(DOCKER_DAEMON_IMAGE_PREFIX, "")));
+    }
+    if (baseImageReference.startsWith(TAR_IMAGE_PREFIX)) {
+      return Jib.from(
+          TarImage.at(Paths.get(baseImageReference.replaceFirst(TAR_IMAGE_PREFIX, ""))));
+    }
+    ImageReference imageReference =
+        ImageReference.parse(baseImageReference.replaceFirst(REGISTRY_IMAGE_PREFIX, ""));
+    RegistryImage registryImage = RegistryImage.named(imageReference);
+    DefaultCredentialRetrievers defaultCredentialRetrievers =
+        DefaultCredentialRetrievers.init(
+            CredentialRetrieverFactory.forImage(
+                imageReference,
+                logEvent -> logger.log(logEvent.getLevel(), logEvent.getMessage())));
+    Credentials.getFromCredentialRetrievers(buildOptions, defaultCredentialRetrievers)
+        .forEach(registryImage::addCredentialRetriever);
+    JibContainerBuilder containerBuilder = Jib.from(registryImage);
+    if (!from.getPlatforms().isEmpty()) {
+      containerBuilder.setPlatforms(
+          from.getPlatforms()
+              .stream()
+              .map(
+                  platformSpec ->
+                      new Platform(platformSpec.getArchitecture(), platformSpec.getOs()))
+              .collect(Collectors.toSet()));
     }
     return containerBuilder;
   }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
@@ -25,6 +25,8 @@ import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
 import com.google.cloud.tools.jib.api.buildplan.LayerObject;
 import com.google.cloud.tools.jib.api.buildplan.Platform;
 import com.google.cloud.tools.jib.api.buildplan.Port;
+import com.google.cloud.tools.jib.cli.cli2.JibCli;
+import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -38,13 +40,27 @@ import java.util.Map;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
 
 public class BuildFilesTest {
 
   @Rule public final TemporaryFolder tmp = new TemporaryFolder();
+  @Rule public MockitoRule rule = MockitoJUnit.rule();
+
+  @Mock ConsoleLogger consoleLogger;
+  @Mock JibCli jibCli;
+
+  @Before
+  public void setUp() {
+    Mockito.when(jibCli.getTemplateParameters()).thenReturn(ImmutableMap.of());
+  }
 
   @Test
   public void testToJibContainerBuilder_allProperties()
@@ -53,7 +69,7 @@ public class BuildFilesTest {
         Paths.get(Resources.getResource("buildfiles/projects/allProperties/jib.yaml").toURI());
     Path projectRoot = buildfile.getParent();
     JibContainerBuilder jibContainerBuilder =
-        BuildFiles.toJibContainerBuilder(projectRoot, buildfile, ImmutableMap.of());
+        BuildFiles.toJibContainerBuilder(projectRoot, buildfile, jibCli, consoleLogger);
 
     ContainerBuildPlan resolved = jibContainerBuilder.toContainerBuildPlan();
     Assert.assertEquals("ubuntu", resolved.getBaseImage());
@@ -93,7 +109,7 @@ public class BuildFilesTest {
     Path buildfile =
         Paths.get(Resources.getResource("buildfiles/projects/allDefaults/jib.yaml").toURI());
     JibContainerBuilder jibContainerBuilder =
-        BuildFiles.toJibContainerBuilder(buildfile.getParent(), buildfile, ImmutableMap.of());
+        BuildFiles.toJibContainerBuilder(buildfile.getParent(), buildfile, jibCli, consoleLogger);
 
     ContainerBuildPlan resolved = jibContainerBuilder.toContainerBuildPlan();
     Assert.assertEquals("scratch", resolved.getBaseImage());
@@ -116,15 +132,15 @@ public class BuildFilesTest {
     Path buildfile =
         Paths.get(Resources.getResource("buildfiles/projects/templating/valid.yaml").toURI());
 
-    JibContainerBuilder jibContainerBuilder =
-        BuildFiles.toJibContainerBuilder(
-            buildfile.getParent(),
-            buildfile,
+    Mockito.when(jibCli.getTemplateParameters())
+        .thenReturn(
             ImmutableMap.of(
                 "unused", "ignored", // keys that are defined but not used do not throw an error
                 "key", "templateKey",
                 "value", "templateValue",
                 "repeated", "repeatedValue"));
+    JibContainerBuilder jibContainerBuilder =
+        BuildFiles.toJibContainerBuilder(buildfile.getParent(), buildfile, jibCli, consoleLogger);
 
     ContainerBuildPlan resolved = jibContainerBuilder.toContainerBuildPlan();
     Map<String, String> expectedLabels =
@@ -146,7 +162,7 @@ public class BuildFilesTest {
         Paths.get(Resources.getResource("buildfiles/projects/templating/missingVar.yaml").toURI());
 
     try {
-      BuildFiles.toJibContainerBuilder(buildfile.getParent(), buildfile, ImmutableMap.of());
+      BuildFiles.toJibContainerBuilder(buildfile.getParent(), buildfile, jibCli, consoleLogger);
       Assert.fail();
     } catch (IllegalArgumentException iae) {
       MatcherAssert.assertThat(
@@ -160,11 +176,11 @@ public class BuildFilesTest {
     Path buildfile =
         Paths.get(Resources.getResource("buildfiles/projects/templating/multiLine.yaml").toURI());
 
-    JibContainerBuilder jibContainerBuilder =
-        BuildFiles.toJibContainerBuilder(
-            buildfile.getParent(),
-            buildfile,
+    Mockito.when(jibCli.getTemplateParameters())
+        .thenReturn(
             ImmutableMap.of("replace" + System.lineSeparator() + "this", "creationTime: 1234"));
+    JibContainerBuilder jibContainerBuilder =
+        BuildFiles.toJibContainerBuilder(buildfile.getParent(), buildfile, jibCli, consoleLogger);
     ContainerBuildPlan resolved = jibContainerBuilder.toContainerBuildPlan();
     Assert.assertEquals(Instant.ofEpochMilli(1234), resolved.getCreationTime());
   }
@@ -178,7 +194,7 @@ public class BuildFilesTest {
                 .toURI());
     Path projectRoot = buildfile.getParent().getParent();
     JibContainerBuilder jibContainerBuilder =
-        BuildFiles.toJibContainerBuilder(projectRoot, buildfile, ImmutableMap.of());
+        BuildFiles.toJibContainerBuilder(projectRoot, buildfile, jibCli, consoleLogger);
 
     ContainerBuildPlan resolved = jibContainerBuilder.toContainerBuildPlan();
     Assert.assertEquals(

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
@@ -52,10 +52,10 @@ import org.mockito.junit.MockitoRule;
 public class BuildFilesTest {
 
   @Rule public final TemporaryFolder tmp = new TemporaryFolder();
-  @Rule public MockitoRule rule = MockitoJUnit.rule();
+  @Rule public final MockitoRule rule = MockitoJUnit.rule();
 
-  @Mock ConsoleLogger consoleLogger;
-  @Mock JibCli jibCli;
+  @Mock private ConsoleLogger consoleLogger;
+  @Mock private JibCli jibCli;
 
   @Before
   public void setUp() {

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
@@ -73,7 +73,7 @@ public class DefaultCredentialRetrievers {
    *     CredentialRetriever}s
    * @return a new {@link DefaultCredentialRetrievers}
    */
-  static DefaultCredentialRetrievers init(CredentialRetrieverFactory credentialRetrieverFactory) {
+  public static DefaultCredentialRetrievers init(CredentialRetrieverFactory credentialRetrieverFactory) {
     return new DefaultCredentialRetrievers(
         credentialRetrieverFactory, System.getProperties(), System.getenv());
   }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/DefaultCredentialRetrievers.java
@@ -73,7 +73,8 @@ public class DefaultCredentialRetrievers {
    *     CredentialRetriever}s
    * @return a new {@link DefaultCredentialRetrievers}
    */
-  public static DefaultCredentialRetrievers init(CredentialRetrieverFactory credentialRetrieverFactory) {
+  public static DefaultCredentialRetrievers init(
+      CredentialRetrieverFactory credentialRetrieverFactory) {
     return new DefaultCredentialRetrievers(
         credentialRetrieverFactory, System.getProperties(), System.getenv());
   }


### PR DESCRIPTION
This doesn have a test, needs to added as an integration test after the system is integrated together. In general it seems like the code around parsing an image and creating a containerizer/container-builder is a little tough and tends to be handled by integration tests.

follow-up issue: https://github.com/GoogleContainerTools/jib/issues/2839