### PR TITLE
Fix sonar code smell: add private constructor to hide implicit public one.

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ArtifactLayers.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ArtifactLayers.java
@@ -31,6 +31,8 @@ public class ArtifactLayers {
   public static final String DEPENDENCIES = "dependencies";
   public static final String SNAPSHOT_DEPENDENCIES = "snapshot dependencies";
 
+  private ArtifactLayers() {}
+
   /**
    * Creates a layer containing contents of a directory. Only paths that match the given predicate
    * will be added.

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ArtifactProcessors.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ArtifactProcessors.java
@@ -45,6 +45,8 @@ public class ArtifactProcessors {
   private static Integer VERSION_NOT_FOUND = 0;
   private static final String DEFAULT_JETTY_APP_ROOT = "/var/lib/jetty/webapps/ROOT";
 
+  private ArtifactProcessors() {}
+
   /**
    * Creates a {@link ArtifactProcessor} instance based on jar type and processing mode.
    *

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ContainerBuilders.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ContainerBuilders.java
@@ -38,6 +38,8 @@ import java.util.Set;
 /** Helper class for creating JibContainerBuilders from JibCli specifications. */
 public class ContainerBuilders {
 
+  private ContainerBuilders() {}
+
   /**
    * Creates a {@link JibContainerBuilder} depending on the base image specified.
    *

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Containerizers.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Containerizers.java
@@ -41,6 +41,8 @@ import java.util.List;
 /** Helper class for creating Containerizers from JibCli specifications. */
 public class Containerizers {
 
+  private Containerizers() {}
+
   /**
    * Create a Containerizer from a command line specification.
    *

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Credentials.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Credentials.java
@@ -25,6 +25,9 @@ import java.util.List;
  * A helper class to process command line args and generate a list of {@link CredentialRetriever}s.
  */
 public class Credentials {
+
+  private Credentials() {}
+
   /**
    * Gets credentials for a target image registry.
    *

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Instants.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/Instants.java
@@ -23,6 +23,9 @@ import java.time.format.DateTimeParseException;
 
 /** Helper class to convert various strings in a buildfile to Instants. */
 public class Instants {
+
+  private Instants() {}
+
   /**
    * Parses a time string into Instant. The string must be time in milliseconds since unix epoch or
    * an iso8601 datetime.

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Layers.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Layers.java
@@ -38,6 +38,8 @@ import java.util.stream.Stream;
 /** Class to convert between different layer representations. */
 class Layers {
 
+  private Layers() {}
+
   /**
    * Convert a layer spec to a list of layer objects.
    *

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Validator.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/Validator.java
@@ -27,6 +27,8 @@ import javax.annotation.Nullable;
  */
 public class Validator {
 
+  private Validator() {}
+
   /**
    * Checks if string is non null and non empty.
    *

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarFiles.java
@@ -33,6 +33,8 @@ import java.util.Optional;
 /** Class to build a container representation from the contents of a jar file. */
 public class JarFiles {
 
+  private JarFiles() {}
+
   /**
    * Generates a {@link JibContainerBuilder} from contents of a jar file.
    *

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarLayers.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/JarLayers.java
@@ -36,6 +36,8 @@ public class JarLayers {
   static final AbsoluteUnixPath APP_ROOT = AbsoluteUnixPath.get("/app");
   static final String JAR = "jar";
 
+  private JarLayers() {}
+
   static List<FileEntriesLayer> getDependenciesLayers(Path jarPath, ProcessingMode mode)
       throws IOException {
     // Get dependencies from Class-Path in the jar's manifest and add a layer each for non-snapshot

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/logging/CliLogger.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/logging/CliLogger.java
@@ -25,6 +25,8 @@ import java.io.PrintWriter;
 /** A simple CLI logger that logs to the command line based on the configured log level. */
 public class CliLogger {
 
+  private CliLogger() {}
+
   /**
    * Create a new logger for the CLI.
    *

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/war/WarFiles.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/war/WarFiles.java
@@ -31,6 +31,8 @@ import javax.annotation.Nullable;
 
 public class WarFiles {
 
+  private WarFiles() {}
+
   /**
    * Generates a {@link JibContainerBuilder} from contents of a WAR file.
    *

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -77,6 +77,8 @@ public class LocalBaseImageSteps {
     }
   }
 
+  private LocalBaseImageSteps() {}
+
   /**
    * Checks the first two bytes of a file to see if it has been gzipped.
    *

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PlatformChecker.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PlatformChecker.java
@@ -27,6 +27,8 @@ import java.util.Set;
 /** Provides helper methods to check platforms. */
 public class PlatformChecker {
 
+  private PlatformChecker() {}
+
   /**
    * Assuming the base image is not a manifest list, checks and warns misconfigured platforms.
    *

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RegistryCredentialRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RegistryCredentialRetriever.java
@@ -28,6 +28,8 @@ import java.util.Optional;
 /** Attempts to retrieve registry credentials. */
 class RegistryCredentialRetriever {
 
+  private RegistryCredentialRetriever() {}
+
   /** Retrieves credentials for the base image. */
   static Optional<Credential> getBaseImageCredential(BuildContext buildContext)
       throws CredentialRetrievalException {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/hash/Digests.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/hash/Digests.java
@@ -35,6 +35,8 @@ import java.util.List;
 // more general.
 public class Digests {
 
+  private Digests() {}
+
   public static DescriptorDigest computeJsonDigest(JsonTemplate template) throws IOException {
     return computeDigest(template, ByteStreams.nullOutputStream()).getDigest();
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAliasGroup.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAliasGroup.java
@@ -27,6 +27,8 @@ import java.util.stream.Stream;
 /** Provides known aliases and alternative hosts for a given registry. */
 public class RegistryAliasGroup {
 
+  private RegistryAliasGroup() {}
+
   private static final ImmutableList<ImmutableSet<String>> REGISTRY_ALIAS_GROUPS =
       ImmutableList.of(
           // Docker Hub alias group (https://github.com/moby/moby/pull/28100)

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarExtractor.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarExtractor.java
@@ -36,6 +36,8 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 /** Extracts a tarball. */
 public class TarExtractor {
 
+  private TarExtractor() {}
+
   /**
    * Extracts a tarball to the specified destination.
    *

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsProxyProvider.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsProxyProvider.java
@@ -36,6 +36,8 @@ class MavenSettingsProxyProvider {
   private static final ImmutableList<String> PROXY_PROPERTIES =
       ImmutableList.of("proxyHost", "proxyPort", "proxyUser", "proxyPassword");
 
+  private MavenSettingsProxyProvider() {}
+
   /**
    * Initializes proxy settings based on Maven settings if they are not already set by the user
    * directly.

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PluginConfigurationProcessor.java
@@ -92,6 +92,8 @@ public class PluginConfigurationProcessor {
   private static final String JIB_CLASSPATH_FILE = "jib-classpath-file";
   private static final String JIB_MAIN_CLASS_FILE = "jib-main-class-file";
 
+  private PluginConfigurationProcessor() {}
+
   /**
    * Generate a runner for image builds to docker daemon.
    *

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ZipUtil.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ZipUtil.java
@@ -35,6 +35,8 @@ import java.util.zip.ZipInputStream;
 /** Utility class for Zip archives. */
 public class ZipUtil {
 
+  private ZipUtil() {}
+
   /**
    * Unzips {@code archive} into {@code destination}.
    *


### PR DESCRIPTION
Batch fix sonar code smell: add private constructor to hide implicit public one.
These are all utility classes with only static members.

list of related sonar issues: https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&resolved=false&rules=java%3AS1118&severities=MAJOR
