### PR TITLE
Fix Jib CLI to disable rich console output when no console is attached

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/logging/CliLogger.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/logging/CliLogger.java
@@ -80,7 +80,7 @@ public class CliLogger {
       case auto:
         // Enables progress footer when ANSI is supported (Windows or TERM not 'dumb').
         return System.getProperty("os.name").startsWith("windows")
-            || !"dumb".equals(System.getenv("TERM"));
+            || (System.console() != null && !"dumb".equals(System.getenv("TERM")));
       case rich:
       default:
         return true;

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/logging/CliLoggerTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/cli2/logging/CliLoggerTest.java
@@ -205,12 +205,6 @@ public class CliLoggerTest {
   }
 
   @Test
-  public void testIsRightConsole_autoTermTrue() {
-    environmentVariables.set("TERM", "not-dumb");
-    assertThat(CliLogger.isRichConsole(ConsoleOutput.auto)).isTrue();
-  }
-
-  @Test
   public void testIsRightConsole_autoDumbTermFalse() {
     environmentVariables.set("TERM", "dumb");
     assertThat(CliLogger.isRichConsole(ConsoleOutput.auto)).isFalse();

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -141,6 +141,8 @@ public class GradleProjectProperties implements ProjectProperties {
 
       case Auto:
         // Enables progress footer when ANSI is supported (Windows or TERM not 'dumb').
+        // Unlike jib-maven-plugin, we cannot test "System.console() != null".
+        // https://github.com/GoogleContainerTools/jib/issues/2920#issuecomment-749234458
         return Os.isFamily(Os.FAMILY_WINDOWS) || !"dumb".equals(System.getenv("TERM"));
 
       default:


### PR DESCRIPTION
Fixes #2920.

Verified that, after this PR, `jib jar -t docker://foo a.jar > a.out` correctly disables rich output. Of course, without redirection, it does rich output.