### PR TITLE
Define constants instead of using String literals

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/SpringBootExplodedProcessor.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/SpringBootExplodedProcessor.java
@@ -43,7 +43,7 @@ import java.util.zip.ZipEntry;
 public class SpringBootExplodedProcessor implements ArtifactProcessor {
 
   private static final String BOOT_INF = "BOOT-INF";
-  
+
   private final Path jarPath;
   private final Path targetExplodedJarRoot;
   private final Integer jarJavaVersion;

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/SpringBootExplodedProcessor.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/SpringBootExplodedProcessor.java
@@ -42,10 +42,11 @@ import java.util.zip.ZipEntry;
 
 public class SpringBootExplodedProcessor implements ArtifactProcessor {
 
+  private static final String BOOT_INF = "BOOT-INF";
+  
   private final Path jarPath;
   private final Path targetExplodedJarRoot;
   private final Integer jarJavaVersion;
-  private static final String BOOT_INF = "BOOT-INF";
 
   /**
    * Constructor for {@link SpringBootExplodedProcessor}.
@@ -70,7 +71,7 @@ public class SpringBootExplodedProcessor implements ArtifactProcessor {
 
     try (JarFile jarFile = new JarFile(jarPath.toFile())) {
       ZipUtil.unzip(jarPath, targetExplodedJarRoot, true);
-      ZipEntry layerIndex = jarFile.getEntry(BOOT_INF + "/" + "layers.idx");
+      ZipEntry layerIndex = jarFile.getEntry(BOOT_INF + "/layers.idx");
       if (layerIndex != null) {
         return createLayersForLayeredSpringBootJar(targetExplodedJarRoot);
       }

--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/SpringBootExplodedProcessor.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/jar/SpringBootExplodedProcessor.java
@@ -45,6 +45,7 @@ public class SpringBootExplodedProcessor implements ArtifactProcessor {
   private final Path jarPath;
   private final Path targetExplodedJarRoot;
   private final Integer jarJavaVersion;
+  private static final String BOOT_INF = "BOOT-INF";
 
   /**
    * Constructor for {@link SpringBootExplodedProcessor}.
@@ -69,7 +70,7 @@ public class SpringBootExplodedProcessor implements ArtifactProcessor {
 
     try (JarFile jarFile = new JarFile(jarPath.toFile())) {
       ZipUtil.unzip(jarPath, targetExplodedJarRoot, true);
-      ZipEntry layerIndex = jarFile.getEntry("BOOT-INF/layers.idx");
+      ZipEntry layerIndex = jarFile.getEntry(BOOT_INF + "/" + "layers.idx");
       if (layerIndex != null) {
         return createLayersForLayeredSpringBootJar(targetExplodedJarRoot);
       }
@@ -78,7 +79,7 @@ public class SpringBootExplodedProcessor implements ArtifactProcessor {
 
       // Non-snapshot layer
       Predicate<Path> isInBootInfLib =
-          path -> path.startsWith(targetExplodedJarRoot.resolve("BOOT-INF").resolve("lib"));
+          path -> path.startsWith(targetExplodedJarRoot.resolve(BOOT_INF).resolve("lib"));
       Predicate<Path> isSnapshot = path -> path.getFileName().toString().contains("SNAPSHOT");
       Predicate<Path> isInBootInfLibAndIsNotSnapshot = isInBootInfLib.and(isSnapshot.negate());
       Predicate<Path> nonSnapshotPredicate = isFile.and(isInBootInfLibAndIsNotSnapshot);
@@ -109,7 +110,7 @@ public class SpringBootExplodedProcessor implements ArtifactProcessor {
       // Classes layer.
       Predicate<Path> isClass = path -> path.getFileName().toString().endsWith(".class");
       Predicate<Path> isInBootInfClasses =
-          path -> path.startsWith(targetExplodedJarRoot.resolve("BOOT-INF").resolve("classes"));
+          path -> path.startsWith(targetExplodedJarRoot.resolve(BOOT_INF).resolve("classes"));
       Predicate<Path> classesPredicate = isInBootInfClasses.and(isClass);
       FileEntriesLayer classesLayer =
           ArtifactLayers.getDirectoryContentsAsLayer(
@@ -158,7 +159,7 @@ public class SpringBootExplodedProcessor implements ArtifactProcessor {
    */
   private static List<FileEntriesLayer> createLayersForLayeredSpringBootJar(
       Path localExplodedJarRoot) throws IOException {
-    Path layerIndexPath = localExplodedJarRoot.resolve("BOOT-INF").resolve("layers.idx");
+    Path layerIndexPath = localExplodedJarRoot.resolve(BOOT_INF).resolve("layers.idx");
     Pattern layerNamePattern = Pattern.compile("- \"(.*)\":");
     Pattern layerEntryPattern = Pattern.compile("  - \"(.*)\"");
     Map<String, List<String>> layersMap = new LinkedHashMap<>();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageReference.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/ImageReference.java
@@ -38,6 +38,7 @@ public class ImageReference {
   private static final String DOCKER_HUB_REGISTRY = "registry-1.docker.io";
   private static final String DEFAULT_TAG = "latest";
   private static final String LIBRARY_REPOSITORY_PREFIX = "library/";
+  private static final String SCRATCH = "scratch";
 
   /**
    * Matches all sequences of alphanumeric characters possibly separated by any number of dashes in
@@ -94,7 +95,7 @@ public class ImageReference {
    * @throws InvalidImageReferenceException if {@code reference} is formatted incorrectly
    */
   public static ImageReference parse(String reference) throws InvalidImageReferenceException {
-    if (reference.equals("scratch")) {
+    if (reference.equals(SCRATCH)) {
       return ImageReference.scratch();
     }
 
@@ -204,7 +205,7 @@ public class ImageReference {
    *     to "scratch"
    */
   public static ImageReference scratch() {
-    return new ImageReference("", "scratch", null, null);
+    return new ImageReference("", SCRATCH, null, null);
   }
 
   /**
@@ -270,9 +271,7 @@ public class ImageReference {
   private ImageReference(
       String registry, String repository, @Nullable String tag, @Nullable String digest) {
     Preconditions.checkArgument(
-        "scratch".equals(repository)
-            || !Strings.isNullOrEmpty(tag)
-            || !Strings.isNullOrEmpty(digest),
+        SCRATCH.equals(repository) || !Strings.isNullOrEmpty(tag) || !Strings.isNullOrEmpty(digest),
         "Either tag or digest needs to be set.");
     this.registry = RegistryAliasGroup.getHost(registry);
     this.repository = repository;
@@ -345,7 +344,7 @@ public class ImageReference {
    */
   public boolean isScratch() {
     return "".equals(registry)
-        && "scratch".equals(repository)
+        && SCRATCH.equals(repository)
         && Strings.isNullOrEmpty(tag)
         && Strings.isNullOrEmpty(digest);
   }
@@ -395,7 +394,7 @@ public class ImageReference {
    */
   private String toString(boolean singleQualifier) {
     if (isScratch()) {
-      return "scratch";
+      return SCRATCH;
     }
 
     StringBuilder referenceString = new StringBuilder();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageTarball.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/ImageTarball.java
@@ -49,6 +49,8 @@ public class ImageTarball {
   /** Time that entry is set in the tar. */
   private static final Instant TAR_ENTRY_MODIFICATION_TIME = Instant.EPOCH;
 
+  private static final String BLOB_PREFIX = "blobs/sha256/";
+
   private final Image image;
   private final ImageReference imageReference;
   private final ImmutableSet<String> allTargetImageTags;
@@ -93,7 +95,7 @@ public class ImageTarball {
       long size = layer.getBlobDescriptor().getSize();
 
       tarStreamBuilder.addBlobEntry(
-          layer.getBlob(), size, "blobs/sha256/" + digest.getHash(), TAR_ENTRY_MODIFICATION_TIME);
+          layer.getBlob(), size, BLOB_PREFIX + digest.getHash(), TAR_ENTRY_MODIFICATION_TIME);
       manifest.addLayer(size, digest);
     }
 
@@ -104,14 +106,14 @@ public class ImageTarball {
     manifest.setContainerConfiguration(configDescriptor.getSize(), configDescriptor.getDigest());
     tarStreamBuilder.addByteEntry(
         JsonTemplateMapper.toByteArray(containerConfiguration),
-        "blobs/sha256/" + configDescriptor.getDigest().getHash(),
+        BLOB_PREFIX + configDescriptor.getDigest().getHash(),
         TAR_ENTRY_MODIFICATION_TIME);
 
     // Adds the manifest to the tarball
     BlobDescriptor manifestDescriptor = Digests.computeDigest(manifest);
     tarStreamBuilder.addByteEntry(
         JsonTemplateMapper.toByteArray(manifest),
-        "blobs/sha256/" + manifestDescriptor.getDigest().getHash(),
+        BLOB_PREFIX + manifestDescriptor.getDigest().getHash(),
         TAR_ENTRY_MODIFICATION_TIME);
 
     // Adds the oci-layout and index.json

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelper.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelper.java
@@ -42,6 +42,8 @@ import java.util.function.Predicate;
 /** Helper for constructing {@link JavaContainerBuilder}-based {@link JibContainerBuilder}s. */
 public class JavaContainerBuilderHelper {
 
+  private static final String GLOB_PREFIX = "glob:";
+
   /**
    * Returns a {@link FileEntriesLayer} for adding the extra directory to the container.
    *
@@ -67,21 +69,21 @@ public class JavaContainerBuilderHelper {
     Map<PathMatcher, FilePermissions> permissionsPathMatchers = new LinkedHashMap<>();
     for (Map.Entry<String, FilePermissions> entry : extraDirectoryPermissions.entrySet()) {
       permissionsPathMatchers.put(
-          FileSystems.getDefault().getPathMatcher("glob:" + entry.getKey()), entry.getValue());
+          FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + entry.getKey()), entry.getValue());
     }
 
     DirectoryWalker walker = new DirectoryWalker(sourceDirectory).filterRoot();
     // add exclusion filters
     excludes
         .stream()
-        .map(pattern -> FileSystems.getDefault().getPathMatcher("glob:" + pattern))
+        .map(pattern -> FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern))
         .forEach(
             pathMatcher ->
                 walker.filter(path -> !pathMatcher.matches(sourceDirectory.relativize(path))));
     // add an inclusion filter
     includes
         .stream()
-        .map(pattern -> FileSystems.getDefault().getPathMatcher("glob:" + pattern))
+        .map(pattern -> FileSystems.getDefault().getPathMatcher(GLOB_PREFIX + pattern))
         .map(
             pathMatcher ->
                 (Predicate<Path>) path -> pathMatcher.matches(sourceDirectory.relativize(path)))


### PR DESCRIPTION
Resolves the following sonar items:
- [`SpringBootExplodedProcessor`](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTJScB_fbtb802Tg&open=AXrlUTJScB_fbtb802Tg)
- [`ImageReference`](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTcgcB_fbtb802XE&open=AXrlUTcgcB_fbtb802XE)
- [`ImageTarball`](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTaocB_fbtb802Wq&open=AXrlUTaocB_fbtb802Wq)
- [`JavaContainerBuilderHelper`](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTTicB_fbtb802Va&open=AXrlUTTicB_fbtb802Va)