### PR TITLE
fix sonar bug to call Optional#isPresent() before accessing value.

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/BuildFiles.java
@@ -94,9 +94,9 @@ public class BuildFiles {
     buildFile.getEntrypoint().ifPresent(containerBuilder::setEntrypoint);
     buildFile.getCmd().ifPresent(containerBuilder::setProgramArguments);
 
-    if (buildFile.getLayers().isPresent()) {
-      containerBuilder.setFileEntriesLayers(
-          Layers.toLayers(projectRoot, buildFile.getLayers().get()));
+    Optional<LayersSpec> layersSpec = buildFile.getLayers();
+    if (layersSpec.isPresent()) {
+      containerBuilder.setFileEntriesLayers(Layers.toLayers(projectRoot, layersSpec.get()));
     }
     return containerBuilder;
   }


### PR DESCRIPTION
Fix sonar bug for fixit: https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTIQcB_fbtb802TR&open=AXrlUTIQcB_fbtb802TR 

This change should be complaint with sonar rules, but is it worth the change or should we just leave it alone? It does make one less call to `buildFile.getLayers()`, so that could be a benefit. 

Note: there are a bunch of similar sonar bugs. 
