### PR TITLE
Migrate away from Docker Hub in integration tests

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
@@ -34,13 +34,13 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,10 +49,17 @@ import org.junit.rules.TemporaryFolder;
 /** Integration tests for {@link Jib}. */
 public class JibIntegrationTest {
 
-  @ClassRule
-  public static final LocalRegistry localRegistry = new LocalRegistry(5000, "username", "password");
+  @ClassRule public static final LocalRegistry localRegistry = new LocalRegistry(5000);
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private final RegistryClient registryClient =
+      RegistryClient.factory(
+              EventHandlers.NONE,
+              "localhost:5000",
+              "jib-scratch",
+              new FailoverHttpClient(true, true, ignored -> {}))
+          .newRegistryClient();
 
   /**
    * Pulls a built image and attempts to run it.
@@ -68,25 +75,9 @@ public class JibIntegrationTest {
     return new Command("docker", "run", "--rm", imageReference).run();
   }
 
-  private static Containerizer getLocalRegistryContainerizer(ImageReference targetImageReference) {
-    return Containerizer.to(
-            RegistryImage.named(targetImageReference)
-                .addCredentialRetriever(() -> Optional.of(Credential.from("username", "password"))))
-        .setAllowInsecureRegistries(true);
-  }
-
-  private static RegistryClient getRegistryClient(
-      ImageReference imageReference, Credential credential) {
-    RegistryClient registryClient =
-        RegistryClient.factory(
-                EventHandlers.NONE,
-                imageReference.getRegistry(),
-                imageReference.getRepository(),
-                new FailoverHttpClient(true, true, ignored -> {}))
-            .setCredential(credential)
-            .newRegistryClient();
-    registryClient.configureBasicAuth();
-    return registryClient;
+  @BeforeClass
+  public static void setUpClass() throws IOException, InterruptedException {
+    localRegistry.pullAndPushToLocal("mirror.gcr.io/library/busybox", "busybox");
   }
 
   @Before
@@ -103,51 +94,43 @@ public class JibIntegrationTest {
   public void testBasic_helloWorld()
       throws InvalidImageReferenceException, InterruptedException, CacheDirectoryCreationException,
           IOException, RegistryException, ExecutionException {
-    ImageReference targetImageReference =
-        ImageReference.of("localhost:5000", "jib-core", "basic-helloworld");
+    String toImage = "localhost:5000/basic-helloworld";
     JibContainer jibContainer =
-        Jib.from("busybox")
+        Jib.from("localhost:5000/busybox")
             .setEntrypoint("echo", "Hello World")
-            .containerize(getLocalRegistryContainerizer(targetImageReference));
+            .containerize(
+                Containerizer.to(RegistryImage.named(toImage)).setAllowInsecureRegistries(true));
 
-    Assert.assertEquals("Hello World\n", pullAndRunBuiltImage(targetImageReference.toString()));
+    Assert.assertEquals("Hello World\n", pullAndRunBuiltImage(toImage));
     Assert.assertEquals(
-        "Hello World\n",
-        pullAndRunBuiltImage(
-            targetImageReference.withQualifier(jibContainer.getDigest().toString()).toString()));
+        "Hello World\n", pullAndRunBuiltImage(toImage + "@" + jibContainer.getDigest()));
   }
 
   @Test
   public void testBasic_dockerDaemonBaseImage()
       throws IOException, InterruptedException, InvalidImageReferenceException, ExecutionException,
           RegistryException, CacheDirectoryCreationException {
-    localRegistry.pull("busybox");
-    ImageReference targetImageReference =
-        ImageReference.of("localhost:5000", "jib-core", "basic-helloworld-dockerdaemon");
+    String toImage = "localhost:5000/basic-dockerdaemon";
     JibContainer jibContainer =
-        Jib.from("docker://busybox")
+        Jib.from("docker://localhost:5000/busybox")
             .setEntrypoint("echo", "Hello World")
-            .containerize(getLocalRegistryContainerizer(targetImageReference));
+            .containerize(
+                Containerizer.to(RegistryImage.named(toImage)).setAllowInsecureRegistries(true));
 
-    Assert.assertEquals("Hello World\n", pullAndRunBuiltImage(targetImageReference.toString()));
+    Assert.assertEquals("Hello World\n", pullAndRunBuiltImage(toImage));
     Assert.assertEquals(
-        "Hello World\n",
-        pullAndRunBuiltImage(
-            targetImageReference.withQualifier(jibContainer.getDigest().toString()).toString()));
+        "Hello World\n", pullAndRunBuiltImage(toImage + "@" + jibContainer.getDigest()));
   }
 
   @Test
   public void testBasic_dockerDaemonBaseImageToDockerDaemon()
       throws IOException, InterruptedException, InvalidImageReferenceException, ExecutionException,
           RegistryException, CacheDirectoryCreationException {
-    localRegistry.pull("busybox");
-    ImageReference targetImageReference =
-        ImageReference.of("localhost:5000", "jib-core", "basic-helloworld-dockerdaemon");
-    Jib.from(DockerDaemonImage.named("busybox"))
+    Jib.from(DockerDaemonImage.named("localhost:5000/busybox"))
         .setEntrypoint("echo", "Hello World")
-        .containerize(Containerizer.to(DockerDaemonImage.named(targetImageReference)));
+        .containerize(Containerizer.to(DockerDaemonImage.named("localhost:5000/docker-to-docker")));
 
-    String output = new Command("docker", "run", "--rm", targetImageReference.toString()).run();
+    String output = new Command("docker", "run", "--rm", "localhost:5000/docker-to-docker").run();
     Assert.assertEquals("Hello World\n", output);
   }
 
@@ -155,22 +138,19 @@ public class JibIntegrationTest {
   public void testBasic_tarBaseImage_dockerSavedCommand()
       throws IOException, InterruptedException, InvalidImageReferenceException, ExecutionException,
           RegistryException, CacheDirectoryCreationException {
-    localRegistry.pull("busybox");
-    Path path = temporaryFolder.getRoot().toPath().resolve("docker-save");
-    new Command("docker", "save", "busybox", "-o", path.toString()).run();
+    Path path = temporaryFolder.getRoot().toPath().resolve("docker-save.tar");
+    new Command("docker", "save", "localhost:5000/busybox", "-o=" + path).run();
 
-    ImageReference targetImageReference =
-        ImageReference.of("localhost:5000", "jib-core", "basic-helloworld-dockersavedtar");
+    String toImage = "localhost:5000/basic-dockersavedcommand";
     JibContainer jibContainer =
         Jib.from("tar://" + path)
             .setEntrypoint("echo", "Hello World")
-            .containerize(getLocalRegistryContainerizer(targetImageReference));
+            .containerize(
+                Containerizer.to(RegistryImage.named(toImage)).setAllowInsecureRegistries(true));
 
-    Assert.assertEquals("Hello World\n", pullAndRunBuiltImage(targetImageReference.toString()));
+    Assert.assertEquals("Hello World\n", pullAndRunBuiltImage(toImage));
     Assert.assertEquals(
-        "Hello World\n",
-        pullAndRunBuiltImage(
-            targetImageReference.withQualifier(jibContainer.getDigest().toString()).toString()));
+        "Hello World\n", pullAndRunBuiltImage(toImage + "@" + jibContainer.getDigest()));
   }
 
   @Test
@@ -180,45 +160,40 @@ public class JibIntegrationTest {
     // tar saved with 'docker save busybox -o busybox.tar'
     Path path = Paths.get(Resources.getResource("core/busybox-docker.tar").toURI());
 
-    ImageReference targetImageReference =
-        ImageReference.of("localhost:5000", "jib-core", "basic-helloworld-dockersavedtar");
+    String toImage = "localhost:5000/basic-dockersavedfile";
     JibContainer jibContainer =
         Jib.from(TarImage.at(path).named("ignored"))
             .setEntrypoint("echo", "Hello World")
-            .containerize(getLocalRegistryContainerizer(targetImageReference));
+            .containerize(
+                Containerizer.to(RegistryImage.named(toImage)).setAllowInsecureRegistries(true));
 
-    Assert.assertEquals("Hello World\n", pullAndRunBuiltImage(targetImageReference.toString()));
+    Assert.assertEquals("Hello World\n", pullAndRunBuiltImage(toImage));
     Assert.assertEquals(
-        "Hello World\n",
-        pullAndRunBuiltImage(
-            targetImageReference.withQualifier(jibContainer.getDigest().toString()).toString()));
+        "Hello World\n", pullAndRunBuiltImage(toImage + "@" + jibContainer.getDigest()));
   }
 
   @Test
   public void testBasic_tarBaseImage_jibImage()
       throws InvalidImageReferenceException, InterruptedException, ExecutionException,
           RegistryException, CacheDirectoryCreationException, IOException, URISyntaxException {
-    ImageReference targetImageReference =
-        ImageReference.of("localhost:5000", "jib-core", "jib-base-image");
     Path outputPath = temporaryFolder.getRoot().toPath().resolve("jib-image.tar");
-    Jib.from("busybox")
+    Jib.from("localhost:5000/busybox")
         .addLayer(
             Collections.singletonList(Paths.get(Resources.getResource("core/hello").toURI())), "/")
         .containerize(
-            Containerizer.to(TarImage.at(outputPath).named(targetImageReference))
+            Containerizer.to(TarImage.at(outputPath).named("ignored"))
                 .setAllowInsecureRegistries(true));
 
-    targetImageReference = ImageReference.of("localhost:5000", "jib-core", "jib-helloworld-jibtar");
+    String toImage = "localhost:5000/basic-jibtar";
     JibContainer jibContainer =
         Jib.from(TarImage.at(outputPath).named("ignored"))
             .setEntrypoint("cat", "/hello")
-            .containerize(getLocalRegistryContainerizer(targetImageReference));
+            .containerize(
+                Containerizer.to(RegistryImage.named(toImage)).setAllowInsecureRegistries(true));
 
-    Assert.assertEquals("Hello World\n", pullAndRunBuiltImage(targetImageReference.toString()));
+    Assert.assertEquals("Hello World\n", pullAndRunBuiltImage(toImage));
     Assert.assertEquals(
-        "Hello World\n",
-        pullAndRunBuiltImage(
-            targetImageReference.withQualifier(jibContainer.getDigest().toString()).toString()));
+        "Hello World\n", pullAndRunBuiltImage(toImage + "@" + jibContainer.getDigest()));
   }
 
   @Test
@@ -228,32 +203,29 @@ public class JibIntegrationTest {
     // tar saved with Jib.from("busybox").addLayer(...("core/hello")).containerize(TarImage.at...)
     Path path = Paths.get(Resources.getResource("core/busybox-jib.tar").toURI());
 
-    ImageReference targetImageReference =
-        ImageReference.of("localhost:5000", "jib-core", "basic-helloworld-jibtar");
+    String toImage = "localhost:5000/basic-jibtar-to-docker";
     JibContainer jibContainer =
         Jib.from(TarImage.at(path).named("ignored"))
             .setEntrypoint("cat", "/hello")
-            .containerize(getLocalRegistryContainerizer(targetImageReference));
+            .containerize(
+                Containerizer.to(RegistryImage.named(toImage)).setAllowInsecureRegistries(true));
 
-    Assert.assertEquals("Hello World\n", pullAndRunBuiltImage(targetImageReference.toString()));
+    Assert.assertEquals("Hello World\n", pullAndRunBuiltImage(toImage));
     Assert.assertEquals(
-        "Hello World\n",
-        pullAndRunBuiltImage(
-            targetImageReference.withQualifier(jibContainer.getDigest().toString()).toString()));
+        "Hello World\n", pullAndRunBuiltImage(toImage + "@" + jibContainer.getDigest()));
   }
 
   @Test
   public void testScratch_defaultPlatform()
       throws IOException, InterruptedException, ExecutionException, RegistryException,
-          CacheDirectoryCreationException {
-    ImageReference targetImageReference =
-        ImageReference.of("localhost:5000", "default-scratch", null);
-    Jib.fromScratch().containerize(getLocalRegistryContainerizer(targetImageReference));
-    RegistryClient registryClient =
-        getRegistryClient(targetImageReference, Credential.from("username", "password"));
+          CacheDirectoryCreationException, InvalidImageReferenceException {
+    Jib.fromScratch()
+        .containerize(
+            Containerizer.to(RegistryImage.named("localhost:5000/jib-scratch:default-platform"))
+                .setAllowInsecureRegistries(true));
 
     V22ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
+        registryClient.pullManifest("default-platform", V22ManifestTemplate.class).getManifest();
     String containerConfig =
         Blobs.writeToString(
             registryClient.pullBlob(
@@ -269,17 +241,15 @@ public class JibIntegrationTest {
   @Test
   public void testScratch_singlePlatform()
       throws IOException, InterruptedException, ExecutionException, RegistryException,
-          CacheDirectoryCreationException {
-    ImageReference targetImageReference =
-        ImageReference.of("localhost:5000", "single-platform-scratch", null);
+          CacheDirectoryCreationException, InvalidImageReferenceException {
     Jib.fromScratch()
         .setPlatforms(ImmutableSet.of(new Platform("arm64", "windows")))
-        .containerize(getLocalRegistryContainerizer(targetImageReference));
-    RegistryClient registryClient =
-        getRegistryClient(targetImageReference, Credential.from("username", "password"));
+        .containerize(
+            Containerizer.to(RegistryImage.named("localhost:5000/jib-scratch:single-platform"))
+                .setAllowInsecureRegistries(true));
 
     V22ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
+        registryClient.pullManifest("single-platform", V22ManifestTemplate.class).getManifest();
     String containerConfig =
         Blobs.writeToString(
             registryClient.pullBlob(
@@ -295,18 +265,16 @@ public class JibIntegrationTest {
   @Test
   public void testScratch_multiPlatform()
       throws IOException, InterruptedException, ExecutionException, RegistryException,
-          CacheDirectoryCreationException {
-    ImageReference targetImageReference =
-        ImageReference.of("localhost:5000", "multi-platform-scratch", null);
+          CacheDirectoryCreationException, InvalidImageReferenceException {
     Jib.fromScratch()
         .setPlatforms(
             ImmutableSet.of(new Platform("arm64", "windows"), new Platform("amd32", "windows")))
-        .containerize(getLocalRegistryContainerizer(targetImageReference));
-    RegistryClient registryClient =
-        getRegistryClient(targetImageReference, Credential.from("username", "password"));
+        .containerize(
+            Containerizer.to(RegistryImage.named("localhost:5000/jib-scratch:multi-platform"))
+                .setAllowInsecureRegistries(true));
 
     V22ManifestListTemplate manifestList =
-        (V22ManifestListTemplate) registryClient.pullManifest("latest").getManifest();
+        (V22ManifestListTemplate) registryClient.pullManifest("multi-platform").getManifest();
     Assert.assertEquals(2, manifestList.getManifests().size());
     ManifestDescriptorTemplate.Platform platform1 =
         manifestList.getManifests().get(0).getPlatform();
@@ -323,23 +291,15 @@ public class JibIntegrationTest {
   public void testOffline()
       throws IOException, InterruptedException, InvalidImageReferenceException, ExecutionException,
           RegistryException, CacheDirectoryCreationException {
-    LocalRegistry tempRegistry = new LocalRegistry(5001);
-    tempRegistry.start();
-    tempRegistry.pullAndPushToLocal("busybox", "busybox");
     Path cacheDirectory = temporaryFolder.getRoot().toPath();
 
-    ImageReference targetImageReferenceOnline =
-        ImageReference.of("localhost:5001", "jib-core", "basic-online");
-    ImageReference targetImageReferenceOffline =
-        ImageReference.of("localhost:5001", "jib-core", "basic-offline");
-
     JibContainerBuilder jibContainerBuilder =
-        Jib.from("localhost:5001/busybox").setEntrypoint("echo", "Hello World");
+        Jib.from("localhost:5000/busybox").setEntrypoint("echo", "Hello World");
 
     // Should fail since Jib can't build to registry offline
     try {
       jibContainerBuilder.containerize(
-          Containerizer.to(RegistryImage.named(targetImageReferenceOffline)).setOfflineMode(true));
+          Containerizer.to(RegistryImage.named("localhost:5000/ignored")).setOfflineMode(true));
       Assert.fail();
     } catch (IllegalStateException ex) {
       Assert.assertEquals("Cannot build to a container registry in offline mode", ex.getMessage());
@@ -348,33 +308,31 @@ public class JibIntegrationTest {
     // Should fail since Jib hasn't cached the base image yet
     try {
       jibContainerBuilder.containerize(
-          Containerizer.to(DockerDaemonImage.named(targetImageReferenceOffline))
+          Containerizer.to(DockerDaemonImage.named("localhost:5000/ignored"))
               .setBaseImageLayersCache(cacheDirectory)
               .setOfflineMode(true));
       Assert.fail();
     } catch (ExecutionException ex) {
       Assert.assertEquals(
-          "Cannot run Jib in offline mode; localhost:5001/busybox not found in local Jib cache",
+          "Cannot run Jib in offline mode; localhost:5000/busybox not found in local Jib cache",
           ex.getCause().getMessage());
     }
 
     // Run online to cache the base image
     jibContainerBuilder.containerize(
-        Containerizer.to(DockerDaemonImage.named(targetImageReferenceOnline))
+        Containerizer.to(RegistryImage.named("localhost:5000/ignored"))
             .setBaseImageLayersCache(cacheDirectory)
             .setAllowInsecureRegistries(true));
 
     // Run again in offline mode, should succeed this time
-    tempRegistry.stop();
     jibContainerBuilder.containerize(
-        Containerizer.to(DockerDaemonImage.named(targetImageReferenceOffline))
+        Containerizer.to(DockerDaemonImage.named("localhost:5000/offline"))
             .setBaseImageLayersCache(cacheDirectory)
             .setOfflineMode(true));
 
     // Verify output
     Assert.assertEquals(
-        "Hello World\n",
-        new Command("docker", "run", "--rm", targetImageReferenceOffline.toString()).run());
+        "Hello World\n", new Command("docker", "run", "--rm", "localhost:5000/offline").run());
   }
 
   /** Ensure that a provided executor is not disposed. */
@@ -382,14 +340,13 @@ public class JibIntegrationTest {
   public void testProvidedExecutorNotDisposed()
       throws InvalidImageReferenceException, InterruptedException, CacheDirectoryCreationException,
           IOException, RegistryException, ExecutionException {
-    ImageReference targetImageReference =
-        ImageReference.of("localhost:5000", "jib-core", "basic-helloworld");
-    Containerizer containerizer = getLocalRegistryContainerizer(targetImageReference);
-
     ExecutorService executorService = Executors.newCachedThreadPool();
     try {
-      containerizer.setExecutorService(executorService);
-      Jib.from("busybox").setEntrypoint("echo", "Hello World").containerize(containerizer);
+      Jib.fromScratch()
+          .containerize(
+              Containerizer.to(RegistryImage.named("localhost:5000/foo"))
+                  .setExecutorService(executorService)
+                  .setAllowInsecureRegistries(true));
       Assert.assertFalse(executorService.isShutdown());
     } finally {
       executorService.shutdown();
@@ -400,14 +357,11 @@ public class JibIntegrationTest {
   public void testManifestListReferenceByShaDoesNotFail()
       throws InvalidImageReferenceException, IOException, InterruptedException, ExecutionException,
           RegistryException, CacheDirectoryCreationException {
-    ImageReference sourceImageReferenceAsManifestList =
-        ImageReference.parse("openjdk@" + ManifestPullerIntegrationTest.KNOWN_MANIFEST_LIST_SHA);
     Containerizer containerizer =
-        Containerizer.to(
-            TarImage.at(temporaryFolder.newFolder("goose").toPath().resolve("moose"))
-                .named("whatever"));
+        Containerizer.to(TarImage.at(temporaryFolder.newFile("goose").toPath()).named("whatever"));
 
-    Jib.from(sourceImageReferenceAsManifestList).containerize(containerizer);
+    Jib.from("gcr.io/distroless/base@" + ManifestPullerIntegrationTest.KNOWN_MANIFEST_LIST_SHA)
+        .containerize(containerizer);
     // pass, no exceptions thrown
   }
 }

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
@@ -299,7 +299,7 @@ public class JibIntegrationTest {
     // Should fail since Jib can't build to registry offline
     try {
       jibContainerBuilder.containerize(
-          Containerizer.to(RegistryImage.named("localhost:5000/ignored")).setOfflineMode(true));
+          Containerizer.to(RegistryImage.named("ignored")).setOfflineMode(true));
       Assert.fail();
     } catch (IllegalStateException ex) {
       Assert.assertEquals("Cannot build to a container registry in offline mode", ex.getMessage());
@@ -308,7 +308,7 @@ public class JibIntegrationTest {
     // Should fail since Jib hasn't cached the base image yet
     try {
       jibContainerBuilder.containerize(
-          Containerizer.to(DockerDaemonImage.named("localhost:5000/ignored"))
+          Containerizer.to(DockerDaemonImage.named("ignored"))
               .setBaseImageLayersCache(cacheDirectory)
               .setOfflineMode(true));
       Assert.fail();
@@ -320,7 +320,7 @@ public class JibIntegrationTest {
 
     // Run online to cache the base image
     jibContainerBuilder.containerize(
-        Containerizer.to(RegistryImage.named("localhost:5000/ignored"))
+        Containerizer.to(DockerDaemonImage.named("ignored"))
             .setBaseImageLayersCache(cacheDirectory)
             .setAllowInsecureRegistries(true));
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
@@ -24,26 +24,17 @@ import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import java.io.IOException;
 import java.security.DigestException;
 import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Test;
 
 /** Integration tests for {@link BlobChecker}. */
 public class BlobCheckerIntegrationTest {
-
-  @ClassRule public static LocalRegistry localRegistry = new LocalRegistry(5000);
-
-  @BeforeClass
-  public static void setUp() throws IOException, InterruptedException {
-    localRegistry.pullAndPushToLocal("busybox", "busybox");
-  }
 
   private final FailoverHttpClient httpClient = new FailoverHttpClient(true, false, ignored -> {});
 
   @Test
   public void testCheck_exists() throws IOException, RegistryException {
     RegistryClient registryClient =
-        RegistryClient.factory(EventHandlers.NONE, "localhost:5000", "busybox", httpClient)
+        RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
     V22ManifestTemplate manifestTemplate =
         registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
@@ -55,7 +46,7 @@ public class BlobCheckerIntegrationTest {
   @Test
   public void testCheck_doesNotExist() throws IOException, RegistryException, DigestException {
     RegistryClient registryClient =
-        RegistryClient.factory(EventHandlers.NONE, "localhost:5000", "busybox", httpClient)
+        RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
     DescriptorDigest fakeBlobDigest =
         DescriptorDigest.fromHash(

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
@@ -21,7 +21,7 @@ import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.http.FailoverHttpClient;
-import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
+import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.common.io.ByteStreams;
 import java.io.IOException;
 import java.security.DigestException;
@@ -29,37 +29,24 @@ import java.util.concurrent.atomic.LongAdder;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 /** Integration tests for {@link BlobPuller}. */
 public class BlobPullerIntegrationTest {
-
-  @ClassRule public static LocalRegistry localRegistry = new LocalRegistry(5000);
-
-  @BeforeClass
-  public static void setUp() throws IOException, InterruptedException {
-    localRegistry.pullAndPushToLocal("busybox", "busybox");
-  }
-
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   private final FailoverHttpClient httpClient = new FailoverHttpClient(true, false, ignored -> {});
 
   @Test
   public void testPull() throws IOException, RegistryException {
     RegistryClient registryClient =
-        RegistryClient.factory(EventHandlers.NONE, "localhost:5000", "busybox", httpClient)
+        RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
-    V21ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V21ManifestTemplate.class).getManifest();
+    V22ManifestTemplate manifestTemplate =
+        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
 
-    DescriptorDigest realDigest = manifestTemplate.getLayerDigests().get(0);
+    DescriptorDigest realDigest = manifestTemplate.getLayers().get(0).getDigest();
 
-    // Pulls a layer BLOB of the busybox image.
+    // Pulls a layer BLOB of the distroless/base image.
     LongAdder totalByteCount = new LongAdder();
     LongAdder expectedSize = new LongAdder();
     Blob pulledBlob =
@@ -82,7 +69,7 @@ public class BlobPullerIntegrationTest {
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
     RegistryClient registryClient =
-        RegistryClient.factory(EventHandlers.NONE, "localhost:5000", "busybox", httpClient)
+        RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
 
     try {
@@ -98,7 +85,7 @@ public class BlobPullerIntegrationTest {
       MatcherAssert.assertThat(
           ex.getMessage(),
           CoreMatchers.containsString(
-              "pull BLOB for localhost:5000/busybox with digest " + nonexistentDigest));
+              "pull BLOB for gcr.io/distroless/base with digest " + nonexistentDigest));
     }
   }
 }

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPusherIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPusherIntegrationTest.java
@@ -31,14 +31,12 @@ import org.junit.Test;
 /** Integration tests for {@link BlobPusher}. */
 public class BlobPusherIntegrationTest {
 
-  @ClassRule public static LocalRegistry localRegistry = new LocalRegistry(5000);
+  @ClassRule public static final LocalRegistry localRegistry = new LocalRegistry(5000);
 
   private final FailoverHttpClient httpClient = new FailoverHttpClient(true, false, ignored -> {});
 
   @Test
-  public void testPush()
-      throws DigestException, IOException, RegistryException, InterruptedException {
-    localRegistry.pullAndPushToLocal("busybox", "busybox");
+  public void testPush() throws DigestException, IOException, RegistryException {
     Blob testBlob = Blobs.from("crepecake");
     // Known digest for 'crepecake'
     DescriptorDigest testBlobDigest =

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
@@ -91,7 +91,7 @@ public class LocalRegistry extends ExternalResource {
               "-e",
               "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd"));
     }
-    dockerTokens.add("registry:2");
+    dockerTokens.add("mirror.gcr.io/library/registry:2");
     new Command(dockerTokens).run();
     waitUntilReady();
   }
@@ -108,7 +108,7 @@ public class LocalRegistry extends ExternalResource {
   }
 
   /**
-   * Pulls an image.
+   * Pulls an image to a Docker daemon (not to this local registry).
    *
    * @param from the image reference to pull
    * @throws IOException if the pull command fails

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestCheckerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestCheckerIntegrationTest.java
@@ -32,7 +32,7 @@ public class ManifestCheckerIntegrationTest {
 
   /** A known manifest list sha for openjdk:11-jre-slim. */
   private static final String KNOWN_MANIFEST =
-      "sha256:8ab7b3078b01ba66b937b7fbe0b9eccf60449cc101c42e99aeefaba0e1781155";
+      "sha256:44cbdb9c24e123882d7894ba78fb6f572d2496889885a47eb4b32241a8c07a00";
 
   /** A fictitious sha to test unknown images. */
   private static final String UNKNOWN_MANIFEST =
@@ -43,10 +43,8 @@ public class ManifestCheckerIntegrationTest {
   @Test
   public void testExistingManifest() throws IOException, RegistryException {
     RegistryClient registryClient =
-        RegistryClient.factory(
-                EventHandlers.NONE, "registry-1.docker.io", "library/openjdk", httpClient)
+        RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
-    registryClient.doPullBearerAuth();
 
     Optional<ManifestAndDigest<ManifestTemplate>> manifestDescriptor =
         registryClient.checkManifest(KNOWN_MANIFEST);
@@ -58,10 +56,8 @@ public class ManifestCheckerIntegrationTest {
   @Test
   public void testNonExistingManifest() throws IOException, RegistryException {
     RegistryClient registryClient =
-        RegistryClient.factory(
-                EventHandlers.NONE, "registry-1.docker.io", "library/openjdk", httpClient)
+        RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
-    registryClient.doPullBearerAuth();
 
     Optional<ManifestAndDigest<ManifestTemplate>> manifestDescriptor =
         registryClient.checkManifest(UNKNOWN_MANIFEST);

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -52,7 +52,6 @@ public class ManifestPullerIntegrationTest {
     RegistryClient registryClient =
         RegistryClient.factory(EventHandlers.NONE, "localhost:5000", "busybox", httpClient)
             .newRegistryClient();
-    registryClient.doPullBearerAuth();
 
     V21ManifestTemplate manifestTemplate =
         registryClient.pullManifest("latest", V21ManifestTemplate.class).getManifest();

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -79,28 +79,30 @@ public class ManifestPullerIntegrationTest {
             .newRegistryClient();
 
     // Ensure ":latest" is a manifest list
-    V22ManifestListTemplate manifestList1 =
+    V22ManifestListTemplate manifestListTargeted =
         registryClient.pullManifest("latest", V22ManifestListTemplate.class).getManifest();
-    Assert.assertEquals(2, manifestList1.getSchemaVersion());
-    Assert.assertTrue(manifestList1.getManifests().size() > 0);
+    Assert.assertEquals(2, manifestListTargeted.getSchemaVersion());
+    Assert.assertTrue(manifestListTargeted.getManifests().size() > 0);
 
     // Generic call to ":latest" pulls a manifest list
-    ManifestTemplate manifestList2 = registryClient.pullManifest("latest").getManifest();
-    Assert.assertEquals(2, manifestList2.getSchemaVersion());
-    MatcherAssert.assertThat(manifestList2, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
-    Assert.assertTrue(((V22ManifestListTemplate) manifestList2).getManifests().size() > 0);
+    ManifestTemplate manifestListGeneric = registryClient.pullManifest("latest").getManifest();
+    Assert.assertEquals(2, manifestListGeneric.getSchemaVersion());
+    MatcherAssert.assertThat(
+        manifestListGeneric, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
+    Assert.assertTrue(((V22ManifestListTemplate) manifestListGeneric).getManifests().size() > 0);
 
     // Referencing a manifest list by sha256, should return a manifest list
-    ManifestTemplate manifestList3 =
+    ManifestTemplate manifestListSha256 =
         registryClient.pullManifest(KNOWN_MANIFEST_LIST_SHA).getManifest();
-    Assert.assertEquals(2, manifestList3.getSchemaVersion());
-    MatcherAssert.assertThat(manifestList3, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
-    Assert.assertTrue(((V22ManifestListTemplate) manifestList3).getManifests().size() > 0);
+    Assert.assertEquals(2, manifestListSha256.getSchemaVersion());
+    MatcherAssert.assertThat(
+        manifestListSha256, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
+    Assert.assertTrue(((V22ManifestListTemplate) manifestListSha256).getManifests().size() > 0);
 
     // Call to ":latest" targeting a manifest pulls a manifest.
-    V22ManifestTemplate manifest =
+    V22ManifestTemplate manifestTargeted =
         registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
-    Assert.assertEquals(2, manifest.getSchemaVersion());
+    Assert.assertEquals(2, manifestTargeted.getSchemaVersion());
   }
 
   @Test

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPusherIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPusherIntegrationTest.java
@@ -30,19 +30,13 @@ import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import java.io.IOException;
 import java.security.DigestException;
 import org.junit.Assert;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 
 /** Integration tests for {@link ManifestPusher}. */
 public class ManifestPusherIntegrationTest {
 
-  @ClassRule public static LocalRegistry localRegistry = new LocalRegistry(5000);
-
-  @BeforeClass
-  public static void setUp() throws IOException, InterruptedException {
-    localRegistry.pullAndPushToLocal("busybox", "busybox");
-  }
+  @ClassRule public static final LocalRegistry localRegistry = new LocalRegistry(5000);
 
   private final FailoverHttpClient httpClient = new FailoverHttpClient(true, false, ignored -> {});
 
@@ -54,10 +48,10 @@ public class ManifestPusherIntegrationTest {
     ManifestTemplate manifestTemplate = registryClient.pullManifest("latest").getManifest();
 
     registryClient =
-        RegistryClient.factory(EventHandlers.NONE, "localhost:5000", "busybox", httpClient)
+        RegistryClient.factory(EventHandlers.NONE, "localhost:5000", "ignored", httpClient)
             .newRegistryClient();
     try {
-      registryClient.pushManifest((V22ManifestTemplate) manifestTemplate, "latest");
+      registryClient.pushManifest(manifestTemplate, "latest");
       Assert.fail("Pushing manifest without its BLOBs should fail");
 
     } catch (RegistryErrorException ex) {


### PR DESCRIPTION
Due to the new Docker Hub rate limit, we are starting to see errors like

```
com.google.cloud.tools.jib.registry.BlobPullerIntegrationTest > classMethod FAILED
    java.lang.RuntimeException: Command 'docker run --rm -d -p 5000:5000 --name registry-a8087b15-fa3c-401c-bcbe-09f2a5e52dc9 registry:2' failed: Unable to find image 'registry:2' locally
    docker: Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit.
    See 'docker run --help'.
```

This PR uses `mirror.gcr.io` when feasible.

Note, normally, one shouldn't directly reference `mirror.gcr.io`, as the mirror is a pull-through cache and doesn't guarantee the existence of images. However, in practice I don't think `busybox` and `registry:2` will ever fail on `mirror.gcr.io`.

The PR also does a lot of cleanups and improves performance by switching to use a local registry.