### PR TITLE
Build option to add architecture suffix to tags when publishing multi-platform images

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -97,10 +97,10 @@ class PushImageStep implements Callable<BuildResult> {
   }
 
   private static Set<String> getChildTags(Image builtImage, Set<String> tags, DescriptorDigest manifestDigest, boolean newTagFeatureEnabled) {
-    if(newTagFeatureEnabled){
+    if (newTagFeatureEnabled) {
       String architecture = builtImage.getArchitecture();
       return tags.stream().map(tag -> tag + "-" + architecture).collect(Collectors.toSet());
-    }else{
+    } else {
       return Collections.singleton(manifestDigest.toString());
     }
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -82,11 +82,7 @@ class PushImageStep implements Callable<BuildResult> {
       Set<String> imageQualifiers =
           singlePlatform
               ? tags
-              : getChildTags(
-                  builtImage,
-                  tags,
-                  manifestDigest,
-                  buildContext.getContainerConfiguration().isPlatformTag());
+              : getChildTags(builtImage, tags, manifestDigest, buildContext.isEnablePlatformTags());
 
       return imageQualifiers.stream()
           .map(
@@ -111,9 +107,8 @@ class PushImageStep implements Callable<BuildResult> {
     if (newTagFeatureEnabled) {
       String architecture = builtImage.getArchitecture();
       return tags.stream().map(tag -> tag + "-" + architecture).collect(Collectors.toSet());
-    } else {
-      return Collections.singleton(manifestDigest.toString());
     }
+    return Collections.singleton(manifestDigest.toString());
   }
 
   static ImmutableList<PushImageStep> makeListForManifestList(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 
 /**
  * Pushes a manifest or a manifest list for a tag. If not a manifest list, returns the manifest
@@ -78,8 +79,8 @@ class PushImageStep implements Callable<BuildResult> {
 
       DescriptorDigest manifestDigest = Digests.computeJsonDigest(manifestTemplate);
 
-      Set<String> imageQualifiers =
-          singlePlatform ? tags : Collections.singleton(manifestDigest.toString());
+      Set<String> imageQualifiers = singlePlatform ? tags : getChildTags(builtImage, tags, manifestDigest, buildContext.getContainerConfiguration().isPlatformTag());
+
       return imageQualifiers.stream()
           .map(
               qualifier ->
@@ -92,6 +93,15 @@ class PushImageStep implements Callable<BuildResult> {
                       manifestDigest,
                       containerConfigurationDigestAndSize.getDigest()))
           .collect(ImmutableList.toImmutableList());
+    }
+  }
+
+  private static Set<String> getChildTags(Image builtImage, Set<String> tags, DescriptorDigest manifestDigest, boolean newTagFeatureEnabled) {
+    if(newTagFeatureEnabled){
+      String architecture = builtImage.getArchitecture();
+      return tags.stream().map(tag -> tag + "-" + architecture).collect(Collectors.toSet());
+    }else{
+      return Collections.singleton(manifestDigest.toString());
     }
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -79,7 +79,14 @@ class PushImageStep implements Callable<BuildResult> {
 
       DescriptorDigest manifestDigest = Digests.computeJsonDigest(manifestTemplate);
 
-      Set<String> imageQualifiers = singlePlatform ? tags : getChildTags(builtImage, tags, manifestDigest, buildContext.getContainerConfiguration().isPlatformTag());
+      Set<String> imageQualifiers =
+          singlePlatform
+              ? tags
+              : getChildTags(
+                  builtImage,
+                  tags,
+                  manifestDigest,
+                  buildContext.getContainerConfiguration().isPlatformTag());
 
       return imageQualifiers.stream()
           .map(
@@ -96,7 +103,11 @@ class PushImageStep implements Callable<BuildResult> {
     }
   }
 
-  private static Set<String> getChildTags(Image builtImage, Set<String> tags, DescriptorDigest manifestDigest, boolean newTagFeatureEnabled) {
+  private static Set<String> getChildTags(
+      Image builtImage,
+      Set<String> tags,
+      DescriptorDigest manifestDigest,
+      boolean newTagFeatureEnabled) {
     if (newTagFeatureEnabled) {
       String architecture = builtImage.getArchitecture();
       return tags.stream().map(tag -> tag + "-" + architecture).collect(Collectors.toSet());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
@@ -99,18 +99,6 @@ public class BuildContext implements Closeable {
     }
 
     /**
-     * Sets whether to automatically add architecture suffix to tags for platform-specific images
-     * when building multi-platform images. For example, when building amd64 and arm64 images for a
-     * given tag, the final tags will be &lt;tag&gt;-amd64 and &lt;tag&gt;-arm64.
-     *
-     * @return this
-     */
-    public Builder setEnablePlatformTags(boolean enablePlatformTags) {
-      this.enablePlatformTags = enablePlatformTags;
-      return this;
-    }
-
-    /**
      * Sets the target image configuration.
      *
      * @param imageConfiguration the {@link ImageConfiguration} describing the target image
@@ -130,6 +118,19 @@ public class BuildContext implements Closeable {
      */
     public Builder setAdditionalTargetImageTags(Set<String> tags) {
       additionalTargetImageTags = ImmutableSet.copyOf(tags);
+      return this;
+    }
+
+    /**
+     * Sets whether to automatically add architecture suffix to tags for platform-specific images
+     * when building multi-platform images. For example, when building amd64 and arm64 images for a
+     * given tag, the final tags will be {@code <tag>-amd64} and {@code <tag>-arm64}.
+     *
+     * @param enablePlatformTags whether to append architecture suffix to tags
+     * @return this
+     */
+    public Builder setEnablePlatformTags(boolean enablePlatformTags) {
+      this.enablePlatformTags = enablePlatformTags;
       return this;
     }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
@@ -99,12 +99,15 @@ public class BuildContext implements Closeable {
     }
 
     /**
-     * Enables/Disables the platform tags.
+     * Sets whether to automatically add architecture suffix to tags for platform-specific images
+     * when building multi-platform images. For example, when building amd64 and arm64 images for a
+     * given tag, the final tags will be &lt;tag&gt;-amd64 and &lt;tag&gt;-arm64.
      *
      * @return this
      */
-    public void setEnablePlatformTags(boolean enablePlatformTags) {
+    public Builder setEnablePlatformTags(boolean enablePlatformTags) {
       this.enablePlatformTags = enablePlatformTags;
+      return this;
     }
 
     /**
@@ -443,7 +446,7 @@ public class BuildContext implements Closeable {
     return baseImageConfiguration;
   }
 
-  public boolean isEnablePlatformTags() {
+  public boolean getEnablePlatformTags() {
     return enablePlatformTags;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
@@ -83,6 +83,7 @@ public class BuildContext implements Closeable {
     @Nullable private ExecutorService executorService;
     private boolean alwaysCacheBaseImage = false;
     private ImmutableListMultimap<String, String> registryMirrors = ImmutableListMultimap.of();
+    private boolean enablePlatformTags = false;
 
     private Builder() {}
 
@@ -95,6 +96,15 @@ public class BuildContext implements Closeable {
     public Builder setBaseImageConfiguration(ImageConfiguration imageConfiguration) {
       baseImageConfiguration = imageConfiguration;
       return this;
+    }
+
+    /**
+     * Enables/Disables the platform tags.
+     *
+     * @return this
+     */
+    public void setEnablePlatformTags(boolean enablePlatformTags) {
+      this.enablePlatformTags = enablePlatformTags;
     }
 
     /**
@@ -328,7 +338,8 @@ public class BuildContext implements Closeable {
               executorService == null ? Executors.newCachedThreadPool() : executorService,
               executorService == null, // shutDownExecutorService
               alwaysCacheBaseImage,
-              registryMirrors);
+              registryMirrors,
+              enablePlatformTags);
 
         case 1:
           throw new IllegalStateException(missingFields.get(0) + " is required but not set");
@@ -386,6 +397,7 @@ public class BuildContext implements Closeable {
   private final boolean shutDownExecutorService;
   private final boolean alwaysCacheBaseImage;
   private final ImmutableListMultimap<String, String> registryMirrors;
+  private final boolean enablePlatformTags;
 
   /** Instantiate with {@link #builder}. */
   private BuildContext(
@@ -405,7 +417,8 @@ public class BuildContext implements Closeable {
       ExecutorService executorService,
       boolean shutDownExecutorService,
       boolean alwaysCacheBaseImage,
-      ImmutableListMultimap<String, String> registryMirrors) {
+      ImmutableListMultimap<String, String> registryMirrors,
+      boolean enablePlatformTags) {
     this.baseImageConfiguration = baseImageConfiguration;
     this.targetImageConfiguration = targetImageConfiguration;
     this.additionalTargetImageTags = additionalTargetImageTags;
@@ -423,10 +436,15 @@ public class BuildContext implements Closeable {
     this.shutDownExecutorService = shutDownExecutorService;
     this.alwaysCacheBaseImage = alwaysCacheBaseImage;
     this.registryMirrors = registryMirrors;
+    this.enablePlatformTags = enablePlatformTags;
   }
 
   public ImageConfiguration getBaseImageConfiguration() {
     return baseImageConfiguration;
+  }
+
+  public boolean isEnablePlatformTags() {
+    return enablePlatformTags;
   }
 
   public ImageConfiguration getTargetImageConfiguration() {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -294,7 +294,6 @@ public class ContainerConfiguration {
       return this;
     }
 
-
     /**
      * Sets the working directory in the container.
      *
@@ -305,8 +304,6 @@ public class ContainerConfiguration {
       this.platformTag = platformTag;
       return this;
     }
-
-
 
     /**
      * Builds the {@link ContainerConfiguration}.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -58,6 +58,7 @@ public class ContainerConfiguration {
     @Nullable private Set<AbsoluteUnixPath> volumes;
     @Nullable private Map<String, String> labels;
     @Nullable private String user;
+    @Nullable private boolean platformTag;
     @Nullable private AbsoluteUnixPath workingDirectory;
 
     /**
@@ -293,6 +294,20 @@ public class ContainerConfiguration {
       return this;
     }
 
+
+    /**
+     * Sets the working directory in the container.
+     *
+     * @param platformTag tag platforms
+     * @return this
+     */
+    public Builder setPlatformTag(boolean platformTag) {
+      this.platformTag = platformTag;
+      return this;
+    }
+
+
+
     /**
      * Builds the {@link ContainerConfiguration}.
      *
@@ -309,7 +324,8 @@ public class ContainerConfiguration {
           volumes == null ? null : ImmutableSet.copyOf(volumes),
           labels == null ? null : ImmutableMap.copyOf(labels),
           user,
-          workingDirectory);
+          workingDirectory,
+          platformTag);
     }
 
     private Builder() {}
@@ -334,6 +350,7 @@ public class ContainerConfiguration {
   @Nullable private final ImmutableMap<String, String> labels;
   @Nullable private final String user;
   @Nullable private final AbsoluteUnixPath workingDirectory;
+  @Nullable private final boolean platformTag;
 
   private ContainerConfiguration(
       ImmutableSet<Platform> platforms,
@@ -345,7 +362,8 @@ public class ContainerConfiguration {
       @Nullable ImmutableSet<AbsoluteUnixPath> volumes,
       @Nullable ImmutableMap<String, String> labels,
       @Nullable String user,
-      @Nullable AbsoluteUnixPath workingDirectory) {
+      @Nullable AbsoluteUnixPath workingDirectory,
+      boolean platformTag) {
     this.platforms = platforms;
     this.creationTime = creationTime;
     this.entrypoint = entrypoint;
@@ -356,6 +374,7 @@ public class ContainerConfiguration {
     this.labels = labels;
     this.user = user;
     this.workingDirectory = workingDirectory;
+    this.platformTag = platformTag;
   }
 
   public ImmutableSet<Platform> getPlatforms() {
@@ -404,6 +423,10 @@ public class ContainerConfiguration {
   @Nullable
   public AbsoluteUnixPath getWorkingDirectory() {
     return workingDirectory;
+  }
+
+  public boolean isPlatformTag() {
+    return platformTag;
   }
 
   @Override

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -321,8 +321,7 @@ public class ContainerConfiguration {
           volumes == null ? null : ImmutableSet.copyOf(volumes),
           labels == null ? null : ImmutableMap.copyOf(labels),
           user,
-          workingDirectory,
-          platformTag);
+          workingDirectory);
     }
 
     private Builder() {}
@@ -347,7 +346,6 @@ public class ContainerConfiguration {
   @Nullable private final ImmutableMap<String, String> labels;
   @Nullable private final String user;
   @Nullable private final AbsoluteUnixPath workingDirectory;
-  @Nullable private final boolean platformTag;
 
   private ContainerConfiguration(
       ImmutableSet<Platform> platforms,
@@ -359,8 +357,7 @@ public class ContainerConfiguration {
       @Nullable ImmutableSet<AbsoluteUnixPath> volumes,
       @Nullable ImmutableMap<String, String> labels,
       @Nullable String user,
-      @Nullable AbsoluteUnixPath workingDirectory,
-      boolean platformTag) {
+      @Nullable AbsoluteUnixPath workingDirectory) {
     this.platforms = platforms;
     this.creationTime = creationTime;
     this.entrypoint = entrypoint;
@@ -371,7 +368,6 @@ public class ContainerConfiguration {
     this.labels = labels;
     this.user = user;
     this.workingDirectory = workingDirectory;
-    this.platformTag = platformTag;
   }
 
   public ImmutableSet<Platform> getPlatforms() {
@@ -420,10 +416,6 @@ public class ContainerConfiguration {
   @Nullable
   public AbsoluteUnixPath getWorkingDirectory() {
     return workingDirectory;
-  }
-
-  public boolean isPlatformTag() {
-    return platformTag;
   }
 
   @Override

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -58,7 +58,6 @@ public class ContainerConfiguration {
     @Nullable private Set<AbsoluteUnixPath> volumes;
     @Nullable private Map<String, String> labels;
     @Nullable private String user;
-    @Nullable private boolean platformTag;
     @Nullable private AbsoluteUnixPath workingDirectory;
 
     /**
@@ -291,17 +290,6 @@ public class ContainerConfiguration {
      */
     public Builder setWorkingDirectory(@Nullable AbsoluteUnixPath workingDirectory) {
       this.workingDirectory = workingDirectory;
-      return this;
-    }
-
-    /**
-     * Sets the working directory in the container.
-     *
-     * @param platformTag tag platforms
-     * @return this
-     */
-    public Builder setPlatformTag(boolean platformTag) {
-      this.platformTag = platformTag;
       return this;
     }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PushImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PushImageStepTest.java
@@ -58,7 +58,6 @@ public class PushImageStepTest {
   @Mock private ContainerConfiguration containerConfig;
   @Mock private DescriptorDigest mockDescriptorDigest;
 
-
   private final V22ManifestListTemplate manifestList = new V22ManifestListTemplate();
 
   @Before
@@ -100,17 +99,21 @@ public class PushImageStepTest {
 
   @Test
   public void testMakeList_multiPlatform_enabled() throws IOException, RegistryException {
-    Image asd = Image.builder(V22ManifestTemplate.class)
-            .setArchitecture("wasm").build();
+    Image asd = Image.builder(V22ManifestTemplate.class).setArchitecture("wasm").build();
 
     Mockito.when(containerConfig.isPlatformTag()).thenReturn(true);
 
     ImmutableList<PushImageStep> pushImageStepList =
         PushImageStep.makeList(
-            buildContext, progressDispatcherFactory, registryClient, new BlobDescriptor(mockDescriptorDigest), asd, false);
+            buildContext,
+            progressDispatcherFactory,
+            registryClient,
+            new BlobDescriptor(mockDescriptorDigest),
+            asd,
+            false);
 
     ArgumentCaptor<String> tagCAtcher = ArgumentCaptor.forClass(String.class);
-    Mockito.when(registryClient.pushManifest(Mockito.any(),tagCAtcher.capture())).thenReturn(null);
+    Mockito.when(registryClient.pushManifest(Mockito.any(), tagCAtcher.capture())).thenReturn(null);
 
     Assert.assertEquals(2, pushImageStepList.size());
     for (PushImageStep pushImageStep : pushImageStepList) {
@@ -118,28 +121,29 @@ public class PushImageStepTest {
       Assert.assertEquals(
           "sha256:0dd75658cf52608fbd72eb95ff5fc5946966258c3676b35d336bfcc7ac5006f1",
           buildResult.getImageDigest().toString());
-      Assert.assertEquals(
-          "mockDescriptorDigest",
-          buildResult.getImageId().toString());
+      Assert.assertEquals("mockDescriptorDigest", buildResult.getImageId().toString());
     }
     Set<String> allValues = ImmutableSet.copyOf(tagCAtcher.getAllValues());
     Set<String> expectedTags = ImmutableSet.of("tag1-wasm", "tag2-wasm");
     Assert.assertEquals(expectedTags, allValues);
-
   }
 
   @Test
   public void testMakeList_multiPlatform_disabled() throws IOException, RegistryException {
-    Image asd = Image.builder(V22ManifestTemplate.class)
-            .setArchitecture("wasm").build();
+    Image asd = Image.builder(V22ManifestTemplate.class).setArchitecture("wasm").build();
     Mockito.when(containerConfig.isPlatformTag()).thenReturn(false);
 
     ImmutableList<PushImageStep> pushImageStepList =
         PushImageStep.makeList(
-            buildContext, progressDispatcherFactory, registryClient, new BlobDescriptor(mockDescriptorDigest), asd, false);
+            buildContext,
+            progressDispatcherFactory,
+            registryClient,
+            new BlobDescriptor(mockDescriptorDigest),
+            asd,
+            false);
 
     ArgumentCaptor<String> tagCAtcher = ArgumentCaptor.forClass(String.class);
-    Mockito.when(registryClient.pushManifest(Mockito.any(),tagCAtcher.capture())).thenReturn(null);
+    Mockito.when(registryClient.pushManifest(Mockito.any(), tagCAtcher.capture())).thenReturn(null);
 
     Assert.assertEquals(1, pushImageStepList.size());
     for (PushImageStep pushImageStep : pushImageStepList) {
@@ -147,14 +151,12 @@ public class PushImageStepTest {
       Assert.assertEquals(
           "sha256:0dd75658cf52608fbd72eb95ff5fc5946966258c3676b35d336bfcc7ac5006f1",
           buildResult.getImageDigest().toString());
-      Assert.assertEquals(
-          "mockDescriptorDigest",
-          buildResult.getImageId().toString());
+      Assert.assertEquals("mockDescriptorDigest", buildResult.getImageId().toString());
     }
     Set<String> allValues = ImmutableSet.copyOf(tagCAtcher.getAllValues());
-    Set<String> expectedTags = ImmutableSet.of("sha256:0dd75658cf52608fbd72eb95ff5fc5946966258c3676b35d336bfcc7ac5006f1");
+    Set<String> expectedTags =
+        ImmutableSet.of("sha256:0dd75658cf52608fbd72eb95ff5fc5946966258c3676b35d336bfcc7ac5006f1");
     Assert.assertEquals(expectedTags, allValues);
-
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PushImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PushImageStepTest.java
@@ -32,6 +32,8 @@ import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.Set;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
@@ -42,9 +44,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
-
-import java.io.IOException;
-import java.util.Set;
 
 /** Tests for {@link PushImageStep}. */
 @RunWith(MockitoJUnitRunner.class)
@@ -98,6 +97,7 @@ public class PushImageStepTest {
           buildResult.getImageId().toString());
     }
   }
+
   @Test
   public void testMakeList_multiPlatform_enabled() throws IOException, RegistryException {
     Image asd = Image.builder(V22ManifestTemplate.class)
@@ -127,6 +127,7 @@ public class PushImageStepTest {
     Assert.assertEquals(expectedTags, allValues);
 
   }
+
   @Test
   public void testMakeList_multiPlatform_disabled() throws IOException, RegistryException {
     Image asd = Image.builder(V22ManifestTemplate.class)

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildContextTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildContextTest.java
@@ -128,6 +128,7 @@ public class BuildContextTest {
             .setApplicationLayersCacheDirectory(expectedApplicationLayersCacheDirectory)
             .setBaseImageLayersCacheDirectory(expectedBaseImageLayersCacheDirectory)
             .setTargetFormat(ImageFormat.OCI)
+            .setEnablePlatformTags(true)
             .setAllowInsecureRegistries(true)
             .setLayerConfigurations(expectedLayerConfigurations)
             .setToolName(expectedCreatedBy)
@@ -177,6 +178,7 @@ public class BuildContextTest {
     Assert.assertEquals(expectedCreatedBy, buildContext.getToolName());
     Assert.assertEquals(expectedRegistryMirrors, buildContext.getRegistryMirrors());
     Assert.assertNotNull(buildContext.getExecutorService());
+    Assert.assertTrue(buildContext.getEnablePlatformTags());
   }
 
   @Test
@@ -220,6 +222,7 @@ public class BuildContextTest {
     Assert.assertEquals(Collections.emptyList(), buildContext.getLayerConfigurations());
     Assert.assertEquals("jib", buildContext.getToolName());
     Assert.assertEquals(0, buildContext.getRegistryMirrors().size());
+    Assert.assertFalse(buildContext.getEnablePlatformTags());
   }
 
   @Test


### PR DESCRIPTION
a PoC for the issue I reported here: #3518