### PR TITLE
Fix example comment in JibExtension

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -52,7 +52,7 @@ import org.gradle.api.tasks.Optional;
  *     jvmFlags = ['-Xms512m', '-Xdebug']
  *     mainClass = 'com.mycompany.myproject.Main'
  *     args = ['arg1', 'arg2']
- *     exposedPorts = ['1000', '2000-2010', '3000']
+ *     ports = ['1000', '2000-2010', '3000']
  *     format = OCI
  *     appRoot = '/app'
  *   }


### PR DESCRIPTION
The example comment uses `exposedPorts` to define which ports the container should expose, the `ContainerParameters` class does not have such a property. The correct property name is `ports`.

I hope that it is OK that I skipped creating a seperate issue, I though it would be for such a trivial change.

See the relevant property in `ContainerParameters` [here](https://github.com/GoogleContainerTools/jib/blob/8d34a28a156894867c6fdd8416a9f03cdf04d863/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java#L171).