### PR TITLE
Check for existence of layers in cache before returning cached base image

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -458,8 +458,8 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
       Verify.verify(manifestsAndConfigs.size() == 1);
       ManifestTemplate manifest = manifestsAndConfigs.get(0).getManifest();
 
-      if (!baseImageLayersCache.verifyCachedLayers(Verify.verifyNotNull(manifest))) {
-        // Not all layers present in cache
+      // Verify all layers described in manifest are present in cache
+      if (!baseImageLayersCache.allLayersCached(Verify.verifyNotNull(manifest))) {
         return Collections.emptyList();
       }
 
@@ -492,8 +492,8 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
       }
 
       ManifestTemplate manifest = Verify.verifyNotNull(manifestAndConfigFound.get().getManifest());
-      if (!baseImageLayersCache.verifyCachedLayers(manifest)) {
-        // Not all layers present in cache
+      // Verify all layers described in manifest are present in cache
+      if (!baseImageLayersCache.allLayersCached(manifest)) {
         return Collections.emptyList();
       }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
@@ -193,8 +193,14 @@ public class Cache {
     return cacheStorageReader.retrieveMetadata(imageReference);
   }
 
-  public boolean verifyCachedLayers(ManifestTemplate manifest) {
-    return cacheStorageReader.allImageLayersExist(manifest);
+  /**
+   * Returns {@code true} if all image layers described in a manifest exist in the cache.
+   *
+   * @param manifest the image manifest
+   * @return a boolean
+   */
+  public boolean allLayersCached(ManifestTemplate manifest) {
+    return cacheStorageReader.allLayersCached(manifest);
   }
 
   /**
@@ -228,7 +234,6 @@ public class Cache {
       throws IOException, CacheCorruptedException {
     return cacheStorageReader.retrieve(layerDigest);
   }
-
 
   /**
    * Retrieves a {@link CachedLayer} for a local base image layer with the given diff id.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
@@ -229,9 +229,6 @@ public class Cache {
     return cacheStorageReader.retrieve(layerDigest);
   }
 
-  public boolean verify(DescriptorDigest layerDigest) {
-    return cacheStorageReader.verify(layerDigest);
-  }
 
   /**
    * Retrieves a {@link CachedLayer} for a local base image layer with the given diff id.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
 import com.google.cloud.tools.jib.image.json.ImageMetadataTemplate;
 import com.google.cloud.tools.jib.image.json.ManifestAndConfigTemplate;
+import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
@@ -192,6 +193,10 @@ public class Cache {
     return cacheStorageReader.retrieveMetadata(imageReference);
   }
 
+  public boolean verifyCachedLayers(ManifestTemplate manifest) {
+    return cacheStorageReader.allImageLayersExist(manifest);
+  }
+
   /**
    * Retrieves the {@link CachedLayer} that was built from the {@code layerEntries}.
    *
@@ -222,6 +227,10 @@ public class Cache {
   public Optional<CachedLayer> retrieve(DescriptorDigest layerDigest)
       throws IOException, CacheCorruptedException {
     return cacheStorageReader.retrieve(layerDigest);
+  }
+
+  public boolean verify(DescriptorDigest layerDigest) {
+    return cacheStorageReader.verify(layerDigest);
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
@@ -174,11 +174,6 @@ class CacheStorageReader {
     }
   }
 
-  boolean verify(DescriptorDigest layerDigest) {
-    Path layerDirectory = cacheStorageFiles.getLayerDirectory(layerDigest);
-    return Files.exists(layerDirectory);
-  }
-
   /**
    * Retrieves the {@link CachedLayer} for the local base image layer with the given diff ID.
    *

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
@@ -41,36 +41,6 @@ import java.util.stream.Stream;
 /** Reads from the default cache storage engine. */
 class CacheStorageReader {
 
-  boolean allImageLayersExist(ManifestTemplate manifestTemplate) {
-
-    if (manifestTemplate instanceof V21ManifestTemplate) {
-      for (DescriptorDigest layerDigest :
-          ((V21ManifestTemplate) manifestTemplate).getLayerDigests()) {
-        Path layerDirectory = cacheStorageFiles.getLayerDirectory(layerDigest);
-        if (!Files.exists(layerDirectory)) {
-          return false;
-        }
-      }
-      return true;
-
-    } else if (manifestTemplate instanceof BuildableManifestTemplate) {
-      for (BuildableManifestTemplate.ContentDescriptorTemplate layerTemplate :
-          ((BuildableManifestTemplate) manifestTemplate).getLayers()) {
-        DescriptorDigest layerDigest = layerTemplate.getDigest();
-        if (layerDigest == null) {
-          return false;
-        }
-        Path layerDirectory = cacheStorageFiles.getLayerDirectory(layerDigest);
-        if (!Files.exists(layerDirectory)) {
-          return false;
-        }
-      }
-      return true;
-    } else {
-      throw new IllegalArgumentException("Unknown manifest type: " + manifestTemplate);
-    }
-  }
-
   @VisibleForTesting
   static void verifyImageMetadata(ImageMetadataTemplate metadata, Path metadataCacheDirectory)
       throws CacheCorruptedException {
@@ -109,6 +79,42 @@ class CacheStorageReader {
 
   CacheStorageReader(CacheStorageFiles cacheStorageFiles) {
     this.cacheStorageFiles = cacheStorageFiles;
+  }
+
+  /**
+   * Returns {@code true} if all image layers described in a manifest have a corresponding file
+   * entry in the cache.
+   *
+   * @param manifest the image manifest
+   * @return a boolean
+   */
+  boolean allLayersCached(ManifestTemplate manifest) {
+
+    if (manifest instanceof V21ManifestTemplate) {
+      for (DescriptorDigest layerDigest : ((V21ManifestTemplate) manifest).getLayerDigests()) {
+        Path layerDirectory = cacheStorageFiles.getLayerDirectory(layerDigest);
+        if (!Files.exists(layerDirectory)) {
+          return false;
+        }
+      }
+      return true;
+
+    } else if (manifest instanceof BuildableManifestTemplate) {
+      for (BuildableManifestTemplate.ContentDescriptorTemplate layerTemplate :
+          ((BuildableManifestTemplate) manifest).getLayers()) {
+        DescriptorDigest layerDigest = layerTemplate.getDigest();
+        if (layerDigest == null) {
+          return false;
+        }
+        Path layerDirectory = cacheStorageFiles.getLayerDirectory(layerDigest);
+        if (!Files.exists(layerDirectory)) {
+          return false;
+        }
+      }
+      return true;
+    } else {
+      throw new IllegalArgumentException("Unknown manifest type: " + manifest);
+    }
   }
 
   /**

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
@@ -105,8 +105,18 @@ class CacheStorageReader {
     }
 
     for (DescriptorDigest layerDigest : layerDigests) {
-      Path layerDirectory = cacheStorageFiles.getLayerDirectory(layerDigest);
-      if (!Files.exists(layerDirectory)) {
+      //      Path layerDirectory = cacheStorageFiles.getLayerDirectory(layerDigest);
+      //      if (!Files.exists(layerDirectory)) {
+      //        return false;
+      //      }
+
+      Optional<CachedLayer> optionalCachedLayer;
+      try {
+        optionalCachedLayer = retrieve(layerDigest);
+      } catch (Exception ex) {
+        return false;
+      }
+      if (!optionalCachedLayer.isPresent()) {
         return false;
       }
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/CacheStorageReader.java
@@ -90,31 +90,27 @@ class CacheStorageReader {
    */
   boolean allLayersCached(ManifestTemplate manifest) {
 
-    if (manifest instanceof V21ManifestTemplate) {
-      for (DescriptorDigest layerDigest : ((V21ManifestTemplate) manifest).getLayerDigests()) {
-        Path layerDirectory = cacheStorageFiles.getLayerDirectory(layerDigest);
-        if (!Files.exists(layerDirectory)) {
-          return false;
-        }
-      }
-      return true;
+    List<DescriptorDigest> layerDigests;
 
+    if (manifest instanceof V21ManifestTemplate) {
+      layerDigests = ((V21ManifestTemplate) manifest).getLayerDigests();
     } else if (manifest instanceof BuildableManifestTemplate) {
-      for (BuildableManifestTemplate.ContentDescriptorTemplate layerTemplate :
-          ((BuildableManifestTemplate) manifest).getLayers()) {
-        DescriptorDigest layerDigest = layerTemplate.getDigest();
-        if (layerDigest == null) {
-          return false;
-        }
-        Path layerDirectory = cacheStorageFiles.getLayerDirectory(layerDigest);
-        if (!Files.exists(layerDirectory)) {
-          return false;
-        }
-      }
-      return true;
+      layerDigests =
+          ((BuildableManifestTemplate) manifest)
+              .getLayers().stream()
+                  .map(BuildableManifestTemplate.ContentDescriptorTemplate::getDigest)
+                  .collect(Collectors.toList());
     } else {
       throw new IllegalArgumentException("Unknown manifest type: " + manifest);
     }
+
+    for (DescriptorDigest layerDigest : layerDigests) {
+      Path layerDirectory = cacheStorageFiles.getLayerDirectory(layerDigest);
+      if (!Files.exists(layerDirectory)) {
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
@@ -155,7 +155,7 @@ public class PullBaseImageStepTest {
     ImageMetadataTemplate imageMetadata =
         new ImageMetadataTemplate(null, Arrays.asList(manifestAndConfig));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
-    Mockito.when(cache.verifyCachedLayers(manifestAndConfig.getManifest())).thenReturn(true);
+    Mockito.when(cache.allLayersCached(manifestAndConfig.getManifest())).thenReturn(true);
 
     ImagesAndRegistryClient result = pullBaseImageStep.call();
     Assert.assertEquals("fat system", result.images.get(0).getOs());
@@ -197,7 +197,7 @@ public class PullBaseImageStepTest {
     ImageMetadataTemplate imageMetadata =
         new ImageMetadataTemplate(null, Arrays.asList(manifestAndConfig));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
-    Mockito.when(cache.verifyCachedLayers(manifestAndConfig.getManifest())).thenReturn(true);
+    Mockito.when(cache.allLayersCached(manifestAndConfig.getManifest())).thenReturn(true);
 
     ImagesAndRegistryClient result = pullBaseImageStep.call();
     Assert.assertEquals("fat system", result.images.get(0).getOs());
@@ -318,7 +318,7 @@ public class PullBaseImageStepTest {
             null, Arrays.asList(new ManifestAndConfigTemplate(v21Manifest, null)));
 
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
-    Mockito.when(cache.verifyCachedLayers(v21Manifest)).thenReturn(true);
+    Mockito.when(cache.allLayersCached(v21Manifest)).thenReturn(true);
 
     List<Image> images = pullBaseImageStep.getCachedBaseImages();
 
@@ -347,7 +347,7 @@ public class PullBaseImageStepTest {
     ImageMetadataTemplate imageMetadata =
         new ImageMetadataTemplate(null, Arrays.asList(manifestAndConfig));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
-    Mockito.when(cache.verifyCachedLayers(manifestAndConfig.getManifest())).thenReturn(true);
+    Mockito.when(cache.allLayersCached(manifestAndConfig.getManifest())).thenReturn(true);
 
     List<Image> images = pullBaseImageStep.getCachedBaseImages();
 
@@ -386,10 +386,10 @@ public class PullBaseImageStepTest {
                     new V22ManifestTemplate(), containerConfigJson2, "sha256:digest2")));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
     Mockito.when(
-            cache.verifyCachedLayers(imageMetadata.getManifestsAndConfigs().get(0).getManifest()))
+            cache.allLayersCached(imageMetadata.getManifestsAndConfigs().get(0).getManifest()))
         .thenReturn(true);
     Mockito.when(
-            cache.verifyCachedLayers(imageMetadata.getManifestsAndConfigs().get(1).getManifest()))
+            cache.allLayersCached(imageMetadata.getManifestsAndConfigs().get(1).getManifest()))
         .thenReturn(true);
 
     Mockito.when(containerConfig.getPlatforms())
@@ -427,7 +427,7 @@ public class PullBaseImageStepTest {
                     "sha256:digest1")));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
     Mockito.when(
-            cache.verifyCachedLayers(imageMetadata.getManifestsAndConfigs().get(0).getManifest()))
+            cache.allLayersCached(imageMetadata.getManifestsAndConfigs().get(0).getManifest()))
         .thenReturn(true);
 
     Mockito.when(containerConfig.getPlatforms())
@@ -467,7 +467,7 @@ public class PullBaseImageStepTest {
             Arrays.asList(
                 unrelatedManifestAndConfig, targetManifestAndConfig, unrelatedManifestAndConfig));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
-    Mockito.when(cache.verifyCachedLayers(targetManifestAndConfig.getManifest())).thenReturn(true);
+    Mockito.when(cache.allLayersCached(targetManifestAndConfig.getManifest())).thenReturn(true);
 
     Mockito.when(containerConfig.getPlatforms())
         .thenReturn(ImmutableSet.of(new Platform("target-arch", "target-os")));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
@@ -155,6 +155,7 @@ public class PullBaseImageStepTest {
     ImageMetadataTemplate imageMetadata =
         new ImageMetadataTemplate(null, Arrays.asList(manifestAndConfig));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
+    Mockito.when(cache.verifyCachedLayers(manifestAndConfig.getManifest())).thenReturn(true);
 
     ImagesAndRegistryClient result = pullBaseImageStep.call();
     Assert.assertEquals("fat system", result.images.get(0).getOs());
@@ -196,6 +197,7 @@ public class PullBaseImageStepTest {
     ImageMetadataTemplate imageMetadata =
         new ImageMetadataTemplate(null, Arrays.asList(manifestAndConfig));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
+    Mockito.when(cache.verifyCachedLayers(manifestAndConfig.getManifest())).thenReturn(true);
 
     ImagesAndRegistryClient result = pullBaseImageStep.call();
     Assert.assertEquals("fat system", result.images.get(0).getOs());
@@ -316,6 +318,7 @@ public class PullBaseImageStepTest {
             null, Arrays.asList(new ManifestAndConfigTemplate(v21Manifest, null)));
 
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
+    Mockito.when(cache.verifyCachedLayers(v21Manifest)).thenReturn(true);
 
     List<Image> images = pullBaseImageStep.getCachedBaseImages();
 
@@ -344,6 +347,7 @@ public class PullBaseImageStepTest {
     ImageMetadataTemplate imageMetadata =
         new ImageMetadataTemplate(null, Arrays.asList(manifestAndConfig));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
+    Mockito.when(cache.verifyCachedLayers(manifestAndConfig.getManifest())).thenReturn(true);
 
     List<Image> images = pullBaseImageStep.getCachedBaseImages();
 
@@ -381,6 +385,12 @@ public class PullBaseImageStepTest {
                 new ManifestAndConfigTemplate(
                     new V22ManifestTemplate(), containerConfigJson2, "sha256:digest2")));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
+    Mockito.when(
+            cache.verifyCachedLayers(imageMetadata.getManifestsAndConfigs().get(0).getManifest()))
+        .thenReturn(true);
+    Mockito.when(
+            cache.verifyCachedLayers(imageMetadata.getManifestsAndConfigs().get(1).getManifest()))
+        .thenReturn(true);
 
     Mockito.when(containerConfig.getPlatforms())
         .thenReturn(ImmutableSet.of(new Platform("arch1", "os1"), new Platform("arch2", "os2")));
@@ -416,6 +426,9 @@ public class PullBaseImageStepTest {
                     new ContainerConfigurationTemplate(),
                     "sha256:digest1")));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
+    Mockito.when(
+            cache.verifyCachedLayers(imageMetadata.getManifestsAndConfigs().get(0).getManifest()))
+        .thenReturn(true);
 
     Mockito.when(containerConfig.getPlatforms())
         .thenReturn(ImmutableSet.of(new Platform("arch1", "os1"), new Platform("arch2", "os2")));
@@ -454,6 +467,7 @@ public class PullBaseImageStepTest {
             Arrays.asList(
                 unrelatedManifestAndConfig, targetManifestAndConfig, unrelatedManifestAndConfig));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
+    Mockito.when(cache.verifyCachedLayers(targetManifestAndConfig.getManifest())).thenReturn(true);
 
     Mockito.when(containerConfig.getPlatforms())
         .thenReturn(ImmutableSet.of(new Platform("target-arch", "target-os")));

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageReaderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageReaderTest.java
@@ -654,15 +654,23 @@ public class CacheStorageReaderTest {
         new ManifestAndConfigTemplate(manifest, new ContainerConfigurationTemplate());
 
     // Create only one of the layer directories.
-    DescriptorDigest firstlayerDigest =
+    DescriptorDigest firstLayerDigest =
         DescriptorDigest.fromHash(manifest.getLayerDigests().get(0).getHash());
-    Files.createDirectories(cacheStorageFiles.getLayerDirectory(firstlayerDigest));
+    Files.createDirectories(cacheStorageFiles.getLayerDirectory(firstLayerDigest));
+    try (OutputStream out =
+        Files.newOutputStream(cacheStorageFiles.getLayerFile(firstLayerDigest, layerDigest2))) {
+      out.write("layerBlob".getBytes(StandardCharsets.UTF_8));
+    }
     Assert.assertFalse(cacheStorageReader.allLayersCached(manifestAndConfig.getManifest()));
 
     // Create the other layer directory.
-    DescriptorDigest secondlayerDigest =
+    DescriptorDigest secondLayerDigest =
         DescriptorDigest.fromHash(manifest.getLayerDigests().get(1).getHash());
-    Files.createDirectories(cacheStorageFiles.getLayerDirectory(secondlayerDigest));
+    Files.createDirectories(cacheStorageFiles.getLayerDirectory(secondLayerDigest));
+    try (OutputStream out =
+        Files.newOutputStream(cacheStorageFiles.getLayerFile(secondLayerDigest, layerDigest2))) {
+      out.write("layerBlob".getBytes(StandardCharsets.UTF_8));
+    }
     Assert.assertTrue(cacheStorageReader.allLayersCached(manifestAndConfig.getManifest()));
   }
 
@@ -683,7 +691,12 @@ public class CacheStorageReaderTest {
     Assert.assertFalse(cacheStorageReader.allLayersCached(manifestAndConfig.getManifest()));
     // Create the layer directory.
     DescriptorDigest layerDigest = manifest.getLayers().get(0).getDigest();
+    manifest.getLayers().get(0);
     Files.createDirectories(cacheStorageFiles.getLayerDirectory(layerDigest));
+    try (OutputStream out =
+        Files.newOutputStream(cacheStorageFiles.getLayerFile(layerDigest, layerDigest2))) {
+      out.write("layerBlob".getBytes(StandardCharsets.UTF_8));
+    }
     Assert.assertTrue(cacheStorageReader.allLayersCached(manifestAndConfig.getManifest()));
   }
 }


### PR DESCRIPTION
**In this PR:**

Implementation of a proposed solution in #3733’s discussions, to check for presence of layer files in cache in addition to the manifest json before returning the cached base image(s). This would also address the unauthorized error described in #2220 and also reported in #2007’s comments.

**Details:**
- Adds `allLayersCached()` method to `Cache` and `CacheStorageReader` that checks for existence of cached layers for all layers described in the image manifest.
- Updates `PullBaseImageStep.getCachedBaseImages()` to invoke this check, and returns no cached images if layers are missing.

**Two approaches for layer check:**
- [`755dcfc`](https://github.com/GoogleContainerTools/jib/commit/755dcfc54990b546117d497b95d0e128513a095d) is a simpler check which verifies that the corresponding layer directory exists in the cache (but not that its contents are valid)
- [`b231d79`](https://github.com/GoogleContainerTools/jib/commit/b231d794c9e717c7f0cfa4feb89ea5d441869400) checks layers by making a call to retrieve the layer, though the retrieved layer is unused and the later `ObtainBaseImageLayerStep` would retrieve it again 

Open to suggestions on what the better approach might be here - the second option does redundant work, but is a more rigorous validation.
