### PR TITLE
Use temurin builds based on older version of ubuntu

### DIFF
--- a/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
+++ b/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
@@ -87,9 +87,13 @@ public class JarCommandTest {
     Path jarPath = Paths.get(Resources.getResource("jarTest/standard/jarWithCp.jar").toURI());
     Integer exitCode =
         new CommandLine(new JibCli())
-            .execute("jar",
-                    "--from", "eclipse-temurin:8-jdk-focal",
-                    "--target", "docker://exploded-jar", jarPath.toString());
+            .execute(
+                "jar",
+                "--from",
+                "eclipse-temurin:8-jdk-focal",
+                "--target",
+                "docker://exploded-jar",
+                jarPath.toString());
     String output = new Command("docker", "run", "--rm", "exploded-jar").run();
     try (JarFile jarFile = new JarFile(jarPath.toFile())) {
       String classPath =
@@ -107,9 +111,13 @@ public class JarCommandTest {
     Path jarPath = Paths.get(Resources.getResource("jarTest/standard/noDependencyJar.jar").toURI());
     Integer exitCode =
         new CommandLine(new JibCli())
-            .execute("jar",
-                    "--from", "eclipse-temurin:8-jdk-focal",
-                    "--target", "docker://exploded-no-dep-jar", jarPath.toString());
+            .execute(
+                "jar",
+                "--from",
+                "eclipse-temurin:8-jdk-focal",
+                "--target",
+                "docker://exploded-no-dep-jar",
+                jarPath.toString());
     String output = new Command("docker", "run", "--rm", "exploded-no-dep-jar").run();
     try (JarFile jarFile = new JarFile(jarPath.toFile())) {
       String classPath =
@@ -129,8 +137,12 @@ public class JarCommandTest {
         new CommandLine(new JibCli())
             .execute(
                 "jar",
-                    "--from", "eclipse-temurin:8-jdk-focal",
-                    "--target", "docker://packaged-jar", jarPath.toString(), "--mode=packaged");
+                "--from",
+                "eclipse-temurin:8-jdk-focal",
+                "--target",
+                "docker://packaged-jar",
+                jarPath.toString(),
+                "--mode=packaged");
     String output = new Command("docker", "run", "--rm", "packaged-jar").run();
     try (JarFile jarFile = new JarFile(jarPath.toFile())) {
       String classPath =
@@ -150,7 +162,8 @@ public class JarCommandTest {
         new CommandLine(new JibCli())
             .execute(
                 "jar",
-                "--from", "eclipse-temurin:8-jdk-focal",
+                "--from",
+                "eclipse-temurin:8-jdk-focal",
                 "--target",
                 "docker://packaged-no-dep-jar",
                 jarPath.toString(),
@@ -174,9 +187,13 @@ public class JarCommandTest {
 
     Integer exitCode =
         new CommandLine(new JibCli())
-            .execute("jar",
-                    "--from", "eclipse-temurin:8-jdk-focal",
-                    "--target", "docker://spring-boot-jar-layered", jarPath.toString());
+            .execute(
+                "jar",
+                "--from",
+                "eclipse-temurin:8-jdk-focal",
+                "--target",
+                "docker://spring-boot-jar-layered",
+                jarPath.toString());
     assertThat(exitCode).isEqualTo(0);
 
     String output =
@@ -198,9 +215,13 @@ public class JarCommandTest {
 
     Integer exitCode =
         new CommandLine(new JibCli())
-            .execute("jar",
-                    "--from", "eclipse-temurin:8-jdk-focal",
-                    "--target", "docker://spring-boot-jar", jarPath.toString());
+            .execute(
+                "jar",
+                "--from",
+                "eclipse-temurin:8-jdk-focal",
+                "--target",
+                "docker://spring-boot-jar",
+                jarPath.toString());
     assertThat(exitCode).isEqualTo(0);
 
     String output =
@@ -222,7 +243,8 @@ public class JarCommandTest {
         new CommandLine(new JibCli())
             .execute(
                 "jar",
-                "--from", "eclipse-temurin:8-jdk-focal",
+                "--from",
+                "eclipse-temurin:8-jdk-focal",
                 "--target",
                 "docker://packaged-spring-boot",
                 jarPath.toString(),

--- a/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
+++ b/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
@@ -87,7 +87,9 @@ public class JarCommandTest {
     Path jarPath = Paths.get(Resources.getResource("jarTest/standard/jarWithCp.jar").toURI());
     Integer exitCode =
         new CommandLine(new JibCli())
-            .execute("jar", "--target", "docker://exploded-jar", jarPath.toString());
+            .execute("jar",
+                    "--from", "eclipse-temurin:8-jdk-focal",
+                    "--target", "docker://exploded-jar", jarPath.toString());
     String output = new Command("docker", "run", "--rm", "exploded-jar").run();
     try (JarFile jarFile = new JarFile(jarPath.toFile())) {
       String classPath =
@@ -105,7 +107,9 @@ public class JarCommandTest {
     Path jarPath = Paths.get(Resources.getResource("jarTest/standard/noDependencyJar.jar").toURI());
     Integer exitCode =
         new CommandLine(new JibCli())
-            .execute("jar", "--target", "docker://exploded-no-dep-jar", jarPath.toString());
+            .execute("jar",
+                    "--from", "eclipse-temurin:8-jdk-focal",
+                    "--target", "docker://exploded-no-dep-jar", jarPath.toString());
     String output = new Command("docker", "run", "--rm", "exploded-no-dep-jar").run();
     try (JarFile jarFile = new JarFile(jarPath.toFile())) {
       String classPath =
@@ -124,7 +128,9 @@ public class JarCommandTest {
     Integer exitCode =
         new CommandLine(new JibCli())
             .execute(
-                "jar", "--target", "docker://packaged-jar", jarPath.toString(), "--mode=packaged");
+                "jar",
+                    "--from", "eclipse-temurin:8-jdk-focal",
+                    "--target", "docker://packaged-jar", jarPath.toString(), "--mode=packaged");
     String output = new Command("docker", "run", "--rm", "packaged-jar").run();
     try (JarFile jarFile = new JarFile(jarPath.toFile())) {
       String classPath =
@@ -144,6 +150,7 @@ public class JarCommandTest {
         new CommandLine(new JibCli())
             .execute(
                 "jar",
+                "--from", "eclipse-temurin:8-jdk-focal",
                 "--target",
                 "docker://packaged-no-dep-jar",
                 jarPath.toString(),
@@ -167,7 +174,9 @@ public class JarCommandTest {
 
     Integer exitCode =
         new CommandLine(new JibCli())
-            .execute("jar", "--target", "docker://spring-boot-jar-layered", jarPath.toString());
+            .execute("jar",
+                    "--from", "eclipse-temurin:8-jdk-focal",
+                    "--target", "docker://spring-boot-jar-layered", jarPath.toString());
     assertThat(exitCode).isEqualTo(0);
 
     String output =
@@ -189,7 +198,9 @@ public class JarCommandTest {
 
     Integer exitCode =
         new CommandLine(new JibCli())
-            .execute("jar", "--target", "docker://spring-boot-jar", jarPath.toString());
+            .execute("jar",
+                    "--from", "eclipse-temurin:8-jdk-focal",
+                    "--target", "docker://spring-boot-jar", jarPath.toString());
     assertThat(exitCode).isEqualTo(0);
 
     String output =
@@ -211,6 +222,7 @@ public class JarCommandTest {
         new CommandLine(new JibCli())
             .execute(
                 "jar",
+                "--from", "eclipse-temurin:8-jdk-focal",
                 "--target",
                 "docker://packaged-spring-boot",
                 jarPath.toString(),


### PR DESCRIPTION
Latest versions of temurin are incompatible with older versions of docker ([source](https://github.com/adoptium/containers/issues/215#issuecomment-1142046045)).

I don't love this fix because it means we are not testing the default Jib CLI behavior, but it will unblock the build.