### PR TITLE
Generate SLSA signatures on GitHub release jar

### DIFF
--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -11,6 +11,8 @@ jobs:
   release:
     name: Release Jib CLI
     runs-on: ubuntu-latest
+    outputs:
+      hashes: ${{ steps.hash.outputs.hashes }}
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -39,10 +41,14 @@ jobs:
         run: |
           git checkout v${{ github.event.inputs.release_version }}-cli
           ./gradlew jib-cli:instDist --stacktrace
-
           cd jib-cli/build/distributions
           mv jib-${{ github.event.inputs.release_version }}.zip jib-jre-${{ github.event.inputs.release_version }}.zip
           sha256sum jib-jre-${{ github.event.inputs.release_version }}.zip > zip.sha256
+
+      - name: Generate SLSA subject for Jib CLI release binaries
+        id: hash
+        working-directory: jib-cli/build/distributions
+        run: echo "::set-output name=hashes::$(cat zip.sha256 | base64 -w0)"
 
       - name: Create pull request
         uses: repo-sync/pull-request@v2.6
@@ -50,7 +56,7 @@ jobs:
         with:
           # Use a personal token to file a PR as a non-bot author to trigger other workflows (e.g., unit tests):
           # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token;
-          github_token: ${{ secrets.GA_RELEASE_PR_PERSONAL_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           source_branch: cli-release-v${{ github.event.inputs.release_version }}
           pr_title: "CLI release v${{ github.event.inputs.release_version }}"
           pr_body: "To be merged after the release is complete."
@@ -103,3 +109,13 @@ jobs:
         with:
           filename: .github/RELEASE_TEMPLATES/cli_release_checklist.md
 
+  provenance:
+    needs: [release]
+    permissions:
+      actions: read # To read the workflow path.
+      id-token: write # To sign the provenance.
+      contents: write # To add assets to a release.
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    with:
+      base64-subjects: "${{ needs.release.outputs.hashes }}"
+      upload-assets: true # upload to a new release

--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           git checkout v${{ github.event.inputs.release_version }}-cli
           ./gradlew jib-cli:instDist --stacktrace
+
           cd jib-cli/build/distributions
           mv jib-${{ github.event.inputs.release_version }}.zip jib-jre-${{ github.event.inputs.release_version }}.zip
           sha256sum jib-jre-${{ github.event.inputs.release_version }}.zip > zip.sha256
@@ -56,7 +57,7 @@ jobs:
         with:
           # Use a personal token to file a PR as a non-bot author to trigger other workflows (e.g., unit tests):
           # https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token;
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GA_RELEASE_PR_PERSONAL_TOKEN }}
           source_branch: cli-release-v${{ github.event.inputs.release_version }}
           pr_title: "CLI release v${{ github.event.inputs.release_version }}"
           pr_body: "To be merged after the release is complete."

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![Build Status](https://storage.googleapis.com/cloud-tools-for-java-kokoro-build-badges/jib-ubuntu-master-orb.svg)
 ![Build Status](https://storage.googleapis.com/cloud-tools-for-java-kokoro-build-badges/jib-windows-master-orb.svg)
 ![Build Status](https://storage.googleapis.com/cloud-tools-for-java-kokoro-build-badges/jib-macos-master-orb.svg)
+![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev/images/gh-badge-level3.svg)
 [![Gitter version](https://img.shields.io/gitter/room/gitterHQ/gitter.svg)](https://gitter.im/google/jib)
 
 # Jib

--- a/jib-cli/README.md
+++ b/jib-cli/README.md
@@ -4,6 +4,7 @@
 
 [![Chocolatey](https://img.shields.io/chocolatey/v/jib.svg)](https://chocolatey.org/packages/jib)
 [![Chocolatey](https://img.shields.io/chocolatey/dt/jib.svg)](https://chocolatey.org/packages/jib)
+![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev/images/gh-badge-level3.svg)
 
 `jib` is a general-purpose command-line utility for building Docker or [OCI](https://github.com/opencontainers/image-spec) container images from file system content as well as JAR files. Jib CLI builds containers [fast and reproducibly without Docker](https://github.com/GoogleContainerTools/jib#goals) like [other Jib tools](https://github.com/GoogleContainerTools/jib#what-is-jib).
 
@@ -55,7 +56,17 @@ Most users should download a ZIP archive (Java application). We are working on r
 
 A JRE is required to run this Jib CLI distribution.
 
-Find the [latest jib-cli 0.10.0 release](https://github.com/GoogleContainerTools/jib/releases/tag/v0.10.0-cli) on the [Releases page](https://github.com/GoogleContainerTools/jib/releases), download `jib-jre-<version>.zip`, and unzip it. The zip file contains the `jib` (`jib.bat` for Windows) script at `jib/bin/`. Optionally, add the binary directory to your `$PATH` so that you can call `jib` from anywhere.
+Find the [latest jib-cli 0.10.0 release](https://github.com/GoogleContainerTools/jib/releases/latest) on the [Releases page](https://github.com/GoogleContainerTools/jib/releases) and download `jib-jre-<version>.zip`.
+
+We generate [SLSA3 signatures](slsa.dev) using the OpenSSF's [slsa-framework/slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator) during the release process. To verify a release binary:
+1. Install the verification tool from [slsa-framework/slsa-verifier#installation](https://github.com/slsa-framework/slsa-verifier#installation).
+2. Download the provenance file `attestation.intoto.jsonl` from the [GitHub releases page](https://github.com/GoogleContainerTools/jib/releases/latest).
+3. Run the verifier:
+```shell
+slsa-verifier -artifact-path <the-zip> -provenance attestation.intoto.jsonl -source github.com/GoogleContainerTools/jib -tag <the-tag>
+```
+
+Unzip the zip file. The zip file contains the `jib` (`jib.bat` for Windows) script at `jib/bin/`. Optionally, add the binary directory to your `$PATH` so that you can call `jib` from anywhere.
 
 ### Windows: Install with `choco`
 

--- a/jib-cli/README.md
+++ b/jib-cli/README.md
@@ -60,10 +60,10 @@ Find the [latest jib-cli 0.10.0 release](https://github.com/GoogleContainerTools
 
 We generate [SLSA3 signatures](slsa.dev) using the OpenSSF's [slsa-framework/slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator) during the release process. To verify a release binary:
 1. Install the verification tool from [slsa-framework/slsa-verifier#installation](https://github.com/slsa-framework/slsa-verifier#installation).
-2. Download the provenance file `attestation.intoto.jsonl` from the [GitHub releases page](https://github.com/GoogleContainerTools/jib/releases/latest).
+2. Download the signature file `attestation.intoto.jsonl` from the [GitHub releases page](https://github.com/GoogleContainerTools/jib/releases/latest).
 3. Run the verifier:
 ```shell
-slsa-verifier -artifact-path <the-zip> -provenance attestation.intoto.jsonl -source github.com/GoogleContainerTools/jib -tag <the-tag>
+slsa-verifier -artifact-path jib-jre-<version>.zip -provenance attestation.intoto.jsonl -source github.com/GoogleContainerTools/jib -tag <the-tag>
 ```
 
 Unzip the zip file. The zip file contains the `jib` (`jib.bat` for Windows) script at `jib/bin/`. Optionally, add the binary directory to your `$PATH` so that you can call `jib` from anywhere.


### PR DESCRIPTION
Hi,

I'm reaching out on behalf of the [Open Source Security Foundation (openssf.org)](https://openssf.org/). We work on improving the security of critical open source projects like yours. 

Together with [GitHub](https://github.blog/2022-04-07-slsa-3-compliance-with-github-actions/), we designed a free, easy-to-use method of code signing. It will help your users verify that your release binaries were built from your repository’s [workflow](https://github.com/GoogleContainerTools/jib/blob/master/.github/workflows/jib-cli-release.yml) and not altered by anyone. It’s just a few lines of code, but it will make your project more secure against third-party tampering and attacks like [Codecov](https://about.codecov.io/apr-2021-post-mortem/) and [CTX](https://sockpuppets.medium.com/how-i-hacked-ctx-and-phpass-modules-656638c6ec5e).

This PR shows how to add this seamless code signing to your workflow. You don’t have to be a cryptography expert or learn complicated tools and [verification](https://github.com/slsa-framework/slsa-verifier/blob/main/README.md#verification-of-provenance) is simple for your users.  

You can read more on the [SLSA blog](https://slsa.dev/blog/2022/06/slsa-github-workflows). Please reach out if you have any questions!
