### PR TITLE
Improve error message when environment map contains null values (#3671)

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/ContainerConfiguration.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 /** Immutable configuration options for the container. */
@@ -141,9 +142,14 @@ public class ContainerConfiguration {
         Preconditions.checkArgument(
             !Iterables.any(environmentMap.keySet(), Objects::isNull),
             "environment map contains null keys");
+        String nullValuedKeys =
+            environmentMap.entrySet().stream()
+                .filter(entry -> entry.getValue() == null)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.joining(", "));
         Preconditions.checkArgument(
-            !Iterables.any(environmentMap.values(), Objects::isNull),
-            "environment map contains null values");
+            nullValuedKeys.isEmpty(),
+            "environment map contains null values for key(s): " + nullValuedKeys);
         this.environmentMap = new HashMap<>(environmentMap);
       }
       return this;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/ContainerConfigurationTest.java
@@ -106,7 +106,7 @@ public class ContainerConfigurationTest {
       ContainerConfiguration.builder().setEnvironment(nullValueMap);
       Assert.fail();
     } catch (IllegalArgumentException ex) {
-      Assert.assertEquals("environment map contains null values", ex.getMessage());
+      Assert.assertEquals("environment map contains null values for key(s): key", ex.getMessage());
     }
   }
 


### PR DESCRIPTION
This PR improves jib's error message when a value in the environment map (`container.environment`) is `null`. 