### PR TITLE
Fix incomplete progress dispatching in PullBaseImageStep

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -132,8 +132,8 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
           RegistryClient noAuthRegistryClient =
               buildContext.newBaseImageRegistryClientFactory().newRegistryClient();
           // TODO: passing noAuthRegistryClient may be problematic. It may return 401 unauthorized
-          // if
-          // layers have to be downloaded. https://github.com/GoogleContainerTools/jib/issues/2220
+          // if layers have to be downloaded.
+          // https://github.com/GoogleContainerTools/jib/issues/2220
           return new ImagesAndRegistryClient(images, noAuthRegistryClient);
         }
       }


### PR DESCRIPTION
Moved the upper code block before `try (ProgressEventDispatcher progressEventDispatcher = ...) {` into that try block.

The upper code block has short-circuiting returns, so taking that path fails to complete the progress allocation given to `PullBaseImageStep`.