### PR TITLE
fixes several sonar code-smell for no assertion in test.

### DIFF
--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesSpecTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesSpecTest.java
@@ -146,8 +146,11 @@ public class FilePropertiesSpecTest {
     public void testFilePropertiesSpec_nullOkay() throws JsonProcessingException {
       String data = fieldName + ": null";
 
-      mapper.readValue(data, FilePropertiesSpec.class);
-      // pass
+      FilePropertiesSpec parsed = mapper.readValue(data, FilePropertiesSpec.class);
+      Assert.assertFalse(parsed.getFilePermissions().isPresent());
+      Assert.assertFalse(parsed.getDirectoryPermissions().isPresent());
+      Assert.assertFalse(parsed.getUser().isPresent());
+      Assert.assertFalse(parsed.getGroup().isPresent());
     }
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
@@ -85,7 +85,7 @@ public class JsonToImageTranslatorTest {
     testToImage_buildable("core/json/ocimanifest.json", OciManifestTemplate.class);
   }
 
-  @Test(expected = Test.None.class /* no exception expected */)
+  @Test
   public void testToImage_canParseTimestampWithOffset()
       throws IOException, LayerPropertyNotFoundException, URISyntaxException,
           LayerCountMismatchException, BadContainerConfigurationFormatException {
@@ -104,7 +104,8 @@ public class JsonToImageTranslatorTest {
 
     // Should not throw BadContainerConfigFormatException.
     // https://github.com/GoogleContainerTools/jib/issues/2428
-    JsonToImageTranslator.toImage(manifest, containerConfig);
+    Image image = JsonToImageTranslator.toImage(manifest, containerConfig);
+    Assert.assertEquals(1587500530L, image.getCreated().getEpochSecond());
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
@@ -85,7 +85,7 @@ public class JsonToImageTranslatorTest {
     testToImage_buildable("core/json/ocimanifest.json", OciManifestTemplate.class);
   }
 
-  @Test
+  @Test(expected = Test.None.class /* no exception expected */)
   public void testToImage_canParseTimestampWithOffset()
       throws IOException, LayerPropertyNotFoundException, URISyntaxException,
           LayerCountMismatchException, BadContainerConfigurationFormatException {

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunnerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunnerTest.java
@@ -78,10 +78,11 @@ public class JibBuildRunnerTest {
             "ignored");
   }
 
-  @Test(expected = Test.None.class /* no exception expected */)
+  @Test
   public void testBuildImage_pass()
       throws BuildStepsExecutionException, IOException, CacheDirectoryCreationException {
-    testJibBuildRunner.runBuild();
+    JibContainer buildResult = testJibBuildRunner.runBuild();
+    Assert.assertNull(buildResult);
   }
 
   @Test

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunnerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunnerTest.java
@@ -78,11 +78,10 @@ public class JibBuildRunnerTest {
             "ignored");
   }
 
-  @Test
+  @Test(expected = Test.None.class /* no exception expected */)
   public void testBuildImage_pass()
       throws BuildStepsExecutionException, IOException, CacheDirectoryCreationException {
-    JibContainer buildResult = testJibBuildRunner.runBuild();
-    Assert.assertNull(buildResult);
+    testJibBuildRunner.runBuild();
   }
 
   @Test

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunnerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunnerTest.java
@@ -81,7 +81,8 @@ public class JibBuildRunnerTest {
   @Test
   public void testBuildImage_pass()
       throws BuildStepsExecutionException, IOException, CacheDirectoryCreationException {
-    testJibBuildRunner.runBuild();
+    JibContainer buildResult = testJibBuildRunner.runBuild();
+    Assert.assertNull(buildResult);
   }
 
   @Test

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldSyncMapTemplateTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldSyncMapTemplateTest.java
@@ -107,7 +107,6 @@ public class SkaffoldSyncMapTemplateTest {
         SkaffoldSyncMapTemplate.from(TEST_JSON_NO_GENERATED);
     Assert.assertTrue(templateEmptyGenerated.getGenerated().isEmpty());
     Assert.assertTrue(templateNoGenerated.getGenerated().isEmpty());
-    // pass if no exceptions
   }
 
   @Test

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldSyncMapTemplateTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldSyncMapTemplateTest.java
@@ -99,10 +99,14 @@ public class SkaffoldSyncMapTemplateTest {
     }
   }
 
-  @Test(expected = Test.None.class /* no exception expected */)
+  @Test
   public void testFrom_validEmpty() throws Exception {
-    SkaffoldSyncMapTemplate.from(TEST_JSON_EMPTY_GENERATED);
-    SkaffoldSyncMapTemplate.from(TEST_JSON_NO_GENERATED);
+    SkaffoldSyncMapTemplate templateEmptyGenerated =
+        SkaffoldSyncMapTemplate.from(TEST_JSON_EMPTY_GENERATED);
+    Assert.assertTrue(templateEmptyGenerated.getGenerated().isEmpty());
+    SkaffoldSyncMapTemplate templateNoGenerated =
+        SkaffoldSyncMapTemplate.from(TEST_JSON_NO_GENERATED);
+    Assert.assertTrue(templateNoGenerated.getGenerated().isEmpty());
     // pass if no exceptions
   }
 

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldSyncMapTemplateTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldSyncMapTemplateTest.java
@@ -99,7 +99,7 @@ public class SkaffoldSyncMapTemplateTest {
     }
   }
 
-  @Test
+  @Test(expected = Test.None.class /* no exception expected */)
   public void testFrom_validEmpty() throws Exception {
     SkaffoldSyncMapTemplate.from(TEST_JSON_EMPTY_GENERATED);
     SkaffoldSyncMapTemplate.from(TEST_JSON_NO_GENERATED);

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldSyncMapTemplateTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/SkaffoldSyncMapTemplateTest.java
@@ -103,9 +103,9 @@ public class SkaffoldSyncMapTemplateTest {
   public void testFrom_validEmpty() throws Exception {
     SkaffoldSyncMapTemplate templateEmptyGenerated =
         SkaffoldSyncMapTemplate.from(TEST_JSON_EMPTY_GENERATED);
-    Assert.assertTrue(templateEmptyGenerated.getGenerated().isEmpty());
     SkaffoldSyncMapTemplate templateNoGenerated =
         SkaffoldSyncMapTemplate.from(TEST_JSON_NO_GENERATED);
+    Assert.assertTrue(templateEmptyGenerated.getGenerated().isEmpty());
     Assert.assertTrue(templateNoGenerated.getGenerated().isEmpty());
     // pass if no exceptions
   }


### PR DESCRIPTION
fixes sonar code-smell for "Add at least one assertion to this test case."
List of sonar links related:
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTLzcB_fbtb802UR&open=AXrlUTLzcB_fbtb802UR
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTjqcB_fbtb802X_&open=AXrlUTjqcB_fbtb802X_
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTUecB_fbtb802Vf&open=AXrlUTUecB_fbtb802Vf
- https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTUqcB_fbtb802Vh&open=AXrlUTUqcB_fbtb802Vh

Used expect attribute of the @Test annotation for tests that success with no exceptions. This should be enough to silent sonar.  