### PR TITLE
Hide and disbale Jib CLI jar sub-command

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/cli2/Jar.java
@@ -33,7 +33,11 @@ import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 
-@CommandLine.Command(name = "jar", showAtFileInUsageHelp = true, description = "Containerize a jar")
+@CommandLine.Command(
+    name = "jar",
+    showAtFileInUsageHelp = true,
+    description = "Containerize a jar",
+    hidden = true)
 public class Jar implements Callable<Integer> {
 
   @CommandLine.Spec
@@ -60,6 +64,13 @@ public class Jar implements Callable<Integer> {
 
   @Override
   public Integer call() {
+    try {
+      // Temporarily disable the command, but allow to proceed in tests.
+      Class.forName("org.junit.Test");
+    } catch (ClassNotFoundException ex) {
+      throw new UnsupportedOperationException("jar command not implemented");
+    }
+
     commonCliOptions.validate();
     SingleThreadedExecutor executor = new SingleThreadedExecutor();
     try (TempDirectoryProvider tempDirectoryProvider = new TempDirectoryProvider()) {


### PR DESCRIPTION
I was not able to find an option in picocli to disable a command. Maybe `hidden` is good enough. But I also added a guard to prevent it from running. (picocli still does argument validation though.)