### PR TITLE
Use adoptopenjdk base image instead of openjdk in the Jib CLI

### DIFF
--- a/jib-cli/CHANGELOG.md
+++ b/jib-cli/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
-- Changed the default base image of the Jib CLI jar command from `OpenJDK` to `AdoptOpenJDK`. ((#3108)[https://github.com/GoogleContainerTools/jib/pull/3108])
+- Changed the default base image of the Jib CLI jar command from `OpenJDK` to `AdoptOpenJDK`. ([#3108](https://github.com/GoogleContainerTools/jib/pull/3108]))
 
 ### Fixed
 

--- a/jib-cli/CHANGELOG.md
+++ b/jib-cli/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
-- Changed the default base image of the Jib CLI jar command from `OpenJDK` to `AdoptOpenJDK`. ([#3108](https://github.com/GoogleContainerTools/jib/pull/3108]))
+- Changed the default base image of the Jib CLI jar command from the `openjdk` images to the `adoptopenjdk` images on Docker Hub. ([#3108](https://github.com/GoogleContainerTools/jib/pull/3108]))
 
 ### Fixed
 

--- a/jib-cli/CHANGELOG.md
+++ b/jib-cli/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
+- Changed the default base image of the Jib CLI jar command from `OpenJDK` to `AdoptOpenJDK`. ((#3108)[https://github.com/GoogleContainerTools/jib/pull/3108])
 
 ### Fixed
 

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
@@ -59,8 +59,8 @@ public class JarFiles {
     } else {
       containerBuilder =
           (processor.getJarJavaVersion() <= 8)
-              ? Jib.from("openjdk:8-jre-slim")
-              : Jib.from("openjdk:11-jre-slim");
+              ? Jib.from("adoptopenjdk:8-jre")
+              : Jib.from("adoptopenjdk:11-jre");
     }
 
     List<FileEntriesLayer> layers = processor.createLayers();

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/jar/JarFilesTest.java
@@ -71,7 +71,7 @@ public class JarFilesTest {
             mockStandardExplodedProcessor, mockJarCommand, mockCommonCliOptions, mockLogger);
     ContainerBuildPlan buildPlan = containerBuilder.toContainerBuildPlan();
 
-    assertThat(buildPlan.getBaseImage()).isEqualTo("openjdk:8-jre-slim");
+    assertThat(buildPlan.getBaseImage()).isEqualTo("adoptopenjdk:8-jre");
   }
 
   @Test
@@ -83,7 +83,7 @@ public class JarFilesTest {
             mockStandardExplodedProcessor, mockJarCommand, mockCommonCliOptions, mockLogger);
     ContainerBuildPlan buildPlan = containerBuilder.toContainerBuildPlan();
 
-    assertThat(buildPlan.getBaseImage()).isEqualTo("openjdk:11-jre-slim");
+    assertThat(buildPlan.getBaseImage()).isEqualTo("adoptopenjdk:11-jre");
   }
 
   @Test
@@ -108,7 +108,7 @@ public class JarFilesTest {
             mockStandardExplodedProcessor, mockJarCommand, mockCommonCliOptions, mockLogger);
     ContainerBuildPlan buildPlan = containerBuilder.toContainerBuildPlan();
 
-    assertThat(buildPlan.getBaseImage()).isEqualTo("openjdk:8-jre-slim");
+    assertThat(buildPlan.getBaseImage()).isEqualTo("adoptopenjdk:8-jre");
     assertThat(buildPlan.getPlatforms()).isEqualTo(ImmutableSet.of(new Platform("amd64", "linux")));
     assertThat(buildPlan.getCreationTime()).isEqualTo(Instant.EPOCH);
     assertThat(buildPlan.getFormat()).isEqualTo(ImageFormat.Docker);
@@ -153,7 +153,7 @@ public class JarFilesTest {
             mockStandardPackagedProcessor, mockJarCommand, mockCommonCliOptions, mockLogger);
     ContainerBuildPlan buildPlan = containerBuilder.toContainerBuildPlan();
 
-    assertThat(buildPlan.getBaseImage()).isEqualTo("openjdk:8-jre-slim");
+    assertThat(buildPlan.getBaseImage()).isEqualTo("adoptopenjdk:8-jre");
     assertThat(buildPlan.getPlatforms()).isEqualTo(ImmutableSet.of(new Platform("amd64", "linux")));
     assertThat(buildPlan.getCreationTime()).isEqualTo(Instant.EPOCH);
     assertThat(buildPlan.getFormat()).isEqualTo(ImageFormat.Docker);
@@ -199,7 +199,7 @@ public class JarFilesTest {
             mockSpringBootExplodedProcessor, mockJarCommand, mockCommonCliOptions, mockLogger);
     ContainerBuildPlan buildPlan = containerBuilder.toContainerBuildPlan();
 
-    assertThat(buildPlan.getBaseImage()).isEqualTo("openjdk:8-jre-slim");
+    assertThat(buildPlan.getBaseImage()).isEqualTo("adoptopenjdk:8-jre");
     assertThat(buildPlan.getPlatforms()).isEqualTo(ImmutableSet.of(new Platform("amd64", "linux")));
     assertThat(buildPlan.getCreationTime()).isEqualTo(Instant.EPOCH);
     assertThat(buildPlan.getFormat()).isEqualTo(ImageFormat.Docker);
@@ -244,7 +244,7 @@ public class JarFilesTest {
             mockSpringBootPackagedProcessor, mockJarCommand, mockCommonCliOptions, mockLogger);
     ContainerBuildPlan buildPlan = containerBuilder.toContainerBuildPlan();
 
-    assertThat(buildPlan.getBaseImage()).isEqualTo("openjdk:8-jre-slim");
+    assertThat(buildPlan.getBaseImage()).isEqualTo("adoptopenjdk:8-jre");
     assertThat(buildPlan.getPlatforms()).isEqualTo(ImmutableSet.of(new Platform("amd64", "linux")));
     assertThat(buildPlan.getCreationTime()).isEqualTo(Instant.EPOCH);
     assertThat(buildPlan.getFormat()).isEqualTo(ImageFormat.Docker);


### PR DESCRIPTION
<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->
