### PR TITLE
Remove VisibleForTesting annotation for code used in production

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/JibCli.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/JibCli.java
@@ -26,7 +26,6 @@ import com.google.cloud.tools.jib.plugins.common.ImageMetadataOutput;
 import com.google.cloud.tools.jib.plugins.common.UpdateChecker;
 import com.google.cloud.tools.jib.plugins.common.globalconfig.GlobalConfig;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.Futures;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -100,7 +99,6 @@ public class JibCli {
     }
   }
 
-  @VisibleForTesting
   static void finishUpdateChecker(
       ConsoleLogger logger, Future<Optional<String>> updateCheckFuture) {
     UpdateChecker.finishUpdateCheck(updateCheckFuture)

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesStack.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesStack.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.jib.cli.buildfile;
 
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.FilePermissions;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -28,7 +27,6 @@ import java.util.List;
  * A class that keeps track of permissions for various stacking file permissions settings in {@link
  * LayerSpec}.
  */
-@VisibleForTesting
 class FilePropertiesStack {
 
   // TODO perhaps use a fixed size list here

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JavaContainerBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JavaContainerBuilder.java
@@ -22,7 +22,6 @@ import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.ModificationTimeProvider;
 import com.google.cloud.tools.jib.api.buildplan.RelativeUnixPath;
 import com.google.cloud.tools.jib.filesystem.DirectoryWalker;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Streams;
@@ -58,7 +57,6 @@ public class JavaContainerBuilder {
   }
 
   /** Represents the different types of layers for a Java application. */
-  @VisibleForTesting
   public enum LayerType {
     DEPENDENCIES("dependencies"),
     SNAPSHOT_DEPENDENCIES("snapshot dependencies"),

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
@@ -61,7 +61,6 @@ public interface BuildableManifestTemplate extends ManifestTemplate {
     @SuppressWarnings("unused")
     private ContentDescriptorTemplate() {}
 
-    @VisibleForTesting
     public long getSize() {
       return size;
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
@@ -61,6 +61,7 @@ public interface BuildableManifestTemplate extends ManifestTemplate {
     @SuppressWarnings("unused")
     private ContentDescriptorTemplate() {}
 
+    @VisibleForTesting
     public long getSize() {
       return size;
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
@@ -61,7 +61,6 @@ public interface BuildableManifestTemplate extends ManifestTemplate {
     @SuppressWarnings("unused")
     private ContentDescriptorTemplate() {}
 
-    @VisibleForTesting
     public long getSize() {
       return size;
     }
@@ -70,7 +69,6 @@ public interface BuildableManifestTemplate extends ManifestTemplate {
       this.size = size;
     }
 
-    @VisibleForTesting
     @Nullable
     public DescriptorDigest getDigest() {
       return digest;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerCredentialHelper.java
@@ -188,7 +188,6 @@ public class DockerCredentialHelper {
     }
   }
 
-  @VisibleForTesting
   Path getCredentialHelper() {
     return credentialHelper;
   }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
@@ -26,7 +26,6 @@ import com.google.cloud.tools.jib.plugins.common.PropertyNames;
 import com.google.cloud.tools.jib.plugins.common.UpdateChecker;
 import com.google.cloud.tools.jib.plugins.common.VersionChecker;
 import com.google.cloud.tools.jib.plugins.common.globalconfig.GlobalConfig;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Futures;
 import java.nio.file.Paths;
@@ -47,7 +46,6 @@ import org.apache.maven.project.MavenProject;
 /** Collection of common methods to share between Maven goals. */
 public class MojoCommon {
   /** Describes a minimum required version or version range for Jib. */
-  @VisibleForTesting
   public static final String REQUIRED_VERSION_PROPERTY_NAME = "jib.requiredVersion";
 
   public static final String VERSION_URL = "https://storage.googleapis.com/jib-versions/jib-maven";

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/VersionChecker.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/VersionChecker.java
@@ -98,7 +98,6 @@ public class VersionChecker<V extends Comparable<? super V>> {
    * @return true if the version is acceptable
    * @throws IllegalArgumentException if the version could not be parsed
    */
-  @VisibleForTesting
   public boolean compatibleVersion(String acceptableVersionRange, String actualVersion) {
     V pluginVersion = parseVersion(actualVersion);
 


### PR DESCRIPTION
In order to be compliant with sonarcloud policy where class members annotated with `@VisibleForTesting` shouldn't be accessed in production code. 
For example:
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTJ2cB_fbtb802Tp&open=AXrlUTJ2cB_fbtb802Tp
