### PR TITLE
Add assertions to WithServerFailoverHttpClientTest and JibPluginTest

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/FailoverHttpClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/FailoverHttpClient.java
@@ -348,4 +348,9 @@ public class FailoverHttpClient {
     String log = "Cannot verify server at " + url + ". Attempting again with no TLS verification.";
     logger.accept(LogEvent.warn(log));
   }
+
+  @VisibleForTesting
+  public Deque<HttpTransport> getTransportsCreated() {
+    return transportsCreated;
+  }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerFailoverHttpClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerFailoverHttpClientTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.jib.http;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.common.io.ByteStreams;
 import java.io.IOException;
@@ -164,10 +166,10 @@ public class WithServerFailoverHttpClientTest {
     } finally {
 
       // Validate that calling shutdown() many times completes with no errors
-      Assert.assertEquals(2, httpClient.getTransportsCreated().size());
+      assertThat(httpClient.getTransportsCreated()).hasSize(2);
       httpClient.shutDown();
       httpClient.shutDown();
-      Assert.assertEquals(0, httpClient.getTransportsCreated().size());
+      assertThat(httpClient.getTransportsCreated()).hasSize(0);
     }
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerFailoverHttpClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/http/WithServerFailoverHttpClientTest.java
@@ -162,8 +162,12 @@ public class WithServerFailoverHttpClientTest {
       ignored1.close();
       ignored2.close();
     } finally {
+
+      // Validate that calling shutdown() many times completes with no errors
+      Assert.assertEquals(2, httpClient.getTransportsCreated().size());
       httpClient.shutDown();
-      httpClient.shutDown(); // test should complete with no error
+      httpClient.shutDown();
+      Assert.assertEquals(0, httpClient.getTransportsCreated().size());
     }
   }
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -81,12 +81,13 @@ public class JibPluginTest {
         getClass().getClassLoader().getResourceAsStream("gradle/plugin-test/build.gradle");
     Files.copy(buildFileContent, buildFile);
 
-    GradleRunner.create()
-        .withProjectDir(testProjectRoot.getRoot())
-        .withPluginClasspath()
-        .withGradleVersion(JibPlugin.GRADLE_MIN_VERSION.getVersion())
-        .build();
-    // pass
+    BuildResult result =
+        GradleRunner.create()
+            .withProjectDir(testProjectRoot.getRoot())
+            .withPluginClasspath()
+            .withGradleVersion(JibPlugin.GRADLE_MIN_VERSION.getVersion())
+            .build();
+    assertThat(result).isNotNull();
   }
 
   @Test


### PR DESCRIPTION
Fixes sonarcloud [issues](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&resolved=false&severities=BLOCKER&types=CODE_SMELL)