### PR TITLE
Upgrade Guava

### DIFF
--- a/examples/helloworld/pom.xml
+++ b/examples/helloworld/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>29.0-jre</version>
+      <version>30.0-jre</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Seems like upgrading to 29.0-jre is not enough to close the following alert:

https://github.com/GoogleContainerTools/jib/security/dependabot/examples/helloworld/pom.xml/com.google.guava:guava/open