### PR TITLE
 fix to keep only one method invocation in try/catch testing for exception

### DIFF
--- a/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/AbsoluteUnixPathTest.java
+++ b/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/AbsoluteUnixPathTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.api.buildplan;
 
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Assert;
 import org.junit.Assume;
@@ -75,13 +76,14 @@ public class AbsoluteUnixPathTest {
 
   @Test
   public void testResolve_Path_notRelative() {
+    AbsoluteUnixPath absolutePath = AbsoluteUnixPath.get("/");
+    Path path = Paths.get("/not/relative");
     try {
-      AbsoluteUnixPath.get("/").resolve(Paths.get("/not/relative"));
+      absolutePath.resolve(path);
       Assert.fail();
 
     } catch (IllegalArgumentException ex) {
-      Assert.assertEquals(
-          "Cannot resolve against absolute Path: " + Paths.get("/not/relative"), ex.getMessage());
+      Assert.assertEquals("Cannot resolve against absolute Path: " + path, ex.getMessage());
     }
   }
 

--- a/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/AbsoluteUnixPathTest.java
+++ b/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/AbsoluteUnixPathTest.java
@@ -76,10 +76,10 @@ public class AbsoluteUnixPathTest {
 
   @Test
   public void testResolve_Path_notRelative() {
-    AbsoluteUnixPath absolutePath = AbsoluteUnixPath.get("/");
+    AbsoluteUnixPath absoluteUnixPath = AbsoluteUnixPath.get("/");
     Path path = Paths.get("/not/relative");
     try {
-      absolutePath.resolve(path);
+      absoluteUnixPath.resolve(path);
       Assert.fail();
 
     } catch (IllegalArgumentException ex) {

--- a/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/AbsoluteUnixPathTest.java
+++ b/jib-build-plan/src/test/java/com/google/cloud/tools/jib/api/buildplan/AbsoluteUnixPathTest.java
@@ -78,13 +78,9 @@ public class AbsoluteUnixPathTest {
   public void testResolve_Path_notRelative() {
     AbsoluteUnixPath absoluteUnixPath = AbsoluteUnixPath.get("/");
     Path path = Paths.get("/not/relative");
-    try {
-      absoluteUnixPath.resolve(path);
-      Assert.fail();
-
-    } catch (IllegalArgumentException ex) {
-      Assert.assertEquals("Cannot resolve against absolute Path: " + path, ex.getMessage());
-    }
+    IllegalArgumentException exception =
+        Assert.assertThrows(IllegalArgumentException.class, () -> absoluteUnixPath.resolve(path));
+    Assert.assertEquals("Cannot resolve against absolute Path: " + path, exception.getMessage());
   }
 
   @Test


### PR DESCRIPTION
Fix sonar issue: [Refactor the body of this try/catch to have only one invocation possibly throwing a runtime exception.](https://sonarcloud.io/project/issues?id=GoogleContainerTools_jib&issues=AXrt9KfgcqoYycIcfN2M&open=AXrt9KfgcqoYycIcfN2M). 

