### PR TITLE
Enable registry mirrors in Jib CLI

### DIFF
--- a/jib-cli/CHANGELOG.md
+++ b/jib-cli/CHANGELOG.md
@@ -9,12 +9,20 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+## 0.4.0
+
+### Added
+
+- Added support for [configuring registry mirrors](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#i-am-hitting-docker-hub-rate-limits-how-can-i-configure-registry-mirrors) for base images. This is useful when hitting [Docker Hub rate limits](https://www.docker.com/increase-rate-limits). Only public mirrors (such as `mirror.gcr.io`) are supported. ([#3134](https://github.com/GoogleContainerTools/jib/pull/3134))
+
 ## 0.3.0
 
 ### Changed
+
 - Changed the default base image of the Jib CLI jar command from the `openjdk` images to the `adoptopenjdk` images on Docker Hub. ([#3108](https://github.com/GoogleContainerTools/jib/pull/3108))
 
 ## 0.2.0
 
 ### Added
+
 - Added the `jar` command which can be used to containerize a JAR with `$ jib jar --target ... my-app.jar`. By default, the command will add the contents of the JAR into optimized layers on the container. ([#11](https://github.com/GoogleContainerTools/jib/projects/11))

--- a/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
+++ b/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
@@ -28,6 +28,8 @@ import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.jar.Attributes;
@@ -35,12 +37,17 @@ import java.util.jar.JarFile;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import picocli.CommandLine;
 
 public class JarCommandTest {
 
   @ClassRule public static final TestProject springBootProject = new TestProject("spring-boot");
+
+  @Rule
+  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Nullable private String containerName;
 

--- a/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
+++ b/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
@@ -28,8 +28,6 @@ import java.io.StringWriter;
 import java.net.HttpURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.jar.Attributes;
@@ -37,17 +35,12 @@ import java.util.jar.JarFile;
 import javax.annotation.Nullable;
 import org.junit.After;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 import picocli.CommandLine;
 
 public class JarCommandTest {
 
   @ClassRule public static final TestProject springBootProject = new TestProject("spring-boot");
-
-  @Rule
-  public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Nullable private String containerName;
 

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
@@ -21,9 +21,11 @@ import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent.Level;
 import com.google.cloud.tools.jib.cli.buildfile.BuildFiles;
 import com.google.cloud.tools.jib.cli.logging.CliLogger;
+import com.google.cloud.tools.jib.plugins.common.globalconfig.GlobalConfig;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
 import com.google.cloud.tools.jib.plugins.common.logging.SingleThreadedExecutor;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Multimaps;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -123,6 +125,10 @@ public class Build implements Callable<Integer> {
 
       JibContainerBuilder containerBuilder =
           BuildFiles.toJibContainerBuilder(contextRoot, buildFile, this, commonCliOptions, logger);
+
+      // Enable registry mirrors
+      GlobalConfig globalConfig = GlobalConfig.readConfig();
+      Multimaps.asMap(globalConfig.getRegistryMirrors()).forEach(containerizer::addRegistryMirrors);
 
       containerBuilder.containerize(containerizer);
     } catch (Exception ex) {

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -28,10 +28,12 @@ import com.google.cloud.tools.jib.cli.jar.JarProcessor;
 import com.google.cloud.tools.jib.cli.jar.JarProcessors;
 import com.google.cloud.tools.jib.cli.jar.ProcessingMode;
 import com.google.cloud.tools.jib.cli.logging.CliLogger;
+import com.google.cloud.tools.jib.plugins.common.globalconfig.GlobalConfig;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
 import com.google.cloud.tools.jib.plugins.common.logging.SingleThreadedExecutor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Multimaps;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -194,6 +196,11 @@ public class Jar implements Callable<Integer> {
       JibContainerBuilder containerBuilder =
           JarFiles.toJibContainerBuilder(processor, this, commonCliOptions, logger);
       Containerizer containerizer = Containerizers.from(commonCliOptions, logger, cacheDirectories);
+
+      // Enable registry mirrors
+      GlobalConfig globalConfig = GlobalConfig.readConfig();
+      Multimaps.asMap(globalConfig.getRegistryMirrors()).forEach(containerizer::addRegistryMirrors);
+
       containerBuilder.containerize(containerizer);
     } catch (Exception ex) {
       if (commonCliOptions.isStacktrace()) {


### PR DESCRIPTION
Fixes #3047.

Did a manual test similar to the one described in #3011 with this `config.json`:
```
{"disableUpdateCheck":false,
 "registryMirrors": [
    {
      "registry": "registry-1.docker.io",
      "mirrors": ["mirror.gcr.io", "localhost:5000"]
    }
]
}
```

(Case where we fall back to Docker Hub):
It first tries `mirror.gcr.io` and if the base image is not found then it tries `localhost:5000`. It fails on `localhost:5000` with a connection error but doesn't fail the entire build. It finally pulls from Docker Hub.

(Case where we pull from mirror.gcr.io):
And using `--from=busybox` for example, results in the image being pulled from mirror.gcr.io.  
