### PR TITLE
Improve assertions in tests

### DIFF
--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
@@ -46,7 +46,9 @@ public class JarTest {
         assertThrows(
             MissingParameterException.class,
             () -> CommandLine.populateCommand(new Jar(), "my-app.jar"));
-    assertThat(mpe.getMessage()).isEqualTo("Missing required option: '--target=<target-image>'");
+    assertThat(mpe)
+        .hasMessageThat()
+        .isEqualTo("Missing required option: '--target=<target-image>'");
   }
 
   @Test
@@ -55,7 +57,7 @@ public class JarTest {
         assertThrows(
             MissingParameterException.class,
             () -> CommandLine.populateCommand(new Jar(), "--target=test-image-ref"));
-    assertThat(mpe.getMessage()).isEqualTo("Missing required parameter: '<jarFile>'");
+    assertThat(mpe).hasMessageThat().isEqualTo("Missing required parameter: '<jarFile>'");
   }
 
   @Test
@@ -358,7 +360,9 @@ public class JarTest {
                     usernameField,
                     "test-username",
                     "my-app.jar"));
-    assertThat(mpe.getMessage()).isEqualTo("Error: Missing required argument(s): " + passwordField);
+    assertThat(mpe)
+        .hasMessageThat()
+        .isEqualTo("Error: Missing required argument(s): " + passwordField);
   }
 
   @Test
@@ -374,7 +378,8 @@ public class JarTest {
                     passwordField,
                     "test-password",
                     "my-app.jar"));
-    assertThat(mpe.getMessage())
+    assertThat(mpe)
+        .hasMessageThat()
         .isEqualTo("Error: Missing required argument(s): " + usernameField + "=<username>");
   }
 
@@ -519,7 +524,8 @@ public class JarTest {
         CommandLine.populateCommand(new Jar(), "--target=tar://sometar.tar", "my-app.jar");
     CommandLine.ParameterException pex =
         assertThrows(CommandLine.ParameterException.class, jarCommand.commonCliOptions::validate);
-    assertThat(pex.getMessage())
+    assertThat(pex)
+        .hasMessageThat()
         .isEqualTo("Missing option: --name must be specified when using --target=tar://....");
   }
 

--- a/jib-maven-plugin/build.gradle
+++ b/jib-maven-plugin/build.gradle
@@ -28,6 +28,8 @@ dependencies {
   testImplementation dependencyStrings.MAVEN_TESTING_HARNESS
 
   testImplementation dependencyStrings.JUNIT
+  testImplementation dependencyStrings.TRUTH
+  testImplementation dependencyStrings.TRUTH8
   testImplementation dependencyStrings.MOCKITO_CORE
   testImplementation dependencyStrings.SLF4J_API
   testImplementation dependencyStrings.SYSTEM_RULES

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojoTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/skaffold/SyncMapMojoTest.java
@@ -16,6 +16,9 @@
 
 package com.google.cloud.tools.jib.maven.skaffold;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.maven.TestProject;
 import com.google.cloud.tools.jib.plugins.common.SkaffoldSyncMapTemplate;
@@ -157,28 +160,27 @@ public class SyncMapMojoTest {
   @Test
   public void testSyncMapMojo_failIfPackagingNotJar() throws IOException {
     Path projectRoot = warProject.getProjectRoot();
-    try {
-      runBuild(projectRoot, null, null);
-      Assert.fail();
-    } catch (VerificationException ex) {
-      Assert.assertTrue(
-          ex.getMessage()
-              .contains(
-                  "org.apache.maven.plugin.MojoExecutionException: Skaffold sync is currently only available for 'jar' style Jib projects, but the packaging of servlet25 is 'war'"));
-    }
+    VerificationException ve =
+        assertThrows(VerificationException.class, () -> runBuild(projectRoot, null, null));
+    assertThat(ve)
+        .hasMessageThat()
+        .contains(
+            "MojoExecutionException: Skaffold sync is currently only available for 'jar' style Jib "
+                + "projects, but the packaging of servlet25 is 'war'");
   }
 
   @Test
   public void testSyncMapMojo_failIfJarContainerizationMode() throws IOException {
     Path projectRoot = simpleTestProject.getProjectRoot();
-    try {
-      runBuild(projectRoot, null, "pom-jar-containerization.xml");
-      Assert.fail();
-    } catch (VerificationException ex) {
-      Assert.assertTrue(
-          ex.getMessage()
-              .contains(
-                  "org.apache.maven.plugin.MojoExecutionException: Skaffold sync is currently only available for Jib projects in 'exploded' containerizing mode, but the containerizing mode of hello-world is 'packaged'"));
-    }
+    VerificationException ve =
+        assertThrows(
+            VerificationException.class,
+            () -> runBuild(projectRoot, null, "pom-jar-containerization.xml"));
+    assertThat(ve)
+        .hasMessageThat()
+        .contains(
+            "MojoExecutionException: Skaffold sync is currently only available for Jib projects in "
+                + "'exploded' containerizing mode, but the containerizing mode of hello-world is "
+                + "'packaged'");
   }
 }


### PR DESCRIPTION
I have seen the flaky test failure several times on Kokoro. Looking at the test, I don't think there is a critical bug. However, the next time we see it, we'd want to get more information.

```
com.google.cloud.tools.jib.maven.skaffold.SyncMapMojoTest > testSyncMapMojo_failIfJarContainerizationMode FAILED
    java.lang.AssertionError
        at org.junit.Assert.fail(Assert.java:87)
        at org.junit.Assert.assertTrue(Assert.java:42)
        at org.junit.Assert.assertTrue(Assert.java:53)
        at com.google.cloud.tools.jib.maven.skaffold.SyncMapMojoTest.testSyncMapMojo_failIfJarContainerizationMode(SyncMapMojoTest.java:178)

Gradle Test Executor 6 finished executing tests.
```