### PR TITLE
Add option to expand wildcard in entrypoint runtime classpath

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fixed `NullPointerException` when pulling an OCI base image whose manifest does not have `mediaType` information. ([#2819](https://github.com/GoogleContainerTools/jib/pull/2819))
+- Fixed `NullPointerException` when pulling an OCI base image whose manifest does not have `mediaType` information. ([#2819](https://github.com/GoogleContainerTools/jib/issues/2819))
 - Fixed build failure when using a Docker daemon base image (`docker://...`) that has duplicate layers. ([#2829](https://github.com/GoogleContainerTools/jib/issues/2829))
 
 ## 0.16.0

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
@@ -35,10 +35,6 @@ public class JibSystemProperties {
 
   @VisibleForTesting public static final String SKIP_EXISTING_IMAGES = "jib.skipExistingImages";
 
-  @VisibleForTesting
-  static final String USE_WILDCARD_FOR_DEPENDENCY_CLASSPATH =
-      "jib.useWildcardForDependencyClasspath";
-
   /**
    * Gets the HTTP connection/read timeouts for registry interactions in milliseconds. This is
    * defined by the {@code jib.httpTimeout} system property. The default value is 20000 if the
@@ -125,17 +121,6 @@ public class JibSystemProperties {
    */
   public static boolean skipExistingImages() {
     return Boolean.getBoolean(SKIP_EXISTING_IMAGES);
-  }
-
-  /**
-   * Gets whether or not to use a wildcard or enumerate dependency JARs in the entrypoint runtime
-   * classpath.
-   *
-   * @return {@code true} if Jib should use a wildcard for dependency JARs; {@code false} to
-   *     enumerate all the JARs
-   */
-  public static boolean useWildcardForDependencyClasspath() {
-    return Boolean.getBoolean(USE_WILDCARD_FOR_DEPENDENCY_CLASSPATH);
   }
 
   private static void checkNumericSystemProperty(String property, Range<Integer> validRange) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/global/JibSystemProperties.java
@@ -24,6 +24,7 @@ import com.google.common.collect.Range;
 public class JibSystemProperties {
 
   public static final String UPSTREAM_CLIENT = "_JIB_UPSTREAM_CLIENT";
+  private static final String DISABLE_USER_AGENT = "_JIB_DISABLE_USER_AGENT";
 
   @VisibleForTesting public static final String HTTP_TIMEOUT = "jib.httpTimeout";
 
@@ -32,9 +33,11 @@ public class JibSystemProperties {
   public static final String SEND_CREDENTIALS_OVER_HTTP = "sendCredentialsOverHttp";
   public static final String SERIALIZE = "jib.serialize";
 
-  private static final String DISABLE_USER_AGENT = "_JIB_DISABLE_USER_AGENT";
-
   @VisibleForTesting public static final String SKIP_EXISTING_IMAGES = "jib.skipExistingImages";
+
+  @VisibleForTesting
+  static final String USE_WILDCARD_FOR_DEPENDENCY_CLASSPATH =
+      "jib.useWildcardForDependencyClasspath";
 
   /**
    * Gets the HTTP connection/read timeouts for registry interactions in milliseconds. This is
@@ -122,6 +125,17 @@ public class JibSystemProperties {
    */
   public static boolean skipExistingImages() {
     return Boolean.getBoolean(SKIP_EXISTING_IMAGES);
+  }
+
+  /**
+   * Gets whether or not to use a wildcard or enumerate dependency JARs in the entrypoint runtime
+   * classpath.
+   *
+   * @return {@code true} if Jib should use a wildcard for dependency JARs; {@code false} to
+   *     enumerate all the JARs
+   */
+  public static boolean useWildcardForDependencyClasspath() {
+    return Boolean.getBoolean(USE_WILDCARD_FOR_DEPENDENCY_CLASSPATH);
   }
 
   private static void checkNumericSystemProperty(String property, Range<Integer> validRange) {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildImageStepTest.java
@@ -370,4 +370,33 @@ public class BuildImageStepTest {
     // Should be exactly 9 total
     Assert.assertEquals(9, image.getHistory().size());
   }
+
+  @Test
+  public void testTruncateLongClasspath_shortClasspath() {
+    ImmutableList<String> entrypoint =
+        ImmutableList.of(
+            "java", "-Dmy-property=value", "-cp", "/app/classes:/app/libs/*", "com.example.Main");
+
+    Assert.assertEquals(
+        "[java, -Dmy-property=value, -cp, /app/classes:/app/libs/*, com.example.Main]",
+        BuildImageStep.truncateLongClasspath(entrypoint));
+  }
+
+  @Test
+  public void testTruncateLongClasspath_longClasspath() {
+    String classpath =
+        "/app/resources:/app/classes:/app/libs/spring-boot-starter-web-2.0.3.RELEASE.jar:/app/libs/"
+            + "shared-library-0.1.0.jar:/app/libs/spring-boot-starter-json-2.0.3.RELEASE.jar:/app/"
+            + "libs/spring-boot-starter-2.0.3.RELEASE.jar:/app/libs/spring-boot-starter-tomcat-2.0."
+            + "3.RELEASE.jar";
+    ImmutableList<String> entrypoint =
+        ImmutableList.of("java", "-Dmy-property=value", "-cp", classpath, "com.example.Main");
+
+    Assert.assertEquals(
+        "[java, -Dmy-property=value, -cp, /app/resources:/app/classes:/app/libs/spring-boot-starter"
+            + "-web-2.0.3.RELEASE.jar:/app/libs/shared-library-0.1.0.jar:/app/libs/spring-boot-"
+            + "starter-json-2.0.3.RELEASE.jar:/app/libs/spring-boot-starter-2.<... classpath "
+            + "truncated ...>, com.example.Main]",
+        BuildImageStep.truncateLongClasspath(entrypoint));
+  }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/global/JibSystemPropertiesTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/global/JibSystemPropertiesTest.java
@@ -166,4 +166,16 @@ public class JibSystemPropertiesTest {
     System.clearProperty(JibSystemProperties.SKIP_EXISTING_IMAGES);
     Assert.assertFalse(JibSystemProperties.skipExistingImages());
   }
+
+  @Test
+  public void testUseWildcardForDependencyClasspath_undefined() {
+    System.clearProperty(JibSystemProperties.USE_WILDCARD_FOR_DEPENDENCY_CLASSPATH);
+    Assert.assertFalse(JibSystemProperties.useWildcardForDependencyClasspath());
+  }
+
+  @Test
+  public void testUseWildcardForDependencyClasspath() {
+    System.setProperty(JibSystemProperties.USE_WILDCARD_FOR_DEPENDENCY_CLASSPATH, "true");
+    Assert.assertTrue(JibSystemProperties.useWildcardForDependencyClasspath());
+  }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/global/JibSystemPropertiesTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/global/JibSystemPropertiesTest.java
@@ -166,16 +166,4 @@ public class JibSystemPropertiesTest {
     System.clearProperty(JibSystemProperties.SKIP_EXISTING_IMAGES);
     Assert.assertFalse(JibSystemProperties.skipExistingImages());
   }
-
-  @Test
-  public void testUseWildcardForDependencyClasspath_undefined() {
-    System.clearProperty(JibSystemProperties.USE_WILDCARD_FOR_DEPENDENCY_CLASSPATH);
-    Assert.assertFalse(JibSystemProperties.useWildcardForDependencyClasspath());
-  }
-
-  @Test
-  public void testUseWildcardForDependencyClasspath() {
-    System.setProperty(JibSystemProperties.USE_WILDCARD_FOR_DEPENDENCY_CLASSPATH, "true");
-    Assert.assertTrue(JibSystemProperties.useWildcardForDependencyClasspath());
-  }
 }

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -5,11 +5,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-### Changed
+- Added an option `jib.container.expandClasspathDependencies` to preserve the order of loading dependencies as configured in a project. The option enumerates dependency JARs instead of using a wildcard (`/app/libs/*`) in the Java runtime classpath for an image entrypoint. ([#1871](https://github.com/GoogleContainerTools/jib/issues/1871), [#1907](https://github.com/GoogleContainerTools/jib/issues/1907), [#2228](https://github.com/GoogleContainerTools/jib/issues/2228), [#2733](https://github.com/GoogleContainerTools/jib/issues/2733))
+    - The option is also useful for AppCDS. ([#2471](https://github.com/GoogleContainerTools/jib/issues/2471))
 
-- Preserves the order of loading dependencies as configured in a project by enumerating dependency JARs instead of using a wildcard (`/app/libs/*`) in the Java runtime classpath for an image entrypoint. ([#1871](https://github.com/GoogleContainerTools/jib/issues/1871), [#1907](https://github.com/GoogleContainerTools/jib/issues/1907), [#2228](https://github.com/GoogleContainerTools/jib/issues/2228), [#2733](https://github.com/GoogleContainerTools/jib/issues/2733))
-    - The feature is also useful for AppCDS. ([#2471](https://github.com/GoogleContainerTools/jib/issues/2471))
-    - If expanding the wildcard causes an issue, set the system property `-Djib.noClasspathOrderPreserving=true`. However, the temporary property may eventually be removed in future releases.
+### Changed
 
 ### Fixed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 
 - Added an option `jib.container.expandClasspathDependencies` to preserve the order of loading dependencies as configured in a project. The option enumerates dependency JARs instead of using a wildcard (`/app/libs/*`) in the Java runtime classpath for an image entrypoint. ([#1871](https://github.com/GoogleContainerTools/jib/issues/1871), [#1907](https://github.com/GoogleContainerTools/jib/issues/1907), [#2228](https://github.com/GoogleContainerTools/jib/issues/2228), [#2733](https://github.com/GoogleContainerTools/jib/issues/2733))
     - The option is also useful for AppCDS. ([#2471](https://github.com/GoogleContainerTools/jib/issues/2471))
+    - Turning on the option may result in a very long classpath string, and the OS may not support passing such a long string to JVM.
 
 ### Changed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,9 +7,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Preserves the order of loading dependencies as configured in a project by enumerating dependency JARs instead of using a wildcard (`/app/libs/*`) in the Java runtime classpath for an image entrypoint. ([#1871](https://github.com/GoogleContainerTools/jib/issues/1871), [#1907](https://github.com/GoogleContainerTools/jib/issues/1907), [#2228](https://github.com/GoogleContainerTools/jib/issues/2228), [#2733](https://github.com/GoogleContainerTools/jib/issues/2733))
+    - The feature is also useful for AppCDS. ([#2471](https://github.com/GoogleContainerTools/jib/issues/2471))
+    - If expanding the wildcard causes an issue, set the system property `-Djib.useWildcardForDependencyClasspath=false`. However, the temporary property may eventually be removed in future releases.
+
 ### Fixed
 
-- Fixed `NullPointerException` when pulling an OCI base image whose manifest does not have `mediaType` information. ([#2819](https://github.com/GoogleContainerTools/jib/pull/2819))
+- Fixed `NullPointerException` when pulling an OCI base image whose manifest does not have `mediaType` information. ([#2819](https://github.com/GoogleContainerTools/jib/issues/2819))
 - Fixed build failure when using a Docker daemon base image (`docker://...`) that has duplicate layers. ([#2829](https://github.com/GoogleContainerTools/jib/issues/2829))
 
 ## 2.6.0

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Preserves the order of loading dependencies as configured in a project by enumerating dependency JARs instead of using a wildcard (`/app/libs/*`) in the Java runtime classpath for an image entrypoint. ([#1871](https://github.com/GoogleContainerTools/jib/issues/1871), [#1907](https://github.com/GoogleContainerTools/jib/issues/1907), [#2228](https://github.com/GoogleContainerTools/jib/issues/2228), [#2733](https://github.com/GoogleContainerTools/jib/issues/2733))
     - The feature is also useful for AppCDS. ([#2471](https://github.com/GoogleContainerTools/jib/issues/2471))
-    - If expanding the wildcard causes an issue, set the system property `-Djib.useWildcardForDependencyClasspath=false`. However, the temporary property may eventually be removed in future releases.
+    - If expanding the wildcard causes an issue, set the system property `-Djib.noClasspathOrderPreserving=true`. However, the temporary property may eventually be removed in future releases.
 
 ### Fixed
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
@@ -37,6 +37,7 @@ public class ContainerParameters {
   private Map<String, String> environment = Collections.emptyMap();
   @Nullable private List<String> entrypoint;
   private List<String> extraClasspath = Collections.emptyList();
+  private boolean expandClasspathDependencies;
   @Nullable private String mainClass;
   @Nullable private List<String> args;
   private ImageFormat format = ImageFormat.Docker;
@@ -103,12 +104,24 @@ public class ContainerParameters {
       return ConfigurationPropertyValidator.parseListProperty(
           System.getProperty(PropertyNames.CONTAINER_EXTRA_CLASSPATH));
     }
-
     return extraClasspath;
   }
 
   public void setExtraClasspath(List<String> classpath) {
-    this.extraClasspath = classpath;
+    extraClasspath = classpath;
+  }
+
+  @Input
+  @Optional
+  public boolean getExpandClasspathDependencies() {
+    if (System.getProperty(PropertyNames.EXPAND_CLASSPATH_DEPENDENCIES) != null) {
+      return Boolean.valueOf(System.getProperty(PropertyNames.EXPAND_CLASSPATH_DEPENDENCIES));
+    }
+    return expandClasspathDependencies;
+  }
+
+  public void setExpandClasspathDependencies(boolean expand) {
+    expandClasspathDependencies = expand;
   }
 
   @Input

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -89,6 +89,11 @@ public class GradleRawConfiguration implements RawConfiguration {
   }
 
   @Override
+  public boolean getExpandClasspathDependencies() {
+    return jibExtension.getContainer().getExpandClasspathDependencies();
+  }
+
+  @Override
   public Optional<String> getMainClass() {
     return Optional.ofNullable(jibExtension.getContainer().getMainClass());
   }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -48,7 +48,7 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -100,10 +100,12 @@ public class GradleProjectPropertiesTest {
   /** Implementation of {@link FileCollection} that just holds a set of {@link File}s. */
   private static class TestFileCollection extends AbstractFileCollection {
 
-    private final Set<File> files;
+    private final Set<File> files = new LinkedHashSet<>();
 
     private TestFileCollection(Set<Path> files) {
-      this.files = files.stream().map(Path::toFile).collect(Collectors.toSet());
+      for (Path file : files) {
+        this.files.add(file.toFile());
+      }
     }
 
     @Override
@@ -237,7 +239,7 @@ public class GradleProjectPropertiesTest {
     FileCollection classesFileCollection = new TestFileCollection(classesFiles);
     Path resourcesOutputDir = getResource("gradle/application/resources");
 
-    Set<Path> allFiles = new HashSet<>(classesFiles);
+    Set<Path> allFiles = new LinkedHashSet<>(classesFiles);
     allFiles.add(resourcesOutputDir);
     allFiles.add(getResource("gradle/application/dependencies/library.jarC.jar"));
     allFiles.add(getResource("gradle/application/dependencies/libraryB.jar"));
@@ -596,6 +598,20 @@ public class GradleProjectPropertiesTest {
         .thenReturn("war.war");
 
     Assert.assertEquals("war.war", gradleProjectProperties.getWarFilePath());
+  }
+
+  @Test
+  public void testGetDependencies() throws URISyntaxException {
+    Assert.assertEquals(
+        Arrays.asList(
+            getResource("gradle/application/dependencies/library.jarC.jar"),
+            getResource("gradle/application/dependencies/libraryB.jar"),
+            getResource("gradle/application/dependencies/libraryA.jar"),
+            getResource("gradle/application/dependencies/dependency-1.0.0.jar"),
+            getResource("gradle/application/dependencies/more/dependency-1.0.0.jar"),
+            getResource("gradle/application/dependencies/another/one/dependency-1.0.0.jar"),
+            getResource("gradle/application/dependencies/dependencyX-1.0.0-SNAPSHOT.jar")),
+        gradleProjectProperties.getDependencies());
   }
 
   private BuildContext setupBuildContext(String appRoot)

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -140,6 +140,7 @@ public class JibExtensionTest {
     Assert.assertEquals(Collections.emptyMap(), testJibExtension.getContainer().getEnvironment());
     Assert.assertEquals(
         Collections.emptyList(), testJibExtension.getContainer().getExtraClasspath());
+    Assert.assertFalse(testJibExtension.getContainer().getExpandClasspathDependencies());
     Assert.assertNull(testJibExtension.getContainer().getMainClass());
     Assert.assertNull(testJibExtension.getContainer().getArgs());
     Assert.assertSame(ImageFormat.Docker, testJibExtension.getContainer().getFormat());
@@ -156,6 +157,7 @@ public class JibExtensionTest {
           container.setEnvironment(ImmutableMap.of("var1", "value1", "var2", "value2"));
           container.setEntrypoint(Arrays.asList("foo", "bar", "baz"));
           container.setExtraClasspath(Arrays.asList("/d1", "/d2", "/d3"));
+          container.setExpandClasspathDependencies(true);
           container.setMainClass("mainClass");
           container.setArgs(Arrays.asList("arg1", "arg2", "arg3"));
           container.setPorts(Arrays.asList("1000", "2000-2010", "3000"));
@@ -170,6 +172,7 @@ public class JibExtensionTest {
     Assert.assertEquals(
         ImmutableMap.of("var1", "value1", "var2", "value2"), container.getEnvironment());
     Assert.assertEquals(ImmutableList.of("/d1", "/d2", "/d3"), container.getExtraClasspath());
+    Assert.assertTrue(testJibExtension.getContainer().getExpandClasspathDependencies());
     Assert.assertEquals("mainClass", testJibExtension.getContainer().getMainClass());
     Assert.assertEquals(Arrays.asList("arg1", "arg2", "arg3"), container.getArgs());
     Assert.assertEquals(Arrays.asList("1000", "2000-2010", "3000"), container.getPorts());
@@ -381,6 +384,8 @@ public class JibExtensionTest {
     System.setProperty("jib.container.extraClasspath", "/d1,/d2,/d3");
     Assert.assertEquals(
         ImmutableList.of("/d1", "/d2", "/d3"), testJibExtension.getContainer().getExtraClasspath());
+    System.setProperty("jib.container.expandClasspathDependencies", "true");
+    Assert.assertTrue(testJibExtension.getContainer().getExpandClasspathDependencies());
     System.setProperty("jib.container.format", "OCI");
     Assert.assertSame(ImageFormat.OCI, testJibExtension.getContainer().getFormat());
     System.setProperty("jib.container.jvmFlags", "flag1,flag2,flag3");

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Added an option `<container><expandClasspathDependencies>` to preserve the order of loading dependencies as configured in a project. The option enumerates dependency JARs instead of using a wildcard (`/app/libs/*`) in the Java runtime classpath for an image entrypoint. ([#1871](https://github.com/GoogleContainerTools/jib/issues/1871), [#1907](https://github.com/GoogleContainerTools/jib/issues/1907), [#2228](https://github.com/GoogleContainerTools/jib/issues/2228), [#2733](https://github.com/GoogleContainerTools/jib/issues/2733))
     - The option is also useful for AppCDS. ([#2471](https://github.com/GoogleContainerTools/jib/issues/2471))
+    - Turning on the option may result in a very long classpath string, and the OS may not support passing such a long string to JVM.
 
 ### Fixed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,9 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Preserves the order of loading dependencies as configured in a project by enumerating dependency JARs instead of using a wildcard (`/app/libs/*`) in the Java runtime classpath for an image entrypoint. ([#1871](https://github.com/GoogleContainerTools/jib/issues/1871), [#1907](https://github.com/GoogleContainerTools/jib/issues/1907), [#2228](https://github.com/GoogleContainerTools/jib/issues/2228), [#2733](https://github.com/GoogleContainerTools/jib/issues/2733))
-    - The feature is also useful for AppCDS. ([#2471](https://github.com/GoogleContainerTools/jib/issues/2471))
-    - If expanding the wildcard causes an issue, set the system property `-Djib.noClasspathOrderPreserving=true`. However, the temporary property may eventually be removed in future releases.
+- Added an option `<container><expandClasspathDependencies>` to preserve the order of loading dependencies as configured in a project. The option enumerates dependency JARs instead of using a wildcard (`/app/libs/*`) in the Java runtime classpath for an image entrypoint. ([#1871](https://github.com/GoogleContainerTools/jib/issues/1871), [#1907](https://github.com/GoogleContainerTools/jib/issues/1907), [#2228](https://github.com/GoogleContainerTools/jib/issues/2228), [#2733](https://github.com/GoogleContainerTools/jib/issues/2733))
+    - The option is also useful for AppCDS. ([#2471](https://github.com/GoogleContainerTools/jib/issues/2471))
 
 ### Fixed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,9 +7,13 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Preserves the order of loading dependencies as configured in a project by enumerating dependency JARs instead of using a wildcard (`/app/libs/*`) in the Java runtime classpath for an image entrypoint. ([#1871](https://github.com/GoogleContainerTools/jib/issues/1871), [#1907](https://github.com/GoogleContainerTools/jib/issues/1907), [#2228](https://github.com/GoogleContainerTools/jib/issues/2228), [#2733](https://github.com/GoogleContainerTools/jib/issues/2733))
+    - The feature is also useful for AppCDS. ([#2471](https://github.com/GoogleContainerTools/jib/issues/2471))
+    - If expanding the wildcard causes an issue, set the system property `-Djib.useWildcardForDependencyClasspath=false`. However, the temporary property may eventually be removed in future releases.
+
 ### Fixed
 
-- Fixed `NullPointerException` when pulling an OCI base image whose manifest does not have `mediaType` information. ([#2819](https://github.com/GoogleContainerTools/jib/pull/2819))
+- Fixed `NullPointerException` when pulling an OCI base image whose manifest does not have `mediaType` information. ([#2819](https://github.com/GoogleContainerTools/jib/issues/2819))
 - Fixed build failure when using a Docker daemon base image (`docker://...`) that has duplicate layers. ([#2829](https://github.com/GoogleContainerTools/jib/issues/2829))
 
 ## 2.6.0

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Preserves the order of loading dependencies as configured in a project by enumerating dependency JARs instead of using a wildcard (`/app/libs/*`) in the Java runtime classpath for an image entrypoint. ([#1871](https://github.com/GoogleContainerTools/jib/issues/1871), [#1907](https://github.com/GoogleContainerTools/jib/issues/1907), [#2228](https://github.com/GoogleContainerTools/jib/issues/2228), [#2733](https://github.com/GoogleContainerTools/jib/issues/2733))
     - The feature is also useful for AppCDS. ([#2471](https://github.com/GoogleContainerTools/jib/issues/2471))
-    - If expanding the wildcard causes an issue, set the system property `-Djib.useWildcardForDependencyClasspath=false`. However, the temporary property may eventually be removed in future releases.
+    - If expanding the wildcard causes an issue, set the system property `-Djib.noClasspathOrderPreserving=true`. However, the temporary property may eventually be removed in future releases.
 
 ### Fixed
 

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -193,6 +193,8 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
 
     @Parameter private List<String> extraClasspath = Collections.emptyList();
 
+    private boolean expandClasspathDependencies;
+
     @Nullable @Parameter private String mainClass;
 
     @Nullable @Parameter private List<String> args;
@@ -503,6 +505,19 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
       return ConfigurationPropertyValidator.parseListProperty(property);
     }
     return container.extraClasspath;
+  }
+
+  /**
+   * Returns whether to expand classpath dependencies.
+   *
+   * @return {@code true} to expand classpath dependencies. {@code false} otherwise.
+   */
+  public boolean getExpandClasspathDependencies() {
+    String property = getProperty(PropertyNames.EXPAND_CLASSPATH_DEPENDENCIES);
+    if (property != null) {
+      return Boolean.valueOf(property);
+    }
+    return container.expandClasspathDependencies;
   }
 
   /**

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -351,6 +351,15 @@ public class MavenProjectProperties implements ProjectProperties {
   }
 
   @Override
+  public List<Path> getDependencies() {
+    return project
+        .getArtifacts()
+        .stream()
+        .map(artifact -> artifact.getFile().toPath())
+        .collect(Collectors.toList());
+  }
+
+  @Override
   public void waitForLoggingThread() {
     singleThreadedExecutor.shutDownAndAwaitTermination(LOGGING_THREAD_SHUTDOWN_TIMEOUT);
   }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
@@ -94,6 +94,11 @@ public class MavenRawConfiguration implements RawConfiguration {
   }
 
   @Override
+  public boolean getExpandClasspathDependencies() {
+    return jibPluginConfiguration.getExpandClasspathDependencies();
+  }
+
+  @Override
   public Optional<String> getMainClass() {
     return Optional.ofNullable(jibPluginConfiguration.getMainClass());
   }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/JibPluginConfigurationTest.java
@@ -75,6 +75,7 @@ public class JibPluginConfigurationTest {
     Assert.assertEquals("", testPluginConfiguration.getAppRoot());
     Assert.assertNull(testPluginConfiguration.getWorkingDirectory());
     Assert.assertTrue(testPluginConfiguration.getExtraClasspath().isEmpty());
+    Assert.assertFalse(testPluginConfiguration.getExpandClasspathDependencies());
     Assert.assertEquals("exploded", testPluginConfiguration.getContainerizingMode());
     Assert.assertEquals("EPOCH_PLUS_SECOND", testPluginConfiguration.getFilesModificationTime());
     Assert.assertEquals("EPOCH", testPluginConfiguration.getCreationTime());
@@ -134,6 +135,8 @@ public class JibPluginConfigurationTest {
     sessionProperties.put("jib.container.extraClasspath", "/foo,/bar");
     Assert.assertEquals(
         ImmutableList.of("/foo", "/bar"), testPluginConfiguration.getExtraClasspath());
+    sessionProperties.put("jib.container.expandClasspathDependencies", "true");
+    Assert.assertTrue(testPluginConfiguration.getExpandClasspathDependencies());
     sessionProperties.put("jib.containerizingMode", "packaged");
     Assert.assertEquals("packaged", testPluginConfiguration.getContainerizingMode());
 
@@ -238,6 +241,8 @@ public class JibPluginConfigurationTest {
     project.getProperties().setProperty("jib.container.extraClasspath", "/foo,/bar");
     Assert.assertEquals(
         ImmutableList.of("/foo", "/bar"), testPluginConfiguration.getExtraClasspath());
+    project.getProperties().setProperty("jib.container.expandClasspathDependencies", "true");
+    Assert.assertTrue(testPluginConfiguration.getExpandClasspathDependencies());
     project.getProperties().setProperty("jib.containerizingMode", "packaged");
     Assert.assertEquals("packaged", testPluginConfiguration.getContainerizingMode());
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -1101,6 +1101,20 @@ public class MavenProjectPropertiesTest {
         Paths.get("/foo/bar/helloworld-1.war"), mavenProjectProperties.getWarArtifact());
   }
 
+  @Test
+  public void testGetDependencies() throws URISyntaxException {
+    Assert.assertEquals(
+        Arrays.asList(
+            getResource("maven/application/dependencies/library.jarC.jar"),
+            getResource("maven/application/dependencies/libraryB.jar"),
+            getResource("maven/application/dependencies/libraryA.jar"),
+            getResource("maven/application/dependencies/more/dependency-1.0.0.jar"),
+            getResource("maven/application/dependencies/another/one/dependency-1.0.0.jar"),
+            testRepository.artifactPathOnDisk("com.test", "dependency", "1.0.0"),
+            testRepository.artifactPathOnDisk("com.test", "dependencyX", "1.0.0-SNAPSHOT")),
+        mavenProjectProperties.getDependencies());
+  }
+
   private BuildContext setUpBuildContext(String appRoot, ContainerizingMode containerizingMode)
       throws InvalidImageReferenceException, IOException, CacheDirectoryCreationException {
     JavaContainerBuilder javaContainerBuilder =

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -586,10 +586,7 @@ public class PluginConfigurationProcessor {
         throw new IllegalStateException("unknown containerizing mode: " + mode);
     }
 
-    // TODO: remove the switch after no user reports an issue for a sufficient amount of time.
-    if (Boolean.getBoolean(PropertyNames.NO_CLASSPATH_ORDER_PRESERVING)) {
-      classpath.add(appRoot.resolve("libs/*").toString());
-    } else {
+    if (rawConfiguration.getExpandClasspathDependencies()) {
       List<String> dependencies =
           projectProperties
               .getDependencies()
@@ -597,6 +594,8 @@ public class PluginConfigurationProcessor {
               .map(path -> appRoot.resolve("libs").resolve(path.getFileName()).toString())
               .collect(Collectors.toList());
       classpath.addAll(dependencies);
+    } else {
+      classpath.add(appRoot.resolve("libs/*").toString());
     }
 
     String classpathString = String.join(":", classpath);

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -587,7 +587,7 @@ public class PluginConfigurationProcessor {
     }
 
     // TODO: remove the switch after no user reports an issue for a sufficient amount of time.
-    if (JibSystemProperties.useWildcardForDependencyClasspath()) {
+    if (Boolean.getBoolean(PropertyNames.NO_CLASSPATH_ORDER_PRESERVING)) {
       classpath.add(appRoot.resolve("libs/*").toString());
     } else {
       List<String> dependencies =

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
@@ -66,6 +66,8 @@ public interface ProjectProperties {
 
   List<Path> getClassFiles() throws IOException;
 
+  List<Path> getDependencies();
+
   Path getDefaultCacheDirectory();
 
   String getJarPluginName();

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
@@ -32,6 +32,8 @@ public class PropertyNames {
   public static final String CONTAINER_APP_ROOT = "jib.container.appRoot";
   public static final String CONTAINER_ARGS = "jib.container.args";
   public static final String CONTAINER_EXTRA_CLASSPATH = "jib.container.extraClasspath";
+  public static final String EXPAND_CLASSPATH_DEPENDENCIES =
+      "jib.container.expandClasspathDependencies";
   public static final String CONTAINER_ENTRYPOINT = "jib.container.entrypoint";
   public static final String CONTAINER_ENVIRONMENT = "jib.container.environment";
   public static final String CONTAINER_FORMAT = "jib.container.format";
@@ -65,7 +67,6 @@ public class PropertyNames {
   public static final String ALWAYS_CACHE_BASE_IMAGE = "jib.alwaysCacheBaseImage";
   public static final String DISABLE_UPDATE_CHECKS = "jib.disableUpdateChecks";
   public static final String CONFIG_DIRECTORY = "jib.configDirectory";
-  public static final String NO_CLASSPATH_ORDER_PRESERVING = "jib.noClasspathOrderPreserving";
 
   private PropertyNames() {}
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
@@ -45,9 +45,6 @@ public class PropertyNames {
   public static final String CONTAINER_FILES_MODIFICATION_TIME =
       "jib.container.filesModificationTime";
   public static final String CONTAINER_CREATION_TIME = "jib.container.creationTime";
-  public static final String USE_ONLY_PROJECT_CACHE = "jib.useOnlyProjectCache";
-  public static final String BASE_IMAGE_CACHE = "jib.baseImageCache";
-  public static final String APPLICATION_CACHE = "jib.applicationCache";
   public static final String ALLOW_INSECURE_REGISTRIES = "jib.allowInsecureRegistries";
   public static final String EXTRA_DIRECTORIES_PATHS = "jib.extraDirectories.paths";
   public static final String EXTRA_DIRECTORIES_PERMISSIONS = "jib.extraDirectories.permissions";
@@ -59,11 +56,16 @@ public class PropertyNames {
   public static final String OUTPUT_PATHS_TAR = "jib.outputPaths.tar";
   public static final String CONTAINERIZING_MODE = "jib.containerizingMode";
   public static final String SKIP = "jib.skip";
-  public static final String CONSOLE = "jib.console";
+
   public static final String CONTAINERIZE = "jib.containerize";
+  public static final String CONSOLE = "jib.console";
+  public static final String USE_ONLY_PROJECT_CACHE = "jib.useOnlyProjectCache";
+  public static final String BASE_IMAGE_CACHE = "jib.baseImageCache";
+  public static final String APPLICATION_CACHE = "jib.applicationCache";
   public static final String ALWAYS_CACHE_BASE_IMAGE = "jib.alwaysCacheBaseImage";
   public static final String DISABLE_UPDATE_CHECKS = "jib.disableUpdateChecks";
   public static final String CONFIG_DIRECTORY = "jib.configDirectory";
+  public static final String NO_CLASSPATH_ORDER_PRESERVING = "jib.noClasspathOrderPreserving";
 
   private PropertyNames() {}
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
@@ -59,11 +59,15 @@ public interface RawConfiguration {
 
   Optional<String> getToCredHelper();
 
+  List<? extends PlatformConfiguration> getPlatforms();
+
   Set<String> getToTags();
 
   Optional<List<String>> getEntrypoint();
 
   List<String> getExtraClasspath();
+
+  boolean getExpandClasspathDependencies();
 
   Optional<List<String>> getProgramArguments();
 
@@ -114,6 +118,4 @@ public interface RawConfiguration {
   Path getImageJsonOutputPath();
 
   List<? extends ExtensionConfiguration> getPluginExtensions();
-
-  List<? extends PlatformConfiguration> getPlatforms();
 }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -163,11 +163,7 @@ public class PluginConfigurationProcessorTest {
     BuildContext buildContext = getBuildContext(processCommonConfiguration());
 
     Assert.assertEquals(
-        Arrays.asList(
-            "java",
-            "-cp",
-            "/app/resources:/app/classes:/app/libs/foo-1.jar:/app/libs/bar-2.jar",
-            "java.lang.Object"),
+        Arrays.asList("java", "-cp", "/app/resources:/app/classes:/app/libs/*", "java.lang.Object"),
         buildContext.getContainerConfiguration().getEntrypoint());
 
     Mockito.verify(containerizer)
@@ -294,11 +290,7 @@ public class PluginConfigurationProcessorTest {
       throws MainClassInferenceException, InvalidAppRootException, IOException,
           InvalidContainerizingModeException {
     Assert.assertEquals(
-        Arrays.asList(
-            "java",
-            "-cp",
-            "/app/resources:/app/classes:/app/libs/foo-1.jar:/app/libs/bar-2.jar",
-            "java.lang.Object"),
+        Arrays.asList("java", "-cp", "/app/resources:/app/classes:/app/libs/*", "java.lang.Object"),
         PluginConfigurationProcessor.computeEntrypoint(rawConfiguration, projectProperties));
   }
 
@@ -308,21 +300,21 @@ public class PluginConfigurationProcessorTest {
           InvalidContainerizingModeException {
     Mockito.when(rawConfiguration.getContainerizingMode()).thenReturn("packaged");
     Assert.assertEquals(
-        Arrays.asList(
-            "java",
-            "-cp",
-            "/app/classpath/*:/app/libs/foo-1.jar:/app/libs/bar-2.jar",
-            "java.lang.Object"),
+        Arrays.asList("java", "-cp", "/app/classpath/*:/app/libs/*", "java.lang.Object"),
         PluginConfigurationProcessor.computeEntrypoint(rawConfiguration, projectProperties));
   }
 
   @Test
-  public void testComputeEntrypoint_noClasspathOrderPreserving()
+  public void testComputeEntrypoint_expandClasspathDependencies()
       throws MainClassInferenceException, InvalidAppRootException, IOException,
           InvalidContainerizingModeException {
-    System.setProperty("jib.noClasspathOrderPreserving", "true");
+    Mockito.when(rawConfiguration.getExpandClasspathDependencies()).thenReturn(true);
     Assert.assertEquals(
-        Arrays.asList("java", "-cp", "/app/resources:/app/classes:/app/libs/*", "java.lang.Object"),
+        Arrays.asList(
+            "java",
+            "-cp",
+            "/app/resources:/app/classes:/app/libs/foo-1.jar:/app/libs/bar-2.jar",
+            "java.lang.Object"),
         PluginConfigurationProcessor.computeEntrypoint(rawConfiguration, projectProperties));
   }
 
@@ -357,11 +349,7 @@ public class PluginConfigurationProcessorTest {
     BuildContext buildContext = getBuildContext(processCommonConfiguration());
 
     Assert.assertEquals(
-        Arrays.asList(
-            "java",
-            "-cp",
-            "/app/resources:/app/classes:/app/libs/foo-1.jar:/app/libs/bar-2.jar",
-            "java.lang.Object"),
+        Arrays.asList("java", "-cp", "/app/resources:/app/classes:/app/libs/*", "java.lang.Object"),
         buildContext.getContainerConfiguration().getEntrypoint());
 
     ArgumentMatcher<LogEvent> isLogWarn = logEvent -> logEvent.getLevel() == LogEvent.Level.WARN;
@@ -385,10 +373,7 @@ public class PluginConfigurationProcessorTest {
 
     Assert.assertEquals(
         Arrays.asList(
-            "java",
-            "-cp",
-            "/foo:/app/resources:/app/classes:/app/libs/foo-1.jar:/app/libs/bar-2.jar",
-            "java.lang.Object"),
+            "java", "-cp", "/foo:/app/resources:/app/classes:/app/libs/*", "java.lang.Object"),
         buildContext.getContainerConfiguration().getEntrypoint());
 
     ArgumentMatcher<LogEvent> isLogWarn = logEvent -> logEvent.getLevel() == LogEvent.Level.WARN;
@@ -500,10 +485,7 @@ public class PluginConfigurationProcessorTest {
 
     Assert.assertEquals(
         Arrays.asList(
-            "java",
-            "-cp",
-            "/my/app/resources:/my/app/classes:/my/app/libs/foo-1.jar:/my/app/libs/bar-2.jar",
-            "java.lang.Object"),
+            "java", "-cp", "/my/app/resources:/my/app/classes:/my/app/libs/*", "java.lang.Object"),
         buildContext.getContainerConfiguration().getEntrypoint());
   }
 

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessorTest.java
@@ -317,10 +317,10 @@ public class PluginConfigurationProcessorTest {
   }
 
   @Test
-  public void testComputeEntrypoint_useWildcardForLibraryClasspath()
+  public void testComputeEntrypoint_noClasspathOrderPreserving()
       throws MainClassInferenceException, InvalidAppRootException, IOException,
           InvalidContainerizingModeException {
-    System.setProperty("jib.useWildcardForDependencyClasspath", "true");
+    System.setProperty("jib.noClasspathOrderPreserving", "true");
     Assert.assertEquals(
         Arrays.asList("java", "-cp", "/app/resources:/app/classes:/app/libs/*", "java.lang.Object"),
         PluginConfigurationProcessor.computeEntrypoint(rawConfiguration, projectProperties));


### PR DESCRIPTION
Gives a viable solution to #1871 (#1907, #2228, #2733).

Also enables the AppCDS support (#2471).

This PR adds the option `jib.container.expandClasspathDependencies` that expands the wildcard `.../libs/*` in the entrypoint JVM classpath. It's off by default. The feature to use an `@argument` file will be added later for a permanent fix for the issue later. See https://github.com/GoogleContainerTools/jib/pull/2866#discussion_r512790086 for details.