### PR TITLE
Remove issue tracker url in most places

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/SpringBootExplodedProcessor.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/SpringBootExplodedProcessor.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.cli.jar;
 
-import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.cli.ArtifactLayers;
 import com.google.cloud.tools.jib.cli.ArtifactProcessor;
@@ -174,9 +173,7 @@ class SpringBootExplodedProcessor implements ArtifactProcessor {
         Verify.verifyNotNull(layerEntries).add(entryMatcher.group(1));
       } else {
         throw new IllegalStateException(
-            "Unable to parse BOOT-INF/layers.idx file in the JAR. Please check the format of "
-                + "layers.idx. If this is a Jib CLI bug, file an issue at "
-                + ProjectInfo.GITHUB_NEW_ISSUE_URL);
+            "Unable to parse BOOT-INF/layers.idx file in the JAR. Please check the format of layers.idx.");
       }
     }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheCorruptedException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheCorruptedException.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.cache;
 
-import com.google.cloud.tools.jib.ProjectInfo;
 import java.nio.file.Path;
 
 /** Thrown if the the cache was found to be corrupted. */
@@ -27,9 +26,7 @@ public class CacheCorruptedException extends Exception {
         message
             + ". You may need to clear the cache by deleting the '"
             + cacheDirectory
-            + "' directory (if this is a bug, please file an issue at "
-            + ProjectInfo.GITHUB_NEW_ISSUE_URL
-            + ")",
+            + "' directory",
         cause);
   }
 
@@ -38,8 +35,6 @@ public class CacheCorruptedException extends Exception {
         message
             + ". You may need to clear the cache by deleting the '"
             + cacheDirectory
-            + "' directory (if this is a bug, please file an issue at "
-            + ProjectInfo.GITHUB_NEW_ISSUE_URL
-            + ")");
+            + "' directory");
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryErrorExceptionBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryErrorExceptionBuilder.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.registry;
 
-import com.google.cloud.tools.jib.ProjectInfo;
 import com.google.cloud.tools.jib.registry.json.ErrorEntryTemplate;
 import javax.annotation.Nullable;
 
@@ -99,9 +98,6 @@ class RegistryErrorExceptionBuilder {
   }
 
   RegistryErrorException build() {
-    // Provides a feedback channel.
-    errorMessageBuilder.append(
-        " | If this is a bug, please file an issue at " + ProjectInfo.GITHUB_NEW_ISSUE_URL);
     return new RegistryErrorException(errorMessageBuilder.toString(), cause);
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageFilesTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageFilesTest.java
@@ -68,10 +68,12 @@ public class CacheStorageFilesTest {
       Assert.fail("Should have thrown CacheCorruptedException");
 
     } catch (CacheCorruptedException ex) {
-      Assert.assertEquals("Layer file did not include valid hash: not long enough. "
-                      + "You may need to clear the cache by deleting the '"
-                      + TEST_CACHE_STORAGE_FILES.getCacheDirectory()
-                      + "' directory", ex.getMessage());
+      Assert.assertEquals(
+          "Layer file did not include valid hash: not long enough. "
+              + "You may need to clear the cache by deleting the '"
+              + TEST_CACHE_STORAGE_FILES.getCacheDirectory()
+              + "' directory",
+          ex.getMessage());
       MatcherAssert.assertThat(ex.getCause(), CoreMatchers.instanceOf(DigestException.class));
     }
 
@@ -81,11 +83,13 @@ public class CacheStorageFilesTest {
               "not valid hash bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"));
       Assert.fail("Should have thrown CacheCorruptedException");
     } catch (CacheCorruptedException ex) {
-      Assert.assertEquals("Layer file did not include valid hash: "
+      Assert.assertEquals(
+          "Layer file did not include valid hash: "
               + "not valid hash bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb. "
               + "You may need to clear the cache by deleting the '"
               + TEST_CACHE_STORAGE_FILES.getCacheDirectory()
-              + "' directory", ex.getMessage());
+              + "' directory",
+          ex.getMessage());
       MatcherAssert.assertThat(ex.getCause(), CoreMatchers.instanceOf(DigestException.class));
     }
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageFilesTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageFilesTest.java
@@ -68,9 +68,10 @@ public class CacheStorageFilesTest {
       Assert.fail("Should have thrown CacheCorruptedException");
 
     } catch (CacheCorruptedException ex) {
-      MatcherAssert.assertThat(
-          ex.getMessage(),
-          CoreMatchers.startsWith("Layer file did not include valid hash: not long enough"));
+      Assert.assertEquals("Layer file did not include valid hash: not long enough. "
+                      + "You may need to clear the cache by deleting the '"
+                      + TEST_CACHE_STORAGE_FILES.getCacheDirectory()
+                      + "' directory", ex.getMessage());
       MatcherAssert.assertThat(ex.getCause(), CoreMatchers.instanceOf(DigestException.class));
     }
 
