### PR TITLE
create obj and call Optional#isPresent() before access. fix sonar bug continued.

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -480,17 +480,18 @@ public class GradleProjectProperties implements ProjectProperties {
       ContainerBuildPlan buildPlan)
       throws JibPluginExtensionException {
     T extraConfig = null;
-    if (config.getExtraConfiguration().isPresent()) {
+    Optional<Object> configs = config.getExtraConfiguration();
+    if (configs.isPresent()) {
       if (!extraConfigType.isPresent()) {
         throw new IllegalArgumentException(
             "extension "
                 + extension.getClass().getSimpleName()
-                + " does not expect extension-specific configruation; remove the inapplicable "
+                + " does not expect extension-specific configuration; remove the inapplicable "
                 + "'pluginExtension.configuration' from Gradle build script");
       } else {
-        // config.getExtraConfiguration().get() is of type Action, so this cast always succeeds.
+        // configs.get() is of type Action, so this cast always succeeds.
         // (Note generic <T> is erased at runtime.)
-        Action<T> action = (Action<T>) config.getExtraConfiguration().get();
+        Action<T> action = (Action<T>) configs.get();
         extraConfig = project.getObjects().newInstance(extraConfigType.get(), project);
         action.execute(extraConfig);
       }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesExtensionTest.java
@@ -431,7 +431,7 @@ public class GradleProjectPropertiesExtensionTest {
       Assert.fail();
     } catch (IllegalArgumentException ex) {
       Assert.assertEquals(
-          "extension BaseExtension does not expect extension-specific configruation; remove the "
+          "extension BaseExtension does not expect extension-specific configuration; remove the "
               + "inapplicable 'pluginExtension.configuration' from Gradle build script",
           ex.getMessage());
     }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -647,14 +647,15 @@ public class MavenProjectProperties implements ProjectProperties {
       ContainerBuildPlan buildPlan)
       throws JibPluginExtensionException {
     Optional<T> extraConfig = Optional.empty();
-    if (config.getExtraConfiguration().isPresent()) {
+    Optional<Object> configs = config.getExtraConfiguration();
+    if (configs.isPresent()) {
       if (!extraConfigType.isPresent()) {
         throw new IllegalArgumentException(
             "extension "
                 + extension.getClass().getSimpleName()
-                + " does not expect extension-specific configruation; remove the inapplicable "
+                + " does not expect extension-specific configuration; remove the inapplicable "
                 + "<pluginExtension><configuration> from pom.xml");
-      } else if (!extraConfigType.get().isInstance(config.getExtraConfiguration().get())) {
+      } else if (!extraConfigType.get().isInstance(configs.get())) {
         throw new JibPluginExtensionException(
             extension.getClass(),
             "extension-specific <configuration> for "
@@ -662,15 +663,15 @@ public class MavenProjectProperties implements ProjectProperties {
                 + " is not of type "
                 + extraConfigType.get().getName()
                 + " but "
-                + config.getExtraConfiguration().get().getClass().getName()
+                + configs.get().getClass().getName()
                 + "; specify the correct type with <pluginExtension><configuration "
                 + "implementation=\""
                 + extraConfigType.get().getName()
                 + "\">");
       } else {
-        // config.getExtraConfiguration() is of type Optional, so this cast always succeeds
+        // configs is of type Optional, so this cast always succeeds
         // without the isInstance() check above. (Note generic <T> is erased at runtime.)
-        extraConfig = (Optional<T>) config.getExtraConfiguration();
+        extraConfig = (Optional<T>) configs;
       }
     }
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesExtensionTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesExtensionTest.java
@@ -427,7 +427,7 @@ public class MavenProjectPropertiesExtensionTest {
       Assert.fail();
     } catch (IllegalArgumentException ex) {
       Assert.assertEquals(
-          "extension BaseExtension does not expect extension-specific configruation; remove the "
+          "extension BaseExtension does not expect extension-specific configuration; remove the "
               + "inapplicable <pluginExtension><configuration> from pom.xml",
           ex.getMessage());
     }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -858,12 +858,12 @@ public class PluginConfigurationProcessor {
   @VisibleForTesting
   static Optional<AbsoluteUnixPath> getWorkingDirectoryChecked(RawConfiguration rawConfiguration)
       throws InvalidWorkingDirectoryException {
-    Optional<String> dir = rawConfiguration.getWorkingDirectory();
-    if (!dir.isPresent()) {
+    Optional<String> directory = rawConfiguration.getWorkingDirectory();
+    if (!directory.isPresent()) {
       return Optional.empty();
     }
 
-    String path = dir.get();
+    String path = directory.get();
     try {
       return Optional.of(AbsoluteUnixPath.get(path));
     } catch (IllegalArgumentException ex) {


### PR DESCRIPTION
Fixing similar sonar bugs of 'Call "Optional#isPresent()" before accessing the value'. 
List of sonar bugs in PR:
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTs_cB_fbtb802ZK&open=AXrlUTs_cB_fbtb802ZK
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrt4J9xN6U6V78Ue75d&open=AXrt4J9xN6U6V78Ue75d
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrt4J9xN6U6V78Ue75e&open=AXrt4J9xN6U6V78Ue75e
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTSzcB_fbtb802VT&open=AXrlUTSzcB_fbtb802VT
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTSzcB_fbtb802VR&open=AXrlUTSzcB_fbtb802VR
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTSzcB_fbtb802VO&open=AXrlUTSzcB_fbtb802VO
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTSzcB_fbtb802VS&open=AXrlUTSzcB_fbtb802VS
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTSzcB_fbtb802VU&open=AXrlUTSzcB_fbtb802VU
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTSzcB_fbtb802VQ&open=AXrlUTSzcB_fbtb802VQ
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTSzcB_fbtb802VP&open=AXrlUTSzcB_fbtb802VP