### PR TITLE
Fix documentation of configuring extraDirectories for Gradle plugin

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -361,7 +361,7 @@ mvn compile resources:copy-resources jib:build
 The same can be accomplished in Gradle by using a `Copy` task. In your `build.gradle`:
 
 ```groovy
-jib.extraDirectories = file('build/extra-directory')
+jib.extraDirectories.paths = ['build/extra-directory']
 
 task setupExtraDir(type: Copy) {
   from file('build/generated/files')


### PR DESCRIPTION
Current documentation: 

https://github.com/GoogleContainerTools/jib/blob/c419354aa42c4c8a2a32f93c1524d0b31b598979/docs/faq.md#i-need-to-add-files-generated-during-the-build-process-to-a-custom-directory-on-the-image

> The same can be accomplished in Gradle by using a `Copy` task. In your `build.gradle`:
>
> ```groovy
> jib.extraDirectories = file('build/extra-directory')
> ```


does not meet the syntax:

https://github.com/GoogleContainerTools/jib/blob/b7bdec593cc4b8614c9a66e2487b2a2ad80f6aed/jib-gradle-plugin#adding-arbitrary-files-to-the-image

> You can configure different directories by using the `jib.extraDirectories.paths` parameter in your `build.gradle`:
>
> ```groovy
> jib {
>   // Copies files from 'src/main/custom-extra-dir' and '/home/user/jib-extras' instead of 'src/main/jib'
>   extraDirectories.paths = ['src/main/custom-extra-dir', '/home/user/jib-extras']
> }
> ```