### PR TITLE
[jib-cli-jar] Add option to specify creation time of container

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Instants.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Instants.java
@@ -14,7 +14,7 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.cli.buildfile;
+package com.google.cloud.tools.jib.cli;
 
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
@@ -22,7 +22,7 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.DateTimeParseException;
 
 /** Helper class to convert various strings in a buildfile to Instants. */
-class Instants {
+public class Instants {
   /**
    * Parses a time string into Instant. The string must be time in milliseconds since unix epoch or
    * an iso8601 datetime.
@@ -31,7 +31,7 @@ class Instants {
    * @param fieldName name of field being parsed (for error messaging)
    * @return Instant value of parsed time
    */
-  static Instant fromMillisOrIso8601(String time, String fieldName) {
+  public static Instant fromMillisOrIso8601(String time, String fieldName) {
     try {
       return Instant.ofEpochMilli(Long.parseLong(time));
     } catch (NumberFormatException nfe) {

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -279,8 +279,9 @@ public class Jar implements Callable<Integer> {
    * @return an optional creation time
    */
   public Optional<Instant> getCreationTime() {
-    return (creationTime == null)
-        ? Optional.empty()
-        : Optional.of(Instants.fromMillisOrIso8601(creationTime, "creationTime"));
+    if (creationTime != null) {
+      return Optional.of(Instants.fromMillisOrIso8601(creationTime, "creationTime"));
+    }
+    return Optional.empty();
   }
 }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -36,6 +36,7 @@ import com.google.common.collect.ImmutableSet;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -151,6 +152,14 @@ public class Jar implements Callable<Integer> {
           "Entrypoint for container. Overrides the default entrypoint, example: --entrypoint='custom entrypoint'")
   private List<String> entrypoint = Collections.emptyList();
 
+  @CommandLine.Option(
+      names = "--creation-time",
+      paramLabel = "<creation-time>",
+      description =
+          "The creation time of the container in milliseconds since epoch or iso8601 format")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  private String creationTime;
+
   @Override
   public Integer call() {
     try {
@@ -263,5 +272,16 @@ public class Jar implements Callable<Integer> {
 
   public List<String> getEntrypoint() {
     return entrypoint;
+  }
+
+  /**
+   * Returns {@link Instant} representing creation time of container.
+   *
+   * @return an optional creation time
+   */
+  public Optional<Instant> getCreationTime() {
+    return (creationTime == null)
+        ? Optional.empty()
+        : Optional.of(Instants.fromMillisOrIso8601(creationTime, "creationTime"));
   }
 }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -155,7 +155,7 @@ public class Jar implements Callable<Integer> {
       names = "--creation-time",
       paramLabel = "<creation-time>",
       description =
-          "The creation time of the container in milliseconds since epoch or iso8601 format")
+          "The creation time of the container in milliseconds since epoch or iso8601 format. Overrides the default (1970-01-01T00:00:00Z)")
   @SuppressWarnings("NullAway.Init") // initialized by picocli
   private String creationTime;
 

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFileSpec.java
@@ -22,6 +22,7 @@ import com.google.cloud.tools.jib.api.Ports;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
 import com.google.cloud.tools.jib.api.buildplan.Port;
+import com.google.cloud.tools.jib.cli.Instants;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesSpec.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesSpec.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.cli.buildfile;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.cloud.tools.jib.api.buildplan.FilePermissions;
+import com.google.cloud.tools.jib.cli.Instants;
 import java.time.Instant;
 import java.util.Optional;
 import javax.annotation.Nullable;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
@@ -74,6 +74,7 @@ public class JarFiles {
         .setProgramArguments(jarOptions.getProgramArguments());
     jarOptions.getUser().ifPresent(containerBuilder::setUser);
     jarOptions.getFormat().ifPresent(containerBuilder::setFormat);
+    jarOptions.getCreationTime().ifPresent(containerBuilder::setCreationTime);
 
     return containerBuilder;
   }

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/InstantsTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/InstantsTest.java
@@ -20,7 +20,7 @@ import java.time.Instant;
 import org.junit.Assert;
 import org.junit.Test;
 
-/** Tests for {@link com.google.cloud.tools.jib.cli.Instants}. */
+/** Tests for {@link Instants}. */
 public class InstantsTest {
 
   @Test

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/InstantsTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/InstantsTest.java
@@ -14,13 +14,13 @@
  * the License.
  */
 
-package com.google.cloud.tools.jib.cli.buildfile;
+package com.google.cloud.tools.jib.cli;
 
 import java.time.Instant;
 import org.junit.Assert;
 import org.junit.Test;
 
-/** Tests for {@link Instants}. */
+/** Tests for {@link com.google.cloud.tools.jib.cli.Instants}. */
 public class InstantsTest {
 
   @Test

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
@@ -502,13 +502,6 @@ public class JarTest {
   }
 
   @Test
-  public void testParse_noImageFormat() {
-    Jar jarCommand =
-        CommandLine.populateCommand(new Jar(), "--target=test-image-ref", "my-app.jar");
-    assertThat(jarCommand.getFormat()).hasValue(ImageFormat.Docker);
-  }
-
-  @Test
   public void testParse_invalidImageFormat() {
     CommandLine.ParameterException exception =
         assertThrows(

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
@@ -520,11 +520,22 @@ public class JarTest {
   }
 
   @Test
-  public void testParse_creationTime() {
+  public void testParse_creationTime_milliseconds() {
     Jar jarCommand =
         CommandLine.populateCommand(
             new Jar(), "--target=test-image-ref", "--creation-time=23", "my-app.jar");
     assertThat(jarCommand.getCreationTime()).hasValue(Instant.ofEpochMilli(23));
+  }
+
+  @Test
+  public void testParse_creationTime_iso8601() {
+    Jar jarCommand =
+        CommandLine.populateCommand(
+            new Jar(),
+            "--target=test-image-ref",
+            "--creation-time=2011-12-03T22:42:05Z",
+            "my-app.jar");
+    assertThat(jarCommand.getCreationTime()).hasValue(Instant.parse("2011-12-03T22:42:05Z"));
   }
 
   @Test

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
@@ -29,6 +29,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.nio.file.Paths;
+import java.time.Instant;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import org.apache.commons.lang3.ArrayUtils;
@@ -516,6 +517,14 @@ public class JarTest {
         CommandLine.populateCommand(
             new Jar(), "--target=test-image-ref", "--entrypoint=java -cp myClass", "my-app.jar");
     assertThat(jarCommand.getEntrypoint()).isEqualTo(ImmutableList.of("java", "-cp", "myClass"));
+  }
+
+  @Test
+  public void testParse_creationTime() {
+    Jar jarCommand =
+        CommandLine.populateCommand(
+            new Jar(), "--target=test-image-ref", "--creation-time=23", "my-app.jar");
+    assertThat(jarCommand.getCreationTime()).hasValue(Instant.ofEpochMilli(23));
   }
 
   @Test

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
@@ -558,13 +558,6 @@ public class JarTest {
   }
 
   @Test
-  public void testParse_noCreationTime() {
-    Jar jarCommand =
-        CommandLine.populateCommand(new Jar(), "--target=test-image-ref", "my-app.jar");
-    assertThat(jarCommand.getCreationTime()).isEmpty();
-  }
-
-  @Test
   public void testValidate_nameMissingFail() {
     Jar jarCommand =
         CommandLine.populateCommand(new Jar(), "--target=tar://sometar.tar", "my-app.jar");

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
@@ -65,6 +65,7 @@ public class JarTest {
   public void testParse_defaults() {
     Jar jarCommand = CommandLine.populateCommand(new Jar(), "-t", "test-image-ref", "my-app.jar");
     CommonCliOptions commonCliOptions = jarCommand.commonCliOptions;
+
     assertThat(commonCliOptions.getTargetImage()).isEqualTo("test-image-ref");
     assertThat(commonCliOptions.getUsernamePassword()).isEmpty();
     assertThat(commonCliOptions.getToUsernamePassword()).isEmpty();
@@ -81,6 +82,17 @@ public class JarTest {
     assertThat(commonCliOptions.isStacktrace()).isFalse();
     assertThat(commonCliOptions.isHttpTrace()).isFalse();
     assertThat(commonCliOptions.isSerialize()).isFalse();
+    assertThat(jarCommand.getFrom()).isEmpty();
+    assertThat(jarCommand.getJvmFlags()).isEmpty();
+    assertThat(jarCommand.getExposedPorts()).isEmpty();
+    assertThat(jarCommand.getVolumes()).isEmpty();
+    assertThat(jarCommand.getEnvironment()).isEmpty();
+    assertThat(jarCommand.getLabels()).isEmpty();
+    assertThat(jarCommand.getUser()).isEmpty();
+    assertThat(jarCommand.getFormat()).hasValue(ImageFormat.Docker);
+    assertThat(jarCommand.getProgramArguments()).isEmpty();
+    assertThat(jarCommand.getEntrypoint()).isEmpty();
+    assertThat(jarCommand.getCreationTime()).isEmpty();
   }
 
   @Test
@@ -490,6 +502,13 @@ public class JarTest {
   }
 
   @Test
+  public void testParse_noImageFormat() {
+    Jar jarCommand =
+        CommandLine.populateCommand(new Jar(), "--target=test-image-ref", "my-app.jar");
+    assertThat(jarCommand.getFormat()).hasValue(ImageFormat.Docker);
+  }
+
+  @Test
   public void testParse_invalidImageFormat() {
     CommandLine.ParameterException exception =
         assertThrows(
@@ -536,6 +555,13 @@ public class JarTest {
             "--creation-time=2011-12-03T22:42:05Z",
             "my-app.jar");
     assertThat(jarCommand.getCreationTime()).hasValue(Instant.parse("2011-12-03T22:42:05Z"));
+  }
+
+  @Test
+  public void testParse_noCreationTime() {
+    Jar jarCommand =
+        CommandLine.populateCommand(new Jar(), "--target=test-image-ref", "my-app.jar");
+    assertThat(jarCommand.getCreationTime()).isEmpty();
   }
 
   @Test

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarFilesTest.java
@@ -255,6 +255,8 @@ public class JarFilesTest {
     Mockito.when(mockJarCommand.getProgramArguments()).thenReturn(ImmutableList.of("arg1"));
     Mockito.when(mockJarCommand.getEntrypoint())
         .thenReturn(ImmutableList.of("custom", "entrypoint"));
+    Mockito.when(mockJarCommand.getCreationTime())
+        .thenReturn(Optional.of(Instant.ofEpochSecond(5)));
 
     JibContainerBuilder containerBuilder =
         JarFiles.toJibContainerBuilder(
@@ -272,5 +274,6 @@ public class JarFilesTest {
     assertThat(buildPlan.getFormat()).isEqualTo(ImageFormat.OCI);
     assertThat(buildPlan.getCmd()).isEqualTo(ImmutableList.of("arg1"));
     assertThat(buildPlan.getEntrypoint()).isEqualTo(ImmutableList.of("custom", "entrypoint"));
+    assertThat(buildPlan.getCreationTime()).isEqualTo(Instant.ofEpochSecond(5));
   }
 }


### PR DESCRIPTION
Required a bit of refactoring to use the `Instants` class which was initially implemented for the build command. 
