### PR TITLE
Upgrade maven-core and maven-compat to 3.8.3 and update unit test setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,7 +80,7 @@ subprojects {
 
     MAVEN_API: 'org.apache.maven:maven-plugin-api:3.8.2',
     MAVEN_CORE: 'org.apache.maven:maven-core:3.8.3',
-    MAVEN_COMPAT: 'org.apache.maven:maven-compat:3.8.1',
+    MAVEN_COMPAT: 'org.apache.maven:maven-compat:3.8.3',
     MAVEN_PLUGIN_ANNOTATIONS: 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.1',
 
     //test

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ subprojects {
     PICOCLI: 'info.picocli:picocli:4.6.1',
 
     MAVEN_API: 'org.apache.maven:maven-plugin-api:3.8.2',
-    MAVEN_CORE: 'org.apache.maven:maven-core:3.8.1',
+    MAVEN_CORE: 'org.apache.maven:maven-core:3.8.3',
     MAVEN_COMPAT: 'org.apache.maven:maven-compat:3.8.1',
     MAVEN_PLUGIN_ANNOTATIONS: 'org.apache.maven.plugin-tools:maven-plugin-annotations:3.6.1',
 

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SettingsFixture.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/SettingsFixture.java
@@ -20,6 +20,7 @@ import com.google.common.base.Preconditions;
 import java.lang.reflect.Field;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import org.apache.maven.settings.Settings;
 import org.apache.maven.settings.building.DefaultSettingsBuilderFactory;
 import org.apache.maven.settings.building.DefaultSettingsBuildingRequest;
@@ -30,6 +31,7 @@ import org.apache.maven.settings.crypto.DefaultSettingsDecrypter;
 import org.apache.maven.settings.crypto.SettingsDecrypter;
 import org.sonatype.plexus.components.cipher.DefaultPlexusCipher;
 import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher;
+import org.sonatype.plexus.components.sec.dispatcher.PasswordDecryptor;
 
 class SettingsFixture {
 
@@ -62,9 +64,11 @@ class SettingsFixture {
     try {
 
       DefaultPlexusCipher injectCypher = new DefaultPlexusCipher();
-
-      DefaultSecDispatcher injectedDispatcher = new DefaultSecDispatcher();
-      injectedDispatcher.setConfigurationFile(settingsSecurityFile.toAbsolutePath().toString());
+      DefaultSecDispatcher injectedDispatcher =
+          new DefaultSecDispatcher(
+              injectCypher,
+              new HashMap<String, PasswordDecryptor>(),
+              settingsSecurityFile.toAbsolutePath().toString());
       setField(DefaultSecDispatcher.class, injectedDispatcher, "_cipher", injectCypher);
 
       return new DefaultSettingsDecrypter(injectedDispatcher);


### PR DESCRIPTION
More details in #3473 
Maven-core 3.8.3 upgraded `plexus-sec-dispatcher` to 2.0 which introduced two constructors for `DefaultSecDispatcher`. This causes the current test setup to break. 