### PR TITLE
upgrade from javax to jakarta namespace

### DIFF
--- a/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/WarCommandTest.java
+++ b/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/WarCommandTest.java
@@ -103,7 +103,7 @@ public class WarCommandTest {
                 "war",
                 "--target",
                 "docker://exploded-war-custom-jetty",
-                "--from=jetty:9.4-jre11",
+                "--from=jetty:11.0-jre11-slim-openjdk",
                 warPath.toString());
     assertThat(exitCode).isEqualTo(0);
     String output =
@@ -125,7 +125,7 @@ public class WarCommandTest {
                 "war",
                 "--target",
                 "docker://exploded-war-tomcat",
-                "--from=tomcat:8.5-jre8-alpine",
+                "--from=tomcat:10-jre8-openjdk-slim",
                 "--app-root",
                 "/usr/local/tomcat/webapps/ROOT",
                 warPath.toString());

--- a/jib-cli/src/integration-test/resources/warTest/build.gradle
+++ b/jib-cli/src/integration-test/resources/warTest/build.gradle
@@ -15,8 +15,8 @@ configurations {
 }
 
 dependencies {
-  providedCompile 'javax.servlet:servlet-api:2.5'
-  moreLibs 'javax.annotation:javax.annotation-api:1.2' // random extra JAR
+  providedCompile 'jakarta.servlet:jakarta.servlet-api:5.0.0'
+  moreLibs 'jakarta.annotation:jakarta.annotation-api:2.1.0' // random extra JAR
 }
 
 war {

--- a/jib-cli/src/integration-test/resources/warTest/src/main/java/example/HelloWorld.java
+++ b/jib-cli/src/integration-test/resources/warTest/src/main/java/example/HelloWorld.java
@@ -16,6 +16,9 @@
 
 package example;
 
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -23,9 +26,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import jakarta.servlet.http.HttpServlet;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 
 public class HelloWorld extends HttpServlet {
 

--- a/jib-cli/src/integration-test/resources/warTest/src/main/java/example/HelloWorld.java
+++ b/jib-cli/src/integration-test/resources/warTest/src/main/java/example/HelloWorld.java
@@ -23,9 +23,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 public class HelloWorld extends HttpServlet {
 


### PR DESCRIPTION
The integration test `WarCommandTest.testWar_jetty()` intentionally uses the latest Jetty docker image. (in the future, if this causes many issues, we can likely delete that test, as there is another test pinning version).

This PR updates the sample itself to use the new Jakarta EE namespace, and updates the base images of remaining WAR tests to be on a version compatible with Jakarta EE 9.