### PR TITLE
basic retry for http client

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blob.java
@@ -38,7 +38,5 @@ public interface Blob {
    * @return {@code true} if {@link #writeTo(OutputStream)} can be called multiple times, {@code
    *     false} otherwise.
    */
-  default boolean isRetryable() {
-    return false;
-  }
+  boolean isRetryable();
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blob.java
@@ -32,7 +32,8 @@ public interface Blob {
   BlobDescriptor writeTo(OutputStream outputStream) throws IOException;
 
   /**
-   * Enables to notify to the HTTP client if the underlying request can be retried.
+   * Enables to notify if the underlying request can be retried
+   * (useful in the context of a retryable HTTP request for ex).
    * @return {@code true} if {@link #writeTo(OutputStream)} can be called multiple times, {@code false} otherwise.
    */
   default boolean isRetryable() {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blob.java
@@ -32,9 +32,11 @@ public interface Blob {
   BlobDescriptor writeTo(OutputStream outputStream) throws IOException;
 
   /**
-   * Enables to notify if the underlying request can be retried
-   * (useful in the context of a retryable HTTP request for ex).
-   * @return {@code true} if {@link #writeTo(OutputStream)} can be called multiple times, {@code false} otherwise.
+   * Enables to notify if the underlying request can be retried (useful in the context of a
+   * retryable HTTP request for ex).
+   *
+   * @return {@code true} if {@link #writeTo(OutputStream)} can be called multiple times, {@code
+   *     false} otherwise.
    */
   default boolean isRetryable() {
     return false;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blob.java
@@ -30,4 +30,12 @@ public interface Blob {
    * @throws IOException if writing the BLOB fails
    */
   BlobDescriptor writeTo(OutputStream outputStream) throws IOException;
+
+  /**
+   * Enables to notify to the HTTP client if the underlying request can be retried.
+   * @return {@code true} if {@link #writeTo(OutputStream)} can be called multiple times, {@code false} otherwise.
+   */
+  default boolean isRetryable() {
+    return false;
+  }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blobs.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/Blobs.java
@@ -50,7 +50,11 @@ public class Blobs {
   }
 
   public static Blob from(WritableContents writable) {
-    return new WritableContentsBlob(writable);
+    return from(writable, false);
+  }
+
+  public static Blob from(WritableContents writable, boolean retryable) {
+    return new WritableContentsBlob(writable, retryable);
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/FileBlob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/FileBlob.java
@@ -39,4 +39,9 @@ class FileBlob implements Blob {
       return Digests.computeDigest(fileIn, outputStream);
     }
   }
+
+  @Override
+  public boolean isRetryable() {
+    return true;
+  }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/InputStreamBlob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/InputStreamBlob.java
@@ -46,4 +46,9 @@ class InputStreamBlob implements Blob {
       isWritten = true;
     }
   }
+
+  @Override
+  public boolean isRetryable() {
+    return false;
+  }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/JsonBlob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/JsonBlob.java
@@ -34,4 +34,9 @@ class JsonBlob implements Blob {
   public BlobDescriptor writeTo(OutputStream outputStream) throws IOException {
     return Digests.computeDigest(template, outputStream);
   }
+
+  @Override
+  public boolean isRetryable() {
+    return true;
+  }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/StringBlob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/StringBlob.java
@@ -39,4 +39,9 @@ class StringBlob implements Blob {
       return Digests.computeDigest(stringIn, outputStream);
     }
   }
+
+  @Override
+  public boolean isRetryable() {
+    return true;
+  }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/WritableContentsBlob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/WritableContentsBlob.java
@@ -25,9 +25,11 @@ import java.io.OutputStream;
 class WritableContentsBlob implements Blob {
 
   private final WritableContents writableContents;
+  private final boolean retryable;
 
-  WritableContentsBlob(WritableContents writableContents) {
+  WritableContentsBlob(WritableContents writableContents, boolean retryable) {
     this.writableContents = writableContents;
+    this.retryable = retryable;
   }
 
   @Override
@@ -38,6 +40,6 @@ class WritableContentsBlob implements Blob {
   // in general it is since the underlying data is accessed in the lambda
   @Override
   public boolean isRetryable() {
-    return true;
+    return retryable;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/WritableContentsBlob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/WritableContentsBlob.java
@@ -37,7 +37,6 @@ class WritableContentsBlob implements Blob {
     return Digests.computeDigest(writableContents, outputStream);
   }
 
-  // in general it is since the underlying data is accessed in the lambda
   @Override
   public boolean isRetryable() {
     return retryable;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/WritableContentsBlob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/WritableContentsBlob.java
@@ -34,4 +34,10 @@ class WritableContentsBlob implements Blob {
   public BlobDescriptor writeTo(OutputStream outputStream) throws IOException {
     return Digests.computeDigest(writableContents, outputStream);
   }
+
+  // in general it is since the underlying data is accessed in the lambda
+  @Override
+  public boolean isRetryable() {
+    return true;
+  }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -305,7 +305,8 @@ public class LocalBaseImageSteps {
                         new NotifyingOutputStream(compressorStream, throttledProgressReporter)) {
                   Blobs.from(layerFile).writeTo(notifyingOutputStream);
                 }
-              });
+              },
+              true);
       return new PreparedLayer.Builder(cache.writeTarLayer(diffId, compressedBlob)).build();
     }
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/BlobHttpContent.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/BlobHttpContent.java
@@ -59,7 +59,7 @@ public class BlobHttpContent implements HttpContent {
 
   @Override
   public boolean retrySupported() {
-    return false;
+    return blob.isRetryable();
   }
 
   @Override

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/FailoverHttpClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/FailoverHttpClient.java
@@ -17,12 +17,15 @@
 package com.google.cloud.tools.jib.http;
 
 import com.google.api.client.http.GenericUrl;
+import com.google.api.client.http.HttpBackOffIOExceptionHandler;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
 import com.google.api.client.http.HttpRequest;
 import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.apache.v2.ApacheHttpTransport;
+import com.google.api.client.util.BackOff;
+import com.google.api.client.util.ExponentialBackOff;
 import com.google.api.client.util.SslUtils;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.common.annotations.VisibleForTesting;
@@ -312,6 +315,19 @@ public class FailoverHttpClient {
         httpTransport
             .createRequestFactory()
             .buildRequest(httpMethod, new GenericUrl(url), request.getHttpContent())
+            .setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff()) {
+              @Override
+              public boolean handleIOException(final HttpRequest request, final boolean supportsRetry) throws IOException {
+                final boolean result = super.handleIOException(request, supportsRetry);
+                final String reqString = request.getRequestMethod() + " " + request.getUrl();
+                if (result) { // google-http-client does not log that properly so let's compensate it
+                  logger.accept(LogEvent.warn(reqString + " failed and will be retried"));
+                } else {
+                  logger.accept(LogEvent.warn(reqString + " failed and will NOT be retried"));
+                }
+                return result;
+              }
+            })
             .setUseRawRedirectUrls(true)
             .setHeaders(requestHeaders);
     if (request.getHttpTimeout() != null) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/FailoverHttpClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/FailoverHttpClient.java
@@ -342,7 +342,7 @@ public class FailoverHttpClient {
                         enableRetries && super.handleIOException(request, supportsRetry);
                     String requestUrl = request.getRequestMethod() + " " + request.getUrl();
                     if (result) { // google-http-client does not log that properly so let's
-                                  // compensate it
+                      // compensate it
                       logger.accept(LogEvent.warn(requestUrl + " failed and will be retried"));
                     } else {
                       logger.accept(LogEvent.warn(requestUrl + " failed and will NOT be retried"));

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/FailoverHttpClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/FailoverHttpClient.java
@@ -317,9 +317,9 @@ public class FailoverHttpClient {
             .buildRequest(httpMethod, new GenericUrl(url), request.getHttpContent())
             .setIOExceptionHandler(new HttpBackOffIOExceptionHandler(new ExponentialBackOff()) {
               @Override
-              public boolean handleIOException(final HttpRequest request, final boolean supportsRetry) throws IOException {
-                final boolean result = super.handleIOException(request, supportsRetry);
-                final String reqString = request.getRequestMethod() + " " + request.getUrl();
+              public boolean handleIOException(HttpRequest request, boolean supportsRetry) throws IOException {
+                boolean result = super.handleIOException(request, supportsRetry);
+                String requestUrl = request.getRequestMethod() + " " + request.getUrl();
                 if (result) { // google-http-client does not log that properly so let's compensate it
                   logger.accept(LogEvent.warn(reqString + " failed and will be retried"));
                 } else {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/FailoverHttpClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/FailoverHttpClient.java
@@ -321,9 +321,9 @@ public class FailoverHttpClient {
                 boolean result = super.handleIOException(request, supportsRetry);
                 String requestUrl = request.getRequestMethod() + " " + request.getUrl();
                 if (result) { // google-http-client does not log that properly so let's compensate it
-                  logger.accept(LogEvent.warn(reqString + " failed and will be retried"));
+                  logger.accept(LogEvent.warn(requestUrl + " failed and will be retried"));
                 } else {
-                  logger.accept(LogEvent.warn(reqString + " failed and will NOT be retried"));
+                  logger.accept(LogEvent.warn(requestUrl + " failed and will NOT be retried"));
                 }
                 return result;
               }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
@@ -176,6 +176,6 @@ public class ReproducibleLayerBuilder {
       tarStreamBuilder.addTarArchiveEntry(entry);
     }
 
-    return Blobs.from(tarStreamBuilder::writeAsTarArchiveTo, true);
+    return Blobs.from(tarStreamBuilder::writeAsTarArchiveTo, false);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
@@ -168,6 +168,6 @@ public class ReproducibleLayerBuilder {
       tarStreamBuilder.addTarArchiveEntry(entry);
     }
 
-    return Blobs.from(tarStreamBuilder::writeAsTarArchiveTo);
+    return Blobs.from(tarStreamBuilder::writeAsTarArchiveTo, true);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -504,7 +504,7 @@ public class RegistryClient {
           } catch (RegistryException ex) {
             throw new IOException(ex);
           }
-        });
+        }, false);
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -504,7 +504,8 @@ public class RegistryClient {
           } catch (RegistryException ex) {
             throw new IOException(ex);
           }
-        }, false);
+        },
+        false);
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -63,7 +63,8 @@ public class TarStreamBuilder {
    */
   public void addTarArchiveEntry(TarArchiveEntry entry) {
     archiveMap.put(
-        entry, entry.isFile() ? Blobs.from(entry.getFile().toPath()) : Blobs.from(ignored -> {}, true));
+        entry,
+        entry.isFile() ? Blobs.from(entry.getFile().toPath()) : Blobs.from(ignored -> {}, true));
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -63,7 +63,7 @@ public class TarStreamBuilder {
    */
   public void addTarArchiveEntry(TarArchiveEntry entry) {
     archiveMap.put(
-        entry, entry.isFile() ? Blobs.from(entry.getPath()) : Blobs.from(ignored -> {}), true);
+        entry, entry.isFile() ? Blobs.from(entry.getPath()) : Blobs.from(ignored -> {}, true));
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -63,7 +63,7 @@ public class TarStreamBuilder {
    */
   public void addTarArchiveEntry(TarArchiveEntry entry) {
     archiveMap.put(
-        entry, entry.isFile() ? Blobs.from(entry.getFile().toPath()) : Blobs.from(ignored -> {}));
+        entry, entry.isFile() ? Blobs.from(entry.getFile().toPath()) : Blobs.from(ignored -> {}, true));
   }
 
   /**
@@ -78,7 +78,7 @@ public class TarStreamBuilder {
     TarArchiveEntry entry = new TarArchiveEntry(name);
     entry.setSize(contents.length);
     entry.setModTime(modificationTime.toEpochMilli());
-    archiveMap.put(entry, Blobs.from(outputStream -> outputStream.write(contents)));
+    archiveMap.put(entry, Blobs.from(outputStream -> outputStream.write(contents), false));
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -78,7 +78,7 @@ public class TarStreamBuilder {
     TarArchiveEntry entry = new TarArchiveEntry(name);
     entry.setSize(contents.length);
     entry.setModTime(modificationTime.toEpochMilli());
-    archiveMap.put(entry, Blobs.from(outputStream -> outputStream.write(contents), false));
+    archiveMap.put(entry, Blobs.from(outputStream -> outputStream.write(contents), true));
   }
 
   /**

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/FailoverHttpClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/FailoverHttpClientTest.java
@@ -503,7 +503,7 @@ public class FailoverHttpClientTest {
           mockInsecureHttpTransport, mockInsecureHttpRequestFactory, mockInsecureHttpRequest);
     }
     return new FailoverHttpClient(
-        insecure, authOverHttp, logger, () -> mockHttpTransport, () -> mockInsecureHttpTransport);
+        true, insecure, authOverHttp, logger, () -> mockHttpTransport, () -> mockInsecureHttpTransport);
   }
 
   private Request fakeRequest(Integer httpTimeout) {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/FailoverHttpClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/FailoverHttpClientTest.java
@@ -16,6 +16,9 @@
 
 package com.google.cloud.tools.jib.http;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import com.google.api.client.http.GenericUrl;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpMethods;
@@ -25,15 +28,21 @@ import com.google.api.client.http.HttpResponse;
 import com.google.api.client.http.HttpTransport;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.blob.Blobs;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.ConnectException;
+import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
@@ -416,6 +425,55 @@ public class FailoverHttpClientTest {
         "Cannot verify server at https://url:2. Attempting again with no TLS verification.");
   }
 
+  @Test
+  public void testRetries() throws IOException {
+    final HttpServer server = HttpServer.create(new InetSocketAddress("localhost", 0), 64);
+    final AtomicReference<HttpHandler> current = new AtomicReference<>();
+    server.createContext("/").setHandler(exchange -> current.get().handle(exchange));
+    final AtomicBoolean failed = new AtomicBoolean();
+    final List<LogEvent> events = new ArrayList<>();
+
+    // simulate a failure
+    current.set(ex -> {
+      if (failed.compareAndSet(false, true)) {
+        // simulate a success after this (first) failure
+        current.set(exch -> {
+          exch.sendResponseHeaders(200, 0);
+          exch.close();
+        });
+
+        // here is the failure - no response sent (IOException for the client)
+        ex.close();
+        return;
+      }
+      // make the test fail
+      ex.sendResponseHeaders(123, 0);
+      ex.close();
+    });
+
+    try {
+      server.start();
+      assertEquals(
+              200,
+              new FailoverHttpClient(true, true, events::add)
+                      .post(new URL("http://localhost:" + server.getAddress().getPort() + "/test"),
+                              Request.builder()
+                                      .setBody(new BlobHttpContent(Blobs.from("foo"), "text/plain"))
+                                      .build())
+                      .getStatusCode());
+    } finally {
+      server.stop(0);
+    }
+    assertTrue(failed.get());
+    assertEquals(1, events.size());
+
+    final LogEvent warn = events.iterator().next();
+    assertEquals(LogEvent.Level.WARN, warn.getLevel());
+    assertEquals(
+            "POST http://localhost:" + server.getAddress().getPort() + "/test failed and will be retried",
+            warn.getMessage());
+  }
+
   private void setUpMocks(
       HttpTransport mockHttpTransport,
       HttpRequestFactory mockHttpRequestFactory,
@@ -426,6 +484,8 @@ public class FailoverHttpClientTest {
             mockHttpRequestFactory.buildRequest(Mockito.any(), urlCaptor.capture(), Mockito.any()))
         .thenReturn(mockHttpRequest);
 
+    Mockito.when(mockHttpRequest.setIOExceptionHandler(Mockito.any()))
+        .thenReturn(mockHttpRequest);
     Mockito.when(mockHttpRequest.setUseRawRedirectUrls(Mockito.anyBoolean()))
         .thenReturn(mockHttpRequest);
     Mockito.when(mockHttpRequest.setHeaders(httpHeadersCaptor.capture()))

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/FailoverHttpClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/FailoverHttpClientTest.java
@@ -434,33 +434,36 @@ public class FailoverHttpClientTest {
     final List<LogEvent> events = new ArrayList<>();
 
     // simulate a failure
-    current.set(ex -> {
-      if (failed.compareAndSet(false, true)) {
-        // simulate a success after this (first) failure
-        current.set(exch -> {
-          exch.sendResponseHeaders(200, 0);
-          exch.close();
-        });
+    current.set(
+        ex -> {
+          if (failed.compareAndSet(false, true)) {
+            // simulate a success after this (first) failure
+            current.set(
+                exch -> {
+                  exch.sendResponseHeaders(200, 0);
+                  exch.close();
+                });
 
-        // here is the failure - no response sent (IOException for the client)
-        ex.close();
-        return;
-      }
-      // make the test fail
-      ex.sendResponseHeaders(423, 0);
-      ex.close();
-    });
+            // here is the failure - no response sent (IOException for the client)
+            ex.close();
+            return;
+          }
+          // make the test fail
+          ex.sendResponseHeaders(423, 0);
+          ex.close();
+        });
 
     try {
       server.start();
       assertEquals(
-              200,
-              new FailoverHttpClient(true, true, events::add)
-                      .post(new URL("http://localhost:" + server.getAddress().getPort() + "/test"),
-                              Request.builder()
-                                      .setBody(new BlobHttpContent(Blobs.from("foo"), "text/plain"))
-                                      .build())
-                      .getStatusCode());
+          200,
+          new FailoverHttpClient(true, true, events::add)
+              .post(
+                  new URL("http://localhost:" + server.getAddress().getPort() + "/test"),
+                  Request.builder()
+                      .setBody(new BlobHttpContent(Blobs.from("foo"), "text/plain"))
+                      .build())
+              .getStatusCode());
     } finally {
       server.stop(0);
     }
@@ -470,8 +473,10 @@ public class FailoverHttpClientTest {
     final LogEvent warn = events.iterator().next();
     assertEquals(LogEvent.Level.WARN, warn.getLevel());
     assertEquals(
-            "POST http://localhost:" + server.getAddress().getPort() + "/test failed and will be retried",
-            warn.getMessage());
+        "POST http://localhost:"
+            + server.getAddress().getPort()
+            + "/test failed and will be retried",
+        warn.getMessage());
   }
 
   private void setUpMocks(
@@ -484,8 +489,7 @@ public class FailoverHttpClientTest {
             mockHttpRequestFactory.buildRequest(Mockito.any(), urlCaptor.capture(), Mockito.any()))
         .thenReturn(mockHttpRequest);
 
-    Mockito.when(mockHttpRequest.setIOExceptionHandler(Mockito.any()))
-        .thenReturn(mockHttpRequest);
+    Mockito.when(mockHttpRequest.setIOExceptionHandler(Mockito.any())).thenReturn(mockHttpRequest);
     Mockito.when(mockHttpRequest.setUseRawRedirectUrls(Mockito.anyBoolean()))
         .thenReturn(mockHttpRequest);
     Mockito.when(mockHttpRequest.setHeaders(httpHeadersCaptor.capture()))
@@ -503,7 +507,12 @@ public class FailoverHttpClientTest {
           mockInsecureHttpTransport, mockInsecureHttpRequestFactory, mockInsecureHttpRequest);
     }
     return new FailoverHttpClient(
-        true, insecure, authOverHttp, logger, () -> mockHttpTransport, () -> mockInsecureHttpTransport);
+        true,
+        insecure,
+        authOverHttp,
+        logger,
+        () -> mockHttpTransport,
+        () -> mockInsecureHttpTransport);
   }
 
   private Request fakeRequest(Integer httpTimeout) {

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/FailoverHttpClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/FailoverHttpClientTest.java
@@ -447,7 +447,7 @@ public class FailoverHttpClientTest {
         return;
       }
       // make the test fail
-      ex.sendResponseHeaders(123, 0);
+      ex.sendResponseHeaders(423, 0);
       ex.close();
     });
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerFailoverHttpClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerFailoverHttpClientTest.java
@@ -81,7 +81,7 @@ public class WithServerFailoverHttpClientTest {
   public void testInsecureConnection_insecureHttpsFailover()
       throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException {
     FailoverHttpClient insecureHttpClient =
-        new FailoverHttpClient(true /*insecure*/, false, logger);
+        new FailoverHttpClient(false, true /*insecure*/, false, logger);
     try (TestWebServer server = new TestWebServer(true, 2);
         Response response = insecureHttpClient.get(new URL(server.getEndpoint()), request)) {
 
@@ -132,7 +132,7 @@ public class WithServerFailoverHttpClientTest {
             + "Content-Length: 0\n\n";
     String targetServerResponse = "HTTP/1.1 200 OK\nContent-Length:12\n\nHello World!";
 
-    FailoverHttpClient httpClient = new FailoverHttpClient(true /*insecure*/, false, logger);
+    FailoverHttpClient httpClient = new FailoverHttpClient(false, true /*insecure*/, false, logger);
     try (TestWebServer server =
         new TestWebServer(false, Arrays.asList(proxyResponse, targetServerResponse), 1)) {
       System.setProperty("http.proxyHost", "localhost");

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerFailoverHttpClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerFailoverHttpClientTest.java
@@ -67,7 +67,8 @@ public class WithServerFailoverHttpClientTest {
   @Test
   public void testSecureConnectionOnInsecureHttpsServer()
       throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException {
-    FailoverHttpClient secureHttpClient = new FailoverHttpClient(false, false /*secure*/, false, logger);
+    FailoverHttpClient secureHttpClient =
+        new FailoverHttpClient(false, false /*secure*/, false, logger);
     try (TestWebServer server = new TestWebServer(true);
         Response ignored = secureHttpClient.get(new URL(server.getEndpoint()), request)) {
       Assert.fail("Should fail if cannot verify peer");

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerFailoverHttpClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerFailoverHttpClientTest.java
@@ -52,7 +52,7 @@ public class WithServerFailoverHttpClientTest {
   public void testGet()
       throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException {
     FailoverHttpClient insecureHttpClient =
-        new FailoverHttpClient(true /*insecure*/, false, logger);
+        new FailoverHttpClient(false, true /*insecure*/, false, logger);
     try (TestWebServer server = new TestWebServer(false);
         Response response = insecureHttpClient.get(new URL(server.getEndpoint()), request)) {
 
@@ -67,7 +67,7 @@ public class WithServerFailoverHttpClientTest {
   @Test
   public void testSecureConnectionOnInsecureHttpsServer()
       throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException {
-    FailoverHttpClient secureHttpClient = new FailoverHttpClient(false /*secure*/, false, logger);
+    FailoverHttpClient secureHttpClient = new FailoverHttpClient(false, false /*secure*/, false, logger);
     try (TestWebServer server = new TestWebServer(true);
         Response ignored = secureHttpClient.get(new URL(server.getEndpoint()), request)) {
       Assert.fail("Should fail if cannot verify peer");
@@ -101,7 +101,7 @@ public class WithServerFailoverHttpClientTest {
   public void testInsecureConnection_plainHttpFailover()
       throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException {
     FailoverHttpClient insecureHttpClient =
-        new FailoverHttpClient(true /*insecure*/, false, logger);
+        new FailoverHttpClient(false, true /*insecure*/, false, logger);
     try (TestWebServer server = new TestWebServer(false, 3)) {
       String httpsUrl = server.getEndpoint().replace("http://", "https://");
       try (Response response = insecureHttpClient.get(new URL(httpsUrl), request)) {
@@ -155,7 +155,7 @@ public class WithServerFailoverHttpClientTest {
   @Test
   public void testClosingResourcesMultipleTimes_noErrors()
       throws IOException, InterruptedException, GeneralSecurityException, URISyntaxException {
-    FailoverHttpClient httpClient = new FailoverHttpClient(true /*insecure*/, false, logger);
+    FailoverHttpClient httpClient = new FailoverHttpClient(false, true /*insecure*/, false, logger);
     try (TestWebServer server = new TestWebServer(false, 2);
         Response ignored1 = httpClient.get(new URL(server.getEndpoint()), request);
         Response ignored2 = httpClient.get(new URL(server.getEndpoint()), request)) {
@@ -190,7 +190,7 @@ public class WithServerFailoverHttpClientTest {
     List<String> responses =
         Arrays.asList(redirect301, redirect302, redirect303, redirect307, redirect308, ok200);
 
-    FailoverHttpClient httpClient = new FailoverHttpClient(true /*insecure*/, false, logger);
+    FailoverHttpClient httpClient = new FailoverHttpClient(false, true /*insecure*/, false, logger);
     try (TestWebServer server = new TestWebServer(false, responses, 1)) {
       httpClient.get(new URL(server.getEndpoint()), request);
 


### PR DESCRIPTION
Follow up of https://github.com/GoogleContainerTools/jib/issues/1409

It enables http client retry when the blob content is re-readable.