### PR TITLE
Update missing CHANGELOG entries

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -24,6 +24,10 @@ All notable changes to this project will be documented in this file.
 
 - Added support for [configuring registry mirrors](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#i-am-hitting-docker-hub-rate-limits-how-can-i-configure-registry-mirrors) for base images. This is useful when hitting [Docker Hub rate limits](https://www.docker.com/increase-rate-limits). Only public mirrors (such as `mirror.gcr.io`) are supported. ([#3011](https://github.com/GoogleContainerTools/jib/issues/3011))
 
+### Changed
+
+- Build will fail if Jib cannot access the [global Jib configuration file](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin#global-jib-configuration). ([#2996](https://github.com/GoogleContainerTools/jib/pull/2996))
+
 ## 2.7.1
 
 ### Fixed

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -20,6 +20,10 @@ All notable changes to this project will be documented in this file.
 
 - Added support for [configuring registry mirrors](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md#i-am-hitting-docker-hub-rate-limits-how-can-i-configure-registry-mirrors) for base images. This is useful when hitting [Docker Hub rate limits](https://www.docker.com/increase-rate-limits). Only public mirrors (such as `mirror.gcr.io`) are supported. ([#3011](https://github.com/GoogleContainerTools/jib/issues/3011))
 
+### Changed
+
+- Build will fail if Jib cannot access the [global Jib configuration file](https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#global-jib-configuration). ([#2996](https://github.com/GoogleContainerTools/jib/pull/2996))
+
 ## 2.7.1
 
 ### Fixed


### PR DESCRIPTION
Closes #3138.

From #2996,

> * Previously, any error from handling `config.json` was a warning and didn't cause a build to fail. Now we consider this as loading a global config, a build will fail if the code cannot load it.