### PR TITLE
Improve Jib CLI release workflow

### DIFF
--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -69,7 +69,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./jib-cli/build/distributions/jib-{{ github.event.inputs.release_version }}.zip
+          asset_path: ./jib-cli/build/distributions/jib-${{ github.event.inputs.release_version }}.zip
           asset_name: jib-jre-{{ github.event.inputs.release_version }}.zip
           asset_content_type: application/zip
 
@@ -80,5 +80,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./jib-cli/build/distributions/zip.sha256
-          asset_name: jib-jre-{{ github.event.inputs.release_version }}.zip.sha256
+          asset_name: jib-jre-${{ github.event.inputs.release_version }}.zip.sha256
           asset_content_type: text/plain

--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./jib-cli/build/distributions/jib-${{ github.event.inputs.release_version }}.zip
-          asset_name: jib-jre-{{ github.event.inputs.release_version }}.zip
+          asset_name: jib-jre-${{ github.event.inputs.release_version }}.zip
           asset_content_type: application/zip
 
       - name: Upload Jib CLI checksum

--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -41,10 +41,7 @@ jobs:
           ./gradlew jib-cli:instDist --stacktrace
 
           cd jib-cli/build/distributions
-          mv jib-${{ github.event.inputs.release_version }}.zip \
-            jib-jre-${{ github.event.inputs.release_version }}.zip
-          sha256sum jib-jre-${{ github.event.inputs.release_version }}.zip \
-            > jib-jre-${{ github.event.inputs.release_version }}.zip.sha256
+          sha256sum jib-${{ github.event.inputs.release_version }}.zip > jib-jre.zip.sha256
 
       - name: Create pull request
         uses: repo-sync/pull-request@v2
@@ -73,7 +70,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./jib-cli/build/install/jib-jre.zip
-          asset_name: jib-jre.zip
+          asset_name: jib-jre-{{ github.event.inputs.release_version }}.zip
           asset_content_type: application/zip
 
       - name: Upload Jib CLI checksum
@@ -83,5 +80,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./jib-cli/build/install/jib-jre.zip.sha256
-          asset_name: jib-jre.zip.sha256
+          asset_name: jib-jre-{{ github.event.inputs.release_version }}.zip.sha256
           asset_content_type: text/plain

--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -41,7 +41,7 @@ jobs:
           ./gradlew jib-cli:instDist --stacktrace
 
           cd jib-cli/build/distributions
-          sha256sum jib-${{ github.event.inputs.release_version }}.zip > jib-jre.zip.sha256
+          sha256sum jib-${{ github.event.inputs.release_version }}.zip > zip.sha256
 
       - name: Create pull request
         uses: repo-sync/pull-request@v2
@@ -69,7 +69,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./jib-cli/build/install/jib-jre.zip
+          asset_path: ./jib-cli/build/distributions/jib-{{ github.event.inputs.release_version }}.zip
           asset_name: jib-jre-{{ github.event.inputs.release_version }}.zip
           asset_content_type: application/zip
 
@@ -79,6 +79,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./jib-cli/build/install/jib-jre.zip.sha256
+          asset_path: ./jib-cli/build/distributions/zip.sha256
           asset_name: jib-jre-{{ github.event.inputs.release_version }}.zip.sha256
           asset_content_type: text/plain

--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -40,9 +40,11 @@ jobs:
           git checkout v${{ github.event.inputs.release_version }}-cli
           ./gradlew jib-cli:instDist --stacktrace
 
-          cd jib-cli/build/install
-          zip -rv jib-jre.zip jib
-          sha256sum jib-jre.zip > jib-jre.zip.sha256
+          cd jib-cli/build/distributions
+          mv jib-${{ github.event.inputs.release_version }}.zip \
+            jib-jre-${{ github.event.inputs.release_version }}.zip
+          sha256sum jib-jre-${{ github.event.inputs.release_version }}.zip \
+            > jib-jre-${{ github.event.inputs.release_version }}.zip.sha256
 
       - name: Create pull request
         uses: repo-sync/pull-request@v2


### PR DESCRIPTION
- There exists `build/distributions/jib-<version>.zip`. No need to manually zip.
- Adds version strings to uploaded assets.