### PR TITLE
Downgrade Google HTTP and auth libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,9 +58,9 @@ subprojects {
     // For Google libraries, check the following boms for best compatibility.
     // - https://github.com/googleapis/java-shared-dependencies
     // - https://github.com/googleapis/java-cloud-bom
-    GOOGLE_HTTP_CLIENT: 'com.google.http-client:google-http-client:1.39.2',
-    GOOGLE_HTTP_CLIENT_APACHE_V2: 'com.google.http-client:google-http-client-apache-v2:1.39.2',
-    GOOGLE_AUTH_LIBRARY_OAUTH2_HTTP: 'com.google.auth:google-auth-library-oauth2-http:1.0.0',
+    GOOGLE_HTTP_CLIENT: 'com.google.http-client:google-http-client:1.34.0',
+    GOOGLE_HTTP_CLIENT_APACHE_V2: 'com.google.http-client:google-http-client-apache-v2:1.34.0',
+    GOOGLE_AUTH_LIBRARY_OAUTH2_HTTP: 'com.google.auth:google-auth-library-oauth2-http:0.18.0',
     GUAVA: 'com.google.guava:guava:30.1.1-jre',
     JSR305: 'com.google.code.findbugs:jsr305:3.0.2', // transitively pulled in by GUAVA
 

--- a/jib-cli/CHANGELOG.md
+++ b/jib-cli/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415), [#3058](https://github.com/GoogleContainerTools/jib/issue/3058), [#3409](https://github.com/GoogleContainerTools/jib/issue/3409))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415), [#3058](https://github.com/GoogleContainerTools/jib/issues/3058), [#3409](https://github.com/GoogleContainerTools/jib/issues/3409))
 
 ### Fixed
 

--- a/jib-cli/CHANGELOG.md
+++ b/jib-cli/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Upgraded Google HTTP libraries to 1.39.2. ([#3387](https://github.com/GoogleContainerTools/jib/pull/3387))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#xxxx](https://github.com/GoogleContainerTools/jib/pull/xxxx))
 
 ### Fixed
 

--- a/jib-cli/CHANGELOG.md
+++ b/jib-cli/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#xxxx](https://github.com/GoogleContainerTools/jib/pull/xxxx))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415))
 
 ### Fixed
 

--- a/jib-cli/CHANGELOG.md
+++ b/jib-cli/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415), [#3058](https://github.com/GoogleContainerTools/jib/issue/3058), [#3409](https://github.com/GoogleContainerTools/jib/issue/3409))
 
 ### Fixed
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Upgraded Google HTTP libraries to 1.39.2. ([#3387](https://github.com/GoogleContainerTools/jib/pull/3387))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#xxxx](https://github.com/GoogleContainerTools/jib/pull/xxxx))
 
 ### Fixed
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415), [#3058](https://github.com/GoogleContainerTools/jib/issue/3058), [#3409](https://github.com/GoogleContainerTools/jib/issue/3409))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415), [#3058](https://github.com/GoogleContainerTools/jib/issues/3058), [#3409](https://github.com/GoogleContainerTools/jib/issues/3409))
 
 ### Fixed
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415), [#3058](https://github.com/GoogleContainerTools/jib/issue/3058), [#3409](https://github.com/GoogleContainerTools/jib/issue/3409))
 
 ### Fixed
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#xxxx](https://github.com/GoogleContainerTools/jib/pull/xxxx))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415))
 
 ### Fixed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415), [#3058](https://github.com/GoogleContainerTools/jib/issue/3058), [#3409](https://github.com/GoogleContainerTools/jib/issue/3409))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415), [#3058](https://github.com/GoogleContainerTools/jib/issues/3058), [#3409](https://github.com/GoogleContainerTools/jib/issues/3409))
 
 ### Fixed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415), [#3058](https://github.com/GoogleContainerTools/jib/issue/3058), [#3409](https://github.com/GoogleContainerTools/jib/issue/3409))
 
 ### Fixed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#xxxx](https://github.com/GoogleContainerTools/jib/pull/xxxx))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415))
 
 ### Fixed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#xxxx](https://github.com/GoogleContainerTools/jib/pull/xxxx))
+
 ### Fixed
 
 ## 3.1.3

--- a/jib-maven-plugin-extension-api/CHANGELOG.md
+++ b/jib-maven-plugin-extension-api/CHANGELOG.md
@@ -14,5 +14,3 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Upgraded jib-build-plan to 0.4.0. ([#2660](https://github.com/GoogleContainerTools/jib/pull/2660))
-
-

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415), [#3058](https://github.com/GoogleContainerTools/jib/issue/3058), [#3409](https://github.com/GoogleContainerTools/jib/issue/3409))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415), [#3058](https://github.com/GoogleContainerTools/jib/issues/3058), [#3409](https://github.com/GoogleContainerTools/jib/issues/3409))
 
 ### Fixed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415), [#3058](https://github.com/GoogleContainerTools/jib/issue/3058), [#3409](https://github.com/GoogleContainerTools/jib/issue/3409))
 
 ### Fixed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#xxxx](https://github.com/GoogleContainerTools/jib/pull/xxxx))
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#3415](https://github.com/GoogleContainerTools/jib/pull/3415))
 
 ### Fixed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Downgraded Google HTTP libraries to 1.34.0 to resolve network issues. ([#3058](https://github.com/GoogleContainerTools/jib/issue/3058) and [#3409](https://github.com/GoogleContainerTools/jib/issue/3409])) ([#xxxx](https://github.com/GoogleContainerTools/jib/pull/xxxx))
+
 ### Fixed
 
 ## 3.1.3


### PR DESCRIPTION
Downgrade Google HTTP and auth libraries to resolve #3058 and #3409. These are the versions used in Jib 2.7.0 as mentioned in https://github.com/GoogleContainerTools/jib/issues/3058#issuecomment-793122490 before upgrading in [#2096](https://github.com/GoogleContainerTools/jib/pull/2960/files).