### PR TITLE
upgrade repo-sync/pull-request to latest version

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -59,7 +59,7 @@ jobs:
             -Prelease.releaseVersion=${{ github.event.inputs.release_version }}
 
       - name: Create pull request
-        uses: repo-sync/pull-request@v2.6
+        uses: repo-sync/pull-request@v2.6.2
         id: create-pr
         with:
           # Use a personal token to file a PR to trigger other workflows (e.g., unit tests).


### PR DESCRIPTION
The Prepare Release Github Actions job is currently resulting in the following error:
```
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```

Similar to https://github.com/GoogleCloudPlatform/app-maven-plugin/pull/465, this PR upgrades repo-sync/pull-request to 2.6.2 to resolve this. 