### PR TITLE
Check if base image has been specified before throwing IllegalArgumentException in JarProcessors

### DIFF
--- a/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
+++ b/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
@@ -159,21 +159,6 @@ public class JarCommandTest {
   }
 
   @Test
-  public void testJar_unknownMode() {
-    StringWriter stringWriter = new StringWriter();
-    CommandLine jibCli = new CommandLine(new JibCli()).setErr(new PrintWriter(stringWriter));
-
-    Integer exitCode =
-        jibCli.execute(
-            "jar", "--target", "docker://jib-cli-image", "ignored.jar", "--mode=unknown");
-
-    assertThat(exitCode).isEqualTo(2);
-    assertThat(stringWriter.toString())
-        .contains(
-            "Invalid value for option '--mode': expected one of [exploded, packaged] (case-sensitive) but was 'unknown'");
-  }
-
-  @Test
   public void testSpringBootLayeredJar_explodedMode() throws IOException, InterruptedException {
     springBootProject.build("-c", "settings-layered.gradle", "clean", "bootJar");
     Path jarParentPath = springBootProject.getProjectRoot().resolve("build").resolve("libs");

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -197,7 +197,7 @@ public class Jar implements Callable<Integer> {
 
       CacheDirectories cacheDirectories =
           CacheDirectories.from(commonCliOptions, jarFile.toAbsolutePath().getParent());
-      JarProcessor processor = JarProcessors.from(jarFile, cacheDirectories, mode);
+      JarProcessor processor = JarProcessors.from(jarFile, cacheDirectories, this);
       JibContainerBuilder containerBuilder =
           JarFiles.toJibContainerBuilder(processor, this, commonCliOptions, logger);
       Containerizer containerizer = Containerizers.from(commonCliOptions, logger, cacheDirectories);
@@ -283,5 +283,9 @@ public class Jar implements Callable<Integer> {
       return Optional.of(Instants.fromMillisOrIso8601(creationTime, "creationTime"));
     }
     return Optional.empty();
+  }
+
+  public ProcessingMode getMode() {
+    return mode;
   }
 }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarProcessors.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarProcessors.java
