### PR TITLE
[Jib CLI] set correct version and User-Agent

### DIFF
--- a/jib-cli/build.gradle
+++ b/jib-cli/build.gradle
@@ -15,6 +15,21 @@ application {
   mainClassName = cliMainClass
 }
 
+sourceSets.main.java.srcDirs += ["${buildDir}/generated-src"]
+
+tasks.register('generateSources', Copy) {
+  // to re-run the task whenever the file changes
+  inputs.file 'gradle.properties'
+
+  from fileTree('src/java-templates')
+  into "${buildDir}/generated-src"
+
+  rename('\\.template$', '')
+  expand(['version': "${version}"])
+}
+
+compileJava.source generateSources
+
 dependencies {
   implementation project(':jib-core')
   implementation project(':jib-plugins-common')

--- a/jib-cli/src/java-templates/com/google/cloud/tools/jib/cli/VersionInfo.java.template
+++ b/jib-cli/src/java-templates/com/google/cloud/tools/jib/cli/VersionInfo.java.template
@@ -27,6 +27,6 @@ public class VersionInfo implements CommandLine.IVersionProvider {
   }
 
   public static String getVersionSimple() {
-    return "preview";
+    return "${version}";
   }
 }


### PR DESCRIPTION
Fixes #3149.

This will make Jib CLI use the version string as defined in `jib-cli/gradle-properties` for the `User-Agent` HTTP header and the output of `$ jib --version`.

Notes:
- Moves `VersionInfo.java` out of `src/main/java` into `src/java-templates` and converts it to a template.
- When compiling, it generates the final `VersionInfo.java` into `build/generated-src` while incorporating the `version` Gradle property into the template. The process is done with the Gradle [`Copy` task](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.Copy.html).

I'm not sure if IntelliJ will require this, but you may need to run the `:jib-cli:compileJava` task once after re-configuring the project.