### PR TITLE
Fix extraDirectories filtering to match relative path

### DIFF
--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -343,12 +343,11 @@ public class SingleProjectIntegrationTest {
         new Command("docker", "run", "--rm", "--entrypoint=ls", targetImage, "-1R", "/extras")
             .run();
 
-    // No "bar" or "*.txt" files. Only copies the following:
-    //   /extras/cat.json
+    //   /extras/cat.txt
     //   /extras/foo
     //   /extras/sub/
     //   /extras/sub/a.json
-    assertThat(output).isEqualTo("/extras:\ncat.json\nfoo\nsub\n\n/extras/sub:\na.json\n");
+    assertThat(output).isEqualTo("/extras:\ncat.txt\nfoo\nsub\n\n/extras/sub:\na.json\n");
   }
 
   @Test

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-extra-dirs-filtering.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-extra-dirs-filtering.gradle
@@ -22,13 +22,13 @@ jib {
       path {
         from = 'src/main/custom-extra-dir3'
         into = '/extras'
-        includes = ['**/*a*']
+        includes = ['**/*a*', '*.txt']
         excludes = ['**/*.txt']
       }
       path {
         from = 'src/main/custom-extra-dir4'
         into = '/extras'
-        includes = ['**/foo']
+        includes = ['foo']
       }
     }
   }

--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
@@ -116,12 +116,11 @@ public class BuildDockerMojoIntegrationTest {
         new Command("docker", "run", "--rm", "--entrypoint=ls", targetImage, "-1R", "/extras")
             .run();
 
-    // No "bar" or "*.txt" files. Only copies the following:
-    //   /extras/cat.json
+    //   /extras/cat.txt
     //   /extras/foo
     //   /extras/sub/
     //   /extras/sub/a.json
-    assertThat(output).isEqualTo("/extras:\ncat.json\nfoo\nsub\n\n/extras/sub:\na.json\n");
+    assertThat(output).isEqualTo("/extras:\ncat.txt\nfoo\nsub\n\n/extras/sub:\na.json\n");
   }
 
   @Test

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-extra-dirs-filtering.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/pom-extra-dirs-filtering.xml
@@ -48,14 +48,14 @@
               <path>
                 <from>${project.basedir}/src/main/jib-custom-3</from>
                 <into>/extras</into>
-                <includes>**/*a*</includes>
+                <includes>**/*a*,*.txt</includes>
                 <excludes>**/*.txt</excludes>
               </path>
               <path>
                 <from>src/main/jib-custom-4</from>
                 <into>/extras</into>
                 <includes>
-                  <include>**/foo</include>
+                  <include>foo</include>
                 </includes>
               </path>
             </paths>

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelper.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelper.java
@@ -75,12 +75,16 @@ public class JavaContainerBuilderHelper {
     excludes
         .stream()
         .map(pattern -> FileSystems.getDefault().getPathMatcher("glob:" + pattern))
-        .forEach(pathMatcher -> walker.filter(path -> !pathMatcher.matches(path)));
+        .forEach(
+            pathMatcher ->
+                walker.filter(path -> !pathMatcher.matches(sourceDirectory.relativize(path))));
     // add an inclusion filter
     includes
         .stream()
         .map(pattern -> FileSystems.getDefault().getPathMatcher("glob:" + pattern))
-        .map(pathMatcher -> (Predicate<Path>) path -> pathMatcher.matches(path))
+        .map(
+            pathMatcher ->
+                (Predicate<Path>) path -> pathMatcher.matches(sourceDirectory.relativize(path)))
         .reduce((matches1, matches2) -> matches1.or(matches2))
         .ifPresent(walker::filter);
     // walk the source tree and add layer entries

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelperTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelperTest.java
@@ -110,9 +110,7 @@ public class JavaContainerBuilderHelperTest {
     assertThat(layerConfiguration.getEntries())
         .comparingElementsUsing(SOURCE_FILE_OF)
         .containsExactly(
-            extraFilesDirectory.resolve("a"),
-            extraFilesDirectory.resolve("a/b/bar"),
-            extraFilesDirectory.resolve("c/cat"));
+            extraFilesDirectory.resolve("a/b/bar"), extraFilesDirectory.resolve("c/cat"));
   }
 
   @Test
@@ -130,6 +128,7 @@ public class JavaContainerBuilderHelperTest {
     assertThat(layerConfiguration.getEntries())
         .comparingElementsUsing(SOURCE_FILE_OF)
         .containsExactly(
+            extraFilesDirectory.resolve("a"),
             extraFilesDirectory.resolve("a/b"),
             extraFilesDirectory.resolve("c"),
             extraFilesDirectory.resolve("foo"));
@@ -158,7 +157,7 @@ public class JavaContainerBuilderHelperTest {
         JavaContainerBuilderHelper.extraDirectoryLayerConfiguration(
             extraFilesDirectory,
             AbsoluteUnixPath.get("/"),
-            Arrays.asList("**/*a*"),
+            Arrays.asList("**/*a*", "a"),
             Arrays.asList("**/*c*"),
             Collections.emptyMap(),
             (ignored1, ignored2) -> Instant.EPOCH);


### PR DESCRIPTION
Most of the time, you'll specify a relative path in `<includes>` and `<excludes>`, which is the case in all of our tests.

Turns out we need to relativize local path to match against the glob matchers. The reason the tests seemed to work was that we always started with `**/`, which works for absolute path. That is, previously, `includes = ['foo']` didn't work.

---

Previous PR: #3173
Issues: #2564 #3164