### PR TITLE
Remove unnecessary file lock operations

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/WriteTarFileStep.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.jib.builder.steps;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.configuration.BuildContext;
-import com.google.cloud.tools.jib.filesystem.FileOperations;
 import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.ImageTarball;
 import java.io.BufferedOutputStream;
@@ -59,7 +58,7 @@ public class WriteTarFileStep implements Callable<BuildResult> {
         Files.createDirectories(outputPath.getParent());
       }
       try (OutputStream outputStream =
-          new BufferedOutputStream(FileOperations.newLockingOutputStream(outputPath))) {
+          new BufferedOutputStream(Files.newOutputStream(outputPath))) {
         new ImageTarball(
                 builtImage,
                 buildContext.getTargetImageConfiguration().getImage(),

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageWriter.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageWriter.java
@@ -21,7 +21,6 @@ import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.blob.Blobs;
-import com.google.cloud.tools.jib.filesystem.FileOperations;
 import com.google.cloud.tools.jib.filesystem.LockFile;
 import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
 import com.google.cloud.tools.jib.hash.CountingDigestOutputStream;
@@ -447,7 +446,7 @@ class CacheStorageWriter {
     // Writes the selector to a temporary file and then moves the file to the intended location.
     Path temporarySelectorFile = Files.createTempFile(null, null);
     temporarySelectorFile.toFile().deleteOnExit();
-    try (OutputStream fileOut = FileOperations.newLockingOutputStream(temporarySelectorFile)) {
+    try (OutputStream fileOut = Files.newOutputStream(temporarySelectorFile)) {
       fileOut.write(layerDigest.getHash().getBytes(StandardCharsets.UTF_8));
     }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/FileOperations.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/FileOperations.java
@@ -18,15 +18,8 @@ package com.google.cloud.tools.jib.filesystem;
 
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
-import java.nio.channels.OverlappingFileLockException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.util.EnumSet;
 
 /** Static methods for operating on the filesystem. */
 public class FileOperations {
@@ -57,32 +50,6 @@ public class FileOperations {
         copyPathConsumer.accept(sourceFile);
       }
     }
-  }
-
-  /**
-   * Acquires an exclusive {@link FileLock} on the {@code file} and opens an {@link OutputStream} to
-   * write to it. The file will be created if it does not exist, or truncated to length 0 if it does
-   * exist. The {@link OutputStream} must be closed to release the lock.
-   *
-   * <p>The locking mechanism should not be used as a concurrency management feature. Rather, this
-   * should be used as a way to prevent concurrent writes to {@code file}. Concurrent attempts to
-   * lock {@code file} will result in {@link OverlappingFileLockException}s.
-   *
-   * @param file the file to write to
-   * @return an {@link OutputStream} that writes to the file
-   * @throws IOException if an I/O exception occurs
-   */
-  public static OutputStream newLockingOutputStream(Path file) throws IOException {
-    EnumSet<StandardOpenOption> createOrTruncate =
-        EnumSet.of(
-            StandardOpenOption.CREATE,
-            StandardOpenOption.WRITE,
-            StandardOpenOption.TRUNCATE_EXISTING);
-    // Channel is closed by outputStream.close().
-    FileChannel channel = FileChannel.open(file, createOrTruncate);
-    // Lock is released when channel is closed.
-    channel.lock();
-    return Channels.newOutputStream(channel);
   }
 
   private FileOperations() {}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/FileOperationsTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/filesystem/FileOperationsTest.java
@@ -17,22 +17,12 @@
 package com.google.cloud.tools.jib.filesystem;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.CharStreams;
 import com.google.common.io.Resources;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.net.URISyntaxException;
-import java.nio.channels.Channels;
-import java.nio.channels.FileChannel;
-import java.nio.channels.FileLock;
-import java.nio.channels.OverlappingFileLockException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,32 +31,7 @@ import org.junit.rules.TemporaryFolder;
 /** Tests for {@link FileOperations}. */
 public class FileOperationsTest {
 
-  private static void verifyWriteWithLock(Path file) throws IOException {
-    OutputStream fileOutputStream = FileOperations.newLockingOutputStream(file);
-
-    // Checks that the file was locked.
-    try (FileChannel channel = FileChannel.open(file, StandardOpenOption.READ)) {
-      // locking should either fail and return null or throw an OverlappingFileLockException
-      FileLock lock = channel.tryLock(0, Long.MAX_VALUE, true);
-      Assert.assertNull("Lock attempt should have failed", lock);
-
-    } catch (OverlappingFileLockException ex) {
-      // pass
-    }
-
-    fileOutputStream.write("jib".getBytes(StandardCharsets.UTF_8));
-    fileOutputStream.close();
-
-    FileChannel channel = FileChannel.open(file, StandardOpenOption.READ);
-    channel.lock(0, Long.MAX_VALUE, true);
-    try (InputStream inputStream = Channels.newInputStream(channel);
-        InputStreamReader inputStreamReader =
-            new InputStreamReader(inputStream, StandardCharsets.UTF_8)) {
-      Assert.assertEquals("jib", CharStreams.toString(inputStreamReader));
-    }
-  }
-
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
   public void testCopy() throws IOException, URISyntaxException {
@@ -89,27 +54,6 @@ public class FileOperationsTest {
     assertFilesEqual(
         dirLayer.resolve("c").resolve("cat"), destDir.resolve("layer").resolve("c").resolve("cat"));
     assertFilesEqual(dirLayer.resolve("foo"), destDir.resolve("layer").resolve("foo"));
-  }
-
-  @Test
-  public void testNewLockingOutputStream_newFile() throws IOException {
-    Path file = Files.createTempFile("", "");
-    // Ensures file doesn't exist.
-    Assert.assertTrue(Files.deleteIfExists(file));
-
-    verifyWriteWithLock(file);
-  }
-
-  @Test
-  public void testNewLockingOutputStream_existingFile() throws IOException {
-    Path file = Files.createTempFile("", "");
-    // Writes out more bytes to ensure proper truncated.
-    byte[] dataBytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
-    Files.write(file, dataBytes, StandardOpenOption.WRITE);
-    Assert.assertTrue(Files.exists(file));
-    Assert.assertEquals(10, Files.size(file));
-
-    verifyWriteWithLock(file);
   }
 
   private void assertFilesEqual(Path file1, Path file2) throws IOException {


### PR DESCRIPTION
I was looking at how we are handling concurrency regarding sharing files and realized there are too many variations. And our use of `FileOperations.newLockingOutputStream()` confuses me, and I think this is not really necessary. 

- `CacheStorageWriter`: locking on a fresh temp file is meaningless. I don't know why we did `newLockingOutputStream()`.
- `WriteTarFileStep`: for this one, it isn't technically meaningless. But this class is for creating an image tar (which can be loaded into Docker with `docker load`), which is by default `<project root>/target/jib-image.tar`. Although the path is configurable, it's unlikely that multiple JVMs (Jib processes) will concurrently write into the same tar path in practice.