### PR TITLE
Upgrade build to 6.0.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ idea.project.settings {
 
 import net.ltgt.gradle.errorprone.CheckSeverity
 
-['jib-core', 'jib-gradle-plugin-extension-api', 'jib-maven-plugin-extension-api'].each { projectName ->
+['jib-core', 'jib-gradle-plugin', 'jib-gradle-plugin-extension-api', 'jib-maven-plugin-extension-api'].each { projectName ->
   project(projectName) {
     apply plugin: 'java-library'
   }

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ idea.project.settings {
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 // `java-library` must be applied before `java`
-// gradle-java-plugin (in jib-gradle-plugin) auto applies java-library, so ensure that happens first
+// java-gradle-plugin (in jib-gradle-plugin) auto applies java-library, so ensure that happens first
 ['jib-core', 'jib-gradle-plugin', 'jib-gradle-plugin-extension-api', 'jib-maven-plugin-extension-api'].each { projectName ->
   project(projectName) {
     apply plugin: 'java-library'

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ idea.project.settings {
 
 import net.ltgt.gradle.errorprone.CheckSeverity
 
+// `java-library` must be applied before `java`
+// gradle-java-plugin (in jib-gradle-plugin) auto applies java-library, so ensure that happens first
 ['jib-core', 'jib-gradle-plugin', 'jib-gradle-plugin-extension-api', 'jib-maven-plugin-extension-api'].each { projectName ->
   project(projectName) {
     apply plugin: 'java-library'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jib-cli/build.gradle
+++ b/jib-cli/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-  id 'java-gradle-plugin'
   id 'application'
   id 'net.researchgate.release'
   id 'eclipse'

--- a/jib-cli/build.gradle
+++ b/jib-cli/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   testImplementation dependencyStrings.SYSTEM_RULES
 
   integrationTestImplementation project(path:':jib-core', configuration:'integrationTests')
+  integrationTestImplementation gradleTestKit()
 }
 
 release {

--- a/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/cli2/TestProject.java
+++ b/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/cli2/TestProject.java
@@ -76,10 +76,7 @@ public class TestProject extends TemporaryFolder implements Closeable {
     copyProject(testProjectName, projectRoot);
 
     gradleRunner =
-        GradleRunner.create()
-            .withGradleVersion(gradleVersion)
-            .withProjectDir(projectRoot.toFile())
-            .withPluginClasspath();
+        GradleRunner.create().withGradleVersion(gradleVersion).withProjectDir(projectRoot.toFile());
   }
 
   public BuildResult build(String... gradleArguments) {

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -72,6 +72,7 @@ pluginBundle {
 }
 
 gradlePlugin {
+  testSourceSets sourceSets.integrationTest, sourceSets.test
   plugins {
     jibPlugin {
       id = 'com.google.cloud.tools.jib'

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
@@ -112,7 +112,6 @@ public class ContainerParameters {
   }
 
   @Input
-  @Optional
   public boolean getExpandClasspathDependencies() {
     if (System.getProperty(PropertyNames.EXPAND_CLASSPATH_DEPENDENCIES) != null) {
       return Boolean.valueOf(System.getProperty(PropertyNames.EXPAND_CLASSPATH_DEPENDENCIES));

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -75,7 +75,6 @@ import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.SourceSetOutput;
 import org.gradle.api.tasks.TaskContainer;
-import org.gradle.api.tasks.TaskDependency;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.tasks.Jar;
 import org.hamcrest.CoreMatchers;
@@ -116,11 +115,6 @@ public class GradleProjectPropertiesTest {
     @Override
     public Set<File> getFiles() {
       return files;
-    }
-
-    @Override
-    public TaskDependency getBuildDependencies() {
-      return task -> Collections.emptySet();
     }
   }
 


### PR DESCRIPTION
- minimum to run jib is still 5.1


There are some eclipse related configurations that maybe we don't need anymore, but I don't have a good way to test eclipse right now.
