### PR TITLE
Bring Jackson BOM back

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,9 +31,10 @@ project.ext.dependencyStrings = [
   COMMONS_COMPRESS: 'org.apache.commons:commons-compress:1.21',
   ZSTD_JNI: 'com.github.luben:zstd-jni:1.5.2-3',
   COMMONS_TEXT: 'org.apache.commons:commons-text:1.9',
-  JACKSON_DATABIND: 'com.fasterxml.jackson.core:jackson-databind:2.13.3',
-  JACKSON_DATAFORMAT_YAML: 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.13.3',
-  JACKSON_DATATYPE_JSR310: 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.13.3',
+  JACKSON_BOM: 'com.fasterxml.jackson:jackson-bom:2.13.4',
+  JACKSON_DATABIND: 'com.fasterxml.jackson.core:jackson-databind',
+  JACKSON_DATAFORMAT_YAML: 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml',
+  JACKSON_DATATYPE_JSR310: 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310',
   ASM: 'org.ow2.asm:asm:9.3',
   PICOCLI: 'info.picocli:picocli:4.6.3',
 

--- a/jib-cli/build.gradle
+++ b/jib-cli/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   implementation project(':jib-plugins-common')
 
   implementation dependencyStrings.COMMONS_TEXT
+  implementation(platform(dependencyStrings.JACKSON_BOM))
   implementation dependencyStrings.JACKSON_DATAFORMAT_YAML
   implementation dependencyStrings.JACKSON_DATABIND
   implementation dependencyStrings.GUAVA

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   implementation dependencyStrings.COMMONS_COMPRESS
   zstdSupportImplementation  dependencyStrings.ZSTD_JNI
   implementation dependencyStrings.GUAVA
+  implementation(platform(dependencyStrings.JACKSON_BOM))
   implementation dependencyStrings.JACKSON_DATABIND
   implementation dependencyStrings.JACKSON_DATATYPE_JSR310
   implementation dependencyStrings.ASM


### PR DESCRIPTION
Jackson BOM was removed in #3625 because a fix was not yet part of the bom. It is fine now to resynchronize dependency versions with the BOM.