### PR TITLE
Mention that JAVA_TOOL_OPTIONS only support a max of 1024 chars

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -214,7 +214,9 @@ spec:
     - name: JAVA_TOOL_OPTIONS
       value: <JVM flags>
 ```
-Note that the `JAVA_TOOL_OPTIONS` environment varible only supports a max length of **1024** characters. Anything longer than this will be cut off by the JVM.
+Note that many JVMs may only support a max length of **1024** characters for the `JAVA_TOOL_OPTIONS` environment variable, and anything longer than this may be cut off by the JVM.
+
+For Java 9+, often you may want to use [`JDK_JAVA_OPTIONS`](https://stackoverflow.com/questions/52986487/what-is-the-difference-between-jdk-java-options-and-java-tool-options-when-using) instead of `JAVA_TOOL_OPTIONS`.
 
 #### Other Environment Variables
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -214,6 +214,7 @@ spec:
     - name: JAVA_TOOL_OPTIONS
       value: <JVM flags>
 ```
+Note that the `JAVA_TOOL_OPTIONS` environment varible only supports a max length of **1024** characters. Anything longer than this will be cut off by the JVM.
 
 #### Other Environment Variables
 


### PR DESCRIPTION
This is to save people from debugging issues with their application and only realizing later why not everything in `JAVA_TOOL_OPTIONS` is being picked up. 
See also http://hg.openjdk.java.net/jdk7/jdk7/hotspot/file/9b0ca45cd756/src/share/vm/runtime/arguments.cpp#l2772 for the size limitation in the JVM code itself.

<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->
