### PR TITLE
Cast operand as long 

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -320,7 +320,7 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
       Set<Platform> platforms = buildContext.getContainerConfiguration().getPlatforms();
       try (ProgressEventDispatcher progressDispatcher2 =
           childProgressDispatcherFactory.create(
-              "pulling platform-specific manifests and container configs", 2 * platforms.size())) {
+              "pulling platform-specific manifests and container configs", 2L * platforms.size())) {
         // If a manifest list, search for the manifests matching the given platforms.
         for (Platform platform : platforms) {
           String message = "Searching for architecture=%s, os=%s in the base image manifest list";


### PR DESCRIPTION
Resolves sonarcloud [item](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTdjcB_fbtb802XW&open=AXrlUTdjcB_fbtb802XW): "Cast one of the operands of this multiplication operation to a 'long'"