### PR TITLE
More samples need to switch to jakarta

### DIFF
--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/war_servlet25/build-tomcat.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/war_servlet25/build-tomcat.gradle
@@ -16,8 +16,8 @@ configurations {
 }
 
 dependencies {
-  providedCompile 'javax.servlet:servlet-api:2.5'
-  moreLibs 'javax.annotation:javax.annotation-api:1.2' // random extra JAR
+  providedCompile 'jakarta.servlet:jakarta.servlet-api:5.0.0'
+  moreLibs 'jakarta.annotation:jakarta.annotation-api:2.1.0' // random extra JAR
 }
 
 war {
@@ -27,7 +27,7 @@ war {
 }
 
 jib {
-  from.image = 'tomcat:8.5-jre8-alpine'
+  from.image = 'tomcat:10-jre8-temurin'
   to {
     image = System.getProperty("_TARGET_IMAGE")
     credHelper = 'gcr'

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/war_servlet25/build.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/war_servlet25/build.gradle
@@ -16,8 +16,8 @@ configurations {
 }
 
 dependencies {
-  providedCompile 'javax.servlet:servlet-api:2.5'
-  moreLibs 'javax.annotation:javax.annotation-api:1.2' // random extra JAR
+  providedCompile 'jakarta.servlet:jakarta.servlet-api:5.0.0'
+  moreLibs 'jakarta.annotation:jakarta.annotation-api:2.1.0' // random extra JAR
 }
 
 war {

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/war_servlet25/src/main/java/example/HelloWorld.java
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/war_servlet25/src/main/java/example/HelloWorld.java
@@ -16,6 +16,9 @@
 
 package example;
 
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -23,9 +26,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 public class HelloWorld extends HttpServlet {
 

--- a/jib-gradle-plugin/src/test/resources/gradle/projects/war_servlet25/build.gradle
+++ b/jib-gradle-plugin/src/test/resources/gradle/projects/war_servlet25/build.gradle
@@ -11,9 +11,13 @@ repositories {
   mavenCentral()
 }
 
+configurations {
+  moreLibs
+}
+
 dependencies {
-  compileOnly 'javax.servlet:servlet-api:2.5'
-  implementation 'javax.annotation:javax.annotation-api:1.2'
+  providedCompile 'jakarta.servlet:jakarta.servlet-api:5.0.0'
+  moreLibs 'jakarta.annotation:jakarta.annotation-api:2.1.0' // random extra JAR
 }
 
 jib {

--- a/jib-gradle-plugin/src/test/resources/gradle/projects/war_servlet25/src/main/java/example/HelloWorld.java
+++ b/jib-gradle-plugin/src/test/resources/gradle/projects/war_servlet25/src/main/java/example/HelloWorld.java
@@ -16,6 +16,9 @@
 
 package example;
 
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -23,9 +26,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 public class HelloWorld extends HttpServlet {
 


### PR DESCRIPTION
in #3661, I only fixed jib-cli. After that, more test failures turned up in gradle plugin.

Notes
- I ought to have switched to Temurin images in the first place.
- The random-looking `configurations {
  moreLibs
}` is there because otherwise the tests can be run from root but not from gradle-plugin subroot.