### PR TITLE
Fix broken Jib CLI logging

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Build.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Build.java
@@ -41,6 +41,7 @@ public class Build implements Callable<Integer> {
       ConsoleLogger logger =
           CliLogger.newLogger(globalOptions.getVerbosity(), globalOptions.getConsoleOutput());
       Containerizer containerizer = Containerizers.from(globalOptions, logger);
+
       JibContainerBuilder containerBuilder =
           BuildFiles.toJibContainerBuilder(
               globalOptions.getContextRoot(), globalOptions.getBuildFile(), globalOptions, logger);

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Containerizers.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Containerizers.java
@@ -52,7 +52,6 @@ public class Containerizers {
    */
   public static Containerizer from(JibCli buildOptions, ConsoleLogger logger)
       throws InvalidImageReferenceException, FileNotFoundException {
-
     Containerizer containerizer = create(buildOptions, logger);
 
     applyHandlers(containerizer, logger);

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/logging/CliLogger.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/logging/CliLogger.java
@@ -48,7 +48,7 @@ public class CliLogger {
         isRichConsole(consoleOutput) && verbosity.atLeast(Verbosity.lifecycle);
     ConsoleLoggerBuilder builder =
         enableRichProgress
-            ? ConsoleLoggerBuilder.rich(executor, true)
+            ? ConsoleLoggerBuilder.rich(executor, false)
             : ConsoleLoggerBuilder.plain(executor);
     if (verbosity.atLeast(Verbosity.error)) {
       builder.error(stderr::println);

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/logging/CliLogger.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/logging/CliLogger.java
@@ -22,36 +22,54 @@ import com.google.cloud.tools.jib.plugins.common.logging.SingleThreadedExecutor;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.PrintStream;
 
-/** A simple cli logger that logs to the command line based on the configured log level. */
+/** A simple CLI logger that logs to the command line based on the configured log level. */
 public class CliLogger {
 
   /**
-   * Create a new logger for the cli.
+   * Create a new logger for the CLI.
    *
    * @param verbosity the configure verbosity
    * @param consoleOutput the configured consoleOutput format
    * @return a new ConsoleLogger instance
    */
   public static ConsoleLogger newLogger(Verbosity verbosity, ConsoleOutput consoleOutput) {
-    CliLogger cliLogger = new CliLogger(verbosity, System.out, System.err);
-    boolean isRichConsole = isRichConsole(consoleOutput);
-
-    return newLogger(cliLogger, isRichConsole, new SingleThreadedExecutor());
+    return newLogger(
+        verbosity, consoleOutput, System.out, System.err, new SingleThreadedExecutor());
   }
 
   @VisibleForTesting
   static ConsoleLogger newLogger(
-      CliLogger cliLogger, boolean isRichConsole, SingleThreadedExecutor executor) {
-    // rich logger will use an explicit progress event handler
+      Verbosity verbosity,
+      ConsoleOutput consoleOutput,
+      PrintStream stdout,
+      PrintStream stderr,
+      SingleThreadedExecutor executor) {
+    boolean enableRichProgress =
+        isRichConsole(consoleOutput) && verbosity.atLeast(Verbosity.lifecycle);
     ConsoleLoggerBuilder builder =
-        isRichConsole
+        enableRichProgress
             ? ConsoleLoggerBuilder.rich(executor, true)
-            : ConsoleLoggerBuilder.plain(executor).progress(cliLogger::lifecycle);
-    builder.error(cliLogger::error);
-    builder.warn(cliLogger::warn);
-    builder.lifecycle(cliLogger::lifecycle);
-    builder.info(cliLogger::info);
-    builder.debug(cliLogger::debug);
+            : ConsoleLoggerBuilder.plain(executor);
+    if (verbosity.atLeast(Verbosity.error)) {
+      builder.error(stderr::println);
+    }
+    if (verbosity.atLeast(Verbosity.warn)) {
+      builder.warn(stdout::println);
+    }
+    if (verbosity.atLeast(Verbosity.lifecycle)) {
+      builder.lifecycle(stdout::println);
+      // Rich progress reporting will be through ProgressEvent (note this is not LogEvent of
+      // Level.PROGRESS), so we ignore PROGRESS LogEvent.
+      if (!enableRichProgress) {
+        builder.progress(stdout::println);
+      }
+    }
+    if (verbosity.atLeast(Verbosity.info)) {
+      builder.info(stdout::println);
+    }
+    if (verbosity.atLeast(Verbosity.debug)) {
+      builder.debug(stdout::println);
+    }
 
     return builder.build();
   }
@@ -68,52 +86,6 @@ public class CliLogger {
       case rich:
       default:
         return true;
-    }
-  }
-
-  private final Verbosity verbosity;
-  private final PrintStream out;
-  private final PrintStream err;
-
-  @VisibleForTesting
-  CliLogger(Verbosity verbosity, PrintStream out, PrintStream err) {
-    this.verbosity = verbosity;
-    this.out = out;
-    this.err = err;
-  }
-
-  @VisibleForTesting
-  void debug(String message) {
-    if (verbosity.atLeast(Verbosity.debug)) {
-      out.println(message);
-    }
-  }
-
-  @VisibleForTesting
-  void info(String message) {
-    if (verbosity.atLeast(Verbosity.info)) {
-      out.println(message);
-    }
-  }
-
-  @VisibleForTesting
-  void lifecycle(String message) {
-    if (verbosity.atLeast(Verbosity.lifecycle)) {
-      out.println(message);
-    }
-  }
-
-  @VisibleForTesting
-  void warn(String message) {
-    if (verbosity.atLeast(Verbosity.warn)) {
-      out.println(message);
-    }
-  }
-
-  @VisibleForTesting
-  void error(String message) {
-    if (verbosity.atLeast(Verbosity.error)) {
-      err.println(message);
     }
   }
 }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarProcessor.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarProcessor.java
@@ -165,7 +165,8 @@ public class JarProcessor {
           jarFile.getManifest().getMainAttributes().getValue(Attributes.Name.MAIN_CLASS);
       if (mainClass == null) {
         throw new IllegalArgumentException(
-            "`Main-Class:` attribute for an application main class not defined in the input Jar's manifest (`META-INF/MANIFEST.MF` in the Jar).");
+            "`Main-Class:` attribute for an application main class not defined in the input Jar's "
+                + "manifest (`META-INF/MANIFEST.MF` in the Jar).");
       }
       String classpath = APP_ROOT + "/explodedJar:" + APP_ROOT + "/dependencies/*";
       return ImmutableList.of("java", "-cp", classpath, mainClass);


### PR DESCRIPTION
Jib CLI logging was misbehaving, ~~swallowing messages and~~ unnecessarily outputting blank lines:
```
$ jib --target=docker://foo build
Base image 'ubuntu' does not use a specific image digest - build may not be reproducible

The base image requires auth. Trying again for ubuntu...

Using credentials from Docker config (/home/chanseok/.docker/config.json) for ubuntu


Using base image with digest: sha256:fff16eea1a8ae92867721d90c59a75652ea66d29c05294e6e2f898704bdb8cf1


Container entrypoint set to [sh, hello.sh]

Executing tasks:
[==============================] 100.0% complete
```

We should be adding message consumers to `ConsoleLoggerBuilder` only when the corresponding log levels should be consumed.

Output after the fix:
```
$ jib --target=docker://foo build
Base image 'ubuntu' does not use a specific image digest - build may not be reproducible
The base image requires auth. Trying again for ubuntu...
Using credentials from Docker config (/home/chanseok/.docker/config.json) for ubuntu
Using base image with digest: sha256:fff16eea1a8ae92867721d90c59a75652ea66d29c05294e6e2f898704bdb8cf1

Container entrypoint set to [sh, hello.sh]
Executing tasks:
[==============================] 100.0% complete
```