@@ -79,13 +80,12 @@ public class CacheStorageFilesTest {
           Paths.get(
               "not valid hash bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"));
       Assert.fail("Should have thrown CacheCorruptedException");
-
     } catch (CacheCorruptedException ex) {
-      MatcherAssert.assertThat(
-          ex.getMessage(),
-          CoreMatchers.startsWith(
-              "Layer file did not include valid hash: "
-                  + "not valid hash bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"));
+      Assert.assertEquals("Layer file did not include valid hash: "
+              + "not valid hash bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb. "
+              + "You may need to clear the cache by deleting the '"
+              + TEST_CACHE_STORAGE_FILES.getCacheDirectory()
+              + "' directory", ex.getMessage());
       MatcherAssert.assertThat(ex.getCause(), CoreMatchers.instanceOf(DigestException.class));
     }
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryEndpointCallerTest.java
@@ -412,8 +412,7 @@ public class RegistryEndpointCallerTest {
         endpointCaller.newRegistryErrorException(httpException);
     Assert.assertSame(httpException, registryException.getCause());
     Assert.assertEquals(
-        "Tried to actionDescription but failed because: manifest unknown | If this is a bug, "
-            + "please file an issue at https://github.com/GoogleContainerTools/jib/issues/new",
+        "Tried to actionDescription but failed because: manifest unknown",
         registryException.getMessage());
   }
 
@@ -430,9 +429,7 @@ public class RegistryEndpointCallerTest {
     Assert.assertEquals(
         "Tried to actionDescription but failed because: registry returned error code 404; "
             + "possible causes include invalid or wrong reference. Actual error output follows:\n"
-            + ">>>>> (404) page not found <<<<<\n"
-            + " | If this is a bug, please file an issue at "
-            + "https://github.com/GoogleContainerTools/jib/issues/new",
+            + ">>>>> (404) page not found <<<<<\n",
         registryException.getMessage());
   }
 
@@ -448,9 +445,7 @@ public class RegistryEndpointCallerTest {
     Assert.assertSame(httpException, registryException.getCause());
     Assert.assertEquals(
         "Tried to actionDescription but failed because: registry returned error code 404 "
-            + "but did not return any details; possible causes include invalid or wrong reference, or proxy/firewall/VPN interfering \n"
-            + " | If this is a bug, please file an issue at "
-            + "https://github.com/GoogleContainerTools/jib/issues/new",
+            + "but did not return any details; possible causes include invalid or wrong reference, or proxy/firewall/VPN interfering \n",
         registryException.getMessage());
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryErrorExceptionBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryErrorExceptionBuilderTest.java
@@ -55,8 +55,7 @@ public class RegistryErrorExceptionBuilderTest {
           "Tried to do something but failed because: manifest invalid (something went wrong), blob "
               + "unknown (something went wrong), manifest unknown, tag invalid, manifest "
               + "unverified, other: some other error happened, unknown error code: unknown (some "
-              + "unknown error happened) | If this is a bug, please file an issue at "
-              + "https://github.com/GoogleContainerTools/jib/issues/new",
+              + "unknown error happened)",
           ex.getMessage());
     }
   }


### PR DESCRIPTION
fixes #3283

I removed the link in most places. I also fixed and make certain tests more strict.
There was one place in which I think the URL should stay, that is: https://github.com/GoogleContainerTools/jib/blob/master/jib-core/src/main/java/com/google/cloud/tools/jib/api/JavaContainerBuilder.java#L661. 
I'm not that familiar with the codebase but it seems really unlikely for this exception not to be caused by a bug.

Feel free to review the PR!