### PR TITLE
use isEmpty instead of size to check empty or not.

### DIFF
--- a/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesStack.java
+++ b/jib-cli/src/main/java/com/google/cloud/tools/jib/cli/buildfile/FilePropertiesStack.java
@@ -63,7 +63,7 @@ class FilePropertiesStack {
 
   /** Remove the last layer from the stack. All values are recalculated. */
   public void pop() {
-    Preconditions.checkState(stack.size() > 0, "Error in file properties stack pop, popping at 0");
+    Preconditions.checkState(!stack.isEmpty(), "Error in file properties stack pop, popping at 0");
     stack.remove(stack.size() - 1);
     updateProperties();
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/MainClassFinder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/MainClassFinder.java
@@ -182,7 +182,7 @@ public class MainClassFinder {
       // Valid class found.
       return Result.success(mainClasses.get(0));
     }
-    if (mainClasses.size() == 0) {
+    if (mainClasses.isEmpty()) {
       // No main class found anywhere.
       return Result.mainClassNotFound();
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -244,7 +244,7 @@ public class LocalBaseImageSteps {
       // Check the first layer to see if the layers are compressed already. 'docker save' output
       // is uncompressed, but a jib-built tar has compressed layers.
       boolean layersAreCompressed =
-          layerFiles.size() > 0 && isGzipped(destination.resolve(layerFiles.get(0)));
+          !layerFiles.isEmpty() && isGzipped(destination.resolve(layerFiles.get(0)));
 
       // Process layer blobs
       try (ProgressEventDispatcher progressEventDispatcher =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -366,7 +366,7 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
 
     List<String> digests =
         manifestListTemplate.getDigestsForPlatform(platform.getArchitecture(), platform.getOs());
-    if (digests.size() == 0) {
+    if (digests.isEmpty()) {
       String errorTemplate =
           buildContext.getBaseImageConfiguration().getImage()
               + " is a manifest list, but the list does not contain an image for architecture=%s, "

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/DockerHealthCheck.java
@@ -97,7 +97,7 @@ public class DockerHealthCheck {
    * @return a new {@link DockerHealthCheck.Builder}
    */
   public static DockerHealthCheck.Builder fromCommand(List<String> command) {
-    Preconditions.checkArgument(command.size() > 0, "command must not be empty");
+    Preconditions.checkArgument(!command.isEmpty(), "command must not be empty");
     Preconditions.checkArgument(
         command.stream().allMatch(Objects::nonNull), "command must not contain null elements");
     return new Builder(ImmutableList.copyOf(command));

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/InitTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/InitTask.java
@@ -48,7 +48,7 @@ public class InitTask extends DefaultTask {
   public void listModulesAndTargets() throws IOException {
     Project project = getProject();
     // Ignore parent projects
-    if (project.getSubprojects().size() > 0) {
+    if (!project.getSubprojects().isEmpty()) {
       return;
     }
     SkaffoldInitOutput skaffoldInitOutput = new SkaffoldInitOutput();

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsProxyProvider.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenSettingsProxyProvider.java
@@ -58,7 +58,7 @@ class MavenSettingsProxyProvider {
           .ifPresent(proxies::add);
     }
 
-    if (proxies.size() == 0) {
+    if (proxies.isEmpty()) {
       return;
     }
 


### PR DESCRIPTION
Fix sonar code smell: Use isEmpty() to check whether the collection is empty or not.
occurrences: [(1)](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTH9cB_fbtb802TO&open=AXrlUTH9cB_fbtb802TO), [(2)](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTcTcB_fbtb802W8&open=AXrlUTcTcB_fbtb802W8), [(3)](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTd5cB_fbtb802XZ&open=AXrlUTd5cB_fbtb802XZ), [(4)](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTdjcB_fbtb802XV&open=AXrlUTdjcB_fbtb802XV), [(5)](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTg7cB_fbtb802Xx&open=AXrlUTg7cB_fbtb802Xx), [(6)](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrlUTrQcB_fbtb802Y8&open=AXrlUTrQcB_fbtb802Y8) and [(7)](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrt4J9nN6U6V78Ue75Z&open=AXrt4J9nN6U6V78Ue75Z) .
