### PR TITLE
Bump jackson dependencies from 2.11.3 to 2.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,9 @@ subprojects {
 
     COMMONS_COMPRESS: 'org.apache.commons:commons-compress:1.20',
     COMMONS_TEXT: 'org.apache.commons:commons-text:1.9',
-    JACKSON_DATABIND: 'com.fasterxml.jackson.core:jackson-databind:2.11.3',
-    JACKSON_DATAFORMAT_YAML: 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.3',
+    JACKSON_DATABIND: 'com.fasterxml.jackson.core:jackson-databind:2.12.0',
+    JACKSON_DATAFORMAT_YAML: 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.0',
+    JACKSON_DATATYPE_JSR310: 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.0',
     ASM: 'org.ow2.asm:asm:9.0',
     PICOCLI: 'info.picocli:picocli:4.5.2',
 

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   implementation dependencyStrings.COMMONS_COMPRESS
   implementation dependencyStrings.GUAVA
   implementation dependencyStrings.JACKSON_DATABIND
+  implementation dependencyStrings.JACKSON_DATATYPE_JSR310
   implementation dependencyStrings.ASM
 
   testImplementation dependencyStrings.JUNIT

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/json/JsonTemplateMapper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/json/JsonTemplateMapper.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -53,7 +54,8 @@ import java.util.List;
  */
 public class JsonTemplateMapper {
 
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper objectMapper =
+      new ObjectMapper().registerModule(new JavaTimeModule());
 
   /**
    * Deserializes a JSON file via a JSON object template.


### PR DESCRIPTION
[Jackson Release notes](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.12)

Adds jsr310 datatype module which is now required for serializing `java.util.time.Instant`.

Bumps [jackson-databind](https://github.com/FasterXML/jackson-databind) from 2.11.3 to 2.12.0.
- [Release notes](https://github.com/FasterXML/jackson-databind/releases)
- [Commits](https://github.com/FasterXML/jackson-databind/compare/jackson-databind-2.11.3...jackson-databind-2.12.0)

Bumps [jackson-dataformat-yaml](https://github.com/FasterXML/jackson-dataformats-text) from 2.11.3 to 2.12.0.
- [Release notes](https://github.com/FasterXML/jackson-dataformats-text/releases)
- [Commits](https://github.com/FasterXML/jackson-dataformats-text/compare/jackson-dataformats-text-2.11.3...jackson-dataformats-text-2.12.0)

---

Also fixes #2931.