### PR TITLE
Rename jib cli zip file before creating sha256 file

### DIFF
--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -41,7 +41,8 @@ jobs:
           ./gradlew jib-cli:instDist --stacktrace
 
           cd jib-cli/build/distributions
-          sha256sum jib-${{ github.event.inputs.release_version }}.zip > zip.sha256
+          mv jib-${{ github.event.inputs.release_version }}.zip jib-jre-${{ github.event.inputs.release_version }}.zip
+          sha256sum jib-jre-${{ github.event.inputs.release_version }}.zip > zip.sha256
 
       - name: Create pull request
         uses: repo-sync/pull-request@v2.6
@@ -75,7 +76,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create-release.outputs.upload_url }}
-          asset_path: ./jib-cli/build/distributions/jib-${{ github.event.inputs.release_version }}.zip
+          asset_path: ./jib-cli/build/distributions/jib-jre-${{ github.event.inputs.release_version }}.zip
           asset_name: jib-jre-${{ github.event.inputs.release_version }}.zip
           asset_content_type: application/zip
 


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/jib/issues/3584 

With the current setup, the [jib zip file is renamed](https://github.com/GoogleContainerTools/jib/blob/71e3977d5b1e81b860b29c3c62c8ea807a1d2d28/.github/workflows/jib-cli-release.yml#L89) **after** the checksum file is created. This is why the contents of the file currently look like this:
```
c0f47017f1218a223f51228cc69fe9d7793e600d8a05b11e4dbdba0dee6bfc11  jib-0.9.0.zip
```

And we end up with  `jib-0.9.0.zip: No such file or directory` when we call `sha256sum -c jib-jre-0.9.0.zip.sha256`. 

Renaming the zip file to jib-jre-{version} before generating the checksum file will result in the right contents:

```
c0f47017f1218a223f51228cc69fe9d7793e600d8a05b11e4dbdba0dee6bfc11  jib-jre-0.9.0.zip
```
 

