### PR TITLE
fix format config on buildSrc kts srcipt

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
@@ -172,6 +172,10 @@ public class ContainerParameters {
   public void setFormat(ImageFormat format) {
     this.format = format;
   }
+  
+  public void setFormat(String format) {
+    this.format = ImageFormat.valueOf(format);
+  }
 
   @Input
   @Optional


### PR DESCRIPTION
in buildSrc srcipt: Cannot access class 'com.google.cloud.tools.jib.api.buildplan.ImageFormat'

<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->
