### PR TITLE
Use Gradle Property and Provider to enable lazy evaluation for jib.container.labels (#3094)

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
@@ -24,6 +24,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import javax.inject.Inject;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 
@@ -43,12 +46,17 @@ public class ContainerParameters {
   private ImageFormat format = ImageFormat.Docker;
   private List<String> ports = Collections.emptyList();
   private List<String> volumes = Collections.emptyList();
-  private Map<String, String> labels = Collections.emptyMap();
+  private MapProperty<String, String> labels;
   private String appRoot = "";
   @Nullable private String user;
   @Nullable private String workingDirectory;
   private String filesModificationTime = "EPOCH_PLUS_SECOND";
   private String creationTime = "EPOCH";
+
+  @Inject
+  public ContainerParameters(ObjectFactory objectFactory) {
+    labels = objectFactory.mapProperty(String.class, String.class).empty();
+  }
 
   @Input
   @Nullable
@@ -195,16 +203,16 @@ public class ContainerParameters {
 
   @Input
   @Optional
-  public Map<String, String> getLabels() {
-    if (System.getProperty(PropertyNames.CONTAINER_LABELS) != null) {
-      return ConfigurationPropertyValidator.parseMapProperty(
-          System.getProperty(PropertyNames.CONTAINER_LABELS));
+  public MapProperty<String, String> getLabels() {
+    String labelsProperty = System.getProperty(PropertyNames.CONTAINER_LABELS);
+    if (labelsProperty != null) {
+      Map<String, String> parsedLabels =
+          ConfigurationPropertyValidator.parseMapProperty(labelsProperty);
+      if (!parsedLabels.equals(labels.get())) {
+        labels.set(parsedLabels);
+      }
     }
     return labels;
-  }
-
-  public void setLabels(Map<String, String> labels) {
-    this.labels = labels;
   }
 
   @Input

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -113,7 +113,7 @@ public class GradleRawConfiguration implements RawConfiguration {
 
   @Override
   public Map<String, String> getLabels() {
-    return jibExtension.getContainer().getLabels();
+    return jibExtension.getContainer().getLabels().get();
   }
 
   @Override

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
@@ -21,14 +21,22 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Sets;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import org.gradle.api.provider.MapProperty;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
 
 /** Test for {@link GradleRawConfiguration}. */
+@RunWith(MockitoJUnitRunner.class)
 public class GradleRawConfigurationTest {
+
+  @Mock private MapProperty<String, String> labels;
 
   @Test
   public void testGetters() {
@@ -67,8 +75,8 @@ public class GradleRawConfigurationTest {
     Mockito.when(containerParameters.getEnvironment())
         .thenReturn(new HashMap<>(ImmutableMap.of("currency", "dollar")));
     Mockito.when(containerParameters.getJvmFlags()).thenReturn(Arrays.asList("-cp", "."));
-    Mockito.when(containerParameters.getLabels())
-        .thenReturn(new HashMap<>(ImmutableMap.of("unit", "cm")));
+    Mockito.when(labels.get()).thenReturn(Collections.singletonMap("unit", "cm"));
+    Mockito.when(containerParameters.getLabels()).thenReturn(labels);
     Mockito.when(containerParameters.getMainClass()).thenReturn("com.example.Main");
     Mockito.when(containerParameters.getPorts()).thenReturn(Arrays.asList("80/tcp", "0"));
     Mockito.when(containerParameters.getUser()).thenReturn("admin:wheel");

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -140,7 +140,7 @@ public class JibExtensionTest {
     assertThat(testJibExtension.getContainer().getArgs()).isNull();
     assertThat(testJibExtension.getContainer().getFormat()).isSameInstanceAs(ImageFormat.Docker);
     assertThat(testJibExtension.getContainer().getPorts()).isEmpty();
-    assertThat(testJibExtension.getContainer().getLabels()).isEmpty();
+    assertThat(testJibExtension.getContainer().getLabels().get()).isEmpty();
     assertThat(testJibExtension.getContainer().getAppRoot()).isEmpty();
     assertThat(testJibExtension.getContainer().getFilesModificationTime())
         .isEqualTo("EPOCH_PLUS_SECOND");
@@ -156,7 +156,6 @@ public class JibExtensionTest {
           container.setMainClass("mainClass");
           container.setArgs(Arrays.asList("arg1", "arg2", "arg3"));
           container.setPorts(Arrays.asList("1000", "2000-2010", "3000"));
-          container.setLabels(ImmutableMap.of("label1", "value1", "label2", "value2"));
           container.setFormat(ImageFormat.OCI);
           container.setAppRoot("some invalid appRoot value");
           container.setFilesModificationTime("some invalid time value");
@@ -172,9 +171,6 @@ public class JibExtensionTest {
     assertThat(testJibExtension.getContainer().getMainClass()).isEqualTo("mainClass");
     assertThat(container.getArgs()).containsExactly("arg1", "arg2", "arg3").inOrder();
     assertThat(container.getPorts()).containsExactly("1000", "2000-2010", "3000").inOrder();
-    assertThat(container.getLabels())
-        .containsExactly("label1", "value1", "label2", "value2")
-        .inOrder();
     assertThat(container.getFormat()).isSameInstanceAs(ImageFormat.OCI);
     assertThat(container.getAppRoot()).isEqualTo("some invalid appRoot value");
     assertThat(container.getFilesModificationTime()).isEqualTo("some invalid time value");
@@ -379,7 +375,7 @@ public class JibExtensionTest {
         .containsExactly("flag1", "flag2", "flag3")
         .inOrder();
     System.setProperty("jib.container.labels", "label1=val1,label2=val2");
-    assertThat(testJibExtension.getContainer().getLabels())
+    assertThat(testJibExtension.getContainer().getLabels().get())
         .containsExactly("label1", "val1", "label2", "val2")
         .inOrder();
     System.setProperty("jib.container.mainClass", "main");

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -35,6 +35,7 @@ import org.gradle.api.tasks.TaskContainer;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.tasks.Jar;
 import org.gradle.testfixtures.ProjectBuilder;
+import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.UnexpectedBuildFailure;
 import org.junit.After;
@@ -356,6 +357,14 @@ public class JibPluginTest {
     assertThat(output)
         .contains(
             "Containerizing application to updated-image, updated-image:updated-tag, updated-image:tag2");
+  }
+
+  @Test
+  public void testLazyEvalForLabels() {
+    BuildResult showLabels = testProject.build("showlabels", "-Djib.console=plain");
+    assertThat(showLabels.getOutput())
+        .contains(
+            "labels contain values [firstkey:updated-first-label, secondKey:updated-second-label]");
   }
 
   private Project createProject(String... plugins) {

--- a/jib-gradle-plugin/src/test/resources/gradle/projects/lazy-evaluation/build.gradle
+++ b/jib-gradle-plugin/src/test/resources/gradle/projects/lazy-evaluation/build.gradle
@@ -22,7 +22,20 @@ project.afterEvaluate {
 
 jib {
     to {
-        image = project.provider {project.ext.value + "-image"}
-        tags = project.provider {[project.ext.value + "-tag", "tag2"]}
+        image = project.provider { project.ext.value + "-image" }
+        tags = project.provider { [project.ext.value + "-tag", "tag2"] }
     }
+    container {
+        labels = project.provider {
+            [
+                    firstkey : project.ext.value + "-first-label",
+                    secondKey: project.ext.value + "-second-label"
+            ]
+        }
+    }
+}
+
+tasks.register('showlabels') {
+    Map<String, String> prop = project.extensions.getByName("jib")["container"]["labels"].get()
+    println("labels contain values " + prop)
 }


### PR DESCRIPTION
Use Gradle Property and Provider to enable lazy evaluation for jib.container.labels (#3094)