### PR TITLE
Upgrade Google HTTP libraries

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,9 @@ project.ext.dependencyStrings = [
   // For Google libraries, check the following boms for best compatibility.
   // - https://github.com/googleapis/java-shared-dependencies
   // - https://github.com/googleapis/java-cloud-bom
-  GOOGLE_HTTP_CLIENT: 'com.google.http-client:google-http-client:1.34.0',
-  GOOGLE_HTTP_CLIENT_APACHE_V2: 'com.google.http-client:google-http-client-apache-v2:1.34.0',
-  GOOGLE_AUTH_LIBRARY_OAUTH2_HTTP: 'com.google.auth:google-auth-library-oauth2-http:0.18.0',
+  GOOGLE_HTTP_CLIENT: 'com.google.http-client:google-http-client:1.42.2',
+  GOOGLE_HTTP_CLIENT_APACHE_V2: 'com.google.http-client:google-http-client-apache-v2:1.42.2',
+  GOOGLE_AUTH_LIBRARY_OAUTH2_HTTP: 'com.google.auth:google-auth-library-oauth2-http:1.10.0',
   GUAVA: 'com.google.guava:guava:31.1-jre',
   JSR305: 'com.google.code.findbugs:jsr305:3.0.2', // transitively pulled in by GUAVA
 

--- a/jib-cli/CHANGELOG.md
+++ b/jib-cli/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
+- Upgraded Google HTTP libraries to 1.42.2 ([#3745](https://github.com/GoogleContainerTools/jib/pull/3745))
 
 ### Fixed
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
+- Upgraded Google HTTP libraries to 1.42.2 ([#3745](https://github.com/GoogleContainerTools/jib/pull/3745))
 
 ### Fixed
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
+- Upgraded Google HTTP libraries to 1.42.2 ([#3745](https://github.com/GoogleContainerTools/jib/pull/3745))
 
 ### Fixed
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
+- Upgraded Google HTTP libraries to 1.42.2 ([#3745](https://github.com/GoogleContainerTools/jib/pull/3745))
 
 ### Fixed
 


### PR DESCRIPTION
Resolves #3416.

Upgrade previously downgraded Google HTTP and auth libraries (#3415) back to latest version, per https://github.com/GoogleContainerTools/jib/issues/3416#issuecomment-1209772087. 

