### PR TITLE
[jib-cli] Add option to create an output JSON file that contains image metadata for the built image

### DIFF
--- a/jib-cli/CHANGELOG.md
+++ b/jib-cli/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Added option to specify json output file that should contain image metadata after build is complete. ([#3187](https://github.com/GoogleContainerTools/jib/pull/3187))
+- Added `--image-metadata-out` option to specify JSON output file that should contain image metadata (image ID, digest, and tags) after build is complete. ([#3187](https://github.com/GoogleContainerTools/jib/pull/3187))
 
 ### Changed
 

--- a/jib-cli/CHANGELOG.md
+++ b/jib-cli/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- Added option to specify json output file that should contain image metadata after build is complete. ([#3187](https://github.com/GoogleContainerTools/jib/pull/3187))
+
 ### Changed
 
 ### Fixed

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.cli;
 
 import com.google.cloud.tools.jib.api.Containerizer;
+import com.google.cloud.tools.jib.api.JibContainer;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.cli.buildfile.BuildFiles;
@@ -131,7 +132,8 @@ public class Build implements Callable<Integer> {
       GlobalConfig globalConfig = GlobalConfig.readConfig();
       Multimaps.asMap(globalConfig.getRegistryMirrors()).forEach(containerizer::addRegistryMirrors);
 
-      containerBuilder.containerize(containerizer);
+      JibContainer jibContainer = containerBuilder.containerize(containerizer);
+      JibCli.writeImageJson(commonCliOptions.getImageJsonOutputPath(), jibContainer);
     } catch (Exception ex) {
       JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
       return 1;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
@@ -133,7 +133,7 @@ public class Build implements Callable<Integer> {
       Multimaps.asMap(globalConfig.getRegistryMirrors()).forEach(containerizer::addRegistryMirrors);
 
       JibContainer jibContainer = containerBuilder.containerize(containerizer);
-      JibCli.writeImageJson(commonCliOptions.getImageJsonOutputPath(), jibContainer);
+      JibCli.writeImageJson(commonCliOptions.getImageJsonPath(), jibContainer);
     } catch (Exception ex) {
       JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
       return 1;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/CommonCliOptions.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/CommonCliOptions.java
@@ -248,8 +248,8 @@ public class CommonCliOptions {
       names = "--image-metadata-out",
       paramLabel = "<path-to-json>",
       description =
-          "A path to the json file that should contain image metadata (for example, digest, id and tags) after build is"
-              + "complete.")
+          "path to the json file that should contain image metadata (for example, digest, id and tags) after build is"
+              + "complete")
   @SuppressWarnings("NullAway.Init") // initialized by picocli
   private Path imageJsonPath;
 

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/CommonCliOptions.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/CommonCliOptions.java
@@ -244,6 +244,15 @@ public class CommonCliOptions {
   @SuppressWarnings("NullAway.Init") // initialized by picocli
   private boolean serialize;
 
+  @CommandLine.Option(
+      names = "--image-json",
+      paramLabel = "<path-to-json>",
+      description =
+          "A path to the destination directory of jib-image.json. If provided, image details (for example, digest, id"
+              + "and tags) will be written to this json file.")
+  @SuppressWarnings("NullAway.Init") // initialized by picocli
+  private Path imageJsonPath;
+
   public Verbosity getVerbosity() {
     return Verify.verifyNotNull(verbosity);
   }
@@ -398,6 +407,18 @@ public class CommonCliOptions {
 
   public List<String> getAdditionalTags() {
     return additionalTags;
+  }
+
+  /**
+   * Returns the full path to jib-image.json.
+   *
+   * @return optional value of path to jib-image.json
+   */
+  public Optional<Path> getImageJsonOutputPath() {
+    if (imageJsonPath != null) {
+      return Optional.of(imageJsonPath.resolve("jib-image.json"));
+    }
+    return Optional.empty();
   }
 
   /** Validates parameters defined in this class that could not be done declaratively. */

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/CommonCliOptions.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/CommonCliOptions.java
@@ -245,12 +245,11 @@ public class CommonCliOptions {
   private boolean serialize;
 
   @CommandLine.Option(
-      names = "--result-json",
+      names = "--image-metadata-out",
       paramLabel = "<path-to-json>",
       description =
           "A path to the json file that should contain image metadata (for example, digest, id and tags) after build is"
-              + "complete.",
-      scope = CommandLine.ScopeType.INHERIT)
+              + "complete.")
   @SuppressWarnings("NullAway.Init") // initialized by picocli
   private Path imageJsonPath;
 

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/CommonCliOptions.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/CommonCliOptions.java
@@ -245,11 +245,12 @@ public class CommonCliOptions {
   private boolean serialize;
 
   @CommandLine.Option(
-      names = "--image-json",
+      names = "--result-json",
       paramLabel = "<path-to-json>",
       description =
-          "A path to the destination directory of jib-image.json. If provided, image details (for example, digest, id"
-              + "and tags) will be written to this json file.")
+          "A path to the json file that should contain image metadata (for example, digest, id and tags) after build is"
+              + "complete.",
+      scope = CommandLine.ScopeType.INHERIT)
   @SuppressWarnings("NullAway.Init") // initialized by picocli
   private Path imageJsonPath;
 
@@ -410,15 +411,12 @@ public class CommonCliOptions {
   }
 
   /**
-   * Returns the full path to jib-image.json.
+   * Returns the full path to the image metadata json file, if provided.
    *
-   * @return optional value of path to jib-image.json
+   * @return optional value of path to image json file
    */
-  public Optional<Path> getImageJsonOutputPath() {
-    if (imageJsonPath != null) {
-      return Optional.of(imageJsonPath.resolve("jib-image.json"));
-    }
-    return Optional.empty();
+  public Optional<Path> getImageJsonPath() {
+    return Optional.ofNullable(imageJsonPath);
   }
 
   /** Validates parameters defined in this class that could not be done declaratively. */

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -204,7 +204,7 @@ public class Jar implements Callable<Integer> {
       Multimaps.asMap(globalConfig.getRegistryMirrors()).forEach(containerizer::addRegistryMirrors);
 
       JibContainer jibContainer = containerBuilder.containerize(containerizer);
-      JibCli.writeImageJson(commonCliOptions.getImageJsonOutputPath(), jibContainer);
+      JibCli.writeImageJson(commonCliOptions.getImageJsonPath(), jibContainer);
     } catch (Exception ex) {
       JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
       return 1;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.cli;
 
 import com.google.cloud.tools.jib.api.Containerizer;
+import com.google.cloud.tools.jib.api.JibContainer;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.api.Ports;
@@ -202,7 +203,8 @@ public class Jar implements Callable<Integer> {
       GlobalConfig globalConfig = GlobalConfig.readConfig();
       Multimaps.asMap(globalConfig.getRegistryMirrors()).forEach(containerizer::addRegistryMirrors);
 
-      containerBuilder.containerize(containerizer);
+      JibContainer jibContainer = containerBuilder.containerize(containerizer);
+      JibCli.writeImageJson(commonCliOptions.getImageJsonOutputPath(), jibContainer);
     } catch (Exception ex) {
       JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
       return 1;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/JibCli.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/JibCli.java
@@ -75,10 +75,10 @@ public class JibCli {
   }
 
   /**
-   * Writes image details (imageId, digest, tags, etc.) to a json file (jib-image.json), if the
-   * destination of the json is provided.
+   * Writes image details (imageId, digest, tags, etc.) to a json file, if the path to the json is
+   * provided.
    *
-   * @param imageJsonOutputPath optional path to jib-image.json (for example,
+   * @param imageJsonOutputPath optional path to json file (for example,
    *     path/to/json/jib-image.json)
    * @param jibContainer the {@link JibContainer} to derive image details from
    * @throws IOException if error occurs when writing to the json file.

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/JibCli.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/JibCli.java
@@ -87,8 +87,8 @@ public class JibCli {
       throws IOException {
     if (imageJsonOutputPath.isPresent()) {
       ImageMetadataOutput metadataOutput = ImageMetadataOutput.fromJibContainer(jibContainer);
-      String imageJson = metadataOutput.toJson();
-      Files.write(imageJsonOutputPath.get(), imageJson.getBytes(StandardCharsets.UTF_8));
+      Files.write(
+          imageJsonOutputPath.get(), metadataOutput.toJson().getBytes(StandardCharsets.UTF_8));
     }
   }
 

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/JibCli.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/JibCli.java
@@ -18,10 +18,17 @@ package com.google.cloud.tools.jib.cli;
 
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.apache.v2.ApacheHttpTransport;
+import com.google.cloud.tools.jib.api.JibContainer;
 import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.plugins.common.ImageMetadataOutput;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -65,6 +72,24 @@ public class JibCli {
             + ": "
             + exception.getMessage()
             + "\u001B[0m");
+  }
+
+  /**
+   * Writes image details (imageId, digest, tags, etc.) to a json file (jib-image.json), if the
+   * destination of the json is provided.
+   *
+   * @param imageJsonOutputPath optional path to jib-image.json (for example,
+   *     path/to/json/jib-image.json)
+   * @param jibContainer the {@link JibContainer} to derive image details from
+   * @throws IOException if error occurs when writing to the json file.
+   */
+  static void writeImageJson(Optional<Path> imageJsonOutputPath, JibContainer jibContainer)
+      throws IOException {
+    if (imageJsonOutputPath.isPresent()) {
+      ImageMetadataOutput metadataOutput = ImageMetadataOutput.fromJibContainer(jibContainer);
+      String imageJson = metadataOutput.toJson();
+      Files.write(imageJsonOutputPath.get(), imageJson.getBytes(StandardCharsets.UTF_8));
+    }
   }
 
   /**

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/BuildTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/BuildTest.java
@@ -68,6 +68,7 @@ public class BuildTest {
     assertThat(commonCliOptions.isStacktrace()).isFalse();
     assertThat(commonCliOptions.getHttpTrace()).isEqualTo(HttpTraceLevel.off);
     assertThat(commonCliOptions.isSerialize()).isFalse();
+    assertThat(commonCliOptions.getImageJsonOutputPath()).isEmpty();
   }
 
   @Test
@@ -103,6 +104,7 @@ public class BuildTest {
     assertThat(commonCliOptions.isStacktrace()).isFalse();
     assertThat(commonCliOptions.getHttpTrace()).isEqualTo(HttpTraceLevel.off);
     assertThat(commonCliOptions.isSerialize()).isFalse();
+    assertThat(commonCliOptions.getImageJsonOutputPath()).isEmpty();
   }
 
   @Test
@@ -125,7 +127,8 @@ public class BuildTest {
             "--verbosity=info",
             "--stacktrace",
             "--http-trace",
-            "--serialize");
+            "--serialize",
+            "--image-json=path/to/json/");
     CommonCliOptions commonCliOptions = buildCommand.commonCliOptions;
     assertThat(commonCliOptions.getTargetImage()).isEqualTo("test-image-ref");
     assertThat(commonCliOptions.getUsernamePassword()).isEmpty();
@@ -149,6 +152,8 @@ public class BuildTest {
     assertThat(commonCliOptions.isStacktrace()).isTrue();
     assertThat(commonCliOptions.getHttpTrace()).isEqualTo(HttpTraceLevel.config);
     assertThat(commonCliOptions.isSerialize()).isTrue();
+    assertThat(commonCliOptions.getImageJsonOutputPath())
+        .hasValue(Paths.get("path/to/json/jib-image.json"));
   }
 
   @Test

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/BuildTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/BuildTest.java
@@ -128,7 +128,7 @@ public class BuildTest {
             "--stacktrace",
             "--http-trace",
             "--serialize",
-            "--result-json=path/to/json/jib-image.json");
+            "--image-metadata-out=path/to/json/jib-image.json");
     CommonCliOptions commonCliOptions = buildCommand.commonCliOptions;
     assertThat(commonCliOptions.getTargetImage()).isEqualTo("test-image-ref");
     assertThat(commonCliOptions.getUsernamePassword()).isEmpty();

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/BuildTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/BuildTest.java
@@ -68,7 +68,7 @@ public class BuildTest {
     assertThat(commonCliOptions.isStacktrace()).isFalse();
     assertThat(commonCliOptions.getHttpTrace()).isEqualTo(HttpTraceLevel.off);
     assertThat(commonCliOptions.isSerialize()).isFalse();
-    assertThat(commonCliOptions.getImageJsonOutputPath()).isEmpty();
+    assertThat(commonCliOptions.getImageJsonPath()).isEmpty();
   }
 
   @Test
@@ -104,7 +104,7 @@ public class BuildTest {
     assertThat(commonCliOptions.isStacktrace()).isFalse();
     assertThat(commonCliOptions.getHttpTrace()).isEqualTo(HttpTraceLevel.off);
     assertThat(commonCliOptions.isSerialize()).isFalse();
-    assertThat(commonCliOptions.getImageJsonOutputPath()).isEmpty();
+    assertThat(commonCliOptions.getImageJsonPath()).isEmpty();
   }
 
   @Test
@@ -128,7 +128,7 @@ public class BuildTest {
             "--stacktrace",
             "--http-trace",
             "--serialize",
-            "--image-json=path/to/json/");
+            "--result-json=path/to/json/jib-image.json");
     CommonCliOptions commonCliOptions = buildCommand.commonCliOptions;
     assertThat(commonCliOptions.getTargetImage()).isEqualTo("test-image-ref");
     assertThat(commonCliOptions.getUsernamePassword()).isEmpty();
@@ -152,7 +152,7 @@ public class BuildTest {
     assertThat(commonCliOptions.isStacktrace()).isTrue();
     assertThat(commonCliOptions.getHttpTrace()).isEqualTo(HttpTraceLevel.config);
     assertThat(commonCliOptions.isSerialize()).isTrue();
-    assertThat(commonCliOptions.getImageJsonOutputPath())
+    assertThat(commonCliOptions.getImageJsonPath())
         .hasValue(Paths.get("path/to/json/jib-image.json"));
   }
 

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
@@ -140,7 +140,7 @@ public class JarTest {
             "--stacktrace",
             "--http-trace",
             "--serialize",
-            "--result-json=path/to/json/jib-image.json",
+            "--image-metadata-out=path/to/json/jib-image.json",
             "my-app.jar");
     CommonCliOptions commonCliOptions = jarCommand.commonCliOptions;
     assertThat(commonCliOptions.getTargetImage()).isEqualTo("test-image-ref");

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
@@ -84,6 +84,7 @@ public class JarTest {
     assertThat(commonCliOptions.isStacktrace()).isFalse();
     assertThat(commonCliOptions.getHttpTrace()).isEqualTo(HttpTraceLevel.off);
     assertThat(commonCliOptions.isSerialize()).isFalse();
+    assertThat(commonCliOptions.getImageJsonOutputPath()).isEmpty();
     assertThat(jarCommand.getFrom()).isEmpty();
     assertThat(jarCommand.getJvmFlags()).isEmpty();
     assertThat(jarCommand.getExposedPorts()).isEmpty();
@@ -119,6 +120,7 @@ public class JarTest {
     assertThat(commonCliOptions.isStacktrace()).isFalse();
     assertThat(commonCliOptions.getHttpTrace()).isEqualTo(HttpTraceLevel.off);
     assertThat(commonCliOptions.isSerialize()).isFalse();
+    assertThat(commonCliOptions.getImageJsonOutputPath()).isEmpty();
   }
 
   @Test
@@ -138,6 +140,7 @@ public class JarTest {
             "--stacktrace",
             "--http-trace",
             "--serialize",
+            "--image-json=path/to/json",
             "my-app.jar");
     CommonCliOptions commonCliOptions = jarCommand.commonCliOptions;
     assertThat(commonCliOptions.getTargetImage()).isEqualTo("test-image-ref");
@@ -157,6 +160,8 @@ public class JarTest {
     assertThat(commonCliOptions.isStacktrace()).isTrue();
     assertThat(commonCliOptions.getHttpTrace()).isEqualTo(HttpTraceLevel.config);
     assertThat(commonCliOptions.isSerialize()).isTrue();
+    assertThat(commonCliOptions.getImageJsonOutputPath())
+        .hasValue(Paths.get("path/to/json/jib-image.json"));
   }
 
   @Test

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
@@ -84,7 +84,7 @@ public class JarTest {
     assertThat(commonCliOptions.isStacktrace()).isFalse();
     assertThat(commonCliOptions.getHttpTrace()).isEqualTo(HttpTraceLevel.off);
     assertThat(commonCliOptions.isSerialize()).isFalse();
-    assertThat(commonCliOptions.getImageJsonOutputPath()).isEmpty();
+    assertThat(commonCliOptions.getImageJsonPath()).isEmpty();
     assertThat(jarCommand.getFrom()).isEmpty();
     assertThat(jarCommand.getJvmFlags()).isEmpty();
     assertThat(jarCommand.getExposedPorts()).isEmpty();
@@ -120,7 +120,7 @@ public class JarTest {
     assertThat(commonCliOptions.isStacktrace()).isFalse();
     assertThat(commonCliOptions.getHttpTrace()).isEqualTo(HttpTraceLevel.off);
     assertThat(commonCliOptions.isSerialize()).isFalse();
-    assertThat(commonCliOptions.getImageJsonOutputPath()).isEmpty();
+    assertThat(commonCliOptions.getImageJsonPath()).isEmpty();
   }
 
   @Test
@@ -140,7 +140,7 @@ public class JarTest {
             "--stacktrace",
             "--http-trace",
             "--serialize",
-            "--image-json=path/to/json",
+            "--result-json=path/to/json/jib-image.json",
             "my-app.jar");
     CommonCliOptions commonCliOptions = jarCommand.commonCliOptions;
     assertThat(commonCliOptions.getTargetImage()).isEqualTo("test-image-ref");
@@ -160,7 +160,7 @@ public class JarTest {
     assertThat(commonCliOptions.isStacktrace()).isTrue();
     assertThat(commonCliOptions.getHttpTrace()).isEqualTo(HttpTraceLevel.config);
     assertThat(commonCliOptions.isSerialize()).isTrue();
-    assertThat(commonCliOptions.getImageJsonOutputPath())
+    assertThat(commonCliOptions.getImageJsonPath())
         .hasValue(Paths.get("path/to/json/jib-image.json"));
   }
 

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JibCliTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JibCliTest.java
@@ -53,7 +53,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class JibCliTest {
 
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Mock private JibContainer mockJibContainer;
 
@@ -102,7 +102,7 @@ public class JibCliTest {
     when(mockJibContainer.getDigest()).thenReturn(DescriptorDigest.fromDigest(digest));
     when(mockJibContainer.getTags()).thenReturn(ImmutableSet.of("latest", "tag-2"));
 
-    Path outputPath = temporaryFolder.newFile("jib-image.json").toPath();
+    Path outputPath = temporaryFolder.getRoot().toPath().resolve("jib-image.json");
     JibCli.writeImageJson(Optional.of(outputPath), mockJibContainer);
 
     String outputJson = new String(Files.readAllBytes(outputPath), StandardCharsets.UTF_8);

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JibCliTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JibCliTest.java
@@ -93,7 +93,7 @@ public class JibCliTest {
   }
 
   @Test
-  public void testWriteToImageJson()
+  public void testWriteImageJson()
       throws InvalidImageReferenceException, IOException, DigestException {
     String imageId = "sha256:61bb3ec31a47cb730eb58a38bbfa813761a51dca69d10e39c24c3d00a7b2c7a9";
     String digest = "sha256:3f1be7e19129edb202c071a659a4db35280ab2bb1a16f223bfd5d1948657b6fc";


### PR DESCRIPTION
For #3183 

Usage:
Calling `jib build --target=${IMAGE_REFERENCE} --image-metadata-out=/my/directory/jib-image.json` will result in the creation of `jib-image.json` (with image details such as image digest, id, tags) in `my/directory/`, if the directory exists.
Same for `jib jar`. 
