### PR TITLE
Set jackson BOM versions in jib-gradle-plugin

### DIFF
--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -30,6 +30,8 @@ dependencies {
   sourceProject project(':jib-plugins-common')
   ensureNoProjectDependencies()
 
+  // transitive dependency from jib-core needs version
+  implementation(platform(dependencyStrings.JACKSON_BOM))
   implementation dependencyStrings.GRADLE_EXTENSION
 
   testImplementation dependencyStrings.JUNIT


### PR DESCRIPTION
The `jib-gradle-plugin` release failed with the following:

```
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':jib-gradle-plugin:publishPlugins'.
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.lambda$executeIfValid$1(ExecuteActionsTaskExecuter.java:187)
...
Caused by: com.gradle.publish.MissingDependencyVersionException: No version found for com.fasterxml.jackson.core:jackson-databind on pom generation.
	at com.gradle.publish.PomWriter.addDependency(PomWriter.java:60)
```

My theory is that once we switched from hardcoded versions to a BOM, that `jib-gradle-plugin` no longer gets the jackson versions from its dependency in `jib-core`.
