### PR TITLE
Disable coloring in build output when `--console=plain` is used

### DIFF
--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLogger.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLogger.java
@@ -50,7 +50,7 @@ class PlainConsoleLogger implements ConsoleLogger {
     Consumer<String> messageConsumer = messageConsumers.get(logLevel);
 
     // remove the color from the message
-    final String plainMessage = message.replaceAll("\u001B\\[[0-9]{1,3}m", "");
+    final String plainMessage = message.replaceAll("\u001B\\[[0-9;]{1,5}m", "");
     singleThreadedExecutor.execute(() -> messageConsumer.accept(plainMessage));
   }
 

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLogger.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLogger.java
@@ -49,7 +49,9 @@ class PlainConsoleLogger implements ConsoleLogger {
     }
     Consumer<String> messageConsumer = messageConsumers.get(logLevel);
 
-    singleThreadedExecutor.execute(() -> messageConsumer.accept(message));
+    // remove the color from the message
+    final String plainMessage = message.replaceAll("\u001B\\[[0-9]{1,3}m", "");
+    singleThreadedExecutor.execute(() -> messageConsumer.accept(plainMessage));
   }
 
   @Override

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLoggerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLoggerTest.java
@@ -49,12 +49,12 @@ public class PlainConsoleLoggerTest {
     testPlainConsoleLogger =
         new PlainConsoleLogger(messageConsumers.build(), singleThreadedExecutor);
 
-    testPlainConsoleLogger.log(Level.LIFECYCLE, "lifecycle");
-    testPlainConsoleLogger.log(Level.PROGRESS, "progress");
+    testPlainConsoleLogger.log(Level.LIFECYCLE, "\u001B[36;1mlifecycle\u001B[0m");
+    testPlainConsoleLogger.log(Level.PROGRESS, "\u001B[33m progress\u001B[0m");
     testPlainConsoleLogger.log(Level.INFO, "info");
     testPlainConsoleLogger.log(Level.DEBUG, "debug");
     testPlainConsoleLogger.log(Level.WARN, "warn");
-    testPlainConsoleLogger.log(Level.ERROR, "error");
+    testPlainConsoleLogger.log(Level.ERROR, "\u001B[31;1m error \u001B[0m");
 
     singleThreadedExecutor.shutDownAndAwaitTermination(SHUTDOWN_TIMEOUT);
 
@@ -63,7 +63,7 @@ public class PlainConsoleLoggerTest {
             Level.LIFECYCLE, Level.PROGRESS, Level.INFO, Level.DEBUG, Level.WARN, Level.ERROR),
         levels);
     Assert.assertEquals(
-        Arrays.asList("lifecycle", "progress", "info", "debug", "warn", "error"), messages);
+        Arrays.asList("lifecycle", " progress", "info", "debug", "warn", " error "), messages);
   }
 
   @Test

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLoggerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLoggerTest.java
@@ -74,7 +74,7 @@ public class PlainConsoleLoggerTest {
     }
 
     testPlainConsoleLogger =
-            new PlainConsoleLogger(messageConsumers.build(), singleThreadedExecutor);
+        new PlainConsoleLogger(messageConsumers.build(), singleThreadedExecutor);
 
     testPlainConsoleLogger.log(Level.LIFECYCLE, "\u001B[36;1mlifecycle\u001B[0m");
     testPlainConsoleLogger.log(Level.PROGRESS, "\u001B[33mprogress\u001B[0m");
@@ -82,12 +82,8 @@ public class PlainConsoleLoggerTest {
 
     singleThreadedExecutor.shutDownAndAwaitTermination(SHUTDOWN_TIMEOUT);
 
-    Assert.assertEquals(
-            Arrays.asList(
-                    Level.LIFECYCLE, Level.PROGRESS, Level.ERROR),
-            levels);
-    Assert.assertEquals(
-            Arrays.asList("lifecycle", "progress", "error"), messages);
+    Assert.assertEquals(Arrays.asList(Level.LIFECYCLE, Level.PROGRESS, Level.ERROR), levels);
+    Assert.assertEquals(Arrays.asList("lifecycle", "progress", "error"), messages);
   }
 
   @Test

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLoggerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/logging/PlainConsoleLoggerTest.java
@@ -49,12 +49,12 @@ public class PlainConsoleLoggerTest {
     testPlainConsoleLogger =
         new PlainConsoleLogger(messageConsumers.build(), singleThreadedExecutor);
 
-    testPlainConsoleLogger.log(Level.LIFECYCLE, "\u001B[36;1mlifecycle\u001B[0m");
-    testPlainConsoleLogger.log(Level.PROGRESS, "\u001B[33m progress\u001B[0m");
+    testPlainConsoleLogger.log(Level.LIFECYCLE, "lifecycle");
+    testPlainConsoleLogger.log(Level.PROGRESS, "progress");
     testPlainConsoleLogger.log(Level.INFO, "info");
     testPlainConsoleLogger.log(Level.DEBUG, "debug");
     testPlainConsoleLogger.log(Level.WARN, "warn");
-    testPlainConsoleLogger.log(Level.ERROR, "\u001B[31;1m error \u001B[0m");
+    testPlainConsoleLogger.log(Level.ERROR, "error");
 
     singleThreadedExecutor.shutDownAndAwaitTermination(SHUTDOWN_TIMEOUT);
 
@@ -63,7 +63,31 @@ public class PlainConsoleLoggerTest {
             Level.LIFECYCLE, Level.PROGRESS, Level.INFO, Level.DEBUG, Level.WARN, Level.ERROR),
         levels);
     Assert.assertEquals(
-        Arrays.asList("lifecycle", " progress", "info", "debug", "warn", " error "), messages);
+        Arrays.asList("lifecycle", "progress", "info", "debug", "warn", "error"), messages);
+  }
+
+  @Test
+  public void testLog_filterOutColors() {
+    ImmutableMap.Builder<Level, Consumer<String>> messageConsumers = ImmutableMap.builder();
+    for (Level level : Level.values()) {
+      messageConsumers.put(level, createMessageConsumer(level));
+    }
+
+    testPlainConsoleLogger =
+            new PlainConsoleLogger(messageConsumers.build(), singleThreadedExecutor);
+
+    testPlainConsoleLogger.log(Level.LIFECYCLE, "\u001B[36;1mlifecycle\u001B[0m");
+    testPlainConsoleLogger.log(Level.PROGRESS, "\u001B[33mprogress\u001B[0m");
+    testPlainConsoleLogger.log(Level.ERROR, "\u001B[31;1merror\u001B[0m");
+
+    singleThreadedExecutor.shutDownAndAwaitTermination(SHUTDOWN_TIMEOUT);
+
+    Assert.assertEquals(
+            Arrays.asList(
+                    Level.LIFECYCLE, Level.PROGRESS, Level.ERROR),
+            levels);
+    Assert.assertEquals(
+            Arrays.asList("lifecycle", "progress", "error"), messages);
   }
 
   @Test


### PR DESCRIPTION
<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->
Fixes #2764