### PR TITLE
Have consistency in instantiating Gradle parameter classes

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BaseImageParameters.java
@@ -42,8 +42,7 @@ public class BaseImageParameters {
     auth = objectFactory.newInstance(AuthParameters.class, "from.auth");
     platforms = objectFactory.listProperty(PlatformParameters.class);
     image = objectFactory.property(String.class);
-    platformParametersSpec =
-        objectFactory.newInstance(PlatformParametersSpec.class, objectFactory, platforms);
+    platformParametersSpec = objectFactory.newInstance(PlatformParametersSpec.class, platforms);
 
     PlatformParameters amd64Linux = new PlatformParameters();
     amd64Linux.setArchitecture("amd64");

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtensionParametersSpec.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ExtensionParametersSpec.java
@@ -18,19 +18,19 @@ package com.google.cloud.tools.jib.gradle;
 
 import javax.inject.Inject;
 import org.gradle.api.Action;
-import org.gradle.api.Project;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 
 /** Allows to add {@link ExtensionParameters} objects to the list property of the same type. */
 public class ExtensionParametersSpec {
 
-  private final Project project;
+  private final ObjectFactory objectFactory;
   private final ListProperty<ExtensionParameters> pluginExtensions;
 
   @Inject
   public ExtensionParametersSpec(
-      Project project, ListProperty<ExtensionParameters> pluginExtensions) {
-    this.project = project;
+      ObjectFactory objectFactory, ListProperty<ExtensionParameters> pluginExtensions) {
+    this.objectFactory = objectFactory;
     this.pluginExtensions = pluginExtensions;
   }
 
@@ -40,7 +40,7 @@ public class ExtensionParametersSpec {
    * @param action closure representing an extension configuration
    */
   public void pluginExtension(Action<? super ExtensionParameters> action) {
-    ExtensionParameters extension = project.getObjects().newInstance(ExtensionParameters.class);
+    ExtensionParameters extension = objectFactory.newInstance(ExtensionParameters.class);
     action.execute(extension);
     pluginExtensions.add(extension);
   }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -115,7 +115,7 @@ public class JibExtension {
 
     pluginExtensions = objectFactory.listProperty(ExtensionParameters.class).empty();
     extensionParametersSpec =
-        objectFactory.newInstance(ExtensionParametersSpec.class, project, pluginExtensions);
+        objectFactory.newInstance(ExtensionParametersSpec.class, pluginExtensions);
     allowInsecureRegistries = objectFactory.property(Boolean.class);
     containerizingMode = objectFactory.property(String.class);
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PlatformParametersSpec.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/PlatformParametersSpec.java
@@ -30,8 +30,8 @@ public class PlatformParametersSpec {
   @Inject
   public PlatformParametersSpec(
       ObjectFactory objectFactory, ListProperty<PlatformParameters> platforms) {
-    this.platforms = platforms;
     this.objectFactory = objectFactory;
+    this.platforms = platforms;
   }
 
   /**


### PR DESCRIPTION
While reviewing #2906, I was perplexed as it seemed working even though `objectFactory.newInstance()` does not pass an `objectFactory` as a constructor argument. Turns out [some classes are auto-injected](https://docs.gradle.org/current/javadoc/org/gradle/api/model/ObjectFactory.html#newInstance-java.lang.Class-java.lang.Object...-):

> In addition to those parameters provided as an argument to this method, the following services are also available for injection:
>
> * ObjectFactory.

To avoid potential confusion in the future, I'm making the usage consistent.