### PR TITLE
Add new release checklist to release process for plugins only

### DIFF
--- a/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
@@ -6,7 +6,7 @@ labels: release
 - [ ] ⚠️ Ensure the release process has succeeded before proceeding
 
 ## GCS
-- [ ] Run the `update_gcs_latest.sh` scripts in the {{ env.PROJECT_NAME }} projects to update GCS with the latest version number
+- [ ] Run the `update_gcs_latest.sh {{ env.RELEASE_VERSION }}` scripts in the {{ env.PROJECT_NAME }} projects to update GCS with the latest version number
 
 ## Github
 - [ ] Update [CHANGELOG.md]({{ env.CHANGELOG_URL }})

--- a/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
@@ -26,4 +26,4 @@ labels: release
 ## Announce
 - [ ] Email jib users
 - [ ] Post to [gitter](https://gitter.im/google/jib)
-- [ ] Menntion on all fixed issues that latest release has addressed the issue (usually any closed issues in a milestone)
+- [ ] Menntion on all fixed issues that latest release has addressed the issue (usually any closed issues in a [milestone](https://github.com/GoogleContainerTools/jib/milestones))

--- a/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
@@ -6,7 +6,7 @@ labels: release
 - [ ] ⚠️ Ensure the release process has succeeded before proceeding
 
 ## GCS
-- [ ] Run the `update_gcs_latest.sh {{ env.RELEASE_VERSION }}` scripts in the {{ env.PROJECT_NAME }} projects to update GCS with the latest version number
+- [ ] Run the {{ env.GCS_UPDATE_SCRIPT }} script to update GCS with the latest version number
 
 ## Github
 - [ ] Update [CHANGELOG.md]({{ env.CHANGELOG_URL }})

--- a/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
@@ -6,7 +6,7 @@ labels: release
 - [ ] ⚠️ Ensure the release process has succeeded before proceeding
 
 ## GCS
-- [ ] Run the {{ env.GCS_UPDATE_SCRIPT }} script to update GCS with the latest version number
+- [ ] Run {{ env.GCS_UPDATE_SCRIPT }} script to update GCS with the latest version number
 
 ## Github
 - [ ] Update [CHANGELOG.md]({{ env.CHANGELOG_URL }})

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -96,7 +96,7 @@ jobs:
           RELEASE_NAME: v${{ github.event.inputs.release_version }}-${{ github.event.inputs.project }}
           CHANGELOG_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-${{ github.event.inputs.project }}-plugin/CHANGELOG.md
           README_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-${{ github.event.inputs.project }}-plugin/README.md
-          RELEASE_VERSION: $ {{ github.events.inputs.release_version }}
+          GCS_UPDATE_SCRIPT: "`./jib-${{ github.event.inputs.project }}-plugin/scripts/update_gcs_latest.sh ${{ github.event.inputs.release_version }}`"
           RELEASE_DRAFT: ${{ steps.create-plugin-release.outputs.html_url }}
           RELEASE_PR: ${{steps.create-pr.outputs.pr_url}}
         with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -92,9 +92,11 @@ jobs:
         if: ${{ github.event.inputs.project == 'maven' || github.event.inputs.project == 'gradle' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECT_NAME: jib-${{ github.event.inputs.project }}-plugin
           RELEASE_NAME: v${{ github.event.inputs.release_version }}-${{ github.event.inputs.project }}
           CHANGELOG_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-${{ github.event.inputs.project }}-plugin/CHANGELOG.md
           README_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-${{ github.event.inputs.project }}-plugin/README.md
+          RELEASE_VERSION: $ {{ github.events.inputs.release_version }}
           RELEASE_DRAFT: ${{ steps.create-plugin-release.outputs.html_url }}
           RELEASE_PR: ${{steps.create-pr.outputs.pr_url}}
         with:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -60,6 +60,7 @@ jobs:
 
       - name: Create pull request
         uses: repo-sync/pull-request@v2
+        id: create-pr
         with:
           # Provided by Actions. No need to create a token.
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -70,6 +71,7 @@ jobs:
 
       - name: Draft Maven/Gradle GitHub release
         uses: actions/create-release@v1
+        id: create-plugin-release
         if: ${{ github.event.inputs.project == 'maven' || github.event.inputs.project == 'gradle' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -85,6 +87,19 @@ jobs:
             ### Major Changes
 
             See [CHANGELOG.md](https://github.com/GoogleContainerTools/jib/blob/master/jib-${{ github.event.inputs.project }}-plugin/CHANGELOG.md) for more details.
+      
+      - uses: JasonEtco/create-an-issue@v2
+        if: ${{ github.event.inputs.project == 'maven' || github.event.inputs.project == 'gradle' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NAME: v${{ github.event.inputs.release_version }}-${{ github.event.inputs.project }}
+          CHANGELOG_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-${{ github.event.inputs.project }}-plugin/CHANGELOG.md
+          README_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-${{ github.event.inputs.project }}-plugin/README.md
+          RELEASE_DRAFT: ${{ steps.create-plugin-release.outputs.html_url }}
+          RELEASE_PR: ${{steps.create-pr.outputs.pr_url}}
+        with:
+          filename: .github/RELEASE_TEMPLATES/plugin_release_checklist.md
+
 
       - name: Draft Jib Core GitHub release
         uses: actions/create-release@v1

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -92,7 +92,6 @@ jobs:
         if: ${{ github.event.inputs.project == 'maven' || github.event.inputs.project == 'gradle' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PROJECT_NAME: jib-${{ github.event.inputs.project }}-plugin
           RELEASE_NAME: v${{ github.event.inputs.release_version }}-${{ github.event.inputs.project }}
           CHANGELOG_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-${{ github.event.inputs.project }}-plugin/CHANGELOG.md
           README_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-${{ github.event.inputs.project }}-plugin/README.md

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -88,7 +88,8 @@ jobs:
 
             See [CHANGELOG.md](https://github.com/GoogleContainerTools/jib/blob/master/jib-${{ github.event.inputs.project }}-plugin/CHANGELOG.md) for more details.
       
-      - uses: JasonEtco/create-an-issue@v2
+      - name: Create Maven/Gradle release checklist issue
+        uses: JasonEtco/create-an-issue@v2
         if: ${{ github.event.inputs.project == 'maven' || github.event.inputs.project == 'gradle' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This will only create a release checklist for the plugin releases.
