### PR TITLE
Re-interrupt threads when InterruptedException is caught

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
@@ -16,18 +16,23 @@
 
 package com.google.cloud.tools.jib.cli;
 
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.Containerizer;
+import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.JibContainer;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.cli.buildfile.BuildFiles;
 import com.google.cloud.tools.jib.cli.logging.CliLogger;
 import com.google.cloud.tools.jib.plugins.common.globalconfig.GlobalConfig;
+import com.google.cloud.tools.jib.plugins.common.globalconfig.InvalidGlobalConfigException;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
 import com.google.cloud.tools.jib.plugins.common.logging.SingleThreadedExecutor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Multimaps;
 import com.google.common.util.concurrent.Futures;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -35,6 +40,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
@@ -142,7 +148,15 @@ public class Build implements Callable<Integer> {
 
       JibContainer jibContainer = containerBuilder.containerize(containerizer);
       JibCli.writeImageJson(commonCliOptions.getImageJsonPath(), jibContainer);
-    } catch (Exception ex) {
+    } catch (IOException
+        | InvalidImageReferenceException
+        | CacheDirectoryCreationException
+        | ExecutionException
+        | RegistryException
+        | InvalidGlobalConfigException ex) {
+      JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
+      return 1;
+    } catch (InterruptedException ex) {
       JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
       Thread.currentThread().interrupt();
       return 1;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
@@ -16,23 +16,18 @@
 
 package com.google.cloud.tools.jib.cli;
 
-import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.Containerizer;
-import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.JibContainer;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent;
-import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.cli.buildfile.BuildFiles;
 import com.google.cloud.tools.jib.cli.logging.CliLogger;
 import com.google.cloud.tools.jib.plugins.common.globalconfig.GlobalConfig;
-import com.google.cloud.tools.jib.plugins.common.globalconfig.InvalidGlobalConfigException;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
 import com.google.cloud.tools.jib.plugins.common.logging.SingleThreadedExecutor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Multimaps;
 import com.google.common.util.concurrent.Futures;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -40,7 +35,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
@@ -148,17 +142,12 @@ public class Build implements Callable<Integer> {
 
       JibContainer jibContainer = containerBuilder.containerize(containerizer);
       JibCli.writeImageJson(commonCliOptions.getImageJsonPath(), jibContainer);
-    } catch (IOException
-        | InvalidImageReferenceException
-        | CacheDirectoryCreationException
-        | ExecutionException
-        | RegistryException
-        | InvalidGlobalConfigException ex) {
-      JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
-      return 1;
     } catch (InterruptedException ex) {
       JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
       Thread.currentThread().interrupt();
+      return 1;
+    } catch (Exception ex) {
+      JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
       return 1;
     } finally {
       JibCli.finishUpdateChecker(logger, updateCheckFuture);

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Build.java
@@ -144,6 +144,7 @@ public class Build implements Callable<Integer> {
       JibCli.writeImageJson(commonCliOptions.getImageJsonPath(), jibContainer);
     } catch (Exception ex) {
       JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
+      Thread.currentThread().interrupt();
       return 1;
     } finally {
       JibCli.finishUpdateChecker(logger, updateCheckFuture);

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -16,25 +16,20 @@
 
 package com.google.cloud.tools.jib.cli;
 
-import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.Containerizer;
-import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.JibContainer;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent;
-import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.cli.jar.JarFiles;
 import com.google.cloud.tools.jib.cli.jar.ProcessingMode;
 import com.google.cloud.tools.jib.cli.logging.CliLogger;
 import com.google.cloud.tools.jib.plugins.common.globalconfig.GlobalConfig;
-import com.google.cloud.tools.jib.plugins.common.globalconfig.InvalidGlobalConfigException;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
 import com.google.cloud.tools.jib.plugins.common.logging.SingleThreadedExecutor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Verify;
 import com.google.common.collect.Multimaps;
 import com.google.common.util.concurrent.Futures;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -42,7 +37,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
@@ -139,17 +133,12 @@ public class Jar implements Callable<Integer> {
 
       JibContainer jibContainer = containerBuilder.containerize(containerizer);
       JibCli.writeImageJson(commonCliOptions.getImageJsonPath(), jibContainer);
-    } catch (IOException
-        | InvalidImageReferenceException
-        | CacheDirectoryCreationException
-        | ExecutionException
-        | RegistryException
-        | InvalidGlobalConfigException ex) {
-      JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
-      return 1;
     } catch (InterruptedException ex) {
       JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
       Thread.currentThread().interrupt();
+      return 1;
+    } catch (Exception ex) {
+      JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
       return 1;
     } finally {
       JibCli.finishUpdateChecker(logger, updateCheckFuture);

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -135,6 +135,7 @@ public class Jar implements Callable<Integer> {
       JibCli.writeImageJson(commonCliOptions.getImageJsonPath(), jibContainer);
     } catch (Exception ex) {
       JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
+      Thread.currentThread().interrupt();
       return 1;
     } finally {
       JibCli.finishUpdateChecker(logger, updateCheckFuture);

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Jar.java
@@ -16,20 +16,25 @@
 
 package com.google.cloud.tools.jib.cli;
 
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.Containerizer;
+import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.JibContainer;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.cli.jar.JarFiles;
 import com.google.cloud.tools.jib.cli.jar.ProcessingMode;
 import com.google.cloud.tools.jib.cli.logging.CliLogger;
 import com.google.cloud.tools.jib.plugins.common.globalconfig.GlobalConfig;
+import com.google.cloud.tools.jib.plugins.common.globalconfig.InvalidGlobalConfigException;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
 import com.google.cloud.tools.jib.plugins.common.logging.SingleThreadedExecutor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Verify;
 import com.google.common.collect.Multimaps;
 import com.google.common.util.concurrent.Futures;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -37,6 +42,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
@@ -133,7 +139,15 @@ public class Jar implements Callable<Integer> {
 
       JibContainer jibContainer = containerBuilder.containerize(containerizer);
       JibCli.writeImageJson(commonCliOptions.getImageJsonPath(), jibContainer);
-    } catch (Exception ex) {
+    } catch (IOException
+        | InvalidImageReferenceException
+        | CacheDirectoryCreationException
+        | ExecutionException
+        | RegistryException
+        | InvalidGlobalConfigException ex) {
+      JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
+      return 1;
+    } catch (InterruptedException ex) {
       JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
       Thread.currentThread().interrupt();
       return 1;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/War.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/War.java
@@ -119,6 +119,7 @@ public class War implements Callable<Integer> {
       JibCli.writeImageJson(commonCliOptions.getImageJsonPath(), jibContainer);
     } catch (Exception ex) {
       JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
+      Thread.currentThread().interrupt();
       return 1;
     } finally {
       JibCli.finishUpdateChecker(logger, updateCheckFuture);

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/War.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/War.java
@@ -16,31 +16,25 @@
 
 package com.google.cloud.tools.jib.cli;
 
-import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.Containerizer;
-import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.JibContainer;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent;
-import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.cli.logging.CliLogger;
 import com.google.cloud.tools.jib.cli.war.WarFiles;
 import com.google.cloud.tools.jib.plugins.common.globalconfig.GlobalConfig;
-import com.google.cloud.tools.jib.plugins.common.globalconfig.InvalidGlobalConfigException;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
 import com.google.cloud.tools.jib.plugins.common.logging.SingleThreadedExecutor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Verify;
 import com.google.common.collect.Multimaps;
 import com.google.common.util.concurrent.Futures;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import picocli.CommandLine;
 
@@ -123,17 +117,12 @@ public class War implements Callable<Integer> {
 
       JibContainer jibContainer = containerBuilder.containerize(containerizer);
       JibCli.writeImageJson(commonCliOptions.getImageJsonPath(), jibContainer);
-    } catch (IOException
-        | InvalidImageReferenceException
-        | CacheDirectoryCreationException
-        | ExecutionException
-        | RegistryException
-        | InvalidGlobalConfigException ex) {
-      JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
-      return 1;
     } catch (InterruptedException ex) {
       JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
       Thread.currentThread().interrupt();
+      return 1;
+    } catch (Exception ex) {
+      JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
       return 1;
     } finally {
       JibCli.finishUpdateChecker(logger, updateCheckFuture);

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/War.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/War.java
@@ -16,25 +16,31 @@
 
 package com.google.cloud.tools.jib.cli;
 
+import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.Containerizer;
+import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import com.google.cloud.tools.jib.api.JibContainer;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
 import com.google.cloud.tools.jib.api.LogEvent;
+import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.cli.logging.CliLogger;
 import com.google.cloud.tools.jib.cli.war.WarFiles;
 import com.google.cloud.tools.jib.plugins.common.globalconfig.GlobalConfig;
+import com.google.cloud.tools.jib.plugins.common.globalconfig.InvalidGlobalConfigException;
 import com.google.cloud.tools.jib.plugins.common.logging.ConsoleLogger;
 import com.google.cloud.tools.jib.plugins.common.logging.SingleThreadedExecutor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Verify;
 import com.google.common.collect.Multimaps;
 import com.google.common.util.concurrent.Futures;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import picocli.CommandLine;
 
@@ -117,7 +123,15 @@ public class War implements Callable<Integer> {
 
       JibContainer jibContainer = containerBuilder.containerize(containerizer);
       JibCli.writeImageJson(commonCliOptions.getImageJsonPath(), jibContainer);
-    } catch (Exception ex) {
+    } catch (IOException
+        | InvalidImageReferenceException
+        | CacheDirectoryCreationException
+        | ExecutionException
+        | RegistryException
+        | InvalidGlobalConfigException ex) {
+      JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
+      return 1;
+    } catch (InterruptedException ex) {
       JibCli.logTerminatingException(logger, ex, commonCliOptions.isStacktrace());
       Thread.currentThread().interrupt();
       return 1;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
@@ -57,6 +57,7 @@ public class LockFile implements Closeable {
       lockMap.computeIfAbsent(lockFile, key -> new ReentrantLock()).lockInterruptibly();
 
     } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
       throw new IOException("Interrupted while trying to acquire lock", ex);
     }
 

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunner.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunner.java
@@ -285,6 +285,7 @@ public class JibBuildRunner {
           message == null ? "(null exception message)" : message, ex.getCause());
 
     } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
       throw new BuildStepsExecutionException(helpfulSuggestions.none(), ex);
     }
 


### PR DESCRIPTION
There are a few more spots in the code where we catch an InterruptedException(causing the thread state to be cleared) but don't restore the state. Re-interrupting the thread causes the interrupted state to be restored. 

- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTJ2cB_fbtb802To&open=AXrlUTJ2cB_fbtb802To
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTKfcB_fbtb802T5&open=AXrlUTKfcB_fbtb802T5
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTLLcB_fbtb802UL&open=AXrlUTLLcB_fbtb802UL
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTfRcB_fbtb802Xg&open=AXrlUTfRcB_fbtb802Xg
-https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTSXcB_fbtb802VA&open=AXrlUTSXcB_fbtb802VA