### PR TITLE
Add imagePushed field to jib-image.json

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
@@ -270,6 +270,11 @@ public class ContainerizerIntegrationTest {
     // Test that both images have the same properties.
     Assert.assertEquals(image1.getDigest(), image2.getDigest());
     Assert.assertEquals(image1.getImageId(), image2.getImageId());
+
+    // Test that the first image was pushed...
+    Assert.assertTrue(image1.isImagePushed());
+    // ...while the second one was skipped
+    Assert.assertFalse(image2.isImagePushed());
   }
 
   @Test

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
@@ -271,9 +271,8 @@ public class ContainerizerIntegrationTest {
     Assert.assertEquals(image1.getDigest(), image2.getDigest());
     Assert.assertEquals(image1.getImageId(), image2.getImageId());
 
-    // Test that the first image was pushed...
+    // Test that the first image was pushed while the second one was skipped
     Assert.assertTrue(image1.isImagePushed());
-    // ...while the second one was skipped
     Assert.assertFalse(image2.isImagePushed());
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainer.java
@@ -29,7 +29,7 @@ public class JibContainer {
   private final DescriptorDigest imageDigest;
   private final DescriptorDigest imageId;
   private final Set<String> tags;
-  private final Boolean imagePushed;
+  private final boolean imagePushed;
 
   @VisibleForTesting
   JibContainer(
@@ -37,7 +37,7 @@ public class JibContainer {
       DescriptorDigest imageDigest,
       DescriptorDigest imageId,
       Set<String> tags,
-      Boolean imagePushed) {
+      boolean imagePushed) {
     this.targetImage = targetImage;
     this.imageDigest = imageDigest;
     this.imageId = imageId;
@@ -67,7 +67,7 @@ public class JibContainer {
    *
    * @return true if pushed.
    */
-  public Boolean isImagePushed() {
+  public boolean isImagePushed() {
     return imagePushed;
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainer.java
@@ -101,7 +101,7 @@ public class JibContainer {
 
   @Override
   public int hashCode() {
-    return Objects.hash(targetImage, imageDigest, imageId, tags);
+    return Objects.hash(targetImage, imageDigest, imageId, tags, imagePushed);
   }
 
   @Override
@@ -116,6 +116,7 @@ public class JibContainer {
     return targetImage.equals(otherContainer.targetImage)
         && imageDigest.equals(otherContainer.imageDigest)
         && imageId.equals(otherContainer.imageId)
-        && tags.equals(otherContainer.tags);
+        && tags.equals(otherContainer.tags)
+        && imagePushed == otherContainer.imagePushed;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/JibContainer.java
@@ -29,17 +29,20 @@ public class JibContainer {
   private final DescriptorDigest imageDigest;
   private final DescriptorDigest imageId;
   private final Set<String> tags;
+  private final Boolean imagePushed;
 
   @VisibleForTesting
   JibContainer(
       ImageReference targetImage,
       DescriptorDigest imageDigest,
       DescriptorDigest imageId,
-      Set<String> tags) {
+      Set<String> tags,
+      Boolean imagePushed) {
     this.targetImage = targetImage;
     this.imageDigest = imageDigest;
     this.imageId = imageId;
     this.tags = tags;
+    this.imagePushed = imagePushed;
   }
 
   static JibContainer from(BuildContext buildContext, BuildResult buildResult) {
@@ -47,7 +50,7 @@ public class JibContainer {
     DescriptorDigest imageDigest = buildResult.getImageDigest();
     DescriptorDigest imageId = buildResult.getImageId();
     Set<String> tags = buildContext.getAllTargetImageTags();
-    return new JibContainer(targetImage, imageDigest, imageId, tags);
+    return new JibContainer(targetImage, imageDigest, imageId, tags, buildResult.isImagePushed());
   }
 
   /**
@@ -57,6 +60,15 @@ public class JibContainer {
    */
   public ImageReference getTargetImage() {
     return targetImage;
+  }
+
+  /**
+   * Returns true if we pushed this image all the way to a registry.
+   *
+   * @return true if pushed.
+   */
+  public Boolean isImagePushed() {
+    return imagePushed;
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildResult.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildResult.java
@@ -36,8 +36,8 @@ public class BuildResult {
    * @return a new {@link BuildResult} with the image's digest and id
    * @throws IOException if writing the digest or container configuration fails
    */
-  public static BuildResult fromImage(
-      Image image, Class<? extends BuildableManifestTemplate> targetFormat) throws IOException {
+  static BuildResult fromImage(Image image, Class<? extends BuildableManifestTemplate> targetFormat)
+      throws IOException {
     ImageToJsonTranslator imageToJsonTranslator = new ImageToJsonTranslator(image);
     BlobDescriptor containerConfigurationBlobDescriptor =
         Digests.computeDigest(imageToJsonTranslator.getContainerConfiguration());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildResult.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildResult.java
@@ -46,15 +46,17 @@ public class BuildResult {
             targetFormat, containerConfigurationBlobDescriptor);
     DescriptorDigest imageDigest = Digests.computeJsonDigest(manifestTemplate);
     DescriptorDigest imageId = containerConfigurationBlobDescriptor.getDigest();
-    return new BuildResult(imageDigest, imageId);
+    return new BuildResult(imageDigest, imageId, false);
   }
 
   private final DescriptorDigest imageDigest;
   private final DescriptorDigest imageId;
+  private final Boolean imagePushed;
 
-  BuildResult(DescriptorDigest imageDigest, DescriptorDigest imageId) {
+  BuildResult(DescriptorDigest imageDigest, DescriptorDigest imageId, boolean imagePushed) {
     this.imageDigest = imageDigest;
     this.imageId = imageId;
+    this.imagePushed = imagePushed;
   }
 
   public DescriptorDigest getImageDigest() {
@@ -63,6 +65,10 @@ public class BuildResult {
 
   public DescriptorDigest getImageId() {
     return imageId;
+  }
+
+  public boolean isImagePushed() {
+    return imagePushed;
   }
 
   @Override
@@ -80,6 +86,7 @@ public class BuildResult {
     }
     BuildResult otherBuildResult = (BuildResult) other;
     return imageDigest.equals(otherBuildResult.imageDigest)
-        && imageId.equals(otherBuildResult.imageId);
+        && imageId.equals(otherBuildResult.imageId)
+        && imagePushed.equals(otherBuildResult.imagePushed);
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildResult.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildResult.java
@@ -36,8 +36,8 @@ public class BuildResult {
    * @return a new {@link BuildResult} with the image's digest and id
    * @throws IOException if writing the digest or container configuration fails
    */
-  static BuildResult fromImage(Image image, Class<? extends BuildableManifestTemplate> targetFormat)
-      throws IOException {
+  public static BuildResult fromImage(
+      Image image, Class<? extends BuildableManifestTemplate> targetFormat) throws IOException {
     ImageToJsonTranslator imageToJsonTranslator = new ImageToJsonTranslator(image);
     BlobDescriptor containerConfigurationBlobDescriptor =
         Digests.computeDigest(imageToJsonTranslator.getContainerConfiguration());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PushImageStep.java
@@ -180,7 +180,7 @@ class PushImageStep implements Callable<BuildResult> {
       eventHandlers.dispatch(LogEvent.info("Pushing manifest for " + imageQualifier + "..."));
 
       registryClient.pushManifest(manifestTemplate, imageQualifier);
-      return new BuildResult(imageDigest, imageId);
+      return new BuildResult(imageDigest, imageId, true);
     }
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -574,18 +574,20 @@ public class StepsRunner {
 
           realizeFutures(manifestPushResults);
 
-          boolean imagePushed =
-              !(JibSystemProperties.skipExistingImages()
-                  && results.manifestCheckResult.get().isPresent());
-
           return manifestPushResults.isEmpty()
               ? new BuildResult(
                   results.manifestCheckResult.get().get().getDigest(),
                   Verify.verifyNotNull(containerConfigPushResult).get().getDigest(),
-                  imagePushed)
+                  determineImagePushed(results.manifestCheckResult.get()))
               // Manifest pushers return the same BuildResult.
               : manifestPushResults.get(0).get();
         });
+  }
+
+  @VisibleForTesting
+  boolean determineImagePushed(Optional<ManifestAndDigest<ManifestTemplate>> manifestResult) {
+
+    return !(JibSystemProperties.skipExistingImages() && manifestResult.isPresent());
   }
 
   private void pushManifestList(ProgressEventDispatcher.Factory progressDispatcherFactory) {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -573,12 +573,16 @@ public class StepsRunner {
                       results.manifestCheckResult.get().isPresent()));
 
           realizeFutures(manifestPushResults);
+
+          boolean imagePushed =
+              !(JibSystemProperties.skipExistingImages()
+                  && results.manifestCheckResult.get().isPresent());
+
           return manifestPushResults.isEmpty()
               ? new BuildResult(
                   results.manifestCheckResult.get().get().getDigest(),
                   Verify.verifyNotNull(containerConfigPushResult).get().getDigest(),
-                  !(JibSystemProperties.skipExistingImages()
-                      && results.manifestCheckResult.get().isPresent()))
+                  imagePushed)
               // Manifest pushers return the same BuildResult.
               : manifestPushResults.get(0).get();
         });

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -578,14 +578,14 @@ public class StepsRunner {
               ? new BuildResult(
                   results.manifestCheckResult.get().get().getDigest(),
                   Verify.verifyNotNull(containerConfigPushResult).get().getDigest(),
-                  determineImagePushed(results.manifestCheckResult.get()))
+                  isImagePushed(results.manifestCheckResult.get()))
               // Manifest pushers return the same BuildResult.
               : manifestPushResults.get(0).get();
         });
   }
 
   @VisibleForTesting
-  boolean determineImagePushed(Optional<ManifestAndDigest<ManifestTemplate>> manifestResult) {
+  boolean isImagePushed(Optional<ManifestAndDigest<ManifestTemplate>> manifestResult) {
 
     return !(JibSystemProperties.skipExistingImages() && manifestResult.isPresent());
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/StepsRunner.java
@@ -576,7 +576,9 @@ public class StepsRunner {
           return manifestPushResults.isEmpty()
               ? new BuildResult(
                   results.manifestCheckResult.get().get().getDigest(),
-                  Verify.verifyNotNull(containerConfigPushResult).get().getDigest())
+                  Verify.verifyNotNull(containerConfigPushResult).get().getDigest(),
+                  !(JibSystemProperties.skipExistingImages()
+                      && results.manifestCheckResult.get().isPresent()))
               // Manifest pushers return the same BuildResult.
               : manifestPushResults.get(0).get();
         });

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerTest.java
@@ -123,7 +123,7 @@ public class JibContainerTest {
   }
 
   @Test
-  public void testCreationViaStaticMethod() {
+  public void testCreation_withBuildContextAndBuildResult() {
     BuildResult buildResult = Mockito.mock(BuildResult.class);
     BuildContext buildContext = Mockito.mock(BuildContext.class);
     ImageConfiguration mockTargetConfiguration = Mockito.mock(ImageConfiguration.class);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerTest.java
@@ -59,7 +59,7 @@ public class JibContainerTest {
     Assert.assertEquals(digest1, container.getDigest());
     Assert.assertEquals(digest2, container.getImageId());
     Assert.assertEquals(tags1, container.getTags());
-    Assert.assertEquals(true, container.isImagePushed());
+    Assert.assertTrue(container.isImagePushed());
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerTest.java
@@ -16,6 +16,11 @@
 
 package com.google.cloud.tools.jib.api;
 
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.tools.jib.builder.steps.BuildResult;
+import com.google.cloud.tools.jib.configuration.BuildContext;
+import com.google.cloud.tools.jib.configuration.ImageConfiguration;
 import com.google.common.collect.ImmutableSet;
 import java.security.DigestException;
 import java.util.Set;
@@ -24,6 +29,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
 
 /** Tests for {@link JibContainer}. */
 public class JibContainerTest {
@@ -105,5 +111,35 @@ public class JibContainerTest {
 
     Assert.assertNotEquals(container1, container2);
     Assert.assertNotEquals(container1.hashCode(), container2.hashCode());
+  }
+
+  @Test
+  public void testEquality_differentImagePushed() {
+    JibContainer container1 = new JibContainer(targetImage1, digest1, digest1, tags1, true);
+    JibContainer container2 = new JibContainer(targetImage1, digest1, digest1, tags1, false);
+
+    Assert.assertNotEquals(container1, container2);
+    Assert.assertNotEquals(container1.hashCode(), container2.hashCode());
+  }
+
+  @Test
+  public void testCreationViaStaticMethod() {
+    BuildResult buildResult = Mockito.mock(BuildResult.class);
+    BuildContext buildContext = Mockito.mock(BuildContext.class);
+    ImageConfiguration mockTargetConfiguration = Mockito.mock(ImageConfiguration.class);
+
+    when(buildResult.getImageDigest()).thenReturn(digest1);
+    when(buildResult.getImageId()).thenReturn(digest1);
+    when(buildResult.isImagePushed()).thenReturn(true);
+    when(mockTargetConfiguration.getImage()).thenReturn(targetImage1);
+    when(buildContext.getTargetImageConfiguration()).thenReturn(mockTargetConfiguration);
+    when(buildContext.getAllTargetImageTags()).thenReturn(ImmutableSet.copyOf(tags1));
+
+    JibContainer container = JibContainer.from(buildContext, buildResult);
+    Assert.assertEquals(targetImage1, container.getTargetImage());
+    Assert.assertEquals(digest1, container.getDigest());
+    Assert.assertEquals(digest1, container.getImageId());
+    Assert.assertEquals(tags1, container.getTags());
+    Assert.assertTrue(container.isImagePushed());
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerTest.java
@@ -53,18 +53,19 @@ public class JibContainerTest {
 
   @Test
   public void testCreation() {
-    JibContainer container = new JibContainer(targetImage1, digest1, digest2, tags1);
+    JibContainer container = new JibContainer(targetImage1, digest1, digest2, tags1, true);
 
     Assert.assertEquals(targetImage1, container.getTargetImage());
     Assert.assertEquals(digest1, container.getDigest());
     Assert.assertEquals(digest2, container.getImageId());
     Assert.assertEquals(tags1, container.getTags());
+    Assert.assertEquals(true, container.isImagePushed());
   }
 
   @Test
   public void testEquality() {
-    JibContainer container1 = new JibContainer(targetImage1, digest1, digest2, tags1);
-    JibContainer container2 = new JibContainer(targetImage1, digest1, digest2, tags1);
+    JibContainer container1 = new JibContainer(targetImage1, digest1, digest2, tags1, true);
+    JibContainer container2 = new JibContainer(targetImage1, digest1, digest2, tags1, true);
 
     Assert.assertEquals(container1, container2);
     Assert.assertEquals(container1.hashCode(), container2.hashCode());
@@ -72,8 +73,8 @@ public class JibContainerTest {
 
   @Test
   public void testEquality_differentTargetImage() {
-    JibContainer container1 = new JibContainer(targetImage1, digest1, digest2, tags1);
-    JibContainer container2 = new JibContainer(targetImage2, digest1, digest2, tags1);
+    JibContainer container1 = new JibContainer(targetImage1, digest1, digest2, tags1, true);
+    JibContainer container2 = new JibContainer(targetImage2, digest1, digest2, tags1, true);
 
     Assert.assertNotEquals(container1, container2);
     Assert.assertNotEquals(container1.hashCode(), container2.hashCode());
@@ -81,8 +82,8 @@ public class JibContainerTest {
 
   @Test
   public void testEquality_differentImageDigest() {
-    JibContainer container1 = new JibContainer(targetImage1, digest1, digest2, tags1);
-    JibContainer container2 = new JibContainer(targetImage1, digest2, digest2, tags1);
+    JibContainer container1 = new JibContainer(targetImage1, digest1, digest2, tags1, true);
+    JibContainer container2 = new JibContainer(targetImage1, digest2, digest2, tags1, true);
 
     Assert.assertNotEquals(container1, container2);
     Assert.assertNotEquals(container1.hashCode(), container2.hashCode());
@@ -90,8 +91,8 @@ public class JibContainerTest {
 
   @Test
   public void testEquality_differentImageId() {
-    JibContainer container1 = new JibContainer(targetImage1, digest1, digest1, tags1);
-    JibContainer container2 = new JibContainer(targetImage1, digest1, digest2, tags1);
+    JibContainer container1 = new JibContainer(targetImage1, digest1, digest1, tags1, true);
+    JibContainer container2 = new JibContainer(targetImage1, digest1, digest2, tags1, true);
 
     Assert.assertNotEquals(container1, container2);
     Assert.assertNotEquals(container1.hashCode(), container2.hashCode());
@@ -99,8 +100,8 @@ public class JibContainerTest {
 
   @Test
   public void testEquality_differentTags() {
-    JibContainer container1 = new JibContainer(targetImage1, digest1, digest1, tags1);
-    JibContainer container2 = new JibContainer(targetImage1, digest1, digest1, tags2);
+    JibContainer container1 = new JibContainer(targetImage1, digest1, digest1, tags1, true);
+    JibContainer container2 = new JibContainer(targetImage1, digest1, digest1, tags2, true);
 
     Assert.assertNotEquals(container1, container2);
     Assert.assertNotEquals(container1.hashCode(), container2.hashCode());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildResultTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildResultTest.java
@@ -58,9 +58,11 @@ public class BuildResultTest {
     BuildResult container1 = new BuildResult(digest1, id, true);
     BuildResult container2 = new BuildResult(digest1, id, true);
     BuildResult container3 = new BuildResult(digest2, id, true);
+    BuildResult container4 = new BuildResult(digest1, id, false);
 
     Assert.assertEquals(container1, container2);
     Assert.assertEquals(container1.hashCode(), container2.hashCode());
+    Assert.assertEquals(container1.hashCode(), container4.hashCode());
     Assert.assertNotEquals(container1, container3);
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildResultTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildResultTest.java
@@ -47,16 +47,17 @@ public class BuildResultTest {
 
   @Test
   public void testCreated() {
-    BuildResult container = new BuildResult(digest1, id);
+    BuildResult container = new BuildResult(digest1, id, true);
     Assert.assertEquals(digest1, container.getImageDigest());
     Assert.assertEquals(id, container.getImageId());
+    Assert.assertTrue(container.isImagePushed());
   }
 
   @Test
   public void testEquality() {
-    BuildResult container1 = new BuildResult(digest1, id);
-    BuildResult container2 = new BuildResult(digest1, id);
-    BuildResult container3 = new BuildResult(digest2, id);
+    BuildResult container1 = new BuildResult(digest1, id, true);
+    BuildResult container2 = new BuildResult(digest1, id, true);
+    BuildResult container3 = new BuildResult(digest2, id, true);
 
     Assert.assertEquals(container1, container2);
     Assert.assertEquals(container1.hashCode(), container2.hashCode());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildResultTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildResultTest.java
@@ -31,6 +31,7 @@ public class BuildResultTest {
   private DescriptorDigest digest1;
   private DescriptorDigest digest2;
   private DescriptorDigest id;
+  private DescriptorDigest id2;
 
   @Before
   public void setUp() throws DigestException {
@@ -43,6 +44,10 @@ public class BuildResultTest {
     id =
         DescriptorDigest.fromDigest(
             "sha256:9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba");
+
+    id2 =
+        DescriptorDigest.fromDigest(
+            "sha256:1234543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba");
   }
 
   @Test
@@ -59,11 +64,17 @@ public class BuildResultTest {
     BuildResult container2 = new BuildResult(digest1, id, true);
     BuildResult container3 = new BuildResult(digest2, id, true);
     BuildResult container4 = new BuildResult(digest1, id, false);
+    BuildResult container5 = new BuildResult(digest1, id2, false);
 
     Assert.assertEquals(container1, container2);
+    Assert.assertEquals(container1, container1);
+    Assert.assertNotEquals(container1, container5);
+    Assert.assertNotEquals(container1, new Object());
+
     Assert.assertEquals(container1.hashCode(), container2.hashCode());
     Assert.assertEquals(container1.hashCode(), container4.hashCode());
     Assert.assertNotEquals(container1, container3);
+    Assert.assertNotEquals(container1, container4);
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/StepsRunnerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/StepsRunnerTest.java
@@ -154,21 +154,28 @@ public class StepsRunnerTest {
   }
 
   @Test
-  public void testDetermineImageSkipped() {
-    System.setProperty(JibSystemProperties.SKIP_EXISTING_IMAGES, "true");
-
-    // Mock out the entire optional here for we do not care about the actual contents of it
+  public void testIsImagePushed_skipExistingEnabledAndManifestPresent() {
     Optional<ManifestAndDigest<ManifestTemplate>> manifestResult = Mockito.mock(Optional.class);
     Mockito.when(manifestResult.isPresent()).thenReturn(true);
+    System.setProperty(JibSystemProperties.SKIP_EXISTING_IMAGES, "true");
 
-    Assert.assertFalse(stepsRunner.determineImagePushed(manifestResult));
+    Assert.assertFalse(stepsRunner.isImagePushed(manifestResult));
+  }
 
+  @Test
+  public void testIsImagePushed_skipExistingImageDisabledAndManifestPresent() {
+    Optional<ManifestAndDigest<ManifestTemplate>> manifestResult = Mockito.mock(Optional.class);
     System.setProperty(JibSystemProperties.SKIP_EXISTING_IMAGES, "false");
-    Mockito.when(manifestResult.isPresent()).thenReturn(true);
-    Assert.assertTrue(stepsRunner.determineImagePushed(manifestResult));
 
+    Assert.assertTrue(stepsRunner.isImagePushed(manifestResult));
+  }
+
+  @Test
+  public void testIsImagePushed_skipExistingImageEnabledAndManifestNotPresent() {
+    Optional<ManifestAndDigest<ManifestTemplate>> manifestResult = Mockito.mock(Optional.class);
     System.setProperty(JibSystemProperties.SKIP_EXISTING_IMAGES, "true");
     Mockito.when(manifestResult.isPresent()).thenReturn(false);
-    Assert.assertTrue(stepsRunner.determineImagePushed(manifestResult));
+
+    Assert.assertTrue(stepsRunner.isImagePushed(manifestResult));
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/StepsRunnerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/StepsRunnerTest.java
@@ -20,8 +20,11 @@ import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.steps.PullBaseImageStep.ImagesAndRegistryClient;
 import com.google.cloud.tools.jib.configuration.BuildContext;
+import com.google.cloud.tools.jib.global.JibSystemProperties;
 import com.google.cloud.tools.jib.image.DigestOnlyLayer;
 import com.google.cloud.tools.jib.image.Image;
+import com.google.cloud.tools.jib.image.json.ManifestTemplate;
+import com.google.cloud.tools.jib.registry.ManifestAndDigest;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ForwardingExecutorService;
 import com.google.common.util.concurrent.Futures;
@@ -30,6 +33,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import java.security.DigestException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -147,5 +151,24 @@ public class StepsRunnerTest {
     // Total three threads scheduled for the three unique layers.
     Mockito.verify(executorService, Mockito.times(3))
         .submit(Mockito.any(ObtainBaseImageLayerStep.class));
+  }
+
+  @Test
+  public void testDetermineImageSkipped() {
+    System.setProperty(JibSystemProperties.SKIP_EXISTING_IMAGES, "true");
+
+    // Mock out the entire optional here for we do not care about the actual contents of it
+    Optional<ManifestAndDigest<ManifestTemplate>> manifestResult = Mockito.mock(Optional.class);
+    Mockito.when(manifestResult.isPresent()).thenReturn(true);
+
+    Assert.assertFalse(stepsRunner.determineImagePushed(manifestResult));
+
+    System.setProperty(JibSystemProperties.SKIP_EXISTING_IMAGES, "false");
+    Mockito.when(manifestResult.isPresent()).thenReturn(true);
+    Assert.assertTrue(stepsRunner.determineImagePushed(manifestResult));
+
+    System.setProperty(JibSystemProperties.SKIP_EXISTING_IMAGES, "true");
+    Mockito.when(manifestResult.isPresent()).thenReturn(false);
+    Assert.assertTrue(stepsRunner.determineImagePushed(manifestResult));
   }
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ImageMetadataOutput.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ImageMetadataOutput.java
@@ -46,17 +46,20 @@ public class ImageMetadataOutput implements JsonTemplate {
   private final String imageId;
   private final String imageDigest;
   private final List<String> tags;
+  private final Boolean imagePushed;
 
   @JsonCreator
   ImageMetadataOutput(
       @JsonProperty(value = "image", required = true) String image,
       @JsonProperty(value = "imageId", required = true) String imageId,
       @JsonProperty(value = "imageDigest", required = true) String imageDigest,
-      @JsonProperty(value = "tags", required = true) List<String> tags) {
+      @JsonProperty(value = "tags", required = true) List<String> tags,
+      @JsonProperty(value = "imagePushed", required = true) Boolean imagePushed) {
     this.image = image;
     this.imageId = imageId;
     this.imageDigest = imageDigest;
     this.tags = tags;
+    this.imagePushed = imagePushed;
   }
 
   @VisibleForTesting
@@ -74,11 +77,12 @@ public class ImageMetadataOutput implements JsonTemplate {
     String image = jibContainer.getTargetImage().toString();
     String imageId = jibContainer.getImageId().toString();
     String imageDigest = jibContainer.getDigest().toString();
+    Boolean imagePushed = jibContainer.isImagePushed();
 
     // Make sure tags always appear in a predictable way, by sorting them into a list
     List<String> tags = ImmutableList.sortedCopyOf(jibContainer.getTags());
 
-    return new ImageMetadataOutput(image, imageId, imageDigest, tags);
+    return new ImageMetadataOutput(image, imageId, imageDigest, tags, imagePushed);
   }
 
   public String getImage() {
@@ -95,6 +99,10 @@ public class ImageMetadataOutput implements JsonTemplate {
 
   public List<String> getTags() {
     return tags;
+  }
+
+  public Boolean isImagePushed() {
+    return imagePushed;
   }
 
   public String toJson() throws IOException {

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ImageMetadataOutputTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/ImageMetadataOutputTest.java
@@ -30,7 +30,8 @@ public class ImageMetadataOutputTest {
           + "\"sha256:61bb3ec31a47cb730eb58a38bbfa813761a51dca69d10e39c24c3d00a7b2c7a9\","
           + "\"imageDigest\":"
           + "\"sha256:3f1be7e19129edb202c071a659a4db35280ab2bb1a16f223bfd5d1948657b6fc\","
-          + "\"tags\":[\"latest\",\"tag\"]"
+          + "\"tags\":[\"latest\",\"tag\"],"
+          + "\"imagePushed\":true"
           + "}";
 
   @Test
@@ -43,6 +44,7 @@ public class ImageMetadataOutputTest {
     Assert.assertEquals(
         "sha256:3f1be7e19129edb202c071a659a4db35280ab2bb1a16f223bfd5d1948657b6fc",
         output.getImageDigest());
+    Assert.assertTrue(output.isImagePushed());
 
     Assert.assertEquals(ImmutableList.of("latest", "tag"), output.getTags());
   }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunnerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunnerTest.java
@@ -250,5 +250,6 @@ public class JibBuildRunnerTest {
     Assert.assertEquals(imageId, metadataOutput.getImageId());
     Assert.assertEquals(digest, metadataOutput.getImageDigest());
     Assert.assertEquals(tags, ImmutableSet.copyOf(metadataOutput.getTags()));
+    Assert.assertTrue(metadataOutput.isImagePushed());
   }
 }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunnerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunnerTest.java
@@ -242,6 +242,7 @@ public class JibBuildRunnerTest {
     Mockito.when(mockJibContainer.getTags()).thenReturn(tags);
     Mockito.when(mockJibContainerBuilder.containerize(mockContainerizer))
         .thenReturn(mockJibContainer);
+    Mockito.when(mockJibContainer.isImagePushed()).thenReturn(true);
     testJibBuildRunner.writeImageJson(outputPath).runBuild();
 
     final String outputJson = new String(Files.readAllBytes(outputPath), StandardCharsets.UTF_8);


### PR DESCRIPTION
This keeps track of which images were pushed onto the target registry, useful for when skipExistingImages option is in use especially in a mono-repo contest.

https://github.com/GoogleContainerTools/jib/issues/3636
