### PR TITLE
Revert using mirror.gcr.io in integration tests

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
@@ -77,7 +77,7 @@ public class JibIntegrationTest {
 
   @BeforeClass
   public static void setUpClass() throws IOException, InterruptedException {
-    localRegistry.pullAndPushToLocal("mirror.gcr.io/library/busybox", "busybox");
+    localRegistry.pullAndPushToLocal("busybox", "busybox");
   }
 
   @Before

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
@@ -91,7 +91,7 @@ public class LocalRegistry extends ExternalResource {
               "-e",
               "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd"));
     }
-    dockerTokens.add("mirror.gcr.io/library/registry:2");
+    dockerTokens.add("registry:2");
     new Command(dockerTokens).run();
     waitUntilReady();
   }

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -42,7 +42,7 @@ public class ManifestPullerIntegrationTest {
 
   @BeforeClass
   public static void setUp() throws IOException, InterruptedException {
-    localRegistry.pullAndPushToLocal("mirror.gcr.io/library/busybox", "busybox");
+    localRegistry.pullAndPushToLocal("busybox", "busybox");
   }
 
   private final FailoverHttpClient httpClient = new FailoverHttpClient(true, false, ignored -> {});


### PR DESCRIPTION
In #2910, I hoped that `busybox` and `registry:2` will always exist in the mirror

> Note, normally, one shouldn't directly reference `mirror.gcr.io`, as the mirror is a pull-through cache and doesn't guarantee the existence of images. However, in practice I don't think `busybox` and `registry:2` will ever fail on `mirror.gcr.io`.

However, that doesn't turn out to be true. :( Reverting the mirror for now. (But we've stripped down unnecessary pulls from Docker Hub in #2910, so hopefully we become much stable while using Docker Hub.)

```
com.google.cloud.tools.jib.api.JibIntegrationTest > classMethod FAILED
    java.lang.RuntimeException: Command 'docker pull mirror.gcr.io/library/busybox' failed: Error response from daemon: manifest for mirror.gcr.io/library/busybox:latest not found: manifest unknown: Failed to fetch "latest" from request
```