### PR TITLE
Add Jib Core and CLI release checklists and update release workflows

### DIFF
--- a/.github/RELEASE_TEMPLATES/cli_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/cli_release_checklist.md
@@ -9,7 +9,6 @@ labels: release
 - [ ] Update [CHANGELOG.md]({{ env.CHANGELOG_URL }})
 - [ ] Update [README.md]({{ env.README_URL }})
 - [ ] Complete [Release]({{ env.RELEASE_DRAFT }})
-- [ ] Merge [PR]({{ env.RELEASE_PR }})
 - [ ] Update the current [milestone](https://github.com/GoogleContainerTools/jib/milestones), roll over any incomplete issues to next milestone.
 
 ## Announce

--- a/.github/RELEASE_TEMPLATES/cli_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/cli_release_checklist.md
@@ -1,0 +1,18 @@
+---
+title: CLI Release {{ env.RELEASE_NAME }}
+labels: release
+---
+## Requirements
+- [ ] ⚠️ Ensure the release process has succeeded before proceeding
+
+## Github
+- [ ] Update [CHANGELOG.md]({{ env.CHANGELOG_URL }})
+- [ ] Update [README.md]({{ env.README_URL }})
+- [ ] Complete [Release]({{ env.RELEASE_DRAFT }})
+- [ ] Merge [PR]({{ env.RELEASE_PR }})
+- [ ] Update the current [milestone](https://github.com/GoogleContainerTools/jib/milestones), roll over any incomplete issues to next milestone.
+
+## Announce
+- [ ] Email jib users
+- [ ] Post to [gitter](https://gitter.im/google/jib)
+- [ ] Mention on all fixed issues that latest release has addressed the issue (usually any closed issues in a [milestone](https://github.com/GoogleContainerTools/jib/milestones))

--- a/.github/RELEASE_TEMPLATES/cli_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/cli_release_checklist.md
@@ -9,6 +9,7 @@ labels: release
 - [ ] Update [CHANGELOG.md]({{ env.CHANGELOG_URL }})
 - [ ] Update [README.md]({{ env.README_URL }})
 - [ ] Complete [Release]({{ env.RELEASE_DRAFT }})
+- [ ] Merge PR ({{ env.RELEASE_PR }})
 - [ ] Update the current [milestone](https://github.com/GoogleContainerTools/jib/milestones), roll over any incomplete issues to next milestone.
 
 ## Announce

--- a/.github/RELEASE_TEMPLATES/core_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/core_release_checklist.md
@@ -9,7 +9,7 @@ labels: release
 - [ ] Update [CHANGELOG.md]({{ env.CHANGELOG_URL }})
 - [ ] Update [README.md]({{ env.README_URL }})
 - [ ] Complete [Release]({{ env.RELEASE_DRAFT }})
-- [ ] Merge [PR]({{ env.RELEASE_PR }})
+- [ ] Merge PR ({{ env.RELEASE_PR }})
 - [ ] Update the current [milestone](https://github.com/GoogleContainerTools/jib/milestones), roll over any incomplete issues to next milestone.
 
 ## Announce

--- a/.github/RELEASE_TEMPLATES/core_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/core_release_checklist.md
@@ -1,0 +1,18 @@
+---
+title: Core Release {{ env.RELEASE_NAME }}
+labels: release
+---
+## Requirements
+- [ ] ⚠️ Ensure the release process has succeeded before proceeding
+
+## Github
+- [ ] Update [CHANGELOG.md]({{ env.CHANGELOG_URL }})
+- [ ] Update [README.md]({{ env.README_URL }})
+- [ ] Complete [Release]({{ env.RELEASE_DRAFT }})
+- [ ] Merge [PR]({{ env.RELEASE_PR }})
+- [ ] Update the current [milestone](https://github.com/GoogleContainerTools/jib/milestones), roll over any incomplete issues to next milestone.
+
+## Announce
+- [ ] Email jib users
+- [ ] Post to [gitter](https://gitter.im/google/jib)
+- [ ] Mention on all fixed issues that latest release has addressed the issue (usually any closed issues in a [milestone](https://github.com/GoogleContainerTools/jib/milestones))

--- a/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
@@ -14,7 +14,7 @@ labels: release
 - [ ] Update [CONTRIBUTING.md](https://github.com/GoogleContainerTools/jib/blob/master/CONTRIBUTING.md)
 - [ ] Update [examples](https://github.com/GoogleContainerTools/jib/tree/master/examples)
 - [ ] Complete [Release]({{ env.RELEASE_DRAFT }})
-- [ ] Merge PR ({{ env.RELEASE_PR }})
+- [ ] Merge [PR]({{ env.RELEASE_PR }})
 - [ ] Update the current [milestone](https://github.com/GoogleContainerTools/jib/milestones), roll over any incomplete issues to next milestone.
 
 #### Skaffold
@@ -27,4 +27,4 @@ labels: release
 ## Announce
 - [ ] Email jib users
 - [ ] Post to [gitter](https://gitter.im/google/jib)
-- [ ] Menntion on all fixed issues that latest release has addressed the issue (usually any closed issues in a [milestone](https://github.com/GoogleContainerTools/jib/milestones))
+- [ ] Mention on all fixed issues that latest release has addressed the issue (usually any closed issues in a [milestone](https://github.com/GoogleContainerTools/jib/milestones))

--- a/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
@@ -14,7 +14,7 @@ labels: release
 - [ ] Update [CONTRIBUTING.md](https://github.com/GoogleContainerTools/jib/blob/master/CONTRIBUTING.md)
 - [ ] Update [examples](https://github.com/GoogleContainerTools/jib/tree/master/examples)
 - [ ] Complete [Release]({{ env.RELEASE_DRAFT }})
-- [ ] Merge [PR]({{ env.RELEASE_PR }})
+- [ ] Merge PR ({{ env.RELEASE_PR }})
 - [ ] Update the current [milestone](https://github.com/GoogleContainerTools/jib/milestones), roll over any incomplete issues to next milestone.
 
 #### Skaffold

--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -45,6 +45,7 @@ jobs:
 
       - name: Create pull request
         uses: repo-sync/pull-request@v2
+        id: create-pr
         with:
           # Use a personal token to file a PR as a non-bot author to trigger other workflows (e.g., unit tests):
           # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token;
@@ -96,6 +97,7 @@ jobs:
           CHANGELOG_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-cli/CHANGELOG.md
           README_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-cli/README.md
           RELEASE_DRAFT: ${{ steps.create-release.outputs.html_url }}
+          RELEASE_PR: ${{steps.create-pr.outputs.pr_url}}
         with:
           filename: .github/RELEASE_TEMPLATES/cli_release_checklist.md
 

--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -56,13 +56,17 @@ jobs:
 
       - name: Draft GitHub release
         uses: actions/create-release@v1
-        id: create_release
+        id: create-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: v${{ github.event.inputs.release_version }}-cli
           release_name: jib-cli v${{ github.event.inputs.release_version }}
           draft: true
+          body: |
+            ### Major Changes
+
+            See [CHANGELOG.md](https://github.com/GoogleContainerTools/jib/blob/master/jib-cli/CHANGELOG.md) for more details.
 
       - name: Upload Jib CLI
         uses: actions/upload-release-asset@v1
@@ -83,3 +87,15 @@ jobs:
           asset_path: ./jib-cli/build/distributions/zip.sha256
           asset_name: jib-jre-${{ github.event.inputs.release_version }}.zip.sha256
           asset_content_type: text/plain
+
+      - name: Create Jib CLI release checklist issue
+        uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NAME: v${{ github.event.inputs.release_version }}-cli
+          CHANGELOG_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-cli/CHANGELOG.md
+          README_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-cli/README.md
+          RELEASE_DRAFT: ${{ steps.create-release.outputs.html_url }}
+        with:
+          filename: .github/RELEASE_TEMPLATES/cli_release_checklist.md
+

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -88,7 +88,7 @@ jobs:
             ### Major Changes
 
             See [CHANGELOG.md](https://github.com/GoogleContainerTools/jib/blob/master/jib-${{ github.event.inputs.project }}-plugin/CHANGELOG.md) for more details.
-      
+
       - name: Create Maven/Gradle release checklist issue
         uses: JasonEtco/create-an-issue@v2
         if: ${{ github.event.inputs.project == 'maven' || github.event.inputs.project == 'gradle' }}
@@ -103,9 +103,9 @@ jobs:
         with:
           filename: .github/RELEASE_TEMPLATES/plugin_release_checklist.md
 
-
-      - name: Draft Jib Core GitHub release
+      - name: Draft Core GitHub release
         uses: actions/create-release@v1
+        id: create-core-release
         if: ${{ github.event.inputs.project == 'core' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -117,3 +117,16 @@ jobs:
             ### Major Changes
 
             See [CHANGELOG.md](https://github.com/GoogleContainerTools/jib/blob/master/jib-core/CHANGELOG.md) for more details.
+
+      - name: Create Core release checklist issue
+        uses: JasonEtco/create-an-issue@v2
+        if: ${{ github.event.inputs.project == 'core' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_NAME: v${{ github.event.inputs.release_version }}-core
+          CHANGELOG_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-core/CHANGELOG.md
+          README_URL: https://github.com/GoogleContainerTools/jib/blob/master/jib-core/README.md
+          RELEASE_DRAFT: ${{ steps.create-core-release.outputs.html_url }}
+          RELEASE_PR: ${{steps.create-pr.outputs.pr_url}}
+        with:
+          filename: .github/RELEASE_TEMPLATES/core_release_checklist.md


### PR DESCRIPTION
This auto-files a checklist issue when releasing Jib Core and Jib CLI.