### PR TITLE
Add more documentation for when InterruptedException is thrown in UpdateChecker

### DIFF
--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
@@ -145,11 +145,9 @@ public class UpdateChecker {
     if (updateMessageFuture.isDone()) {
       try {
         return updateMessageFuture.get();
-      } catch (InterruptedException ex) {
-        // Restore the interrupted status
-        Thread.currentThread().interrupt();
-      } catch (ExecutionException ex) {
-        // fail silently
+      } catch (InterruptedException | ExecutionException ex) {
+        // No need to restore the interrupted status. The intention here is to silently consume any
+        // kind of error
       }
     }
     updateMessageFuture.cancel(true);

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
@@ -145,8 +145,11 @@ public class UpdateChecker {
     if (updateMessageFuture.isDone()) {
       try {
         return updateMessageFuture.get();
-      } catch (InterruptedException | ExecutionException ignored) {
-        // Fail silently;
+      } catch (InterruptedException ex) {
+        // Restore the interrupted status
+        Thread.currentThread().interrupt();
+      } catch (ExecutionException ex) {
+        // fail silently
       }
     }
     updateMessageFuture.cancel(true);


### PR DESCRIPTION
<del>Fixes this sonarcloud [issue](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&open=AXrlUTRncB_fbtb802U6&resolved=false&severities=MAJOR&types=BUG): "Either re-interrupt this method or rethrow the "InterruptedException" that can be caught here."</del>

UPDATE : As described [here](https://github.com/GoogleContainerTools/jib/pull/3369#issuecomment-891340043) the update checker is a special case where we intend to silently consume any kind of error. Added a comment explaining this instead of restoring interrupted status.

