### PR TITLE
Remove use of wildcards from return types

### DIFF
--- a/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlan.java
+++ b/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/ContainerBuildPlan.java
@@ -479,7 +479,7 @@ public class ContainerBuildPlan {
     return cmd == null ? null : new ArrayList<>(cmd);
   }
 
-  public List<? extends LayerObject> getLayers() {
+  public List<LayerObject> getLayers() {
     return new ArrayList<>(layers);
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/Timer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/Timer.java
@@ -41,7 +41,7 @@ class Timer implements TimerEvent.Timer {
   }
 
   @Override
-  public Optional<? extends Timer> getParent() {
+  public Optional<TimerEvent.Timer> getParent() {
     return Optional.ofNullable(parentTimer);
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/TimerEvent.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/event/events/TimerEvent.java
@@ -58,7 +58,7 @@ public class TimerEvent implements JibEvent {
      *
      * @return the parent of this {@link Timer}
      */
-    Optional<? extends Timer> getParent();
+    Optional<Timer> getParent();
   }
 
   private final State state;

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -162,14 +162,16 @@ public class GradleRawConfiguration implements RawConfiguration {
   }
 
   @Override
-  public List<? extends ExtraDirectoriesConfiguration> getExtraDirectories() {
+  public List<ExtraDirectoriesConfiguration> getExtraDirectories() {
     for (ExtraDirectoryParameters path : jibExtension.getExtraDirectories().getPaths()) {
       if (path.getFrom().equals(Paths.get(""))) {
         throw new IllegalArgumentException(
             "Incomplete extraDirectories.paths configuration; source directory must be set");
       }
     }
-    return jibExtension.getExtraDirectories().getPaths();
+    return (List<ExtraDirectoriesConfiguration>)
+        (List<? extends ExtraDirectoriesConfiguration>)
+            jibExtension.getExtraDirectories().getPaths();
   }
 
   @Override
@@ -213,12 +215,14 @@ public class GradleRawConfiguration implements RawConfiguration {
   }
 
   @Override
-  public List<? extends ExtensionConfiguration> getPluginExtensions() {
-    return jibExtension.getPluginExtensions().get();
+  public List<ExtensionConfiguration> getPluginExtensions() {
+    return (List<ExtensionConfiguration>)
+        (List<? extends ExtensionConfiguration>) jibExtension.getPluginExtensions().get();
   }
 
   @Override
-  public List<? extends PlatformConfiguration> getPlatforms() {
-    return jibExtension.getFrom().getPlatforms().get();
+  public List<PlatformConfiguration> getPlatforms() {
+    return (List<PlatformConfiguration>)
+        (List<? extends PlatformConfiguration>) jibExtension.getFrom().getPlatforms().get();
   }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenRawConfiguration.java
@@ -166,8 +166,10 @@ public class MavenRawConfiguration implements RawConfiguration {
   }
 
   @Override
-  public List<? extends ExtraDirectoriesConfiguration> getExtraDirectories() {
-    return MojoCommon.getExtraDirectories(jibPluginConfiguration);
+  public List<ExtraDirectoriesConfiguration> getExtraDirectories() {
+    return (List<ExtraDirectoriesConfiguration>)
+        (List<? extends ExtraDirectoriesConfiguration>)
+            MojoCommon.getExtraDirectories(jibPluginConfiguration);
   }
 
   @Override
@@ -211,12 +213,14 @@ public class MavenRawConfiguration implements RawConfiguration {
   }
 
   @Override
-  public List<? extends ExtensionConfiguration> getPluginExtensions() {
-    return jibPluginConfiguration.getPluginExtensions();
+  public List<ExtensionConfiguration> getPluginExtensions() {
+    return (List<ExtensionConfiguration>)
+        (List<? extends ExtensionConfiguration>) jibPluginConfiguration.getPluginExtensions();
   }
 
   @Override
-  public List<? extends PlatformConfiguration> getPlatforms() {
-    return jibPluginConfiguration.getPlatforms();
+  public List<PlatformConfiguration> getPlatforms() {
+    return (List<PlatformConfiguration>)
+        (List<? extends PlatformConfiguration>) jibPluginConfiguration.getPlatforms();
   }
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/RawConfiguration.java
@@ -69,7 +69,7 @@ public interface RawConfiguration {
 
   Optional<String> getToCredHelper();
 
-  List<? extends PlatformConfiguration> getPlatforms();
+  List<PlatformConfiguration> getPlatforms();
 
   Set<String> getToTags();
 
@@ -109,7 +109,7 @@ public interface RawConfiguration {
 
   String getCreationTime();
 
-  List<? extends ExtraDirectoriesConfiguration> getExtraDirectories();
+  List<ExtraDirectoriesConfiguration> getExtraDirectories();
 
   Map<String, FilePermissions> getExtraDirectoryPermissions();
 
@@ -127,5 +127,5 @@ public interface RawConfiguration {
 
   Path getImageJsonOutputPath();
 
-  List<? extends ExtensionConfiguration> getPluginExtensions();
+  List<ExtensionConfiguration> getPluginExtensions();
 }


### PR DESCRIPTION
Removes the use of wildcards from the following classes:
- [`RawConfiguration`](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTSscB_fbtb802VE&open=AXrlUTSscB_fbtb802VE)
- [`ContainerBuildPlan`](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrt9KgqcqoYycIcfN2S&open=AXrt9KgqcqoYycIcfN2S)
- [`TimerEvent`](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTfGcB_fbtb802Xf&open=AXrlUTfGcB_fbtb802Xf)

