### PR TITLE
fix: error when base image doesn't support target platforms

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -42,6 +42,7 @@ import com.google.cloud.tools.jib.image.json.ImageMetadataTemplate;
 import com.google.cloud.tools.jib.image.json.JsonToImageTranslator;
 import com.google.cloud.tools.jib.image.json.ManifestAndConfigTemplate;
 import com.google.cloud.tools.jib.image.json.ManifestTemplate;
+import com.google.cloud.tools.jib.image.json.PlatformNotFoundInBaseImageException;
 import com.google.cloud.tools.jib.image.json.UnknownManifestFormatException;
 import com.google.cloud.tools.jib.image.json.UnlistedPlatformInManifestListException;
 import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
@@ -442,7 +443,8 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
   @VisibleForTesting
   List<Image> getCachedBaseImages()
       throws IOException, CacheCorruptedException, BadContainerConfigurationFormatException,
-          LayerCountMismatchException, UnlistedPlatformInManifestListException {
+          LayerCountMismatchException, UnlistedPlatformInManifestListException,
+          PlatformNotFoundInBaseImageException {
     ImageReference baseImage = buildContext.getBaseImageConfiguration().getImage();
     Optional<ImageMetadataTemplate> metadata =
         buildContext.getBaseImageLayersCache().retrieveMetadata(baseImage);

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/PlatformNotFoundInBaseImageException.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/PlatformNotFoundInBaseImageException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2022 Google LLC.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package com.google.cloud.tools.jib.image.json;
+
+import com.google.cloud.tools.jib.api.RegistryException;
+
+/** Exception thrown when build target platforms are not found in the base image. */
+public class PlatformNotFoundInBaseImageException extends RegistryException {
+
+  public PlatformNotFoundInBaseImageException(String message) {
+    super(message);
+  }
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PlatformCheckerTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PlatformCheckerTest.java
@@ -70,7 +70,7 @@ public class PlatformCheckerTest {
   }
 
   @Test
-  public void testCheckManifestPlatform_noWarningIfDefaultAmd64Linux()
+  public void testCheckManifestPlatform_noExceptionIfDefaultAmd64Linux()
       throws PlatformNotFoundInBaseImageException {
     Mockito.when(containerConfig.getPlatforms())
         .thenReturn(ImmutableSet.of(new Platform("amd64", "linux")));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
@@ -38,6 +38,7 @@ import com.google.cloud.tools.jib.image.json.BadContainerConfigurationFormatExce
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
 import com.google.cloud.tools.jib.image.json.ImageMetadataTemplate;
 import com.google.cloud.tools.jib.image.json.ManifestAndConfigTemplate;
+import com.google.cloud.tools.jib.image.json.PlatformNotFoundInBaseImageException;
 import com.google.cloud.tools.jib.image.json.UnlistedPlatformInManifestListException;
 import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestListTemplate;
@@ -243,8 +244,8 @@ public class PullBaseImageStepTest {
   @Test
   public void testGetCachedBaseImages_emptyCache()
       throws InvalidImageReferenceException, IOException, CacheCorruptedException,
-          UnlistedPlatformInManifestListException, BadContainerConfigurationFormatException,
-          LayerCountMismatchException {
+          UnlistedPlatformInManifestListException, PlatformNotFoundInBaseImageException,
+          BadContainerConfigurationFormatException, LayerCountMismatchException {
     ImageReference imageReference = ImageReference.parse("cat");
     Mockito.when(buildContext.getBaseImageConfiguration())
         .thenReturn(ImageConfiguration.builder(imageReference).build());
@@ -257,7 +258,7 @@ public class PullBaseImageStepTest {
   public void testGetCachedBaseImages_v21ManifestCached()
       throws InvalidImageReferenceException, IOException, CacheCorruptedException,
           UnlistedPlatformInManifestListException, BadContainerConfigurationFormatException,
-          LayerCountMismatchException, DigestException {
+          LayerCountMismatchException, DigestException, PlatformNotFoundInBaseImageException {
     ImageReference imageReference = ImageReference.parse("cat");
     Mockito.when(buildContext.getBaseImageConfiguration())
         .thenReturn(ImageConfiguration.builder(imageReference).build());
@@ -286,7 +287,7 @@ public class PullBaseImageStepTest {
   public void testGetCachedBaseImages_v22ManifestCached()
       throws InvalidImageReferenceException, IOException, CacheCorruptedException,
           UnlistedPlatformInManifestListException, BadContainerConfigurationFormatException,
-          LayerCountMismatchException {
+          LayerCountMismatchException, PlatformNotFoundInBaseImageException {
     ImageReference imageReference = ImageReference.parse("cat");
     Mockito.when(buildContext.getBaseImageConfiguration())
         .thenReturn(ImageConfiguration.builder(imageReference).build());
@@ -312,7 +313,7 @@ public class PullBaseImageStepTest {
   public void testGetCachedBaseImages_v22ManifestListCached()
       throws InvalidImageReferenceException, IOException, CacheCorruptedException,
           UnlistedPlatformInManifestListException, BadContainerConfigurationFormatException,
-          LayerCountMismatchException {
+          LayerCountMismatchException, PlatformNotFoundInBaseImageException {
     ImageReference imageReference = ImageReference.parse("cat");
     Mockito.when(buildContext.getBaseImageConfiguration())
         .thenReturn(ImageConfiguration.builder(imageReference).build());
@@ -352,7 +353,7 @@ public class PullBaseImageStepTest {
   public void testGetCachedBaseImages_v22ManifestListCached_partialMatches()
       throws InvalidImageReferenceException, IOException, CacheCorruptedException,
           UnlistedPlatformInManifestListException, BadContainerConfigurationFormatException,
-          LayerCountMismatchException {
+          LayerCountMismatchException, PlatformNotFoundInBaseImageException {
     ImageReference imageReference = ImageReference.parse("cat");
     Mockito.when(buildContext.getBaseImageConfiguration())
         .thenReturn(ImageConfiguration.builder(imageReference).build());
@@ -382,8 +383,8 @@ public class PullBaseImageStepTest {
   @Test
   public void testGetCachedBaseImages_v22ManifestListCached_onlyPlatforms()
       throws InvalidImageReferenceException, IOException, CacheCorruptedException,
-          UnlistedPlatformInManifestListException, BadContainerConfigurationFormatException,
-          LayerCountMismatchException {
+          UnlistedPlatformInManifestListException, PlatformNotFoundInBaseImageException,
+          BadContainerConfigurationFormatException, LayerCountMismatchException {
     ImageReference imageReference = ImageReference.parse("cat");
     Mockito.when(buildContext.getBaseImageConfiguration())
         .thenReturn(ImageConfiguration.builder(imageReference).build());
@@ -422,7 +423,8 @@ public class PullBaseImageStepTest {
 
   @Test
   public void testTryMirrors_noMatchingMirrors()
-      throws LayerCountMismatchException, BadContainerConfigurationFormatException {
+      throws LayerCountMismatchException, BadContainerConfigurationFormatException,
+          PlatformNotFoundInBaseImageException {
     Mockito.when(imageConfiguration.getImageRegistry()).thenReturn("registry");
     Mockito.when(buildContext.getRegistryMirrors())
         .thenReturn(ImmutableListMultimap.of("unmatched1", "mirror1", "unmatched2", "mirror2"));
@@ -475,6 +477,8 @@ public class PullBaseImageStepTest {
         .thenReturn(registryClientFactory);
     Mockito.when(registryClient.pullManifest(Mockito.any()))
         .thenThrow(new RegistryException("not found"));
+    Mockito.when(containerConfig.getPlatforms())
+        .thenReturn(ImmutableSet.of(new Platform("amd64", "linux")));
 
     RegistryClient.Factory gcrRegistryClientFactory = setUpWorkingRegistryClientFactory();
     Mockito.when(buildContext.newBaseImageRegistryClientFactory("gcr.io"))
@@ -513,7 +517,8 @@ public class PullBaseImageStepTest {
         .thenReturn(registryClientFactory);
     Mockito.when(registryClient.pullManifest(Mockito.any()))
         .thenThrow(new RegistryException("not found"));
-
+    Mockito.when(containerConfig.getPlatforms())
+        .thenReturn(ImmutableSet.of(new Platform("amd64", "linux")));
     RegistryClient.Factory dockerHubRegistryClientFactory = setUpWorkingRegistryClientFactory();
     Mockito.when(buildContext.newBaseImageRegistryClientFactory())
         .thenReturn(dockerHubRegistryClientFactory);


### PR DESCRIPTION
Fixes #3563: Converts warnings to exceptions.

- [X] Create a new issue at https://github.com/GoogleContainerTools/jib/issues/new/choose.
- [ ] Ensure that your implementation plan is approved by the team.
- [X] Verify that integration tests and unit tests are passing after the change.
- [X] Address all checkstyle issues. Refer to the [style guide](https://github.com/GoogleContainerTools/jib/blob/0ed7dca36864b6b19ff61629fc578018041fa15f/STYLE_GUIDE.md#style-guide).

