### PR TITLE
Check if file exists when executable path is passed in through jib dockerClient.executable

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
@@ -40,6 +40,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFileAttributes;
+import java.nio.file.attribute.PosixFilePermission;
 import java.security.DigestException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -103,30 +105,27 @@ public class CliDockerClient implements DockerClient {
   public static final Path DEFAULT_DOCKER_CLIENT = Paths.get("docker");
 
   /**
-   * Checks if Docker is installed on the user's system and accessible by running the default {@code
-   * docker} command.
+   * Checks if Docker is installed on the user's system by running the `docker` command.
    *
    * @return {@code true} if Docker is installed on the user's system and accessible
    */
   public static boolean isDefaultDockerInstalled() {
-    return isDockerInstalled(DEFAULT_DOCKER_CLIENT);
-  }
-
-  /**
-   * Checks if Docker is installed on the user's system and accessible by running the given {@code
-   * docker} executable.
-   *
-   * @param dockerExecutable path to the executable to test running
-   * @return {@code true} if Docker is installed on the user's system and accessible
-   */
-  public static boolean isDockerInstalled(Path dockerExecutable) {
     try {
-      new ProcessBuilder(dockerExecutable.toString()).start();
+      new ProcessBuilder(DEFAULT_DOCKER_CLIENT.toString()).start();
       return true;
-
     } catch (IOException ex) {
       return false;
     }
+  }
+
+  /**
+   * Checks if Docker is installed by verifying if the executable passed in exists.
+   *
+   * @param dockerExecutable path to the executable to verify
+   * @return {@code true} if executable exists on the system
+   */
+  public static boolean isDockerInstalled(Path dockerExecutable) {
+    return Files.exists(dockerExecutable);
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
@@ -40,8 +40,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.attribute.PosixFileAttributes;
-import java.nio.file.attribute.PosixFilePermission;
 import java.security.DigestException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -119,10 +117,11 @@ public class CliDockerClient implements DockerClient {
   }
 
   /**
-   * Checks if Docker is installed by verifying if the executable passed in exists.
+   * Checks if Docker is installed on the user's system and by verifying if the executable path
+   * provided has the appropriate permissions.
    *
-   * @param dockerExecutable path to the executable to verify
-   * @return {@code true} if executable exists on the system
+   * @param dockerExecutable path to the executable to test running
+   * @return {@code true} if Docker is installed on the user's system and accessible
    */
   public static boolean isDockerInstalled(Path dockerExecutable) {
     return Files.exists(dockerExecutable);

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/CliDockerClientTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/CliDockerClientTest.java
@@ -24,11 +24,13 @@ import com.google.cloud.tools.jib.image.ImageTarball;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
+import com.google.common.io.Resources;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.security.DigestException;
@@ -72,6 +74,13 @@ public class CliDockerClientTest {
   @Test
   public void testIsDockerInstalled_fail() {
     Assert.assertFalse(CliDockerClient.isDockerInstalled(Paths.get("path/to/nonexistent/file")));
+  }
+
+  @Test
+  public void testIsDockerInstalled_pass() throws URISyntaxException {
+    Assert.assertTrue(
+        CliDockerClient.isDockerInstalled(
+            Paths.get(Resources.getResource("core/docker/emptyFile").toURI())));
   }
 
   @Test

--- a/jib-gradle-plugin/README.md
+++ b/jib-gradle-plugin/README.md
@@ -290,7 +290,7 @@ Property | Type | Default | Description
 
 Property | Type | Default | Description
 --- | --- | --- | ---
-`executable` | `File` | `docker` | Sets the path to the Docker executable that is called to load the image into the Docker daemon.
+`executable` | `File` | `docker` | Sets the path to the Docker executable that is called to load the image into the Docker daemon. **Please note**: Users are responsible for ensuring that the Docker path passed in is valid and has the right permissions to be executed.
 `environment` | `Map<String, String>` | *None* | Sets environment variables used by the Docker executable.
 
 #### System Properties

--- a/jib-maven-plugin/README.md
+++ b/jib-maven-plugin/README.md
@@ -341,7 +341,7 @@ Property | Type | Default | Description
 
 Property | Type | Default | Description
 --- | --- | --- | ---
-`executable` | string | `docker` | Sets the path to the Docker executable that is called to load the image into the Docker daemon.
+`executable` | string | `docker` | Sets the path to the Docker executable that is called to load the image into the Docker daemon. **Please note**: Users are responsible for ensuring that the Docker path passed in is valid and has the right permissions to be executed.
 `environment` | map | *None* | Sets environment variables used by the Docker executable.
 
 #### System Properties


### PR DESCRIPTION
Currently, in order to verify if the docker path provided (either default or specified by the user) is installed correctly, we actually run the executable. The side effect of this is that any arbitrary executable can be executed by Jib.

This PR avoids the need to run the executable by using Files.isExecutable which verifies if the path provided exists and the JVM has the correct permissions to execute the path. However in the case of verifying whether docker is on PATH, running the `docker` command seems unavoidable at the moment. Reasoning in https://github.com/GoogleContainerTools/jib/pull/3744#discussion_r955307325

Verified with `./gradlew jib-gradle-plugin:integrationTest`