### PR TITLE
Field name changes to fix sonar issues

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/blob/InputStreamBlob.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/blob/InputStreamBlob.java
@@ -34,13 +34,13 @@ class InputStreamBlob implements Blob {
   }
 
   @Override
-  public BlobDescriptor writeTo(OutputStream outputStream) throws IOException {
+  public BlobDescriptor writeTo(OutputStream outStream) throws IOException {
     // Cannot rewrite.
     if (isWritten) {
       throw new IllegalStateException("Cannot rewrite Blob backed by an InputStream");
     }
-    try (InputStream inputStream = this.inputStream) {
-      return Digests.computeDigest(inputStream, outputStream);
+    try (InputStream inStream = this.inputStream) {
+      return Digests.computeDigest(inStream, outStream);
 
     } finally {
       isWritten = true;

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
@@ -33,12 +33,12 @@ public class LockFile implements Closeable {
 
   private static final ConcurrentHashMap<Path, Lock> lockMap = new ConcurrentHashMap<>();
 
-  private final Path lockFile;
+  private final Path lockFilePath;
   private final FileLock fileLock;
   private final OutputStream outputStream;
 
-  private LockFile(Path lockFile, FileLock fileLock, OutputStream outputStream) {
-    this.lockFile = lockFile;
+  private LockFile(Path lockFilePath, FileLock fileLock, OutputStream outputStream) {
+    this.lockFilePath = lockFilePath;
     this.fileLock = fileLock;
     this.outputStream = outputStream;
   }
@@ -86,7 +86,7 @@ public class LockFile implements Closeable {
       throw new IllegalStateException("Unable to release lock", ex);
 
     } finally {
-      Preconditions.checkNotNull(lockMap.get(lockFile)).unlock();
+      Preconditions.checkNotNull(lockMap.get(lockFilePath)).unlock();
     }
   }
 }

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/JibPluginConfiguration.java
@@ -668,7 +668,7 @@ public abstract class JibPluginConfiguration extends AbstractMojo {
       List<String> paths = ConfigurationPropertyValidator.parseListProperty(property);
       return paths
           .stream()
-          .map(from -> new ExtraDirectoryParameters(new File(from), "/"))
+          .map(path -> new ExtraDirectoryParameters(new File(path), "/"))
           .collect(Collectors.toList());
     }
     return extraDirectories.getPaths();

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLoggerBuilder.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLoggerBuilder.java
@@ -47,9 +47,9 @@ public class ConsoleLoggerBuilder {
   public static ConsoleLoggerBuilder rich(
       SingleThreadedExecutor singleThreadedExecutor, boolean enableTwoCursorUpJump) {
     return new ConsoleLoggerBuilder(
-        levelMessageConsumerMap ->
+        messageConsumerMap ->
             new AnsiLoggerWithFooter(
-                levelMessageConsumerMap, singleThreadedExecutor, enableTwoCursorUpJump));
+                messageConsumerMap, singleThreadedExecutor, enableTwoCursorUpJump));
   }
 
   /**
@@ -61,8 +61,7 @@ public class ConsoleLoggerBuilder {
    */
   public static ConsoleLoggerBuilder plain(SingleThreadedExecutor singleThreadedExecutor) {
     return new ConsoleLoggerBuilder(
-        levelMessageConsumerMap ->
-            new PlainConsoleLogger(levelMessageConsumerMap, singleThreadedExecutor));
+        messageConsumerMap -> new PlainConsoleLogger(messageConsumerMap, singleThreadedExecutor));
   }
 
   private final ImmutableMap.Builder<Level, Consumer<String>> messageConsumers =

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLoggerBuilder.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/logging/ConsoleLoggerBuilder.java
@@ -47,9 +47,9 @@ public class ConsoleLoggerBuilder {
   public static ConsoleLoggerBuilder rich(
       SingleThreadedExecutor singleThreadedExecutor, boolean enableTwoCursorUpJump) {
     return new ConsoleLoggerBuilder(
-        messageConsumers ->
+        levelMessageConsumerMap ->
             new AnsiLoggerWithFooter(
-                messageConsumers, singleThreadedExecutor, enableTwoCursorUpJump));
+                levelMessageConsumerMap, singleThreadedExecutor, enableTwoCursorUpJump));
   }
 
   /**
@@ -61,7 +61,8 @@ public class ConsoleLoggerBuilder {
    */
   public static ConsoleLoggerBuilder plain(SingleThreadedExecutor singleThreadedExecutor) {
     return new ConsoleLoggerBuilder(
-        messageConsumers -> new PlainConsoleLogger(messageConsumers, singleThreadedExecutor));
+        levelMessageConsumerMap ->
+            new PlainConsoleLogger(levelMessageConsumerMap, singleThreadedExecutor));
   }
 
   private final ImmutableMap.Builder<Level, Consumer<String>> messageConsumers =


### PR DESCRIPTION
renaming to fix Sonar issue:
- Local variables should not shadow class fields: occurrences  [(1)](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTYHcB_fbtb802V1&open=AXrlUTYHcB_fbtb802V1), [(2)](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrt4J-EN6U6V78Ue75k&open=AXrt4J-EN6U6V78Ue75k) , [(3)](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTQ4cB_fbtb802U3&open=AXrlUTQ4cB_fbtb802U3) and [(4)](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTQ4cB_fbtb802U4&open=AXrlUTQ4cB_fbtb802U4)

- [A field should not duplicate the name of its containing class](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTfRcB_fbtb802Xi&open=AXrlUTfRcB_fbtb802Xi)


