### PR TITLE
Fix try-with-resources issue from sonarcloud

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.filesystem;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Verify;
 import java.io.Closeable;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -61,15 +62,16 @@ public class LockFile implements Closeable {
     }
 
     Files.createDirectories(lockFile.getParent());
-    FileOutputStream outputStream = new FileOutputStream(lockFile.toFile());
     FileLock fileLock = null;
+    FileOutputStream outputStream = null;
     try {
+      outputStream = new FileOutputStream(lockFile.toFile());
       fileLock = outputStream.getChannel().lock();
       return new LockFile(lockFile, fileLock, outputStream);
 
     } finally {
       if (fileLock == null) {
-        outputStream.close();
+        Verify.verifyNotNull(outputStream).close();
       }
     }
   }


### PR DESCRIPTION
Fixing try-with-resources issue from [sonarcloud](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTfRcB_fbtb802Xj&open=AXrlUTfRcB_fbtb802Xj): "Use try-with-resources or close this "FileOutputStream" in a "finally" clause."
I'm hoping moving outputStream into the try block should help with this.