### PR TITLE
Increase retry attempts and fix the issue of exception being consumed

### DIFF
--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -18,6 +18,7 @@ dependencies {
 
   testImplementation dependencyStrings.JUNIT
   testImplementation dependencyStrings.TRUTH
+  testImplementation dependencyStrings.TRUTH8
   testImplementation dependencyStrings.MOCKITO_CORE
   testImplementation dependencyStrings.SLF4J_API
   testImplementation dependencyStrings.SYSTEM_RULES

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Retry.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Retry.java
@@ -57,7 +57,7 @@ public class Retry<E extends Exception> {
    * @return the instance
    */
   public static <E extends Exception> Retry<E> action(Action<E> action) {
-    return new Retry<E>(action);
+    return new Retry<>(action);
   }
 
   private final Action<E> action;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
@@ -345,16 +345,14 @@ public class CacheStorageWriterTest {
     Exception exception =
         assertThrows(
             IOException.class,
-            () -> CacheStorageWriter.moveIfDoesNotExist(Paths.get("/foo"), Paths.get("/bar")));
+            () -> CacheStorageWriter.moveIfDoesNotExist(Paths.get("foo"), Paths.get("bar")));
     assertThat(exception)
         .hasMessageThat()
-        .isEqualTo(
-            "unable to move: /foo to /bar; such failures are often caused by interference from "
-                + "antivirus (https://github.com/GoogleContainerTools/jib/issues/3127#issuecomment-796838294), "
-                + "or rarely if the operation is not supported by the file system (for example: "
-                + "special non-local file system)");
+        .contains(
+            "unable to move: foo to bar; such failures are often caused by interference from "
+                + "antivirus");
     assertThat(exception).hasCauseThat().isInstanceOf(NoSuchFileException.class);
-    assertThat(exception.getCause()).hasMessageThat().isEqualTo("/foo");
+    assertThat(exception.getCause()).hasMessageThat().isEqualTo("foo");
   }
 
   private void verifyCachedLayer(CachedLayer cachedLayer, Blob uncompressedLayerBlob)

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
@@ -16,6 +16,9 @@
 
 package com.google.cloud.tools.jib.cache;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
@@ -334,6 +337,21 @@ public class CacheStorageWriterTest {
     ContainerConfigurationTemplate savedContainerConfig =
         JsonTemplateMapper.readJsonFromFile(savedConfigPath, ContainerConfigurationTemplate.class);
     Assert.assertEquals("wasm", savedContainerConfig.getArchitecture());
+  }
+
+  @Test
+  public void testMoveIfDoesNotExist_exceptionAfterFailure() {
+    Exception exception =
+        assertThrows(
+            IOException.class,
+            () -> CacheStorageWriter.moveIfDoesNotExist(Paths.get("/foo"), Paths.get("/bar")));
+    assertThat(exception)
+        .hasMessageThat()
+        .isEqualTo(
+            "unable to move: /foo to /bar; such failures are often caused by interference from "
+                + "antivirus (https://github.com/GoogleContainerTools/jib/issues/3127#issuecomment-796838294), "
+                + "or rarely if the operation is not supported by the file system (for example: "
+                + "special non-local file system)");
   }
 
   private void verifyCachedLayer(CachedLayer cachedLayer, Blob uncompressedLayerBlob)

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
@@ -43,6 +43,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.DigestException;
@@ -352,6 +353,8 @@ public class CacheStorageWriterTest {
                 + "antivirus (https://github.com/GoogleContainerTools/jib/issues/3127#issuecomment-796838294), "
                 + "or rarely if the operation is not supported by the file system (for example: "
                 + "special non-local file system)");
+    assertThat(exception).hasCauseThat().isInstanceOf(NoSuchFileException.class);
+    assertThat(exception.getCause()).hasMessageThat().isEqualTo("/foo");
   }
 
   private void verifyCachedLayer(CachedLayer cachedLayer, Blob uncompressedLayerBlob)


### PR DESCRIPTION
Helps with #3127.

- `.maximumRetries(10)`, increased from 5. The delay is 15ms, so we only increase the total time by 75ms.
- As reported, the helpful error message is not shown when the operation fails due to repeated `FilesSstemException`s.
- Improves the error message. If the user still hits the issue, it's possible that the anti-virus software is impacting the performance a lot. The link provides not only a workaround but the potential to increase performance.