### PR TITLE
Added support for username and password tokens in dockercfg auth

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/json/DockerConfigTemplate.java
@@ -33,6 +33,8 @@ import javax.annotation.Nullable;
  *   "auths": {
  *     "registry": {
  *       "auth": "username:password string in base64",
+ *       "username": "..."
+ *       "password": "..."
  *       "identityToken": "..."
  *     },
  *     "anotherregistry": {},
@@ -66,6 +68,10 @@ public class DockerConfigTemplate implements JsonTemplate {
 
     @Nullable private String auth;
 
+    @Nullable private String username;
+
+    @Nullable private String password;
+
     // Both "identitytoken" and "identityToken" have been observed. For example,
     // https://github.com/GoogleContainerTools/jib/issues/2488
     // https://github.com/spotify/docker-client/issues/580
@@ -74,6 +80,16 @@ public class DockerConfigTemplate implements JsonTemplate {
     @Nullable
     public String getAuth() {
       return auth;
+    }
+
+    @Nullable
+    public String getUsername() {
+      return username;
+    }
+
+    @Nullable
+    public String getPassword() {
+      return password;
     }
 
     @Nullable

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetrieverTest.java
@@ -77,6 +77,36 @@ public class DockerConfigCredentialRetrieverTest {
   }
 
   @Test
+  public void testRetrieve_authTakesPrecedenceOverUsernameAndPassword() throws IOException {
+    DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
+        DockerConfigCredentialRetriever.create("auth and userpw registry", dockerConfigFile);
+
+    Optional<Credential> credentials = dockerConfigCredentialRetriever.retrieve(mockLogger);
+    Assert.assertTrue(credentials.isPresent());
+    Assert.assertEquals("some", credentials.get().getUsername());
+    Assert.assertEquals("auth", credentials.get().getPassword());
+    Mockito.verify(mockLogger)
+        .accept(
+            LogEvent.info(
+                "Docker config auths section defines credentials for auth and userpw registry"));
+  }
+
+  @Test
+  public void testRetrieve_hasAuthWithUsernameAndPassword() throws IOException {
+    DockerConfigCredentialRetriever dockerConfigCredentialRetriever =
+        DockerConfigCredentialRetriever.create("userpw registry", dockerConfigFile);
+
+    Optional<Credential> credentials = dockerConfigCredentialRetriever.retrieve(mockLogger);
+    Assert.assertTrue(credentials.isPresent());
+    Assert.assertEquals("someuser", credentials.get().getUsername());
+    Assert.assertEquals("somepw", credentials.get().getPassword());
+    Mockito.verify(mockLogger)
+        .accept(
+            LogEvent.info(
+                "Docker config auths section defines username and password for userpw registry"));
+  }
+
+  @Test
   public void testRetrieve_hasAuth_legacyConfigFormat() throws IOException, URISyntaxException {
     dockerConfigFile = Paths.get(Resources.getResource("core/json/legacy_dockercfg").toURI());
 

--- a/jib-core/src/test/resources/core/json/dockerconfig.json
+++ b/jib-core/src/test/resources/core/json/dockerconfig.json
@@ -2,6 +2,8 @@
   "auths":{
     "some other registry":{"auth":"c29tZTpvdGhlcjphdXRo"},
     "some registry":{"auth":"c29tZTphdXRo","password":"ignored"},
+    "auth and userpw registry":{"auth":"c29tZTphdXRo","username":"ignored","password":"ignored"},
+    "userpw registry":{"username":"someuser","password":"somepw"},
     "https://registry":{"auth":"dG9rZW4="},
 
     "example.com":{"auth":"should not match example"},


### PR DESCRIPTION
<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->
Support username and password tokens from dockercfg auths #3364
