### PR TITLE
[#3609] maven: readme: fix docker image misprinting

### DIFF
--- a/jib-maven-plugin/README.md
+++ b/jib-maven-plugin/README.md
@@ -261,7 +261,7 @@ Field | Type | Default | Description
 
 Property | Type | Default | Description
 --- | --- | --- | ---
-`image` | string | `temurin-eclipse:{8,11,17}-jre` (or `jetty` for WAR) | The image reference for the base image. The source type can be specified using a [special type prefix](#setting-the-base-image).
+`image` | string | `eclipse-temurin:{8,11,17}-jre` (or `jetty` for WAR) | The image reference for the base image. The source type can be specified using a [special type prefix](#setting-the-base-image).
 `auth` | [`auth`](#auth-object) | *None* | Specifies credentials directly (alternative to `credHelper`).
 `credHelper` | string | *None* | Specifies a credential helper that can authenticate pulling the base image. This parameter can either be configured as an absolute path to the credential helper executable or as a credential helper suffix (following `docker-credential-`).
 `platforms` | list | See [`platform`](#platform-object) | Configures platforms of base images to select from a manifest list.


### PR DESCRIPTION
issue: https://github.com/GoogleContainerTools/jib/issues/3609