### PR TITLE
Avoid running executable to verify if docker is correctly installed and clarify documentation for `jib.dockerClient.executable`

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
@@ -103,8 +103,8 @@ public class CliDockerClient implements DockerClient {
   public static final Path DEFAULT_DOCKER_CLIENT = Paths.get("docker");
 
   /**
-   * Checks if Docker is installed on the user's system and accessible by running the default {@code
-   * docker} command.
+   * Checks if Docker is installed on the user's system by verifying if the executable path provided
+   * exists and the JVM has the appropriate permissions to execute it.
    *
    * @return {@code true} if Docker is installed on the user's system and accessible
    */
@@ -113,20 +113,14 @@ public class CliDockerClient implements DockerClient {
   }
 
   /**
-   * Checks if Docker is installed on the user's system and accessible by running the given {@code
-   * docker} executable.
+   * Checks if Docker is installed on the user's system and by verifying if the executable path
+   * provided exists and the JVM has the appropriate permissions to execute it.
    *
    * @param dockerExecutable path to the executable to test running
    * @return {@code true} if Docker is installed on the user's system and accessible
    */
   public static boolean isDockerInstalled(Path dockerExecutable) {
-    try {
-      new ProcessBuilder(dockerExecutable.toString()).start();
-      return true;
-
-    } catch (IOException ex) {
-      return false;
-    }
+    return Files.isExecutable(dockerExecutable);
   }
 
   /**

--- a/jib-gradle-plugin/README.md
+++ b/jib-gradle-plugin/README.md
@@ -290,7 +290,7 @@ Property | Type | Default | Description
 
 Property | Type | Default | Description
 --- | --- | --- | ---
-`executable` | `File` | `docker` | Sets the path to the Docker executable that is called to load the image into the Docker daemon.
+`executable` | `File` | `docker` | Sets the path to the Docker executable that is called to load the image into the Docker daemon. **Please note**: Users are responsible for ensuring that the Docker path passed in is valid and has the right permissions to be executed.
 `environment` | `Map<String, String>` | *None* | Sets environment variables used by the Docker executable.
 
 #### System Properties

--- a/jib-maven-plugin/README.md
+++ b/jib-maven-plugin/README.md
@@ -341,7 +341,7 @@ Property | Type | Default | Description
 
 Property | Type | Default | Description
 --- | --- | --- | ---
-`executable` | string | `docker` | Sets the path to the Docker executable that is called to load the image into the Docker daemon.
+`executable` | string | `docker` | Sets the path to the Docker executable that is called to load the image into the Docker daemon. **Please note**: Users are responsible for ensuring that the Docker path passed in is valid and has the right permissions to be executed.
 `environment` | map | *None* | Sets environment variables used by the Docker executable.
 
 #### System Properties


### PR DESCRIPTION
Currently, in order to verify if the docker path provided (either default or specified by the user) is installed correctly, we actually run the executable. The side effect of this is that any arbitrary executable can be executed by Jib. 

This PR avoids the need to run the executable by using `Files.isExecutable` which verifies if the path provided exists and the JVM has the correct permissions to execute the path. 