### PR TITLE
change to try-with-resources as FileLock implements AutoCloseable.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
@@ -62,15 +62,8 @@ public class LockFile implements Closeable {
 
     Files.createDirectories(lockFile.getParent());
     FileOutputStream outputStream = new FileOutputStream(lockFile.toFile());
-    FileLock fileLock = null;
-    try {
-      fileLock = outputStream.getChannel().lock();
+    try (FileLock fileLock = outputStream.getChannel().lock(); ) {
       return new LockFile(lockFile, fileLock, outputStream);
-
-    } finally {
-      if (fileLock == null) {
-        outputStream.close();
-      }
     }
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
@@ -62,7 +62,7 @@ public class LockFile implements Closeable {
 
     Files.createDirectories(lockFile.getParent());
     FileOutputStream outputStream = new FileOutputStream(lockFile.toFile());
-    try (FileLock fileLock = outputStream.getChannel().lock(); ) {
+    try (FileLock fileLock = outputStream.getChannel().lock()) {
       return new LockFile(lockFile, fileLock, outputStream);
     }
   }


### PR DESCRIPTION
Fixes code smell in sonar: [Change this "try" to a try-with-resources.
](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTfRcB_fbtb802Xh&open=AXrlUTfRcB_fbtb802Xh)