### PR TITLE
Convert jib.*.auth.username and jib.*.auth.password to properties

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 - Added an option `jib.container.expandClasspathDependencies` to preserve the order of loading dependencies as configured in a project. The option enumerates dependency JARs instead of using a wildcard (`/app/libs/*`) in the Java runtime classpath for an image entrypoint. ([#1871](https://github.com/GoogleContainerTools/jib/issues/1871), [#1907](https://github.com/GoogleContainerTools/jib/issues/1907), [#2228](https://github.com/GoogleContainerTools/jib/issues/2228), [#2733](https://github.com/GoogleContainerTools/jib/issues/2733))
     - The option is also useful for AppCDS. ([#2471](https://github.com/GoogleContainerTools/jib/issues/2471))
     - Turning on the option may result in a very long classpath string, and the OS may not support passing such a long string to JVM.
+- Added lazy evaluation for `jib.(to|from).auth.(username|password)` and `jib.from.image` using Gradle Property and Provider. ([#2905](https://github.com/GoogleContainerTools/jib/issues/2905))
 
 ### Changed
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/AuthParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/AuthParameters.java
@@ -19,6 +19,9 @@ package com.google.cloud.tools.jib.gradle;
 import com.google.cloud.tools.jib.plugins.common.AuthProperty;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
@@ -29,12 +32,14 @@ import org.gradle.api.tasks.Optional;
  */
 public class AuthParameters implements AuthProperty {
 
-  @Nullable private String username;
-  @Nullable private String password;
+  private Property<String> username;
+  private Property<String> password;
   private final String source;
 
   @Inject
-  public AuthParameters(String source) {
+  public AuthParameters(ObjectFactory objectFactory, String source) {
+    username = objectFactory.property(String.class);
+    password = objectFactory.property(String.class);
     this.source = source;
   }
 
@@ -43,11 +48,15 @@ public class AuthParameters implements AuthProperty {
   @Override
   @Nullable
   public String getUsername() {
-    return username;
+    return username.getOrNull();
   }
 
   public void setUsername(String username) {
-    this.username = username;
+    this.username.set(username);
+  }
+
+  public void setUsername(Provider<String> username) {
+    this.username.set(username);
   }
 
   @Input
@@ -55,11 +64,15 @@ public class AuthParameters implements AuthProperty {
   @Override
   @Nullable
   public String getPassword() {
-    return password;
+    return password.getOrNull();
   }
 
   public void setPassword(String password) {
-    this.password = password;
+    this.password.set(password);
+  }
+
+  public void setPassword(Provider<String> password) {
+    this.password.set(password);
   }
 
   @Internal

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
@@ -22,6 +22,8 @@ import javax.inject.Inject;
 import org.gradle.api.Action;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
@@ -30,7 +32,7 @@ import org.gradle.api.tasks.Optional;
 public class BaseImageParameters {
 
   private final AuthParameters auth;
-  @Nullable private String image;
+  private Property<String> image;
   @Nullable private String credHelper;
   private final PlatformParametersSpec platformParametersSpec;
   private final ListProperty<PlatformParameters> platforms;
@@ -39,6 +41,7 @@ public class BaseImageParameters {
   public BaseImageParameters(ObjectFactory objectFactory) {
     auth = objectFactory.newInstance(AuthParameters.class, "from.auth");
     platforms = objectFactory.listProperty(PlatformParameters.class);
+    image = objectFactory.property(String.class);
     platformParametersSpec =
         objectFactory.newInstance(PlatformParametersSpec.class, objectFactory, platforms);
 
@@ -66,11 +69,15 @@ public class BaseImageParameters {
     if (System.getProperty(PropertyNames.FROM_IMAGE) != null) {
       return System.getProperty(PropertyNames.FROM_IMAGE);
     }
-    return image;
+    return image.getOrNull();
   }
 
   public void setImage(String image) {
-    this.image = image;
+    this.image.set(image);
+  }
+
+  public void setImage(Provider<String> image) {
+    this.image.set(image);
   }
 
   @Input


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/jib/issues/2905

The following are now properties and not plain strings:
- from.auth.username
- from.auth.password
- from.image
- to.auth.username
- to.auth.password
