### PR TITLE
Use jackson-bom and bump jackson-databind to 2.13.2.2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,10 @@ project.ext.dependencyStrings = [
 
   COMMONS_COMPRESS: 'org.apache.commons:commons-compress:1.21',
   COMMONS_TEXT: 'org.apache.commons:commons-text:1.9',
-  JACKSON_DATABIND: 'com.fasterxml.jackson.core:jackson-databind:2.13.2',
-  JACKSON_DATAFORMAT_YAML: 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.2',
-  JACKSON_DATATYPE_JSR310: 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.2',
+  JACKSON_BOM: 'com.fasterxml.jackson:jackson-bom:2.13.2.20220328',
+  JACKSON_DATABIND: 'com.fasterxml.jackson.core:jackson-databind',
+  JACKSON_DATAFORMAT_YAML: 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml',
+  JACKSON_DATATYPE_JSR310: 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310',
   ASM: 'org.ow2.asm:asm:9.2',
   PICOCLI: 'info.picocli:picocli:4.6.3',
 

--- a/jib-cli/build.gradle
+++ b/jib-cli/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   implementation project(':jib-plugins-common')
 
   implementation dependencyStrings.COMMONS_TEXT
+  implementation(platform(dependencyStrings.JACKSON_BOM))
   implementation dependencyStrings.JACKSON_DATAFORMAT_YAML
   implementation dependencyStrings.JACKSON_DATABIND
   implementation dependencyStrings.GUAVA

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -12,6 +12,7 @@ dependencies {
 
   implementation dependencyStrings.COMMONS_COMPRESS
   implementation dependencyStrings.GUAVA
+  implementation(platform(dependencyStrings.JACKSON_BOM))
   implementation dependencyStrings.JACKSON_DATABIND
   implementation dependencyStrings.JACKSON_DATATYPE_JSR310
   implementation dependencyStrings.ASM


### PR DESCRIPTION

- Bump jackson-databind to the latest 2.13.2.2.
- Switch and use jackson-bom to manage jackson dependency versions.