### PR TITLE
Fix class cast exception in gradle plugin main class detection logic

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Fix ClassCastException when using non string value for `Main-Class` manifest attribute ([#3396](https://github.com/GoogleContainerTools/jib/issues/3396))
+- Fixed `ClassCastException` when using non-`String` value (for example, [`Provider`](https://docs.gradle.org/current/javadoc/org/gradle/api/provider/Provider.html)) for `Main-Class` manifest attribute of the `jar` task. ([#3396](https://github.com/GoogleContainerTools/jib/issues/3396))
 
 ## 3.1.4
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
+- Fix ClassCastException when using non string value for `Main-Class` manifest attribute ([#3396](https://github.com/GoogleContainerTools/jib/issues/3396))
+
 ## 3.1.4
 
 ### Changed
@@ -62,8 +64,8 @@ All notable changes to this project will be documented in this file.
     jib {
       configurationName = 'myconfig'
     }
-```                                                                                                                                                                      
-  
+```
+
 ### Changed
 
 - [Switched the default base images](https://github.com/GoogleContainerTools/jib/blob/master/docs/default_base_image.md) from Distroless to [`adoptopenjdk:{8,11}-jre`](https://hub.docker.com/_/adoptopenjdk) and [`jetty`](https://hub.docker.com/_/jetty) (for WAR). ([#3124](https://github.com/GoogleContainerTools/jib/pull/3124))

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -72,6 +72,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.WarPlugin;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.jvm.tasks.Jar;
@@ -370,7 +371,22 @@ public class GradleProjectProperties implements ProjectProperties {
     if (jarTask == null) {
       return null;
     }
-    return (String) jarTask.getManifest().getAttributes().get("Main-Class");
+
+    Object value = jarTask.getManifest().getAttributes().get("Main-Class");
+
+    if (value instanceof Provider) {
+      value = ((Provider<?>) value).getOrNull();
+    }
+
+    if (value instanceof String) {
+      return (String) value;
+    }
+
+    if (value == null) {
+      return null;
+    }
+
+    return String.valueOf(value);
   }
 
   @Override

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -66,6 +66,7 @@ import org.gradle.api.java.archives.internal.DefaultManifest;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.bundling.War;
 import org.gradle.jvm.tasks.Jar;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -177,6 +178,27 @@ public class GradleProjectPropertiesTest {
 
   @Test
   public void testGetMainClassFromJar_missing() {
+    assertThat(gradleProjectProperties.getMainClassFromJarPlugin()).isNull();
+  }
+
+  @Test
+  public void testGetMainClassFromJarAsProperty_success() {
+    Property<String> mainClass =
+        project.getObjects().property(String.class).value("some.main.class");
+
+    Jar jar = project.getTasks().withType(Jar.class).getByName("jar");
+    jar.setManifest(new DefaultManifest(null).attributes(ImmutableMap.of("Main-Class", mainClass)));
+
+    assertThat(gradleProjectProperties.getMainClassFromJarPlugin()).isEqualTo("some.main.class");
+  }
+
+  @Test
+  public void testGetMainClassFromJarAsPropertyWithValueNull_missing() {
+    Property<String> mainClass = project.getObjects().property(String.class).value((String) null);
+
+    Jar jar = project.getTasks().withType(Jar.class).getByName("jar");
+    jar.setManifest(new DefaultManifest(null).attributes(ImmutableMap.of("Main-Class", mainClass)));
+
     assertThat(gradleProjectProperties.getMainClassFromJarPlugin()).isNull();
   }
 


### PR DESCRIPTION
The main class detection logic in the gradle plugin always assumed that
the `Main-Class` attribute, set in the main jar task, is a string. This
is not always true, as it sometimes makes sense to set it to a provider
of String in order to link multiple configurations together.

The logic now tests the class of the value returned for the `Main-Class`
attribute and in case of an `Provider<?>` value, it will call the `get`
method. If the provider is not set, this will cause the task to fail.
The resulting object is then transformed to a String.

fixes #3396
