### PR TITLE
fix sonar issue: Use already-defined constant 'DIGEST_PREFIX'.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/DescriptorDigest.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/DescriptorDigest.java
@@ -89,7 +89,7 @@ public class DescriptorDigest {
 
   @Override
   public String toString() {
-    return "sha256:" + hash;
+    return DIGEST_PREFIX + hash;
   }
 
   /** Pass-through hash code of the digest string. */


### PR DESCRIPTION
Fix for sonar issue: [Use already-defined constant 'DIGEST_PREFIX' instead of duplicating its value here.](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTbrcB_fbtb802Ww&open=AXrlUTbrcB_fbtb802Ww)