### PR TITLE
Update privacy page for Jib CLI

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -2,10 +2,10 @@ The privacy of our users is very important to us.
 Your use of this software is subject to the <a href=https://policies.google.com/privacy>Google Privacy Policy</a>.
 
 ## Update check
-Many Jib users are unaware of new releases. To encourage users to stay up-to-date, Jib 2.0.0 and later will
+Many Jib users are unaware of new releases. To encourage users to stay up-to-date, the Jib Maven and Jib Gradle plugins (2.0.0 and later) and Jib CLI (0.6.0 and later) will
 periodically check to see if there is a new version of Jib is available. This check fetches a simple text
 file hosted in Google Cloud Storage. As a side effect this request is logged, which includes the request path,
-source IP address, and the user-agent string. The user-agent is set by Jib and includes the Jib plugin type
+source IP address, and the user-agent string. The user-agent is set by Jib and includes the Jib tool name
 and version.
 
 ### How to disable update checks

--- a/jib-cli/README.md
+++ b/jib-cli/README.md
@@ -37,6 +37,7 @@ The CLI tool is powered by [Jib Core](https://github.com/GoogleContainerTools/ji
 * [Global Jib Configuration](#global-jib-configuration)
 * [References](#references)
   * [Fully Annotated Build File (`jib.yaml`)](#fully-annotated-build-file-jibyaml)
+* [Privacy](#privacy)
 
 ## Get the Jib CLI
 
@@ -387,3 +388,6 @@ Parameters that will be overwritten:
 - `workingDirectory`
 - `entrypoint`
 - `cmd`
+
+## Privacy
+See the [Privacy page](https://github.com/GoogleContainerTools/jib/blob/master/docs/privacy.md).


### PR DESCRIPTION
Also includes link to the privacy page in jib-cli/README.

To be submitted after #3165.
