### PR TITLE
Allow jib images to be built from TarArchiveEntries on alternative FileSystems

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ReproducibleLayerBuilder.java
@@ -24,6 +24,7 @@ import com.google.cloud.tools.jib.tar.TarStreamBuilder;
 import com.google.common.base.Verify;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -51,7 +52,7 @@ public class ReproducibleLayerBuilder {
      * are treated the same in {@link TarArchiveEntry#TarArchiveEntry(File, String)}, except for
      * modification time, UID, GID, etc., which are wiped away in {@link #build}).
      */
-    private static final File DIRECTORY_FILE = Paths.get(".").toFile();
+    private static final Path DIRECTORY_FILE = Paths.get(".");
 
     private final List<TarArchiveEntry> entries = new ArrayList<>();
     private final Set<String> names = new HashSet<>();
@@ -62,8 +63,9 @@ public class ReproducibleLayerBuilder {
      * modification time set to {@link FileEntriesLayer#DEFAULT_MODIFICATION_TIME}.
      *
      * @param tarArchiveEntry the {@link TarArchiveEntry}
+     * @throws IOException if an I/O error occurs
      */
-    private void add(TarArchiveEntry tarArchiveEntry) {
+    private void add(TarArchiveEntry tarArchiveEntry) throws IOException {
       if (names.contains(tarArchiveEntry.getName())) {
         return;
       }
@@ -137,8 +139,9 @@ public class ReproducibleLayerBuilder {
    * Builds and returns the layer {@link Blob}.
    *
    * @return the new layer
+   * @throws IOException if an I/O error occurs
    */
-  public Blob build() {
+  public Blob build() throws IOException {
     UniqueTarArchiveEntries uniqueTarArchiveEntries = new UniqueTarArchiveEntries();
 
     // Adds all the layer entries as tar entries.
@@ -147,7 +150,7 @@ public class ReproducibleLayerBuilder {
       // adds parent directories for each extraction path.
       TarArchiveEntry entry =
           new TarArchiveEntry(
-              layerEntry.getSourceFile().toFile(), layerEntry.getExtractionPath().toString());
+              layerEntry.getSourceFile(), layerEntry.getExtractionPath().toString());
 
       // Sets the entry's permissions by masking out the permission bits from the entry's mode (the
       // lowest 9 bits) then using a bitwise OR to set them to the layerEntry's permissions.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -62,8 +62,7 @@ public class TarStreamBuilder {
    * @param entry the {@link TarArchiveEntry}
    */
   public void addTarArchiveEntry(TarArchiveEntry entry) {
-    archiveMap.put(
-        entry, entry.isFile() ? Blobs.from(entry.getFile().toPath()) : Blobs.from(ignored -> {}));
+    archiveMap.put(entry, entry.isFile() ? Blobs.from(entry.getPath()) : Blobs.from(ignored -> {}));
   }
 
   /**

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/tar/TarStreamBuilderTest.java
@@ -161,26 +161,24 @@ public class TarStreamBuilderTest {
   }
 
   /** Creates a TarStreamBuilder using TarArchiveEntries. */
-  private void setUpWithTarEntries() {
+  private void setUpWithTarEntries() throws IOException {
     // Prepares a test TarStreamBuilder.
     testTarStreamBuilder.addTarArchiveEntry(
-        new TarArchiveEntry(fileA.toFile(), "some/path/to/resourceFileA"));
-    testTarStreamBuilder.addTarArchiveEntry(new TarArchiveEntry(fileB.toFile(), "crepecake"));
-    testTarStreamBuilder.addTarArchiveEntry(
-        new TarArchiveEntry(directoryA.toFile(), "some/path/to"));
+        new TarArchiveEntry(fileA, "some/path/to/resourceFileA"));
+    testTarStreamBuilder.addTarArchiveEntry(new TarArchiveEntry(fileB, "crepecake"));
+    testTarStreamBuilder.addTarArchiveEntry(new TarArchiveEntry(directoryA, "some/path/to"));
     testTarStreamBuilder.addTarArchiveEntry(
         new TarArchiveEntry(
-            fileA.toFile(),
+            fileA,
             "some/really/long/path/that/exceeds/100/characters/abcdefghijklmnopqrstuvwxyz0123456789012345678901234567890"));
   }
 
   /** Creates a TarStreamBuilder using Strings. */
-  private void setUpWithStrings() {
+  private void setUpWithStrings() throws IOException {
     // Prepares a test TarStreamBuilder.
     testTarStreamBuilder.addByteEntry(fileAContents, "some/path/to/resourceFileA", Instant.EPOCH);
     testTarStreamBuilder.addByteEntry(fileBContents, "crepecake", Instant.EPOCH);
-    testTarStreamBuilder.addTarArchiveEntry(
-        new TarArchiveEntry(directoryA.toFile(), "some/path/to"));
+    testTarStreamBuilder.addTarArchiveEntry(new TarArchiveEntry(directoryA, "some/path/to"));
     testTarStreamBuilder.addByteEntry(
         fileAContents,
         "some/really/long/path/that/exceeds/100/characters/abcdefghijklmnopqrstuvwxyz0123456789012345678901234567890",
@@ -188,12 +186,11 @@ public class TarStreamBuilderTest {
   }
 
   /** Creates a TarStreamBuilder using Strings and TarArchiveEntries. */
-  private void setUpWithStringsAndTarEntries() {
+  private void setUpWithStringsAndTarEntries() throws IOException {
     // Prepares a test TarStreamBuilder.
     testTarStreamBuilder.addByteEntry(fileAContents, "some/path/to/resourceFileA", Instant.EPOCH);
-    testTarStreamBuilder.addTarArchiveEntry(new TarArchiveEntry(fileB.toFile(), "crepecake"));
-    testTarStreamBuilder.addTarArchiveEntry(
-        new TarArchiveEntry(directoryA.toFile(), "some/path/to"));
+    testTarStreamBuilder.addTarArchiveEntry(new TarArchiveEntry(fileB, "crepecake"));
+    testTarStreamBuilder.addTarArchiveEntry(new TarArchiveEntry(directoryA, "some/path/to"));
     testTarStreamBuilder.addByteEntry(
         fileAContents,
         "some/really/long/path/that/exceeds/100/characters/abcdefghijklmnopqrstuvwxyz0123456789012345678901234567890",


### PR DESCRIPTION
<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->
Upgrade to latest version of commons-compress, and replace a few usages of toFile and toPath round-trips with using Paths directly. Useful for staging files using the nio filesystem, for example extracting files to a [jimfs](https://github.com/google/jimfs) filesystem before adding them to a docker image.