### PR TITLE
Fix integration test after changing base image

### DIFF
--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -497,7 +497,7 @@ public class BuildImageMojoIntegrationTest {
     Assert.assertEquals(
         "", buildAndRun(emptyTestProject.getProjectRoot(), targetImage, "pom.xml", false));
     assertThat(getCreationTime(targetImage)).isEqualTo(Instant.EPOCH);
-    assertThat(getWorkingDirectory(targetImage)).isEqualTo("/");
+    assertThat(getWorkingDirectory(targetImage)).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
The working directory is not configured in the new base image.