### PR TITLE
fix format config on buildSrc kts srcipt

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
@@ -172,6 +172,10 @@ public class ContainerParameters {
   public void setFormat(ImageFormat format) {
     this.format = format;
   }
+  
+  public void setFormat(String format) {
+    this.format = ImageFormat.valueOf(format);
+  }
 
   @Input
   @Optional

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
@@ -172,7 +172,7 @@ public class ContainerParameters {
   public void setFormat(ImageFormat format) {
     this.format = format;
   }
-  
+
   public void setFormat(String format) {
     this.format = ImageFormat.valueOf(format);
   }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -222,6 +222,7 @@ public class JibExtensionTest {
         container -> {
           container.setFormat("OCI");
         });
+    ContainerParameters container = testJibExtension.getContainer();
     assertThat(container.getFormat()).isSameInstanceAs(ImageFormat.OCI);
   }
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -212,6 +212,8 @@ public class JibExtensionTest {
     assertThat(container.getArgs()).containsExactly("arg1", "arg2", "arg3").inOrder();
     assertThat(container.getPorts()).containsExactly("1000", "2000-2010", "3000").inOrder();
     assertThat(container.getFormat()).isSameInstanceAs(ImageFormat.OCI);
+    container.setFormat("Docker");
+    assertThat(container.getFormat()).isSameInstanceAs(ImageFormat.Docker);
     assertThat(container.getAppRoot()).isEqualTo("some invalid appRoot value");
     assertThat(container.getFilesModificationTime()).isEqualTo("some invalid time value");
   }

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -212,10 +212,17 @@ public class JibExtensionTest {
     assertThat(container.getArgs()).containsExactly("arg1", "arg2", "arg3").inOrder();
     assertThat(container.getPorts()).containsExactly("1000", "2000-2010", "3000").inOrder();
     assertThat(container.getFormat()).isSameInstanceAs(ImageFormat.OCI);
-    container.setFormat("Docker");
-    assertThat(container.getFormat()).isSameInstanceAs(ImageFormat.Docker);
     assertThat(container.getAppRoot()).isEqualTo("some invalid appRoot value");
     assertThat(container.getFilesModificationTime()).isEqualTo("some invalid time value");
+  }
+
+  @Test
+  public void testSetFormat() {
+    testJibExtension.container(
+        container -> {
+          container.setFormat("OCI");
+        });
+    assertThat(container.getFormat()).isSameInstanceAs(ImageFormat.OCI);
   }
 
   @Test


### PR DESCRIPTION
in buildSrc srcipt: Cannot access class 'com.google.cloud.tools.jib.api.buildplan.ImageFormat'

<!--
Before filing a pull request, make sure:

1. A corresponding issue exists or file an issue, and that
2. Your implementation plan is approved by the community.

This helps to reduce the chance of having a pull request rejected.
-->