@@ -39,7 +39,7 @@ public class JarProcessors {
    *
    * @param jarPath path to the jar
    * @param cacheDirectories the location of the relevant caches
-   * @param jarOptions jar command line options
+   * @param jarOptions jar cli options
    * @return JarProcessor
    * @throws IOException if I/O error occurs when opening the jar file
    */

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarProcessors.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarProcessors.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.cli.jar;
 
 import com.google.cloud.tools.jib.cli.CacheDirectories;
+import com.google.cloud.tools.jib.cli.Jar;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.DataInputStream;
 import java.io.IOException;
@@ -38,14 +39,14 @@ public class JarProcessors {
    *
    * @param jarPath path to the jar
    * @param cacheDirectories the location of the relevant caches
-   * @param mode processing mode
+   * @param jarOptions jar command line options
    * @return JarProcessor
    * @throws IOException if I/O error occurs when opening the jar file
    */
-  public static JarProcessor from(
-      Path jarPath, CacheDirectories cacheDirectories, ProcessingMode mode) throws IOException {
+  public static JarProcessor from(Path jarPath, CacheDirectories cacheDirectories, Jar jarOptions)
+      throws IOException {
     Integer jarJavaVersion = determineJavaMajorVersion(jarPath);
-    if (jarJavaVersion > 11) {
+    if (jarJavaVersion > 11 && !jarOptions.getFrom().isPresent()) {
       throw new IllegalStateException(
           "The input JAR ("
               + jarPath
@@ -55,6 +56,7 @@ public class JarProcessors {
     }
 
     String jarType = determineJarType(jarPath);
+    ProcessingMode mode = jarOptions.getMode();
     if (jarType.equals(SPRING_BOOT) && mode.equals(ProcessingMode.packaged)) {
       return new SpringBootPackagedProcessor(jarPath, jarJavaVersion);
     } else if (jarType.equals(SPRING_BOOT) && mode.equals(ProcessingMode.exploded)) {

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
@@ -553,7 +553,7 @@ public class JarTest {
   }
 
   @Test
-  public void testParse_mode_packaged() {
+  public void testParse_mode() {
     Jar jarCommand =
         CommandLine.populateCommand(
             new Jar(), "--target=test-image-ref", "--mode=packaged", "my-app.jar");

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
@@ -24,6 +24,7 @@ import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.api.Ports;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
+import com.google.cloud.tools.jib.cli.jar.ProcessingMode;
 import com.google.cloud.tools.jib.cli.logging.Verbosity;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -93,6 +94,7 @@ public class JarTest {
     assertThat(jarCommand.getProgramArguments()).isEmpty();
     assertThat(jarCommand.getEntrypoint()).isEmpty();
     assertThat(jarCommand.getCreationTime()).isEmpty();
+    assertThat(jarCommand.getMode()).isEqualTo(ProcessingMode.exploded);
   }
 
   @Test
@@ -548,6 +550,28 @@ public class JarTest {
             "--creation-time=2011-12-03T22:42:05Z",
             "my-app.jar");
     assertThat(jarCommand.getCreationTime()).hasValue(Instant.parse("2011-12-03T22:42:05Z"));
+  }
+
+  @Test
+  public void testParse_mode_packaged() {
+    Jar jarCommand =
+        CommandLine.populateCommand(
+            new Jar(), "--target=test-image-ref", "--mode=packaged", "my-app.jar");
+    assertThat(jarCommand.getMode()).isEqualTo(ProcessingMode.packaged);
+  }
+
+  @Test
+  public void testParse_invalidMode() {
+    CommandLine.ParameterException exception =
+        assertThrows(
+            CommandLine.ParameterException.class,
+            () ->
+                CommandLine.populateCommand(
+                    new Jar(), "--target=test-image-ref", "--mode=unknown", "my-app.jar"));
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo(
+            "Invalid value for option '--mode': expected one of [exploded, packaged] (case-sensitive) but was 'unknown'");
   }
 
   @Test

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarProcessorsTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarProcessorsTest.java
@@ -125,7 +125,8 @@ public class JarProcessorsTest {
   }
 
   @Test
-  public void testGetMajorJavaVersion_versionNotFound() throws URISyntaxException, IOException {
+  public void testDetermineJavaMajorVersion_versionNotFound()
+      throws URISyntaxException, IOException {
     Path jarPath = Paths.get(Resources.getResource(STANDARD).toURI());
     Integer version = JarProcessors.determineJavaMajorVersion(jarPath);
     assertThat(version).isEqualTo(0);

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarProcessorsTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarProcessorsTest.java
@@ -99,7 +99,7 @@ public class JarProcessorsTest {
   }
 
   @Test
-  public void testFrom_incompatibleBaseImage() throws URISyntaxException {
+  public void testFrom_incompatibleDefaultBaseImage() throws URISyntaxException {
     Path jarPath = Paths.get(Resources.getResource(JAVA_14_JAR).toURI());
 
     IllegalStateException exception =
@@ -112,7 +112,7 @@ public class JarProcessorsTest {
   }
 
   @Test
-  public void testFrom_incompatibleBaseImage_baseImageSpecified()
+  public void testFrom_incompatibleDefaultBaseImage_baseImageSpecified()
       throws URISyntaxException, IOException {
     Path jarPath = Paths.get(Resources.getResource(JAVA_14_JAR).toURI());
     when(mockJarCommand.getMode()).thenReturn(ProcessingMode.exploded);

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarProcessorsTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarProcessorsTest.java
@@ -23,11 +23,13 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.google.cloud.tools.jib.cli.CacheDirectories;
+import com.google.cloud.tools.jib.cli.Jar;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -44,6 +46,7 @@ public class JarProcessorsTest {
   private static final String JAVA_14_JAR = "jar/java14WithModuleInfo.jar";
 
   @Mock private CacheDirectories mockCacheDirectories;
+  @Mock private Jar mockJarCommand;
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -52,9 +55,9 @@ public class JarProcessorsTest {
     Path jarPath = Paths.get(Resources.getResource(STANDARD).toURI());
     Path explodedJarRoot = temporaryFolder.getRoot().toPath();
     when(mockCacheDirectories.getExplodedJarDirectory()).thenReturn(explodedJarRoot);
+    when(mockJarCommand.getMode()).thenReturn(ProcessingMode.exploded);
 
-    JarProcessor processor =
-        JarProcessors.from(jarPath, mockCacheDirectories, ProcessingMode.exploded);
+    JarProcessor processor = JarProcessors.from(jarPath, mockCacheDirectories, mockJarCommand);
 
     verify(mockCacheDirectories).getExplodedJarDirectory();
     assertThat(processor).isInstanceOf(StandardExplodedProcessor.class);
@@ -63,8 +66,9 @@ public class JarProcessorsTest {
   @Test
   public void testFrom_standardPackaged() throws IOException, URISyntaxException {
     Path jarPath = Paths.get(Resources.getResource(STANDARD).toURI());
-    JarProcessor processor =
-        JarProcessors.from(jarPath, mockCacheDirectories, ProcessingMode.packaged);
+    when(mockJarCommand.getMode()).thenReturn(ProcessingMode.packaged);
+
+    JarProcessor processor = JarProcessors.from(jarPath, mockCacheDirectories, mockJarCommand);
 
     verifyNoInteractions(mockCacheDirectories);
     assertThat(processor).isInstanceOf(StandardPackagedProcessor.class);
@@ -73,8 +77,9 @@ public class JarProcessorsTest {
   @Test
   public void testFrom_springBootPackaged() throws IOException, URISyntaxException {
     Path jarPath = Paths.get(Resources.getResource(SPRING_BOOT).toURI());
-    JarProcessor processor =
-        JarProcessors.from(jarPath, mockCacheDirectories, ProcessingMode.packaged);
+    when(mockJarCommand.getMode()).thenReturn(ProcessingMode.packaged);
+
+    JarProcessor processor = JarProcessors.from(jarPath, mockCacheDirectories, mockJarCommand);
 
     verifyNoInteractions(mockCacheDirectories);
     assertThat(processor).isInstanceOf(SpringBootPackagedProcessor.class);
@@ -85,9 +90,9 @@ public class JarProcessorsTest {
     Path jarPath = Paths.get(Resources.getResource(SPRING_BOOT).toURI());
     Path explodedJarRoot = temporaryFolder.getRoot().toPath();
     when(mockCacheDirectories.getExplodedJarDirectory()).thenReturn(explodedJarRoot);
+    when(mockJarCommand.getMode()).thenReturn(ProcessingMode.exploded);
 
-    JarProcessor processor =
-        JarProcessors.from(jarPath, mockCacheDirectories, ProcessingMode.exploded);
+    JarProcessor processor = JarProcessors.from(jarPath, mockCacheDirectories, mockJarCommand);
 
     verify(mockCacheDirectories).getExplodedJarDirectory();
     assertThat(processor).isInstanceOf(SpringBootExplodedProcessor.class);
@@ -96,13 +101,27 @@ public class JarProcessorsTest {
   @Test
   public void testFrom_incompatibleBaseImage() throws URISyntaxException {
     Path jarPath = Paths.get(Resources.getResource(JAVA_14_JAR).toURI());
+
     IllegalStateException exception =
         assertThrows(
             IllegalStateException.class,
-            () -> JarProcessors.from(jarPath, mockCacheDirectories, ProcessingMode.exploded));
+            () -> JarProcessors.from(jarPath, mockCacheDirectories, mockJarCommand));
     assertThat(exception)
         .hasMessageThat()
         .startsWith("The input JAR (" + jarPath + ") is compiled with Java 14");
+  }
+
+  @Test
+  public void testFrom_incompatibleBaseImage_baseImageSpecified()
+      throws URISyntaxException, IOException {
+    Path jarPath = Paths.get(Resources.getResource(JAVA_14_JAR).toURI());
+    when(mockJarCommand.getMode()).thenReturn(ProcessingMode.exploded);
+    when(mockJarCommand.getFrom()).thenReturn(Optional.of("base-image"));
+
+    JarProcessor processor = JarProcessors.from(jarPath, mockCacheDirectories, mockJarCommand);
+
+    verify(mockCacheDirectories).getExplodedJarDirectory();
+    assertThat(processor).isInstanceOf(StandardExplodedProcessor.class);
   }
 
   @Test


### PR DESCRIPTION
Discovered this while manually testing the CLI Jar Command: IllegalArgumentException was being thrown even when `--from` was specified. 