### PR TITLE
fix: fix broken integration tests

### DIFF
--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildDockerMojoIntegrationTest.java
@@ -269,7 +269,7 @@ public class BuildDockerMojoIntegrationTest {
     buildToDockerDaemon(simpleTestProject, targetImage, "pom-cred-helper-1.xml");
     Assert.assertEquals(
         "Hello, world. \n1970-01-01T00:00:01Z\n",
-        new Command("docker", "run", "--rm", "my-artifact-id:1").run());
+        new Command("docker", "run", "--rm", targetImage).run());
   }
 
   @Test
@@ -279,6 +279,6 @@ public class BuildDockerMojoIntegrationTest {
     buildToDockerDaemon(simpleTestProject, targetImage, "pom-cred-helper-2.xml");
     Assert.assertEquals(
         "Hello, world. \n1970-01-01T00:00:01Z\n",
-        new Command("docker", "run", "--rm", "my-artifact-id:1").run());
+        new Command("docker", "run", "--rm", targetImage).run());
   }
 }


### PR DESCRIPTION
The user contribution #3575 broke integration tests. We don't run integration tests on PRs (integration tests require accessing an internal GCP project), so sometimes we get into this.