### PR TITLE
remaining javax.servlet instances

### DIFF
--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/WarProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/WarProjectIntegrationTest.java
@@ -49,7 +49,6 @@ public class WarProjectIntegrationTest {
   @Test
   public void testBuild_tomcatServlet25()
       throws IOException, InterruptedException, DigestException {
-    // jkljlk
     verifyBuildAndRun(servlet25Project, "war_tomcat_servlet25:gradle", "build-tomcat.gradle");
   }
 

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/WarProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/WarProjectIntegrationTest.java
@@ -49,6 +49,7 @@ public class WarProjectIntegrationTest {
   @Test
   public void testBuild_tomcatServlet25()
       throws IOException, InterruptedException, DigestException {
+    // jkljlk
     verifyBuildAndRun(servlet25Project, "war_tomcat_servlet25:gradle", "build-tomcat.gradle");
   }
 

--- a/jib-gradle-plugin/src/test/resources/gradle/projects/war_servlet25/pom-tomcat.xml
+++ b/jib-gradle-plugin/src/test/resources/gradle/projects/war_servlet25/pom-tomcat.xml
@@ -16,15 +16,15 @@
 
   <dependencies>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>5.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>  <!-- random dependency -->
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.2</version>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>2.1.0</version>
     </dependency>
   </dependencies>
 

--- a/jib-gradle-plugin/src/test/resources/gradle/projects/war_servlet25/pom.xml
+++ b/jib-gradle-plugin/src/test/resources/gradle/projects/war_servlet25/pom.xml
@@ -16,15 +16,15 @@
 
   <dependencies>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>5.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>  <!-- random dependency -->
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.2</version>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>2.1.0</version>
     </dependency>
   </dependencies>
 

--- a/jib-maven-plugin/src/test/resources/maven/projects/war_servlet25/pom-tomcat.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/war_servlet25/pom-tomcat.xml
@@ -16,15 +16,15 @@
 
   <dependencies>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>5.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>  <!-- random dependency -->
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.2</version>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>2.1.0</version>
     </dependency>
   </dependencies>
 

--- a/jib-maven-plugin/src/test/resources/maven/projects/war_servlet25/pom.xml
+++ b/jib-maven-plugin/src/test/resources/maven/projects/war_servlet25/pom.xml
@@ -16,15 +16,15 @@
 
   <dependencies>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.5</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>5.0.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>  <!-- random dependency -->
-      <groupId>javax.annotation</groupId>
-      <artifactId>javax.annotation-api</artifactId>
-      <version>1.2</version>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+      <version>2.1.0</version>
     </dependency>
   </dependencies>
 

--- a/jib-maven-plugin/src/test/resources/maven/projects/war_servlet25/src/main/java/example/HelloWorld.java
+++ b/jib-maven-plugin/src/test/resources/maven/projects/war_servlet25/src/main/java/example/HelloWorld.java
@@ -16,6 +16,9 @@
 
 package example;
 
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -23,9 +26,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 public class HelloWorld extends HttpServlet {
 


### PR DESCRIPTION
Takes out the remaining appearances of javax.servlet in favor of Jakarta.
Follow up to #3661 and #3663.