### PR TITLE
#3158 - [Jib core] Tar archives with same contents are not reproducible

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageTarball.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageTarball.java
@@ -49,7 +49,7 @@ public class ImageTarball {
   private final Image image;
   private final ImageReference imageReference;
   private final ImmutableSet<String> allTargetImageTags;
-  private final Instant creationTime = Instant.EPOCH;
+  private static final Instant TAR_ENTRY_MODIFICATION_TIME = Instant.EPOCH;
 
   /**
    * Instantiate with an {@link Image}.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -77,7 +77,7 @@ public class TarStreamBuilder {
   public void addByteEntry(byte[] contents, String name, Instant modificationTime) {
     TarArchiveEntry entry = new TarArchiveEntry(name);
     entry.setSize(contents.length);
-    entry.setModTime(modificationTime.getEpochSecond());
+    entry.setModTime(modificationTime.toEpochMilli());
     archiveMap.put(entry, Blobs.from(outputStream -> outputStream.write(contents)));
   }
 
@@ -93,7 +93,7 @@ public class TarStreamBuilder {
   public void addBlobEntry(Blob blob, long size, String name, Instant modificationTime) {
     TarArchiveEntry entry = new TarArchiveEntry(name);
     entry.setSize(size);
-    entry.setModTime(modificationTime.getEpochSecond());
+    entry.setModTime(modificationTime.toEpochMilli());
     archiveMap.put(entry, blob);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.blob.Blobs;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -71,10 +72,12 @@ public class TarStreamBuilder {
    *
    * @param contents the bytes to add to the tarball
    * @param name the name of the entry (i.e. filename)
+   * @param modTime the time the entry is created
    */
-  public void addByteEntry(byte[] contents, String name) {
+  public void addByteEntry(byte[] contents, String name, Instant modTime) {
     TarArchiveEntry entry = new TarArchiveEntry(name);
     entry.setSize(contents.length);
+    entry.setModTime(modTime.getEpochSecond());
     archiveMap.put(entry, Blobs.from(outputStream -> outputStream.write(contents)));
   }
 
@@ -85,10 +88,12 @@ public class TarStreamBuilder {
    * @param blob the {@link Blob} to add to the tarball
    * @param size the size (in bytes) of {@code blob}
    * @param name the name of the entry (i.e. filename)
+   * @param modTime the time the entry is created
    */
-  public void addBlobEntry(Blob blob, long size, String name) {
+  public void addBlobEntry(Blob blob, long size, String name, Instant modTime) {
     TarArchiveEntry entry = new TarArchiveEntry(name);
     entry.setSize(size);
+    entry.setModTime(modTime.getEpochSecond());
     archiveMap.put(entry, blob);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.blob.Blobs;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -28,6 +29,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 
 /** Builds a tarball archive. */
 public class TarStreamBuilder {
+  public static final Instant DEFAULT_MODIFICATION_TIME = Instant.ofEpochSecond(1);
 
   /**
    * Maps from {@link TarArchiveEntry} to a {@link Blob}. The order of the entries is the order they
@@ -89,6 +91,7 @@ public class TarStreamBuilder {
   public void addBlobEntry(Blob blob, long size, String name) {
     TarArchiveEntry entry = new TarArchiveEntry(name);
     entry.setSize(size);
+    entry.setModTime(DEFAULT_MODIFICATION_TIME.getEpochSecond());
     archiveMap.put(entry, blob);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -74,7 +74,7 @@ public class TarStreamBuilder {
    * @param name the name of the entry (i.e. filename)
    * @param modTime the time the entry is created
    */
-  public void addByteEntry(byte[] contents, String name, Instant modTime) {
+  public void addByteEntry(byte[] contents, String name, Instant modificationTime) {
     TarArchiveEntry entry = new TarArchiveEntry(name);
     entry.setSize(contents.length);
     entry.setModTime(modTime.getEpochSecond());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -72,7 +72,7 @@ public class TarStreamBuilder {
    *
    * @param contents the bytes to add to the tarball
    * @param name the name of the entry (i.e. filename)
-   * @param modTime the time the entry is created
+   * @param modificationTime the modification time of the entry
    */
   public void addByteEntry(byte[] contents, String name, Instant modificationTime) {
     TarArchiveEntry entry = new TarArchiveEntry(name);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -21,7 +21,6 @@ import com.google.cloud.tools.jib.blob.Blobs;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
-import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -29,7 +28,6 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 
 /** Builds a tarball archive. */
 public class TarStreamBuilder {
-  public static final Instant DEFAULT_MODIFICATION_TIME = Instant.ofEpochSecond(1);
 
   /**
    * Maps from {@link TarArchiveEntry} to a {@link Blob}. The order of the entries is the order they
@@ -91,7 +89,6 @@ public class TarStreamBuilder {
   public void addBlobEntry(Blob blob, long size, String name) {
     TarArchiveEntry entry = new TarArchiveEntry(name);
     entry.setSize(size);
-    entry.setModTime(DEFAULT_MODIFICATION_TIME.getEpochSecond());
     archiveMap.put(entry, blob);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -77,7 +77,7 @@ public class TarStreamBuilder {
   public void addByteEntry(byte[] contents, String name, Instant modificationTime) {
     TarArchiveEntry entry = new TarArchiveEntry(name);
     entry.setSize(contents.length);
-    entry.setModTime(modTime.getEpochSecond());
+    entry.setModTime(modificationTime.getEpochSecond());
     archiveMap.put(entry, Blobs.from(outputStream -> outputStream.write(contents)));
   }
 
@@ -88,12 +88,12 @@ public class TarStreamBuilder {
    * @param blob the {@link Blob} to add to the tarball
    * @param size the size (in bytes) of {@code blob}
    * @param name the name of the entry (i.e. filename)
-   * @param modTime the time the entry is created
+   * @param modificationTime the modification time of the entry
    */
-  public void addBlobEntry(Blob blob, long size, String name, Instant modTime) {
+  public void addBlobEntry(Blob blob, long size, String name, Instant modificationTime) {
     TarArchiveEntry entry = new TarArchiveEntry(name);
     entry.setSize(size);
-    entry.setModTime(modTime.getEpochSecond());
+    entry.setModTime(modificationTime.getEpochSecond());
     archiveMap.put(entry, blob);
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
@@ -100,15 +100,15 @@ public class TarStreamBuilderTest {
 
   @Test
   public void testToBlob_multiByte() throws IOException {
-    Instant MODIFICATION_TIME = Instant.ofEpochMilli(1618041179516l);
-    Instant TIME_FROM_TAR_ARCHIVE_ENTRY = MODIFICATION_TIME.truncatedTo(SECONDS);
+    Instant modificationTime = Instant.ofEpochMilli(1618041179516l);
+    Instant timeFromTarArchiveEntry = modificationTime.truncatedTo(SECONDS);
 
     testTarStreamBuilder.addByteEntry(
-        "日本語".getBytes(StandardCharsets.UTF_8), "test", MODIFICATION_TIME);
+        "日本語".getBytes(StandardCharsets.UTF_8), "test", modificationTime);
     testTarStreamBuilder.addByteEntry(
-        "asdf".getBytes(StandardCharsets.UTF_8), "crepecake", MODIFICATION_TIME);
+        "asdf".getBytes(StandardCharsets.UTF_8), "crepecake", modificationTime);
     testTarStreamBuilder.addBlobEntry(
-        Blobs.from("jib"), "jib".getBytes(StandardCharsets.UTF_8).length, "jib", MODIFICATION_TIME);
+        Blobs.from("jib"), "jib".getBytes(StandardCharsets.UTF_8).length, "jib", modificationTime);
 
     // Writes the BLOB and captures the output.
     ByteArrayOutputStream tarByteOutputStream = new ByteArrayOutputStream();
@@ -131,13 +131,13 @@ public class TarStreamBuilderTest {
     Assert.assertEquals("crepecake", headerFile.getName());
     Assert.assertEquals(
         "asdf", new String(ByteStreams.toByteArray(tarArchiveInputStream), StandardCharsets.UTF_8));
-    Assert.assertEquals(TIME_FROM_TAR_ARCHIVE_ENTRY, headerFile.getModTime().toInstant());
+    Assert.assertEquals(timeFromTarArchiveEntry, headerFile.getModTime().toInstant());
 
     headerFile = tarArchiveInputStream.getNextTarEntry();
     Assert.assertEquals("jib", headerFile.getName());
     Assert.assertEquals(
         "jib", new String(ByteStreams.toByteArray(tarArchiveInputStream), StandardCharsets.UTF_8));
-    Assert.assertEquals(TIME_FROM_TAR_ARCHIVE_ENTRY, headerFile.getModTime().toInstant());
+    Assert.assertEquals(timeFromTarArchiveEntry, headerFile.getModTime().toInstant());
 
     Assert.assertNull(tarArchiveInputStream.getNextTarEntry());
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.jib.tar;
 
+import static java.time.temporal.ChronoUnit.SECONDS;
+
 import com.google.cloud.tools.jib.blob.Blobs;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Resources;
@@ -37,8 +39,6 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import static java.time.temporal.ChronoUnit.SECONDS;
 
 /** Tests for {@link TarStreamBuilder}. */
 public class TarStreamBuilderTest {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
@@ -43,7 +43,6 @@ import org.junit.Test;
 /** Tests for {@link TarStreamBuilder}. */
 public class TarStreamBuilderTest {
 
-
   private Path fileA;
   private Path fileB;
   private Path directoryA;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
@@ -38,8 +38,11 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import static java.time.temporal.ChronoUnit.SECONDS;
+
 /** Tests for {@link TarStreamBuilder}. */
 public class TarStreamBuilderTest {
+
 
   private Path fileA;
   private Path fileB;
@@ -97,12 +100,15 @@ public class TarStreamBuilderTest {
 
   @Test
   public void testToBlob_multiByte() throws IOException {
+    Instant MODIFICATION_TIME = Instant.ofEpochMilli(1618041179516l);
+    Instant TIME_FROM_TAR_ARCHIVE_ENTRY = MODIFICATION_TIME.truncatedTo(SECONDS);
+
     testTarStreamBuilder.addByteEntry(
-        "日本語".getBytes(StandardCharsets.UTF_8), "test", Instant.EPOCH);
+        "日本語".getBytes(StandardCharsets.UTF_8), "test", MODIFICATION_TIME);
     testTarStreamBuilder.addByteEntry(
-        "asdf".getBytes(StandardCharsets.UTF_8), "crepecake", Instant.EPOCH);
+        "asdf".getBytes(StandardCharsets.UTF_8), "crepecake", MODIFICATION_TIME);
     testTarStreamBuilder.addBlobEntry(
-        Blobs.from("jib"), "jib".getBytes(StandardCharsets.UTF_8).length, "jib", Instant.EPOCH);
+        Blobs.from("jib"), "jib".getBytes(StandardCharsets.UTF_8).length, "jib", MODIFICATION_TIME);
 
     // Writes the BLOB and captures the output.
     ByteArrayOutputStream tarByteOutputStream = new ByteArrayOutputStream();
@@ -125,13 +131,13 @@ public class TarStreamBuilderTest {
     Assert.assertEquals("crepecake", headerFile.getName());
     Assert.assertEquals(
         "asdf", new String(ByteStreams.toByteArray(tarArchiveInputStream), StandardCharsets.UTF_8));
-    Assert.assertEquals(Instant.EPOCH, headerFile.getModTime().toInstant());
+    Assert.assertEquals(TIME_FROM_TAR_ARCHIVE_ENTRY, headerFile.getModTime().toInstant());
 
     headerFile = tarArchiveInputStream.getNextTarEntry();
     Assert.assertEquals("jib", headerFile.getName());
     Assert.assertEquals(
         "jib", new String(ByteStreams.toByteArray(tarArchiveInputStream), StandardCharsets.UTF_8));
-    Assert.assertEquals(Instant.EPOCH, headerFile.getModTime().toInstant());
+    Assert.assertEquals(TIME_FROM_TAR_ARCHIVE_ENTRY, headerFile.getModTime().toInstant());
 
     Assert.assertNull(tarArchiveInputStream.getNextTarEntry());
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
@@ -100,7 +100,7 @@ public class TarStreamBuilderTest {
 
   @Test
   public void testToBlob_multiByte() throws IOException {
-    Instant modificationTime = Instant.ofEpochMilli(1618041179516l);
+    Instant modificationTime = Instant.ofEpochMilli(1618041179516L);
     Instant timeFromTarArchiveEntry = modificationTime.truncatedTo(SECONDS);
 
     testTarStreamBuilder.addByteEntry(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
@@ -29,7 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -130,26 +129,6 @@ public class TarStreamBuilderTest {
         "jib", new String(ByteStreams.toByteArray(tarArchiveInputStream), StandardCharsets.UTF_8));
 
     Assert.assertNull(tarArchiveInputStream.getNextTarEntry());
-  }
-
-  @Test
-  public void testTarStreamAreReproducible() throws IOException, InterruptedException {
-    testTarStreamBuilder.addBlobEntry(
-        Blobs.from("jib"), "jib".getBytes(StandardCharsets.UTF_8).length, "jib");
-    ByteArrayOutputStream firstTarByteOutputStream = new ByteArrayOutputStream();
-    testTarStreamBuilder.writeAsTarArchiveTo(firstTarByteOutputStream);
-
-    Thread.sleep(2000);
-
-    TarStreamBuilder anotherTestTarStreamBuilder = new TarStreamBuilder();
-    anotherTestTarStreamBuilder.addBlobEntry(
-        Blobs.from("jib"), "jib".getBytes(StandardCharsets.UTF_8).length, "jib");
-    ByteArrayOutputStream secondTarByteOutputStream = new ByteArrayOutputStream();
-    anotherTestTarStreamBuilder.writeAsTarArchiveTo(secondTarByteOutputStream);
-
-    Assert.assertTrue(
-        Arrays.equals(
-            firstTarByteOutputStream.toByteArray(), secondTarByteOutputStream.toByteArray()));
   }
 
   /** Creates a TarStreamBuilder using TarArchiveEntries. */

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -129,6 +130,26 @@ public class TarStreamBuilderTest {
         "jib", new String(ByteStreams.toByteArray(tarArchiveInputStream), StandardCharsets.UTF_8));
 
     Assert.assertNull(tarArchiveInputStream.getNextTarEntry());
+  }
+
+  @Test
+  public void testTarStreamAreReproducible() throws IOException, InterruptedException {
+    testTarStreamBuilder.addBlobEntry(
+        Blobs.from("jib"), "jib".getBytes(StandardCharsets.UTF_8).length, "jib");
+    ByteArrayOutputStream firstTarByteOutputStream = new ByteArrayOutputStream();
+    testTarStreamBuilder.writeAsTarArchiveTo(firstTarByteOutputStream);
+
+    Thread.sleep(2000);
+
+    TarStreamBuilder anotherTestTarStreamBuilder = new TarStreamBuilder();
+    anotherTestTarStreamBuilder.addBlobEntry(
+        Blobs.from("jib"), "jib".getBytes(StandardCharsets.UTF_8).length, "jib");
+    ByteArrayOutputStream secondTarByteOutputStream = new ByteArrayOutputStream();
+    anotherTestTarStreamBuilder.writeAsTarArchiveTo(secondTarByteOutputStream);
+
+    Assert.assertTrue(
+        Arrays.equals(
+            firstTarByteOutputStream.toByteArray(), secondTarByteOutputStream.toByteArray()));
   }
 
   /** Creates a TarStreamBuilder using TarArchiveEntries. */

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
@@ -97,9 +97,10 @@ public class TarStreamBuilderTest {
 
   @Test
   public void testToBlob_multiByte() throws IOException {
-    testTarStreamBuilder.addByteEntry("日本語".getBytes(StandardCharsets.UTF_8), "test", creationTime);
     testTarStreamBuilder.addByteEntry(
-        "asdf".getBytes(StandardCharsets.UTF_8), "crepecake", creationTime);
+        "日本語".getBytes(StandardCharsets.UTF_8), "test", Instant.EPOCH);
+    testTarStreamBuilder.addByteEntry(
+        "asdf".getBytes(StandardCharsets.UTF_8), "crepecake", Instant.EPOCH);
     testTarStreamBuilder.addBlobEntry(
         Blobs.from("jib"), "jib".getBytes(StandardCharsets.UTF_8).length, "jib", Instant.EPOCH);
 
@@ -124,11 +125,13 @@ public class TarStreamBuilderTest {
     Assert.assertEquals("crepecake", headerFile.getName());
     Assert.assertEquals(
         "asdf", new String(ByteStreams.toByteArray(tarArchiveInputStream), StandardCharsets.UTF_8));
+    Assert.assertEquals(Instant.EPOCH, headerFile.getModTime().toInstant());
 
     headerFile = tarArchiveInputStream.getNextTarEntry();
     Assert.assertEquals("jib", headerFile.getName());
     Assert.assertEquals(
         "jib", new String(ByteStreams.toByteArray(tarArchiveInputStream), StandardCharsets.UTF_8));
+    Assert.assertEquals(Instant.EPOCH, headerFile.getModTime().toInstant());
 
     Assert.assertNull(tarArchiveInputStream.getNextTarEntry());
   }
@@ -150,27 +153,27 @@ public class TarStreamBuilderTest {
   /** Creates a TarStreamBuilder using Strings. */
   private void setUpWithStrings() {
     // Prepares a test TarStreamBuilder.
-    testTarStreamBuilder.addByteEntry(fileAContents, "some/path/to/resourceFileA", creationTime);
-    testTarStreamBuilder.addByteEntry(fileBContents, "crepecake", creationTime);
+    testTarStreamBuilder.addByteEntry(fileAContents, "some/path/to/resourceFileA", Instant.EPOCH);
+    testTarStreamBuilder.addByteEntry(fileBContents, "crepecake", Instant.EPOCH);
     testTarStreamBuilder.addTarArchiveEntry(
         new TarArchiveEntry(directoryA.toFile(), "some/path/to"));
     testTarStreamBuilder.addByteEntry(
         fileAContents,
         "some/really/long/path/that/exceeds/100/characters/abcdefghijklmnopqrstuvwxyz0123456789012345678901234567890",
-        creationTime);
+        Instant.EPOCH);
   }
 
   /** Creates a TarStreamBuilder using Strings and TarArchiveEntries. */
   private void setUpWithStringsAndTarEntries() {
     // Prepares a test TarStreamBuilder.
-    testTarStreamBuilder.addByteEntry(fileAContents, "some/path/to/resourceFileA", creationTime);
+    testTarStreamBuilder.addByteEntry(fileAContents, "some/path/to/resourceFileA", Instant.EPOCH);
     testTarStreamBuilder.addTarArchiveEntry(new TarArchiveEntry(fileB.toFile(), "crepecake"));
     testTarStreamBuilder.addTarArchiveEntry(
         new TarArchiveEntry(directoryA.toFile(), "some/path/to"));
     testTarStreamBuilder.addByteEntry(
         fileAContents,
         "some/really/long/path/that/exceeds/100/characters/abcdefghijklmnopqrstuvwxyz0123456789012345678901234567890",
-        creationTime);
+        Instant.EPOCH);
   }
 
   /** Creates a compressed blob from the TarStreamBuilder and verifies it. */
@@ -215,18 +218,21 @@ public class TarStreamBuilderTest {
     // Verifies fileB was archived correctly.
     TarArchiveEntry headerFileB = tarArchiveInputStream.getNextTarEntry();
     Assert.assertEquals("crepecake", headerFileB.getName());
+    Assert.assertEquals(Instant.EPOCH, headerFileB.getModTime().toInstant());
     byte[] fileBString = ByteStreams.toByteArray(tarArchiveInputStream);
     Assert.assertArrayEquals(fileBContents, fileBString);
 
     // Verifies directoryA was archived correctly.
     TarArchiveEntry headerDirectoryA = tarArchiveInputStream.getNextTarEntry();
     Assert.assertEquals("some/path/to/", headerDirectoryA.getName());
+    Assert.assertEquals(Instant.EPOCH, headerDirectoryA.getModTime().toInstant());
 
     // Verifies the long file was archived correctly.
     TarArchiveEntry headerFileALong = tarArchiveInputStream.getNextTarEntry();
     Assert.assertEquals(
         "some/really/long/path/that/exceeds/100/characters/abcdefghijklmnopqrstuvwxyz0123456789012345678901234567890",
         headerFileALong.getName());
+    Assert.assertEquals(Instant.EPOCH, headerFileALong);
     byte[] fileALongString = ByteStreams.toByteArray(tarArchiveInputStream);
     Assert.assertArrayEquals(fileAContents, fileALongString);
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
@@ -101,7 +101,7 @@ public class TarStreamBuilderTest {
     testTarStreamBuilder.addByteEntry(
         "asdf".getBytes(StandardCharsets.UTF_8), "crepecake", creationTime);
     testTarStreamBuilder.addBlobEntry(
-        Blobs.from("jib"), "jib".getBytes(StandardCharsets.UTF_8).length, "jib", creationTime);
+        Blobs.from("jib"), "jib".getBytes(StandardCharsets.UTF_8).length, "jib", Instant.EPOCH);
 
     // Writes the BLOB and captures the output.
     ByteArrayOutputStream tarByteOutputStream = new ByteArrayOutputStream();

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
@@ -47,7 +47,6 @@ public class TarStreamBuilderTest {
   private byte[] fileAContents;
   private byte[] fileBContents;
   private TarStreamBuilder testTarStreamBuilder = new TarStreamBuilder();
-  private final Instant creationTime = Instant.EPOCH;
 
   @Before
   public void setup() throws URISyntaxException, IOException {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
@@ -29,6 +29,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
@@ -46,6 +47,7 @@ public class TarStreamBuilderTest {
   private byte[] fileAContents;
   private byte[] fileBContents;
   private TarStreamBuilder testTarStreamBuilder = new TarStreamBuilder();
+  private final Instant creationTime = Instant.EPOCH;
 
   @Before
   public void setup() throws URISyntaxException, IOException {
@@ -96,10 +98,11 @@ public class TarStreamBuilderTest {
 
   @Test
   public void testToBlob_multiByte() throws IOException {
-    testTarStreamBuilder.addByteEntry("日本語".getBytes(StandardCharsets.UTF_8), "test");
-    testTarStreamBuilder.addByteEntry("asdf".getBytes(StandardCharsets.UTF_8), "crepecake");
+    testTarStreamBuilder.addByteEntry("日本語".getBytes(StandardCharsets.UTF_8), "test", creationTime);
+    testTarStreamBuilder.addByteEntry(
+        "asdf".getBytes(StandardCharsets.UTF_8), "crepecake", creationTime);
     testTarStreamBuilder.addBlobEntry(
-        Blobs.from("jib"), "jib".getBytes(StandardCharsets.UTF_8).length, "jib");
+        Blobs.from("jib"), "jib".getBytes(StandardCharsets.UTF_8).length, "jib", creationTime);
 
     // Writes the BLOB and captures the output.
     ByteArrayOutputStream tarByteOutputStream = new ByteArrayOutputStream();
@@ -148,25 +151,27 @@ public class TarStreamBuilderTest {
   /** Creates a TarStreamBuilder using Strings. */
   private void setUpWithStrings() {
     // Prepares a test TarStreamBuilder.
-    testTarStreamBuilder.addByteEntry(fileAContents, "some/path/to/resourceFileA");
-    testTarStreamBuilder.addByteEntry(fileBContents, "crepecake");
+    testTarStreamBuilder.addByteEntry(fileAContents, "some/path/to/resourceFileA", creationTime);
+    testTarStreamBuilder.addByteEntry(fileBContents, "crepecake", creationTime);
     testTarStreamBuilder.addTarArchiveEntry(
         new TarArchiveEntry(directoryA.toFile(), "some/path/to"));
     testTarStreamBuilder.addByteEntry(
         fileAContents,
-        "some/really/long/path/that/exceeds/100/characters/abcdefghijklmnopqrstuvwxyz0123456789012345678901234567890");
+        "some/really/long/path/that/exceeds/100/characters/abcdefghijklmnopqrstuvwxyz0123456789012345678901234567890",
+        creationTime);
   }
 
   /** Creates a TarStreamBuilder using Strings and TarArchiveEntries. */
   private void setUpWithStringsAndTarEntries() {
     // Prepares a test TarStreamBuilder.
-    testTarStreamBuilder.addByteEntry(fileAContents, "some/path/to/resourceFileA");
+    testTarStreamBuilder.addByteEntry(fileAContents, "some/path/to/resourceFileA", creationTime);
     testTarStreamBuilder.addTarArchiveEntry(new TarArchiveEntry(fileB.toFile(), "crepecake"));
     testTarStreamBuilder.addTarArchiveEntry(
         new TarArchiveEntry(directoryA.toFile(), "some/path/to"));
     testTarStreamBuilder.addByteEntry(
         fileAContents,
-        "some/really/long/path/that/exceeds/100/characters/abcdefghijklmnopqrstuvwxyz0123456789012345678901234567890");
+        "some/really/long/path/that/exceeds/100/characters/abcdefghijklmnopqrstuvwxyz0123456789012345678901234567890",
+        creationTime);
   }
 
   /** Creates a compressed blob from the TarStreamBuilder and verifies it. */

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
@@ -218,21 +218,18 @@ public class TarStreamBuilderTest {
     // Verifies fileB was archived correctly.
     TarArchiveEntry headerFileB = tarArchiveInputStream.getNextTarEntry();
     Assert.assertEquals("crepecake", headerFileB.getName());
-    Assert.assertEquals(Instant.EPOCH, headerFileB.getModTime().toInstant());
     byte[] fileBString = ByteStreams.toByteArray(tarArchiveInputStream);
     Assert.assertArrayEquals(fileBContents, fileBString);
 
     // Verifies directoryA was archived correctly.
     TarArchiveEntry headerDirectoryA = tarArchiveInputStream.getNextTarEntry();
     Assert.assertEquals("some/path/to/", headerDirectoryA.getName());
-    Assert.assertEquals(Instant.EPOCH, headerDirectoryA.getModTime().toInstant());
 
     // Verifies the long file was archived correctly.
     TarArchiveEntry headerFileALong = tarArchiveInputStream.getNextTarEntry();
     Assert.assertEquals(
         "some/really/long/path/that/exceeds/100/characters/abcdefghijklmnopqrstuvwxyz0123456789012345678901234567890",
         headerFileALong.getName());
-    Assert.assertEquals(Instant.EPOCH, headerFileALong);
     byte[] fileALongString = ByteStreams.toByteArray(tarArchiveInputStream);
     Assert.assertArrayEquals(fileAContents, fileALongString);
 


### PR DESCRIPTION
Fixes #3158.

Sets the mod time on TarArchiveEntry to DEFAULT_MODIFICATION_TIME (Epoch second 1) in order to create reproducible Tar images. Associated unit test creates 2 tars output streams from the same input 2 seconds apart to show the failure if we don't explicitly set the TarArchiveEntry mod time
