### PR TITLE
chore: Set tempFolder permissions for local registry test

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/LocalRegistry.java
@@ -26,8 +26,12 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.FileAttribute;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import javax.annotation.Nullable;
 import org.junit.rules.ExternalResource;
@@ -76,7 +80,9 @@ public class LocalRegistry extends ExternalResource {
       // BCrypt generates hashes using $2a$ algorithm (instead of $2y$ from docs), but this seems
       // to work okay
       String credentialString = username + ":" + BCrypt.hashpw(password, BCrypt.gensalt());
-      Path tempFolder = Files.createTempDirectory(Paths.get("/tmp"), "");
+      FileAttribute<Set<PosixFilePermission>> attrs =
+          PosixFilePermissions.asFileAttribute(PosixFilePermissions.fromString("rwxr-xr-x"));
+      Path tempFolder = Files.createTempDirectory(Paths.get("/tmp"), "", attrs);
       Files.write(
           tempFolder.resolve("htpasswd"), credentialString.getBytes(StandardCharsets.UTF_8));
       boolean isOnKokoroCI =


### PR DESCRIPTION
Set explicit permissions to `tempFolder` created for local registry integration tests to `755`.

- Currently the default permissions set for `tempFolder`  is `700`, but it seems like docker running on macOS are sometimes unable to access this.

Possibly related: https://github.com/GoogleContainerTools/jib/pull/3598

