### PR TITLE
Jackson 2.12.0 compatibility (register jsr310 JavaTime module explicitly)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,8 +66,9 @@ subprojects {
 
     COMMONS_COMPRESS: 'org.apache.commons:commons-compress:1.20',
     COMMONS_TEXT: 'org.apache.commons:commons-text:1.9',
-    JACKSON_DATABIND: 'com.fasterxml.jackson.core:jackson-databind:2.11.3',
-    JACKSON_DATAFORMAT_YAML: 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.11.3',
+    JACKSON_DATABIND: 'com.fasterxml.jackson.core:jackson-databind:2.12.0',
+    JACKSON_DATAFORMAT_YAML: 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.0',
+    JACKSON_DATAFORMAT_JSR310: 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.12.0',
     ASM: 'org.ow2.asm:asm:9.0',
     PICOCLI: 'info.picocli:picocli:4.5.2',
 

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -13,6 +13,7 @@ dependencies {
   implementation dependencyStrings.COMMONS_COMPRESS
   implementation dependencyStrings.GUAVA
   implementation dependencyStrings.JACKSON_DATABIND
+  implementation dependencyStrings.JACKSON_DATAFORMAT_JSR310
   implementation dependencyStrings.ASM
 
   testImplementation dependencyStrings.JUNIT

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/json/JsonTemplateMapper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/json/JsonTemplateMapper.java
@@ -18,6 +18,7 @@ package com.google.cloud.tools.jib.json;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.CollectionType;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -53,7 +54,13 @@ import java.util.List;
  */
 public class JsonTemplateMapper {
 
-  private static final ObjectMapper objectMapper = new ObjectMapper();
+  private static final ObjectMapper objectMapper = createObjectMapper();
+
+  private static ObjectMapper createObjectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    return mapper;
+  }
 
   /**
    * Deserializes a JSON file via a JSON object template.


### PR DESCRIPTION
**Before this PR**

I've filed this issue: https://github.com/GoogleContainerTools/jib/issues/2931, summary below:

When I tried to use `jib-core` with jackson 2.12.0 on the classpath, `com.google.cloud.tools.jib.cache.Cache` stops working because `LayerEntryTemplate` has an `Instant` field and jackson will no longer serialize/deserialize this type [out of the box](https://github.com/FasterXML/jackson-databind/blob/jackson-databind-2.12.0/src/main/java/com/fasterxml/jackson/databind/util/BeanUtil.java#L301-L304), and we get this message:

> Java 8 date/time type `java.time.Instant` not supported by default: add Module "com.fasterxml.jackson.datatype:jackson-datatype-jsr310" to enable handling

**After this PR**

Users of jib-core should find functionality works fine with jackson 2.12 on the classpath.

**Possible downsides**

Imposing the jackson 2.11.x -> 2.12 upgrade on downstream consumers might be a bit disruptive, because it might surface subtle behaviour changes in their own jackson usage.

**Alternative options**

- we could add the jsr310 jar (to become _compatible_ with jackson 2.12) but still only compile against jackson 2.11.3
- we could change `LayerEntryTemplate` to use a epoch milli long instead of an Instant

