### PR TITLE
Add option to specify base image for cli jar command

### DIFF
--- a/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
+++ b/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
@@ -247,10 +247,8 @@ public class JarCommandTest {
         new CommandLine(new JibCli())
             .execute(
                 "jar",
-                "--target",
-                "docker://cli-gcr-base",
-                "--from",
-                "gcr.io/google-appengine/openjdk:8",
+                "--target=docker://cli-gcr-base",
+                "--from=gcr.io/google-appengine/openjdk:8",
                 jarPath.toString());
     assertThat(exitCode).isEqualTo(0);
     String output = new Command("docker", "run", "--rm", "cli-gcr-base").run();

--- a/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
+++ b/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
@@ -239,6 +239,24 @@ public class JarCommandTest {
     assertThat(getContent(new URL("http://localhost:8080"))).isEqualTo("Hello world");
   }
 
+  @Test
+  public void testJar_baseImageSpecified()
+      throws IOException, URISyntaxException, InterruptedException {
+    Path jarPath = Paths.get(Resources.getResource("jarTest/standard/noDependencyJar.jar").toURI());
+    Integer exitCode =
+        new CommandLine(new JibCli())
+            .execute(
+                "jar",
+                "--target",
+                "docker://cli-gcr-base",
+                "--from",
+                "gcr.io/google-appengine/openjdk:8",
+                jarPath.toString());
+    assertThat(exitCode).isEqualTo(0);
+    String output = new Command("docker", "run", "--rm", "cli-gcr-base").run();
+    assertThat(output).isEqualTo("Hello World");
+  }
+
   @Nullable
   private static String getContent(URL url) throws InterruptedException {
     for (int i = 0; i < 40; i++) {

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ContainerBuilders.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ContainerBuilders.java
@@ -36,11 +36,11 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 
-/** Creates jib container builder. */
+/** Helper class for creating JibContainerBuilders from JibCli specifications. */
 public class ContainerBuilders {
 
   /**
-   * Generates a {@link JibContainerBuilder} depending on the base image specified.
+   * Creates a {@link JibContainerBuilder} depending on the base image specified.
    *
    * @param baseImageReference base image
    * @param platforms platforms for multi-platform support in build command.

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ContainerBuilders.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ContainerBuilders.java
@@ -33,8 +33,7 @@ import com.google.cloud.tools.jib.plugins.common.DefaultCredentialRetrievers;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
 import java.io.FileNotFoundException;
 import java.nio.file.Paths;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.Set;
 
 /** Helper class for creating JibContainerBuilders from JibCli specifications. */
 public class ContainerBuilders {
@@ -42,8 +41,8 @@ public class ContainerBuilders {
   /**
    * Creates a {@link JibContainerBuilder} depending on the base image specified.
    *
-   * @param baseImageReference base image
-   * @param platforms platforms for multi-platform support in build command.
+   * @param baseImageReference base image reference
+   * @param platforms platforms for multi-platform support in build command
    * @param commonCliOptions common cli options
    * @param logger console logger
    * @return a {@link JibContainerBuilder}
@@ -52,7 +51,7 @@ public class ContainerBuilders {
    */
   public static JibContainerBuilder create(
       String baseImageReference,
-      List<Platform> platforms,
+      Set<Platform> platforms,
       CommonCliOptions commonCliOptions,
       ConsoleLogger logger)
       throws InvalidImageReferenceException, FileNotFoundException {
@@ -76,7 +75,7 @@ public class ContainerBuilders {
         .forEach(registryImage::addCredentialRetriever);
     JibContainerBuilder containerBuilder = Jib.from(registryImage);
     if (!platforms.isEmpty()) {
-      containerBuilder.setPlatforms(platforms.stream().collect(Collectors.toSet()));
+      containerBuilder.setPlatforms(platforms);
     }
     return containerBuilder;
   }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ContainerBuilders.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ContainerBuilders.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.cli;
+
+import static com.google.cloud.tools.jib.api.Jib.DOCKER_DAEMON_IMAGE_PREFIX;
+import static com.google.cloud.tools.jib.api.Jib.REGISTRY_IMAGE_PREFIX;
+import static com.google.cloud.tools.jib.api.Jib.TAR_IMAGE_PREFIX;
+
+import com.google.cloud.tools.jib.api.DockerDaemonImage;
+import com.google.cloud.tools.jib.api.ImageReference;
+import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
+import com.google.cloud.tools.jib.api.Jib;
+import com.google.cloud.tools.jib.api.JibContainerBuilder;
+import com.google.cloud.tools.jib.api.RegistryImage;
+import com.google.cloud.tools.jib.api.TarImage;
+import com.google.cloud.tools.jib.api.buildplan.Platform;
+import com.google.cloud.tools.jib.frontend.CredentialRetrieverFactory;
+import com.google.cloud.tools.jib.plugins.common.DefaultCredentialRetrievers;
+import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
+import java.io.FileNotFoundException;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Creates jib container builder. */
+public class ContainerBuilders {
+
+  /**
+   * Generates a {@link JibContainerBuilder} depending on the base image specified.
+   *
+   * @param baseImageReference base image
+   * @param platforms platforms for multi-platform support in build command.
+   * @param commonCliOptions common cli options
+   * @param logger console logger
+   * @return a {@link JibContainerBuilder}
+   * @throws InvalidImageReferenceException if the baseImage reference cannot be parsed
+   * @throws FileNotFoundException if credential helper file cannot be found
+   */
+  public static JibContainerBuilder create(
+      String baseImageReference,
+      List<Platform> platforms,
+      CommonCliOptions commonCliOptions,
+      ConsoleLogger logger)
+      throws InvalidImageReferenceException, FileNotFoundException {
+    if (baseImageReference.startsWith(DOCKER_DAEMON_IMAGE_PREFIX)) {
+      return Jib.from(
+          DockerDaemonImage.named(baseImageReference.replaceFirst(DOCKER_DAEMON_IMAGE_PREFIX, "")));
+    }
+    if (baseImageReference.startsWith(TAR_IMAGE_PREFIX)) {
+      return Jib.from(
+          TarImage.at(Paths.get(baseImageReference.replaceFirst(TAR_IMAGE_PREFIX, ""))));
+    }
+    ImageReference imageReference =
+        ImageReference.parse(baseImageReference.replaceFirst(REGISTRY_IMAGE_PREFIX, ""));
+    RegistryImage registryImage = RegistryImage.named(imageReference);
+    DefaultCredentialRetrievers defaultCredentialRetrievers =
+        DefaultCredentialRetrievers.init(
+            CredentialRetrieverFactory.forImage(
+                imageReference,
+                logEvent -> logger.log(logEvent.getLevel(), logEvent.getMessage())));
+    Credentials.getFromCredentialRetrievers(commonCliOptions, defaultCredentialRetrievers)
+        .forEach(registryImage::addCredentialRetriever);
+    JibContainerBuilder containerBuilder = Jib.from(registryImage);
+    if (!platforms.isEmpty()) {
+      containerBuilder.setPlatforms(platforms.stream().collect(Collectors.toSet()));
+    }
+    return containerBuilder;
+  }
+}

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -125,9 +125,9 @@ public class Jar implements Callable<Integer> {
   }
 
   /**
-   * Returns the base image.
+   * Returns the user specified base image.
    *
-   * @return base image
+   * @return an optional base image
    */
   public Optional<String> getFrom() {
     if (from != null) {

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -31,6 +31,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
@@ -63,6 +64,13 @@ public class Jar implements Callable<Integer> {
           "The jar processing mode, candidates: ${COMPLETION-CANDIDATES}, default: ${DEFAULT-VALUE}")
   @SuppressWarnings("NullAway.Init") // initialized by picocli
   private ProcessingMode mode;
+
+  @CommandLine.Option(
+      names = "--from",
+      paramLabel = "<from>",
+      description = "The base image to use.")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  private String from;
 
   @Override
   public Integer call() {
@@ -98,7 +106,8 @@ public class Jar implements Callable<Integer> {
       }
 
       JarProcessor processor = JarProcessors.from(jarFile, tempDirectoryProvider, mode);
-      JibContainerBuilder containerBuilder = JarFiles.toJibContainerBuilder(processor);
+      JibContainerBuilder containerBuilder =
+          JarFiles.toJibContainerBuilder(processor, this, commonCliOptions, logger);
       CacheDirectories cacheDirectories =
           CacheDirectories.from(commonCliOptions, jarFile.toAbsolutePath().getParent());
       Containerizer containerizer = Containerizers.from(commonCliOptions, logger, cacheDirectories);
@@ -113,5 +122,17 @@ public class Jar implements Callable<Integer> {
       executor.shutDownAndAwaitTermination(Duration.ofSeconds(3));
     }
     return 0;
+  }
+
+  /**
+   * Returns the base image.
+   *
+   * @return base image
+   */
+  public Optional<String> getFrom() {
+    if (from != null) {
+      return Optional.of(from);
+    }
+    return Optional.empty();
   }
 }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -130,9 +130,6 @@ public class Jar implements Callable<Integer> {
    * @return an optional base image
    */
   public Optional<String> getFrom() {
-    if (from != null) {
-      return Optional.of(from);
-    }
-    return Optional.empty();
+    return Optional.ofNullable(from);
   }
 }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
@@ -31,8 +31,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -105,17 +104,12 @@ public class BuildFiles {
   private static JibContainerBuilder createJibContainerBuilder(
       BaseImageSpec baseImageSpec, CommonCliOptions commonCliOptions, ConsoleLogger logger)
       throws InvalidImageReferenceException, FileNotFoundException {
-    List<Platform> platforms = new ArrayList<>();
-    if (!baseImageSpec.getPlatforms().isEmpty()) {
-      platforms =
-          baseImageSpec
-              .getPlatforms()
-              .stream()
-              .map(
-                  platformSpec ->
-                      new Platform(platformSpec.getArchitecture(), platformSpec.getOs()))
-              .collect(Collectors.toList());
-    }
+    LinkedHashSet<Platform> platforms =
+        baseImageSpec
+            .getPlatforms()
+            .stream()
+            .map(platformSpec -> new Platform(platformSpec.getArchitecture(), platformSpec.getOs()))
+            .collect(Collectors.toCollection(LinkedHashSet::new));
     return ContainerBuilders.create(baseImageSpec.getImage(), platforms, commonCliOptions, logger);
   }
 }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
@@ -16,34 +16,25 @@
 
 package com.google.cloud.tools.jib.cli.buildfile;
 
-import static com.google.cloud.tools.jib.api.Jib.DOCKER_DAEMON_IMAGE_PREFIX;
-import static com.google.cloud.tools.jib.api.Jib.REGISTRY_IMAGE_PREFIX;
-import static com.google.cloud.tools.jib.api.Jib.TAR_IMAGE_PREFIX;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import com.google.cloud.tools.jib.api.DockerDaemonImage;
-import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.Jib;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
-import com.google.cloud.tools.jib.api.RegistryImage;
-import com.google.cloud.tools.jib.api.TarImage;
 import com.google.cloud.tools.jib.api.buildplan.Platform;
 import com.google.cloud.tools.jib.cli.Build;
 import com.google.cloud.tools.jib.cli.CommonCliOptions;
-import com.google.cloud.tools.jib.cli.Credentials;
-import com.google.cloud.tools.jib.frontend.CredentialRetrieverFactory;
-import com.google.cloud.tools.jib.plugins.common.DefaultCredentialRetrievers;
+import com.google.cloud.tools.jib.cli.ContainerBuilders;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
 import com.google.common.base.Charsets;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.LinkedHashSet;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.text.StringSubstitutor;
 import org.apache.commons.text.io.StringSubstitutorReader;
@@ -87,10 +78,10 @@ public class BuildFiles {
       throws InvalidImageReferenceException, IOException {
     BuildFileSpec buildFile =
         toBuildFileSpec(buildFilePath, buildCommandOptions.getTemplateParameters());
-
+    Optional<BaseImageSpec> baseImageSpec = buildFile.getFrom();
     JibContainerBuilder containerBuilder =
-        buildFile.getFrom().isPresent()
-            ? createJibContainerBuilder(buildFile.getFrom().get(), commonCliOptions, logger)
+        baseImageSpec.isPresent()
+            ? createJibContainerBuilder(baseImageSpec.get(), commonCliOptions, logger)
             : Jib.fromScratch();
 
     buildFile.getCreationTime().ifPresent(containerBuilder::setCreationTime);
@@ -111,40 +102,20 @@ public class BuildFiles {
     return containerBuilder;
   }
 
-  // TODO: add testing, need to do via intergration tests as there's no good way to extract out that
-  //   the base image was populated as the user intended currently.
-  static JibContainerBuilder createJibContainerBuilder(
-      BaseImageSpec from, CommonCliOptions commonCliOptions, ConsoleLogger logger)
+  private static JibContainerBuilder createJibContainerBuilder(
+      BaseImageSpec baseImageSpec, CommonCliOptions commonCliOptions, ConsoleLogger logger)
       throws InvalidImageReferenceException, FileNotFoundException {
-    String baseImageReference = from.getImage();
-    if (baseImageReference.startsWith(DOCKER_DAEMON_IMAGE_PREFIX)) {
-      return Jib.from(
-          DockerDaemonImage.named(baseImageReference.replaceFirst(DOCKER_DAEMON_IMAGE_PREFIX, "")));
-    }
-    if (baseImageReference.startsWith(TAR_IMAGE_PREFIX)) {
-      return Jib.from(
-          TarImage.at(Paths.get(baseImageReference.replaceFirst(TAR_IMAGE_PREFIX, ""))));
-    }
-    ImageReference imageReference =
-        ImageReference.parse(baseImageReference.replaceFirst(REGISTRY_IMAGE_PREFIX, ""));
-    RegistryImage registryImage = RegistryImage.named(imageReference);
-    DefaultCredentialRetrievers defaultCredentialRetrievers =
-        DefaultCredentialRetrievers.init(
-            CredentialRetrieverFactory.forImage(
-                imageReference,
-                logEvent -> logger.log(logEvent.getLevel(), logEvent.getMessage())));
-    Credentials.getFromCredentialRetrievers(commonCliOptions, defaultCredentialRetrievers)
-        .forEach(registryImage::addCredentialRetriever);
-    JibContainerBuilder containerBuilder = Jib.from(registryImage);
-    if (!from.getPlatforms().isEmpty()) {
-      containerBuilder.setPlatforms(
-          from.getPlatforms()
+    List<Platform> platforms = new ArrayList<>();
+    if (!baseImageSpec.getPlatforms().isEmpty()) {
+      platforms =
+          baseImageSpec
+              .getPlatforms()
               .stream()
               .map(
                   platformSpec ->
                       new Platform(platformSpec.getArchitecture(), platformSpec.getOs()))
-              .collect(Collectors.toCollection(LinkedHashSet::new)));
+              .collect(Collectors.toList());
     }
-    return containerBuilder;
+    return ContainerBuilders.create(baseImageSpec.getImage(), platforms, commonCliOptions, logger);
   }
 }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
@@ -73,7 +73,7 @@ public class JarFiles {
     return containerBuilder;
   }
 
-  static JibContainerBuilder createJibContainerBuilder(
+  private static JibContainerBuilder createJibContainerBuilder(
       String from, CommonCliOptions commonCliOptions, ConsoleLogger logger)
       throws InvalidImageReferenceException, FileNotFoundException {
     String baseImageReference = from;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
@@ -16,27 +16,16 @@
 
 package com.google.cloud.tools.jib.cli.jar;
 
-import static com.google.cloud.tools.jib.api.Jib.DOCKER_DAEMON_IMAGE_PREFIX;
-import static com.google.cloud.tools.jib.api.Jib.REGISTRY_IMAGE_PREFIX;
-import static com.google.cloud.tools.jib.api.Jib.TAR_IMAGE_PREFIX;
-
-import com.google.cloud.tools.jib.api.DockerDaemonImage;
-import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.Jib;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
-import com.google.cloud.tools.jib.api.RegistryImage;
-import com.google.cloud.tools.jib.api.TarImage;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.cli.CommonCliOptions;
-import com.google.cloud.tools.jib.cli.Credentials;
+import com.google.cloud.tools.jib.cli.ContainerBuilders;
 import com.google.cloud.tools.jib.cli.Jar;
-import com.google.cloud.tools.jib.frontend.CredentialRetrieverFactory;
-import com.google.cloud.tools.jib.plugins.common.DefaultCredentialRetrievers;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.List;
 
 /** Class to build a container representation from the contents of a jar file. */
@@ -64,37 +53,13 @@ public class JarFiles {
     // Use distroless as the default base image.
     JibContainerBuilder containerBuilder =
         jarOptions.getFrom().isPresent()
-            ? createJibContainerBuilder(jarOptions.getFrom().get(), commonCliOptions, logger)
+            ? ContainerBuilders.create(
+                jarOptions.getFrom().get(), Collections.emptyList(), commonCliOptions, logger)
             : Jib.from("gcr.io/distroless/java");
 
     List<FileEntriesLayer> layers = processor.createLayers();
     List<String> entrypoint = processor.computeEntrypoint();
     containerBuilder.setEntrypoint(entrypoint).setFileEntriesLayers(layers);
     return containerBuilder;
-  }
-
-  private static JibContainerBuilder createJibContainerBuilder(
-      String from, CommonCliOptions commonCliOptions, ConsoleLogger logger)
-      throws InvalidImageReferenceException, FileNotFoundException {
-    String baseImageReference = from;
-    if (baseImageReference.startsWith(DOCKER_DAEMON_IMAGE_PREFIX)) {
-      return Jib.from(
-          DockerDaemonImage.named(baseImageReference.replaceFirst(DOCKER_DAEMON_IMAGE_PREFIX, "")));
-    }
-    if (baseImageReference.startsWith(TAR_IMAGE_PREFIX)) {
-      return Jib.from(
-          TarImage.at(Paths.get(baseImageReference.replaceFirst(TAR_IMAGE_PREFIX, ""))));
-    }
-    ImageReference imageReference =
-        ImageReference.parse(baseImageReference.replaceFirst(REGISTRY_IMAGE_PREFIX, ""));
-    RegistryImage registryImage = RegistryImage.named(imageReference);
-    DefaultCredentialRetrievers defaultCredentialRetrievers =
-        DefaultCredentialRetrievers.init(
-            CredentialRetrieverFactory.forImage(
-                imageReference,
-                logEvent -> logger.log(logEvent.getLevel(), logEvent.getMessage())));
-    Credentials.getFromCredentialRetrievers(commonCliOptions, defaultCredentialRetrievers)
-        .forEach(registryImage::addCredentialRetriever);
-    return Jib.from(registryImage);
   }
 }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
@@ -54,7 +54,7 @@ public class JarFiles {
     JibContainerBuilder containerBuilder =
         jarOptions.getFrom().isPresent()
             ? ContainerBuilders.create(
-                jarOptions.getFrom().get(), Collections.emptyList(), commonCliOptions, logger)
+                jarOptions.getFrom().get(), Collections.emptySet(), commonCliOptions, logger)
             : Jib.from("gcr.io/distroless/java");
 
     List<FileEntriesLayer> layers = processor.createLayers();

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
@@ -16,11 +16,27 @@
 
 package com.google.cloud.tools.jib.cli.jar;
 
+import static com.google.cloud.tools.jib.api.Jib.DOCKER_DAEMON_IMAGE_PREFIX;
+import static com.google.cloud.tools.jib.api.Jib.REGISTRY_IMAGE_PREFIX;
+import static com.google.cloud.tools.jib.api.Jib.TAR_IMAGE_PREFIX;
+
+import com.google.cloud.tools.jib.api.DockerDaemonImage;
+import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.Jib;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
+import com.google.cloud.tools.jib.api.RegistryImage;
+import com.google.cloud.tools.jib.api.TarImage;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
+import com.google.cloud.tools.jib.cli.CommonCliOptions;
+import com.google.cloud.tools.jib.cli.Credentials;
+import com.google.cloud.tools.jib.cli.Jar;
+import com.google.cloud.tools.jib.frontend.CredentialRetrieverFactory;
+import com.google.cloud.tools.jib.plugins.common.DefaultCredentialRetrievers;
+import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.List;
 
 /** Class to build a container representation from the contents of a jar file. */
@@ -30,20 +46,55 @@ public class JarFiles {
    * Generates a {@link JibContainerBuilder} from contents of a jar file.
    *
    * @param processor jar processor
+   * @param jarOptions jar cli options
+   * @param commonCliOptions common cli options
+   * @param logger console logger
    * @return JibContainerBuilder
    * @throws IOException if I/O error occurs when opening the jar file or if temporary directory
    *     provided doesn't exist
    * @throws InvalidImageReferenceException if the base image reference is invalid
    */
-  public static JibContainerBuilder toJibContainerBuilder(JarProcessor processor)
+  public static JibContainerBuilder toJibContainerBuilder(
+      JarProcessor processor,
+      Jar jarOptions,
+      CommonCliOptions commonCliOptions,
+      ConsoleLogger logger)
       throws IOException, InvalidImageReferenceException {
 
-    // Use distroless as the base image.
-    JibContainerBuilder containerBuilder = Jib.from("gcr.io/distroless/java");
+    // Use distroless as the default base image.
+    JibContainerBuilder containerBuilder =
+        jarOptions.getFrom().isPresent()
+            ? createJibContainerBuilder(jarOptions.getFrom().get(), commonCliOptions, logger)
+            : Jib.from("gcr.io/distroless/java");
 
     List<FileEntriesLayer> layers = processor.createLayers();
     List<String> entrypoint = processor.computeEntrypoint();
     containerBuilder.setEntrypoint(entrypoint).setFileEntriesLayers(layers);
     return containerBuilder;
+  }
+
+  static JibContainerBuilder createJibContainerBuilder(
+      String from, CommonCliOptions commonCliOptions, ConsoleLogger logger)
+      throws InvalidImageReferenceException, FileNotFoundException {
+    String baseImageReference = from;
+    if (baseImageReference.startsWith(DOCKER_DAEMON_IMAGE_PREFIX)) {
+      return Jib.from(
+          DockerDaemonImage.named(baseImageReference.replaceFirst(DOCKER_DAEMON_IMAGE_PREFIX, "")));
+    }
+    if (baseImageReference.startsWith(TAR_IMAGE_PREFIX)) {
+      return Jib.from(
+          TarImage.at(Paths.get(baseImageReference.replaceFirst(TAR_IMAGE_PREFIX, ""))));
+    }
+    ImageReference imageReference =
+        ImageReference.parse(baseImageReference.replaceFirst(REGISTRY_IMAGE_PREFIX, ""));
+    RegistryImage registryImage = RegistryImage.named(imageReference);
+    DefaultCredentialRetrievers defaultCredentialRetrievers =
+        DefaultCredentialRetrievers.init(
+            CredentialRetrieverFactory.forImage(
+                imageReference,
+                logEvent -> logger.log(logEvent.getLevel(), logEvent.getMessage())));
+    Credentials.getFromCredentialRetrievers(commonCliOptions, defaultCredentialRetrievers)
+        .forEach(registryImage::addCredentialRetriever);
+    return Jib.from(registryImage);
   }
 }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTestHelper.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTestHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC.
+ * Copyright 2021 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTestHelper.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTestHelper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.api;
+
+import com.google.cloud.tools.jib.configuration.BuildContext;
+
+/** Test helper to expose package-private members of {@link JibContainerBuilder}. */
+public class JibContainerBuilderTestHelper {
+
+  public static BuildContext toBuildContext(
+      JibContainerBuilder jibContainerBuilder, Containerizer containerizer)
+      throws CacheDirectoryCreationException {
+    return jibContainerBuilder.toBuildContext(containerizer);
+  }
+
+  private JibContainerBuilderTestHelper() {}
+}

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/ContainerBuildersTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/ContainerBuildersTest.java
@@ -51,7 +51,7 @@ public class ContainerBuildersTest {
       throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
     JibContainerBuilder containerBuilder =
         ContainerBuilders.create(
-            "docker://docker-image-ref", Collections.EMPTY_SET, mockCommonCliOptions, mockLogger);
+            "docker://docker-image-ref", Collections.emptySet(), mockCommonCliOptions, mockLogger);
     BuildContext buildContext =
         JibContainerBuilderTestHelper.toBuildContext(
             containerBuilder, Containerizer.to(RegistryImage.named("ignored")));
@@ -68,7 +68,7 @@ public class ContainerBuildersTest {
     JibContainerBuilder containerBuilder =
         ContainerBuilders.create(
             "registry://registry-image-ref",
-            Collections.EMPTY_SET,
+            Collections.emptySet(),
             mockCommonCliOptions,
             mockLogger);
     BuildContext buildContext =
@@ -86,7 +86,7 @@ public class ContainerBuildersTest {
       throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
     JibContainerBuilder containerBuilder =
         ContainerBuilders.create(
-            "tar:///path/to.tar", Collections.EMPTY_SET, mockCommonCliOptions, mockLogger);
+            "tar:///path/to.tar", Collections.emptySet(), mockCommonCliOptions, mockLogger);
     BuildContext buildContext =
         JibContainerBuilderTestHelper.toBuildContext(
             containerBuilder, Containerizer.to(RegistryImage.named("ignored")));

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/ContainerBuildersTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/ContainerBuildersTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.cli;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
+import com.google.cloud.tools.jib.api.Containerizer;
+import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
+import com.google.cloud.tools.jib.api.JibContainerBuilder;
+import com.google.cloud.tools.jib.api.JibContainerBuilderTestHelper;
+import com.google.cloud.tools.jib.api.RegistryImage;
+import com.google.cloud.tools.jib.api.buildplan.Platform;
+import com.google.cloud.tools.jib.configuration.BuildContext;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
+import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+/** Tests for {@link ContainerBuilders}. */
+@RunWith(MockitoJUnitRunner.class)
+public class ContainerBuildersTest {
+
+  @Mock private CommonCliOptions mockCommonCliOptions;
+
+  @Mock private ConsoleLogger mockLogger;
+
+  @Test
+  public void testCreate_dockerBaseImage()
+      throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
+    JibContainerBuilder containerBuilder =
+        ContainerBuilders.create(
+            "docker://docker-image-ref", Collections.EMPTY_LIST, mockCommonCliOptions, mockLogger);
+    BuildContext buildContext =
+        JibContainerBuilderTestHelper.toBuildContext(
+            containerBuilder, Containerizer.to(RegistryImage.named("ignored")));
+    ImageConfiguration imageConfiguration = buildContext.getBaseImageConfiguration();
+
+    assertThat(imageConfiguration.getImage().toString()).isEqualTo("docker-image-ref");
+    assertThat(imageConfiguration.getDockerClient().isPresent()).isTrue();
+    assertThat(imageConfiguration.getTarPath().isPresent()).isFalse();
+  }
+
+  @Test
+  public void testCreate_registry()
+      throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
+    JibContainerBuilder containerBuilder =
+        ContainerBuilders.create(
+            "registry://registry-image-ref",
+            Collections.EMPTY_LIST,
+            mockCommonCliOptions,
+            mockLogger);
+    BuildContext buildContext =
+        JibContainerBuilderTestHelper.toBuildContext(
+            containerBuilder, Containerizer.to(RegistryImage.named("ignored")));
+    ImageConfiguration imageConfiguration = buildContext.getBaseImageConfiguration();
+
+    assertThat(imageConfiguration.getImage().toString()).isEqualTo("registry-image-ref");
+    assertThat(imageConfiguration.getDockerClient().isPresent()).isFalse();
+    assertThat(imageConfiguration.getTarPath().isPresent()).isFalse();
+  }
+
+  @Test
+  public void testCreate_tarBase()
+      throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
+    JibContainerBuilder containerBuilder =
+        ContainerBuilders.create(
+            "tar:///path/to.tar", Collections.EMPTY_LIST, mockCommonCliOptions, mockLogger);
+    BuildContext buildContext =
+        JibContainerBuilderTestHelper.toBuildContext(
+            containerBuilder, Containerizer.to(RegistryImage.named("ignored")));
+    ImageConfiguration imageConfiguration = buildContext.getBaseImageConfiguration();
+
+    assertThat(imageConfiguration.getTarPath()).isEqualTo(Optional.of(Paths.get("/path/to.tar")));
+    assertThat(imageConfiguration.getDockerClient().isPresent()).isFalse();
+  }
+
+  @Test
+  public void testCreate_platforms()
+      throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
+    JibContainerBuilder containerBuilder =
+        ContainerBuilders.create(
+            "registry://registry-image-ref",
+            ImmutableList.of(new Platform("arch1", "os1"), new Platform("arch2", "os2")),
+            mockCommonCliOptions,
+            mockLogger);
+
+    assertThat(containerBuilder.toContainerBuildPlan().getPlatforms())
+        .isEqualTo(ImmutableSet.of(new Platform("arch1", "os1"), new Platform("arch2", "os2")));
+  }
+}

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/ContainerBuildersTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/ContainerBuildersTest.java
@@ -28,7 +28,6 @@ import com.google.cloud.tools.jib.api.buildplan.Platform;
 import com.google.cloud.tools.jib.configuration.BuildContext;
 import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -52,7 +51,7 @@ public class ContainerBuildersTest {
       throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
     JibContainerBuilder containerBuilder =
         ContainerBuilders.create(
-            "docker://docker-image-ref", Collections.EMPTY_LIST, mockCommonCliOptions, mockLogger);
+            "docker://docker-image-ref", Collections.EMPTY_SET, mockCommonCliOptions, mockLogger);
     BuildContext buildContext =
         JibContainerBuilderTestHelper.toBuildContext(
             containerBuilder, Containerizer.to(RegistryImage.named("ignored")));
@@ -69,7 +68,7 @@ public class ContainerBuildersTest {
     JibContainerBuilder containerBuilder =
         ContainerBuilders.create(
             "registry://registry-image-ref",
-            Collections.EMPTY_LIST,
+            Collections.EMPTY_SET,
             mockCommonCliOptions,
             mockLogger);
     BuildContext buildContext =
@@ -87,7 +86,7 @@ public class ContainerBuildersTest {
       throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
     JibContainerBuilder containerBuilder =
         ContainerBuilders.create(
-            "tar:///path/to.tar", Collections.EMPTY_LIST, mockCommonCliOptions, mockLogger);
+            "tar:///path/to.tar", Collections.EMPTY_SET, mockCommonCliOptions, mockLogger);
     BuildContext buildContext =
         JibContainerBuilderTestHelper.toBuildContext(
             containerBuilder, Containerizer.to(RegistryImage.named("ignored")));
@@ -98,12 +97,11 @@ public class ContainerBuildersTest {
   }
 
   @Test
-  public void testCreate_platforms()
-      throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
+  public void testCreate_platforms() throws IOException, InvalidImageReferenceException {
     JibContainerBuilder containerBuilder =
         ContainerBuilders.create(
             "registry://registry-image-ref",
-            ImmutableList.of(new Platform("arch1", "os1"), new Platform("arch2", "os2")),
+            ImmutableSet.of(new Platform("arch1", "os1"), new Platform("arch2", "os2")),
             mockCommonCliOptions,
             mockLogger);
 

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
@@ -404,6 +404,14 @@ public class JarTest {
   }
 
   @Test
+  public void testParse_from() {
+    Jar jarCommand =
+        CommandLine.populateCommand(
+            new Jar(), "--target", "test-image-ref", "--from", "base-image-ref", "my-app.jar");
+    assertThat(jarCommand.getFrom()).hasValue("base-image-ref");
+  }
+
+  @Test
   public void testValidate_nameMissingFail() {
     Jar jarCommand =
         CommandLine.populateCommand(new Jar(), "--target=tar://sometar.tar", "my-app.jar");

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarFilesTest.java
@@ -276,7 +276,7 @@ public class JarFilesTest {
 
     ImageConfiguration imageConfiguration = getCommonImageConfiguration();
 
-    assertThat(imageConfiguration.getTarPath().get().toString()).isEqualTo("/path/to.tar");
+    assertThat(imageConfiguration.getTarPath()).isEqualTo(Optional.of(Paths.get("/path/to.tar")));
     assertThat(imageConfiguration.getDockerClient().isPresent()).isFalse();
   }
 

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarFilesTest.java
@@ -18,12 +18,8 @@ package com.google.cloud.tools.jib.cli.jar;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
-import com.google.cloud.tools.jib.api.Containerizer;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
-import com.google.cloud.tools.jib.api.JibContainerBuilderTestHelper;
-import com.google.cloud.tools.jib.api.RegistryImage;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.ContainerBuildPlan;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
@@ -31,8 +27,6 @@ import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
 import com.google.cloud.tools.jib.api.buildplan.Platform;
 import com.google.cloud.tools.jib.cli.CommonCliOptions;
 import com.google.cloud.tools.jib.cli.Jar;
-import com.google.cloud.tools.jib.configuration.BuildContext;
-import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
@@ -50,8 +44,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 /** Tests for {@link JarFiles}. */
 @RunWith(MockitoJUnitRunner.class)
 public class JarFilesTest {
-
-  @Mock private JarProcessor mockJarProcessor;
 
   @Mock private StandardExplodedProcessor mockStandardExplodedProcessor;
 
@@ -243,51 +235,5 @@ public class JarFilesTest {
                     AbsoluteUnixPath.get("/app/spring-boot.jar"))
                 .build()
                 .getEntries());
-  }
-
-  @Test
-  public void testToJibContainerBuilder_dockerBaseImage()
-      throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
-    Mockito.when(mockJarCommand.getFrom()).thenReturn(Optional.of("docker://docker-image-ref"));
-
-    ImageConfiguration imageConfiguration = getCommonImageConfiguration();
-
-    assertThat(imageConfiguration.getImage().toString()).isEqualTo("docker-image-ref");
-    assertThat(imageConfiguration.getDockerClient().isPresent()).isTrue();
-    assertThat(imageConfiguration.getTarPath().isPresent()).isFalse();
-  }
-
-  @Test
-  public void testToJibContainerBuilder_registry()
-      throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
-    Mockito.when(mockJarCommand.getFrom()).thenReturn(Optional.of("registry://registry-image-ref"));
-
-    ImageConfiguration imageConfiguration = getCommonImageConfiguration();
-
-    assertThat(imageConfiguration.getImage().toString()).isEqualTo("registry-image-ref");
-    assertThat(imageConfiguration.getDockerClient().isPresent()).isFalse();
-    assertThat(imageConfiguration.getTarPath().isPresent()).isFalse();
-  }
-
-  @Test
-  public void testToJibContainerBuilder_tarBase()
-      throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
-    Mockito.when(mockJarCommand.getFrom()).thenReturn(Optional.of("tar:///path/to.tar"));
-
-    ImageConfiguration imageConfiguration = getCommonImageConfiguration();
-
-    assertThat(imageConfiguration.getTarPath()).isEqualTo(Optional.of(Paths.get("/path/to.tar")));
-    assertThat(imageConfiguration.getDockerClient().isPresent()).isFalse();
-  }
-
-  private ImageConfiguration getCommonImageConfiguration()
-      throws IOException, InvalidImageReferenceException, CacheDirectoryCreationException {
-    JibContainerBuilder containerBuilder =
-        JarFiles.toJibContainerBuilder(
-            mockJarProcessor, mockJarCommand, mockCommonCliOptions, mockLogger);
-    BuildContext buildContext =
-        JibContainerBuilderTestHelper.toBuildContext(
-            containerBuilder, Containerizer.to(RegistryImage.named("ignored")));
-    return buildContext.getBaseImageConfiguration();
   }
 }


### PR DESCRIPTION
Closes #2923
This PR adds the `--from` option to the jib cli jar subcommand. It will be used to specify the desired base image. 