### PR TITLE
Avoid using wildcards in the return type. 

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ContainerConfigurationTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ContainerConfigurationTemplate.java
@@ -115,7 +115,7 @@ public class ContainerConfigurationTemplate implements JsonTemplate {
     @Nullable private HealthCheckObjectTemplate Healthcheck;
 
     /** Network ports the container exposes. */
-    @Nullable private Map<String, Map<?, ?>> ExposedPorts;
+    @Nullable private Map<String, Map<String, String>> ExposedPorts;
 
     /** Labels. */
     @Nullable private Map<String, String> Labels;
@@ -127,7 +127,7 @@ public class ContainerConfigurationTemplate implements JsonTemplate {
     @Nullable private String User;
 
     /** Volumes. */
-    @Nullable private Map<String, Map<?, ?>> Volumes;
+    @Nullable private Map<String, Map<String, String>> Volumes;
   }
 
   /** Template for inner JSON object representing the healthcheck configuration. */
@@ -266,7 +266,7 @@ public class ContainerConfigurationTemplate implements JsonTemplate {
     Preconditions.checkNotNull(config.Healthcheck).Retries = retries;
   }
 
-  public void setContainerExposedPorts(@Nullable Map<String, Map<?, ?>> exposedPorts) {
+  public void setContainerExposedPorts(@Nullable Map<String, Map<String, String>> exposedPorts) {
     config.ExposedPorts = exposedPorts;
   }
 
@@ -282,7 +282,7 @@ public class ContainerConfigurationTemplate implements JsonTemplate {
     config.User = user;
   }
 
-  public void setContainerVolumes(@Nullable Map<String, Map<?, ?>> volumes) {
+  public void setContainerVolumes(@Nullable Map<String, Map<String, String>> volumes) {
     config.Volumes = volumes;
   }
 
@@ -370,7 +370,7 @@ public class ContainerConfigurationTemplate implements JsonTemplate {
   }
 
   @Nullable
-  Map<String, Map<?, ?>> getContainerExposedPorts() {
+  Map<String, Map<String, String>> getContainerExposedPorts() {
     return config.ExposedPorts;
   }
 
@@ -390,7 +390,7 @@ public class ContainerConfigurationTemplate implements JsonTemplate {
   }
 
   @Nullable
-  Map<String, Map<?, ?>> getContainerVolumes() {
+  Map<String, Map<String, String>> getContainerVolumes() {
     return config.Volumes;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslator.java
@@ -48,7 +48,7 @@ public class ImageToJsonTranslator {
    */
   @VisibleForTesting
   @Nullable
-  static Map<String, Map<?, ?>> portSetToMap(@Nullable Set<Port> exposedPorts) {
+  static Map<String, Map<String, String>> portSetToMap(@Nullable Set<Port> exposedPorts) {
     return setToMap(exposedPorts, port -> port.getPort() + "/" + port.getProtocol());
   }
 
@@ -63,7 +63,7 @@ public class ImageToJsonTranslator {
    */
   @VisibleForTesting
   @Nullable
-  static Map<String, Map<?, ?>> volumesSetToMap(@Nullable Set<AbsoluteUnixPath> volumes) {
+  static Map<String, Map<String, String>> volumesSetToMap(@Nullable Set<AbsoluteUnixPath> volumes) {
     return setToMap(volumes, AbsoluteUnixPath::toString);
   }
 
@@ -105,7 +105,7 @@ public class ImageToJsonTranslator {
    * @return an map
    */
   @Nullable
-  private static <E> Map<String, Map<?, ?>> setToMap(
+  private static <E> Map<String, Map<String, String>> setToMap(
       @Nullable Set<E> set, Function<E, String> keyMapper) {
     if (set == null) {
       return null;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslator.java
@@ -225,13 +225,13 @@ public class JsonToImageTranslator {
    * @return a set of {@link Port}s
    */
   @VisibleForTesting
-  static ImmutableSet<Port> portMapToSet(@Nullable Map<String, Map<?, ?>> portMap)
+  static ImmutableSet<Port> portMapToSet(@Nullable Map<String, Map<String, String>> portMap)
       throws BadContainerConfigurationFormatException {
     if (portMap == null) {
       return ImmutableSet.of();
     }
     ImmutableSet.Builder<Port> ports = new ImmutableSet.Builder<>();
-    for (Map.Entry<String, Map<?, ?>> entry : portMap.entrySet()) {
+    for (Map.Entry<String, Map<String, String>> entry : portMap.entrySet()) {
       String port = entry.getKey();
       Matcher matcher = PORT_PATTERN.matcher(port);
       if (!matcher.matches()) {
@@ -254,7 +254,8 @@ public class JsonToImageTranslator {
    * @return a set of {@link AbsoluteUnixPath}s
    */
   @VisibleForTesting
-  static ImmutableSet<AbsoluteUnixPath> volumeMapToSet(@Nullable Map<String, Map<?, ?>> volumeMap)
+  static ImmutableSet<AbsoluteUnixPath> volumeMapToSet(
+      @Nullable Map<String, Map<String, String>> volumeMap)
       throws BadContainerConfigurationFormatException {
     if (volumeMap == null) {
       return ImmutableSet.of();

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/JsonToImageTranslatorTest.java
@@ -110,7 +110,7 @@ public class JsonToImageTranslatorTest {
 
   @Test
   public void testPortMapToList() throws BadContainerConfigurationFormatException {
-    ImmutableSortedMap<String, Map<?, ?>> input =
+    ImmutableSortedMap<String, Map<String, String>> input =
         ImmutableSortedMap.of(
             "1000",
             ImmutableMap.of(),
@@ -121,13 +121,13 @@ public class JsonToImageTranslatorTest {
     ImmutableSet<Port> expected = ImmutableSet.of(Port.tcp(1000), Port.tcp(2000), Port.udp(3000));
     Assert.assertEquals(expected, JsonToImageTranslator.portMapToSet(input));
 
-    ImmutableList<Map<String, Map<?, ?>>> badInputs =
+    ImmutableList<Map<String, Map<String, String>>> badInputs =
         ImmutableList.of(
             ImmutableMap.of("abc", ImmutableMap.of()),
             ImmutableMap.of("1000-2000", ImmutableMap.of()),
             ImmutableMap.of("/udp", ImmutableMap.of()),
             ImmutableMap.of("123/xxx", ImmutableMap.of()));
-    for (Map<String, Map<?, ?>> badInput : badInputs) {
+    for (Map<String, Map<String, String>> badInput : badInputs) {
       try {
         JsonToImageTranslator.portMapToSet(badInput);
         Assert.fail();
@@ -139,7 +139,7 @@ public class JsonToImageTranslatorTest {
 
   @Test
   public void testVolumeMapToList() throws BadContainerConfigurationFormatException {
-    ImmutableSortedMap<String, Map<?, ?>> input =
+    ImmutableSortedMap<String, Map<String, String>> input =
         ImmutableSortedMap.of(
             "/var/job-result-data", ImmutableMap.of(), "/var/log/my-app-logs", ImmutableMap.of());
     ImmutableSet<AbsoluteUnixPath> expected =
@@ -148,12 +148,12 @@ public class JsonToImageTranslatorTest {
             AbsoluteUnixPath.get("/var/log/my-app-logs"));
     Assert.assertEquals(expected, JsonToImageTranslator.volumeMapToSet(input));
 
-    ImmutableList<Map<String, Map<?, ?>>> badInputs =
+    ImmutableList<Map<String, Map<String, String>>> badInputs =
         ImmutableList.of(
             ImmutableMap.of("var/job-result-data", ImmutableMap.of()),
             ImmutableMap.of("log", ImmutableMap.of()),
             ImmutableMap.of("C:/udp", ImmutableMap.of()));
-    for (Map<String, Map<?, ?>> badInput : badInputs) {
+    for (Map<String, Map<String, String>> badInput : badInputs) {
       try {
         JsonToImageTranslator.volumeMapToSet(badInput);
         Assert.fail();


### PR DESCRIPTION
Resolves sonarcloud [item](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTY4cB_fbtb802WJ&open=AXrlUTY4cB_fbtb802WJ): "Remove usage of generic wildcard type"
