### PR TITLE
fix sonar blocker -- no assertion in test case.

### DIFF
--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
@@ -114,11 +114,11 @@ public class ContainerConfigurationTest {
   @SuppressWarnings("JdkObsolete") // for hashtable
   public void testBuilder_environmentMapTypes() {
     // Can accept empty environment.
-    ContainerConfiguration.builder().setEnvironment(ImmutableMap.of()).build();
-
+    Assert.assertNotNull(
+        ContainerConfiguration.builder().setEnvironment(ImmutableMap.of()).build());
     // Can handle other map types (https://github.com/GoogleContainerTools/jib/issues/632)
-    ContainerConfiguration.builder().setEnvironment(new TreeMap<>());
-    ContainerConfiguration.builder().setEnvironment(new Hashtable<>());
+    Assert.assertNotNull(ContainerConfiguration.builder().setEnvironment(new TreeMap<>()));
+    Assert.assertNotNull(ContainerConfiguration.builder().setEnvironment(new Hashtable<>()));
   }
 
   @Test


### PR DESCRIPTION
fixes [this sonar code-smell](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTnzcB_fbtb802Ye&open=AXrlUTnzcB_fbtb802Ye).

Adding `assertNotNull` works and looks like we just want to make sure it works without breaking in this test case. 
But is there a better way to handle this?
