### PR TITLE
[Jib-CLI] Print short error message when invalid option is passed in

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
@@ -35,6 +35,7 @@ import picocli.CommandLine.Model.CommandSpec;
 
 @CommandLine.Command(
     name = "build",
+    mixinStandardHelpOptions = true,
     showAtFileInUsageHelp = true,
     description = "Build a container")
 public class Build implements Callable<Integer> {

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/CommonCliOptions.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/CommonCliOptions.java
@@ -35,7 +35,6 @@ public class CommonCliOptions {
   @SuppressWarnings("NullAway.Init") // initialized by picocli
   private CommandSpec spec;
 
-  // Build Configuration
   @CommandLine.Option(
       names = {"-t", "--target"},
       required = true,

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -46,7 +46,11 @@ import java.util.stream.Collectors;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 
-@CommandLine.Command(name = "jar", showAtFileInUsageHelp = true, description = "Containerize a jar")
+@CommandLine.Command(
+    name = "jar",
+    mixinStandardHelpOptions = true,
+    showAtFileInUsageHelp = true,
+    description = "Containerize a jar")
 public class Jar implements Callable<Integer> {
 
   @CommandLine.Spec

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/JibCli.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/JibCli.java
@@ -34,7 +34,10 @@ public class JibCli {
    * @param args the command-line arguments
    */
   public static void main(String[] args) {
-    int exitCode = new CommandLine(new JibCli()).execute(args);
+    int exitCode =
+        new CommandLine(new JibCli())
+            .setParameterExceptionHandler(new ShortErrorMessageHandler())
+            .execute(args);
     System.exit(exitCode);
   }
 }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ShortErrorMessageHandler.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ShortErrorMessageHandler.java
@@ -17,13 +17,15 @@
 package com.google.cloud.tools.jib.cli;
 
 import java.io.PrintWriter;
+
+import com.google.common.annotations.VisibleForTesting;
 import picocli.CommandLine;
 import picocli.CommandLine.IParameterExceptionHandler;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.ParameterException;
 
 /** Class to print a short error message when an invalid input is passed in. */
-class ShortErrorMessageHandler implements IParameterExceptionHandler {
+public class ShortErrorMessageHandler implements IParameterExceptionHandler {
 
   @Override
   public int handleParseException(ParameterException exception, String[] args) {
@@ -33,9 +35,10 @@ class ShortErrorMessageHandler implements IParameterExceptionHandler {
     // Print error message
     writer.println(exception.getMessage());
     CommandLine.UnmatchedArgumentException.printSuggestions(exception, writer);
+    writer.print(command.getHelp().fullSynopsis());
 
     CommandSpec commandSpec = command.getCommandSpec();
-    writer.printf("Try '%s --help' for more information on usage.%n", commandSpec.qualifiedName());
+    writer.printf("Run '%s --help' for more information on usage.%n", commandSpec.qualifiedName());
     return command.getExitCodeExceptionMapper() != null
         ? command.getExitCodeExceptionMapper().getExitCode(exception)
         : commandSpec.exitCodeOnInvalidInput();

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ShortErrorMessageHandler.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ShortErrorMessageHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC.
+ * Copyright 2021 Google LLC.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ShortErrorMessageHandler.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ShortErrorMessageHandler.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.cli;
+
+import java.io.PrintWriter;
+import picocli.CommandLine;
+import picocli.CommandLine.IParameterExceptionHandler;
+import picocli.CommandLine.Model.CommandSpec;
+import picocli.CommandLine.ParameterException;
+
+/** Class to print a short error message when an invalid input is passed in. */
+class ShortErrorMessageHandler implements IParameterExceptionHandler {
+
+  @Override
+  public int handleParseException(ParameterException exception, String[] args) {
+    CommandLine command = exception.getCommandLine();
+    PrintWriter writer = command.getErr();
+
+    // Print error message
+    writer.println(exception.getMessage());
+    CommandLine.UnmatchedArgumentException.printSuggestions(exception, writer);
+
+    CommandSpec commandSpec = command.getCommandSpec();
+    writer.printf("Try '%s --help' for more information on usage.%n", commandSpec.qualifiedName());
+    return command.getExitCodeExceptionMapper() != null
+        ? command.getExitCodeExceptionMapper().getExitCode(exception)
+        : commandSpec.exitCodeOnInvalidInput();
+  }
+}

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ShortErrorMessageHandler.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ShortErrorMessageHandler.java
@@ -17,8 +17,6 @@
 package com.google.cloud.tools.jib.cli;
 
 import java.io.PrintWriter;
-
-import com.google.common.annotations.VisibleForTesting;
 import picocli.CommandLine;
 import picocli.CommandLine.IParameterExceptionHandler;
 import picocli.CommandLine.Model.CommandSpec;


### PR DESCRIPTION
For #3128

Calling `jib` results in:
```
Missing required subcommand
Usage: jib [-hV] [@<filename>...] COMMAND
Run 'jib --help' for more information on usage.
```

Calling `jib jar` results in:
```
Missing required options and parameters: '--target=<target-image>', '<jarFile>'
Usage: jib jar [-hV] [--allow-insecure-registries]
               [--send-credentials-over-http]
               [--base-image-cache=<cache-directory>] [--console=<type>]
               [--creation-time=<creation-time>] [--from=<base-image>]
               [--image-format=<image-format>] [--mode=<mode>]
               [--name=<image-reference>] [--project-cache=<cache-directory>]
               -t=<target-image> [-u=<user>] [--verbosity=<level>]
               [--additional-tags=<tag>[,<tag>...]]...
               [--entrypoint=<entrypoint>[\s+<entrypoint>...]]...
               [--environment-variables=<key>=<value>[,<key>=<value>...]]...
               [--expose=<port>[,<port>...]]... [--jvm-flags=<jvm-flag>[,
               <jvm-flag>...]]... [--labels=<key>=<value>[,
               <key>=<value>...]]... [--program-args=<program-argument>[,
               <program-argument>...]]... [--volumes=<volume>[,<volume>...]]...
               [--credential-helper=<credential-helper> |
               [--username=<username> --password[=<password>]] |
               [[--to-credential-helper=<credential-helper> |
               [--to-username=<username> --to-password[=<password>]]]
               [--from-credential-helper=<credential-helper> |
               [--from-username=<username> --from-password[=<password>]]]]]
               [@<filename>...] <jarFile>
Run 'jib jar --help' for more information on usage.
```

