### PR TITLE
Use `-Prelease.useAutomaticVersion=true` for non-interactive release and remove unnecessary branch and tag pushes

### DIFF
--- a/jib-build-plan/scripts/prepare_release.sh
+++ b/jib-build-plan/scripts/prepare_release.sh
@@ -47,7 +47,10 @@ BRANCH=build_plan_release_v${VERSION}
 git checkout -b ${BRANCH}
 
 # Changes the version for release and creates the commits/tags.
-echo | ./gradlew :jib-build-plan:release -Prelease.releaseVersion=${VERSION} ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
+./gradlew :jib-build-plan:release \
+  -Prelease.useAutomaticVersion=true \
+  -Prelease.releaseVersion=${VERSION} \
+  ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
 
 # Pushes the release branch and tag to Github.
 git push origin ${BRANCH}

--- a/jib-core/scripts/prepare_release.sh
+++ b/jib-core/scripts/prepare_release.sh
@@ -47,7 +47,10 @@ BRANCH=core_release_v${VERSION}
 git checkout -b ${BRANCH}
 
 # Changes the version for release and creates the commits/tags.
-echo | ./gradlew :jib-core:release -Prelease.releaseVersion=${VERSION} ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
+./gradlew :jib-core:release \
+  -Prelease.useAutomaticVersion=true \
+  -Prelease.releaseVersion=${VERSION} \
+  ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
 
 # Pushes the release branch and tag to Github.
 git push origin ${BRANCH}

--- a/jib-gradle-plugin-extension-api/scripts/prepare_release.sh
+++ b/jib-gradle-plugin-extension-api/scripts/prepare_release.sh
@@ -47,7 +47,10 @@ BRANCH=gradle_extension_release_v${VERSION}
 git checkout -b ${BRANCH}
 
 # Changes the version for release and creates the commits/tags.
-echo | ./gradlew :jib-gradle-plugin-extension-api:release -Prelease.releaseVersion=${VERSION} ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
+./gradlew :jib-gradle-plugin-extension-api:release \
+  -Prelease.useAutomaticVersion=true \
+  -Prelease.releaseVersion=${VERSION} \
+  ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
 
 # Pushes the release branch and tag to Github.
 git push origin ${BRANCH}

--- a/jib-gradle-plugin/scripts/prepare_release.sh
+++ b/jib-gradle-plugin/scripts/prepare_release.sh
@@ -47,7 +47,10 @@ BRANCH=gradle_release_v${VERSION}
 git checkout -b ${BRANCH}
 
 # Changes the version for release and creates the commits/tags.
-echo | ./gradlew jib-gradle-plugin:release -Prelease.releaseVersion=${VERSION} ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
+./gradlew jib-gradle-plugin:release \
+  -Prelease.useAutomaticVersion=true \
+  -Prelease.releaseVersion=${VERSION} \
+  ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
 
 # Pushes the release branch and tag to Github.
 git push origin ${BRANCH}

--- a/jib-maven-plugin-extension-api/scripts/prepare_release.sh
+++ b/jib-maven-plugin-extension-api/scripts/prepare_release.sh
@@ -47,7 +47,10 @@ BRANCH=maven_extension_release_v${VERSION}
 git checkout -b ${BRANCH}
 
 # Changes the version for release and creates the commits/tags.
-echo | ./gradlew :jib-maven-plugin-extension-api:release -Prelease.releaseVersion=${VERSION} ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
+./gradlew :jib-maven-plugin-extension-api:release \
+  -Prelease.useAutomaticVersion=true \
+  -Prelease.releaseVersion=${VERSION} \
+  ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
 
 # Pushes the release branch and tag to Github.
 git push origin ${BRANCH}

--- a/jib-maven-plugin/scripts/prepare_release.sh
+++ b/jib-maven-plugin/scripts/prepare_release.sh
@@ -47,7 +47,10 @@ BRANCH=maven_release_v${VERSION}
 git checkout -b ${BRANCH}
 
 # Changes the version for release and creates the commits/tags.
-echo | ./gradlew jib-maven-plugin:release -Prelease.releaseVersion=${VERSION} ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
+./gradlew jib-maven-plugin:release \
+  -Prelease.useAutomaticVersion=true \
+  -Prelease.releaseVersion=${VERSION} \
+  ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
 
 # Pushes the release branch and tag to Github.
 git push origin ${BRANCH}

--- a/jib-plugins-extension-common/scripts/prepare_release.sh
+++ b/jib-plugins-extension-common/scripts/prepare_release.sh
@@ -47,7 +47,10 @@ BRANCH=extension_common_release_v${VERSION}
 git checkout -b ${BRANCH}
 
 # Changes the version for release and creates the commits/tags.
-echo | ./gradlew :jib-plugins-extension-common:release -Prelease.releaseVersion=${VERSION} ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
+./gradlew :jib-plugins-extension-common:release \
+  -Prelease.useAutomaticVersion=true \
+  -Prelease.releaseVersion=${VERSION} \
+  ${POST_RELEASE_VERSION:+"-Prelease.newVersion=${POST_RELEASE_VERSION}"}
 
 # Pushes the release branch and tag to Github.
 git push origin ${BRANCH}


### PR DESCRIPTION
We've been using `echo | ./gradlew release` to suppress interactive prompts, but we can use [`-Prelease.useAutomaticVersion=true`](https://github.com/researchgate/gradle-release#working-in-continuous-integration) instead.

Also learned that the `release` task pushes the branch and the tag, so no need to manually push them.