### PR TITLE
remove expression that's always false.

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ArtifactProcessors.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/ArtifactProcessors.java
@@ -146,7 +146,7 @@ public class ArtifactProcessors {
                   new DataInputStream(loader.getResourceAsStream(jarEntry))) {
 
             // Check magic number
-            if (classFile == null || classFile.readInt() != 0xCAFEBABE) {
+            if (classFile.readInt() != 0xCAFEBABE) {
               throw new IllegalArgumentException(
                   "The class file (" + jarEntry + ") is of an invalid format.");
             }


### PR DESCRIPTION
Fixes [this](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTK5cB_fbtb802UG&open=AXrlUTK5cB_fbtb802UG) sonar code smell.

removed `classFile == null` is always false. And the case where `classFile` is empty is covered by the catch block. 