### PR TITLE
Add warTest/ to Eclipse classpath exclusion list

### DIFF
--- a/jib-cli/build.gradle
+++ b/jib-cli/build.gradle
@@ -69,7 +69,7 @@ eclipse.classpath.plusConfigurations += [configurations.integrationTestImplement
 eclipse.classpath.file.whenMerged {
   entries.each {
     if (it.path == 'src/integration-test/resources') {
-      it.excludes += 'jarTest/'
+      it.excludes += ['jarTest/', 'warTest/']
     }
   }
 }


### PR DESCRIPTION
We recently added the `warTest/` directory as test resources. Without excluding it, Eclipse considers it as project source.