### PR TITLE
🎁 Jib CLI > Add the windows install process with chocolatey 🎁 

### DIFF
--- a/jib-cli/README.md
+++ b/jib-cli/README.md
@@ -2,6 +2,9 @@
 
 <img src="https://img.shields.io/badge/status-preview-orange">
 
+[![Chocolatey](https://img.shields.io/chocolatey/v/jib.svg)](https://chocolatey.org/packages/jib)
+[![Chocolatey](https://img.shields.io/chocolatey/dt/jib.svg)](https://chocolatey.org/packages/jib)
+
 `jib` is a general-purpose command-line utility for building Docker or [OCI](https://github.com/opencontainers/image-spec) container images from file system content as well as JAR files. Jib CLI builds containers [fast and reproducibly without Docker](https://github.com/GoogleContainerTools/jib#goals) like [other Jib tools](https://github.com/GoogleContainerTools/jib#what-is-jib).
 
 ```sh
@@ -22,6 +25,7 @@ The CLI tool is powered by [Jib Core](https://github.com/GoogleContainerTools/ji
 ## Table of Contents
 * [Get the Jib CLI](#get-the-jib-cli)
   * [Download a Java Application](#download-a-java-application)
+  * [Install on Windows with `choco`](#Windows-install-with-choco)
   * [Build Yourself from Source (for Advanced Users)](#build-yourself-from-source-for-advanced-users)
 * [Supported Commands](#supported-commands)
 * [Build Command](#build-command)
@@ -47,6 +51,28 @@ Most users should download a ZIP archive (Java application). We are working on r
 A JRE is required to run this Jib CLI distribution.
 
 Find the [latest jib-cli 0.5.0 release](https://github.com/GoogleContainerTools/jib/releases/tag/v0.5.0-cli) on the [Releases page](https://github.com/GoogleContainerTools/jib/releases), download `jib-jre-<version>.zip`, and unzip it. The zip file contains the `jib` (`jib.bat` for Windows) script at `jib/bin/`. Optionally, add the binary directory to your `$PATH` so that you can call `jib` from anywhere.
+
+### Windows install with choco
+
+On Windows, you can use the [`choco`](https://community.chocolatey.org/packages/jib) commmand to install, upgrade or uninstall `Jib`.
+
+To install Jib CLI, run the following command from the command line or from PowerShell:
+
+```
+choco install jib
+```
+
+To upgrade Jib CLI, run the following command from the command line or from PowerShell:
+
+```
+choco upgrade jib
+```
+
+To uninstall Jib CLI, run the following command from the command line or from PowerShell:
+
+```
+choco uninstall jib
+```
 
 ### Build Yourself from Source (for Advanced Users)
 

--- a/jib-cli/README.md
+++ b/jib-cli/README.md
@@ -25,7 +25,7 @@ The CLI tool is powered by [Jib Core](https://github.com/GoogleContainerTools/ji
 ## Table of Contents
 * [Get the Jib CLI](#get-the-jib-cli)
   * [Download a Java Application](#download-a-java-application)
-  * [Install on Windows with `choco`](#Windows-install-with-choco)
+  * [Windows: Install with `choco`](#windows-install-with-choco)
   * [Build Yourself from Source (for Advanced Users)](#build-yourself-from-source-for-advanced-users)
 * [Supported Commands](#supported-commands)
 * [Build Command](#build-command)
@@ -52,25 +52,12 @@ A JRE is required to run this Jib CLI distribution.
 
 Find the [latest jib-cli 0.5.0 release](https://github.com/GoogleContainerTools/jib/releases/tag/v0.5.0-cli) on the [Releases page](https://github.com/GoogleContainerTools/jib/releases), download `jib-jre-<version>.zip`, and unzip it. The zip file contains the `jib` (`jib.bat` for Windows) script at `jib/bin/`. Optionally, add the binary directory to your `$PATH` so that you can call `jib` from anywhere.
 
-### Windows install with choco
+### Windows: Install with `choco`
 
-On Windows, you can use the [`choco`](https://community.chocolatey.org/packages/jib) commmand to install, upgrade or uninstall `Jib`.
-
-To install Jib CLI, run the following command from the command line or from PowerShell:
-
+On Windows, you can use the [`choco`](https://community.chocolatey.org/packages/jib) command. To install, upgradle, or uninstall Jib CLI, run the following commands from the command-line or PowerShell:
 ```
 choco install jib
-```
-
-To upgrade Jib CLI, run the following command from the command line or from PowerShell:
-
-```
 choco upgrade jib
-```
-
-To uninstall Jib CLI, run the following command from the command line or from PowerShell:
-
-```
 choco uninstall jib
 ```
 


### PR DESCRIPTION
Hi, I'm a Jib fan.
Most of the time, i'm running Jib from `maven` and `gradle` , but recently I had to use it from command line. To help windows colleagues adopt it, I created a [Chocolatey package](https://community.chocolatey.org/packages/jib) to make the install process even easier under windows.

Hopefully you'll like it.

Thanks a lot for Jib, it helps us save so much time !


https://twitter.com/rastadidi/status/1380255793648312321

Kind Regards,
Adrien

<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->
