### PR TITLE
Improve progress reporting in PullBaseImageStep

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -339,17 +339,17 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
         (BuildableManifestTemplate) manifestAndDigest.getManifest();
     Preconditions.checkArgument(manifest.getSchemaVersion() == 2);
 
+    if (manifest.getContainerConfiguration() == null
+        || manifest.getContainerConfiguration().getDigest() == null) {
+      throw new UnknownManifestFormatException(
+          "Invalid container configuration in Docker V2.2/OCI manifest: \n"
+              + JsonTemplateMapper.toUtf8String(manifest));
+    }
+
     try (ThrottledProgressEventDispatcherWrapper progressDispatcherWrapper =
         new ThrottledProgressEventDispatcherWrapper(
             progressDispatcherFactory,
             "pull container configuration " + manifest.getContainerConfiguration().getDigest())) {
-      if (manifest.getContainerConfiguration() == null
-          || manifest.getContainerConfiguration().getDigest() == null) {
-        throw new UnknownManifestFormatException(
-            "Invalid container configuration in Docker V2.2/OCI manifest: \n"
-                + JsonTemplateMapper.toUtf8String(manifest));
-      }
-
       String containerConfigString =
           Blobs.writeToString(
               registryClient.pullBlob(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -270,7 +270,7 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
                   (V22ManifestListTemplate) manifestTemplate, platform);
           // TODO: pull multiple manifests (+ container configs) in parallel.
           ManifestAndDigest<?> imageManifestAndDigest = registryClient.pullManifest(manifestDigest);
-          progressDispatcher1.dispatchProgress(1);
+          progressDispatcher2.dispatchProgress(1);
 
           BuildableManifestTemplate imageManifest =
               (BuildableManifestTemplate) imageManifestAndDigest.getManifest();


### PR DESCRIPTION
`PullBaseImageStep` has got complicated over time, and the progress reporting was broken. I am trying to improve the situation with this PR. It's still not perfect, but I think it's better.

- At function call boundaries, I think it's often better to pass a dispatcher factory. The callee will have the freedom to decide how to sub-divide the given progress node.
- I think it's more robust to do `try (... = factory.create("description", size)) { ... }` at the beginning of a function as early as possible.