### PR TITLE
chore: refactor gradle integration test to cater for both local and kokoro release environment

### DIFF
--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -151,8 +151,8 @@ public class SingleProjectIntegrationTest {
     assertThat(history).contains("jib-gradle-plugin");
 
     String output = new Command("docker", "run", "--rm", imageReference).run();
-    List<String> outputList = processOutput(output);
-    assertThat(outputList)
+    List<String> processedOutput = processOutput(output);
+    assertThat(processedOutput)
         .containsExactly(
             "Hello, world. An argument.",
             "1970-01-01T00:00:01Z",
@@ -216,9 +216,9 @@ public class SingleProjectIntegrationTest {
         .contains("No classes files were found - did you compile your project?");
 
     String output = JibRunHelper.buildAndRun(simpleTestProject, targetImage);
-    List<String> outputList = processOutput(output);
+    List<String> processedOutput = processOutput(output);
 
-    assertThat(outputList)
+    assertThat(processedOutput)
         .containsExactly(
             "Hello, world. An argument.",
             "1970-01-01T00:00:01Z",
@@ -258,8 +258,9 @@ public class SingleProjectIntegrationTest {
     String output =
         JibRunHelper.buildAndRunFromLocalBase(
             targetImage, "docker://gcr.io/distroless/java:latest");
-    List<String> outputList = processOutput(output);
-    assertThat(outputList)
+    List<String> processedOutput = processOutput(output);
+
+    assertThat(processedOutput)
         .containsExactly(
             "Hello, world. An argument.",
             "1970-01-01T00:00:01Z",
@@ -280,9 +281,9 @@ public class SingleProjectIntegrationTest {
             + "/simplewithtarbase:gradle"
             + System.nanoTime();
     String output = JibRunHelper.buildAndRunFromLocalBase(targetImage, "tar://" + path);
-    List<String> outputList = processOutput(output);
+    List<String> processedOutput = processOutput(output);
 
-    assertThat(outputList)
+    assertThat(processedOutput)
         .containsExactly(
             "Hello, world. An argument.",
             "1970-01-01T00:00:01Z",
@@ -326,8 +327,9 @@ public class SingleProjectIntegrationTest {
     String output =
         JibRunHelper.buildToDockerDaemonAndRun(
             simpleTestProject, targetImage, "build-java17.gradle");
-    List<String> outputList = processOutput(output);
-    assertThat(outputList).containsExactly("Hello, world. ", "1970-01-01T00:00:01Z");
+    List<String> processedOutput = processOutput(output);
+
+    assertThat(processedOutput).containsExactly("Hello, world. ", "1970-01-01T00:00:01Z");
   }
 
   @Test
@@ -336,11 +338,12 @@ public class SingleProjectIntegrationTest {
     assumeTrue(isJavaRuntimeAtLeast(11));
 
     String targetImage = "simpleimage:gradle" + System.nanoTime();
-    List<String> output =
-        processOutput(
-            JibRunHelper.buildToDockerDaemonAndRun(
-                simpleTestProject, targetImage, "build-java11.gradle"));
-    assertThat(output).containsExactly("Hello, world. ", "1970-01-01T00:00:01Z");
+    String output =
+        JibRunHelper.buildToDockerDaemonAndRun(
+            simpleTestProject, targetImage, "build-java11.gradle");
+    List<String> processedOutput = processOutput(output);
+
+    assertThat(processedOutput).containsExactly("Hello, world. ", "1970-01-01T00:00:01Z");
   }
 
   @Test
@@ -365,11 +368,12 @@ public class SingleProjectIntegrationTest {
   public void testDockerDaemon_simple_multipleExtraDirectories()
       throws DigestException, IOException, InterruptedException {
     String targetImage = "simpleimage:gradle" + System.nanoTime();
-    List<String> output =
-        processOutput(
-            JibRunHelper.buildToDockerDaemonAndRun(
-                simpleTestProject, targetImage, "build-extra-dirs.gradle"));
-    assertThat(output)
+    String output =
+        JibRunHelper.buildToDockerDaemonAndRun(
+            simpleTestProject, targetImage, "build-extra-dirs.gradle");
+    List<String> processedOutput = processOutput(output);
+
+    assertThat(processedOutput)
         .containsExactly(
             "Hello, world. ",
             "1970-01-01T00:00:01Z",
@@ -386,11 +390,12 @@ public class SingleProjectIntegrationTest {
   public void testDockerDaemon_simple_multipleExtraDirectoriesWithAlternativeConfig()
       throws DigestException, IOException, InterruptedException {
     String targetImage = "simpleimage:gradle" + System.nanoTime();
-    List<String> output =
-        processOutput(
-            JibRunHelper.buildToDockerDaemonAndRun(
-                simpleTestProject, targetImage, "build-extra-dirs2.gradle"));
-    assertThat(output)
+    String output =
+        JibRunHelper.buildToDockerDaemonAndRun(
+            simpleTestProject, targetImage, "build-extra-dirs2.gradle");
+    List<String> processedOutput = processOutput(output);
+
+    assertThat(processedOutput)
         .containsExactly(
             "Hello, world. ",
             "1970-01-01T00:00:01Z",
@@ -407,12 +412,12 @@ public class SingleProjectIntegrationTest {
   public void testDockerDaemon_simple_multipleExtraDirectoriesWithClosure()
       throws DigestException, IOException, InterruptedException {
     String targetImage = "simpleimage:gradle" + System.nanoTime();
-    List<String> output =
-        processOutput(
-            JibRunHelper.buildToDockerDaemonAndRun(
-                    simpleTestProject, targetImage, "build-extra-dirs3.gradle")
-               );
-    assertThat(output)
+    String output =
+        JibRunHelper.buildToDockerDaemonAndRun(
+            simpleTestProject, targetImage, "build-extra-dirs3.gradle");
+    List<String> processedOutput = processOutput(output);
+
+    assertThat(processedOutput)
         .containsExactly(
             "Hello, world. ",
             "1970-01-01T00:00:01Z",
@@ -481,10 +486,11 @@ public class SingleProjectIntegrationTest {
   @Test
   public void testDockerDaemon_simple() throws IOException, InterruptedException, DigestException {
     String targetImage = "simpleimage:gradle" + System.nanoTime();
-    List<String> output =
-        processOutput(
-            JibRunHelper.buildToDockerDaemonAndRun(simpleTestProject, targetImage, "build.gradle"));
-    assertThat(output)
+    String output =
+        JibRunHelper.buildToDockerDaemonAndRun(simpleTestProject, targetImage, "build.gradle");
+    List<String> processedOutput = processOutput(output);
+
+    assertThat(processedOutput)
         .containsExactly(
             "Hello, world. An argument.",
             "1970-01-01T00:00:01Z",
@@ -503,12 +509,11 @@ public class SingleProjectIntegrationTest {
   public void testDockerDaemon_jarContainerization()
       throws DigestException, IOException, InterruptedException {
     String targetImage = "simpleimage:gradle" + System.nanoTime();
-    List<String> output =
-       processOutput(
-            JibRunHelper.buildToDockerDaemonAndRun(
-                    simpleTestProject, targetImage, "build-jar-containerization.gradle")
-               );
-    assertThat(output)
+    String output =
+        JibRunHelper.buildToDockerDaemonAndRun(
+            simpleTestProject, targetImage, "build-jar-containerization.gradle");
+    List<String> processedOutput = processOutput(output);
+    assertThat(processedOutput)
         .containsExactly(
             "Hello, world. ", "Implementation-Title: helloworld", "Implementation-Version: 1");
   }
@@ -533,9 +538,11 @@ public class SingleProjectIntegrationTest {
   public void testDockerDaemon_timestampCustom()
       throws DigestException, IOException, InterruptedException {
     String targetImage = "simpleimage:gradle" + System.nanoTime();
-    String output = JibRunHelper.buildToDockerDaemonAndRun(
-        simpleTestProject, targetImage, "build-timestamps-custom.gradle");
+    String output =
+        JibRunHelper.buildToDockerDaemonAndRun(
+            simpleTestProject, targetImage, "build-timestamps-custom.gradle");
     List<String> processedOutput = processOutput(output);
+
     assertThat(processedOutput).containsExactly("Hello, world. ", "2011-12-03T01:15:30Z");
     assertThat(JibRunHelper.getCreationTime(targetImage))
         .isEqualTo(Instant.parse("2013-11-04T21:29:30Z"));
@@ -588,8 +595,10 @@ public class SingleProjectIntegrationTest {
     assertThat(buildResult.getOutput()).contains(outputPath);
 
     new Command("docker", "load", "--input", outputPath).run();
-    List<String> output = processOutput(new Command("docker", "run", "--rm", targetImage).run());
-    assertThat(output)
+    String output = new Command("docker", "run", "--rm", targetImage).run();
+    List<String> processedOutput = processOutput(output);
+
+    assertThat(processedOutput)
         .containsExactly(
             "Hello, world. An argument.",
             "1970-01-01T00:00:01Z",

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-jar-containerization.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-jar-containerization.gradle
@@ -24,9 +24,7 @@ jar {
 }
 
 jib {
-  to {
-    image = System.getProperty("_TARGET_IMAGE")
-  }
+  to.image = System.getProperty("_TARGET_IMAGE")
   from.image = 'eclipse-temurin:11-jdk-focal'
   containerizingMode = 'packaged'
 }

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-timestamps-custom.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-timestamps-custom.gradle
@@ -17,6 +17,8 @@ dependencies {
 jib {
   from.image = 'eclipse-temurin:11-jdk-focal'
   to.image = System.getProperty("_TARGET_IMAGE")
-  container.filesModificationTime = '2011-12-03T10:15:30+09:00'
-  container.creationTime = '2013-11-05T06:29:30+09:00'
+  container {
+    filesModificationTime = '2011-12-03T10:15:30+09:00'
+    creationTime = '2013-11-05T06:29:30+09:00'
+  }
 }


### PR DESCRIPTION
Recent changes in the Kokoro release environment temporarily patch in a jvm argument (`-Djavax.net.ssl.trustStore=/var/cache/proxy.crt.jks`) causing the container build by Jib to be modified when run. Since Jib gradle integration tests try to assert on the container configuration values (including jvm args) of the generated Jib container, this causes the tests to fail with the following assertion error:
```
com.google.cloud.tools.jib.gradle.SingleProjectIntegrationTest > testBuildTar_simple FAILED
    value of:
        run()
    diff (-expected +actual):
        @@ -6,4 +6,5 @@
         cat
         1970-01-01T00:00:01Z
         1970-01-01T00:00:01Z
        +-Djavax.net.ssl.trustStore=/var/cache/proxy.crt.jks
     
        at com.google.cloud.tools.jib.gradle.SingleProjectIntegrationTest.testBuildTar_simple(SingleProjectIntegrationTest.java:499)
```

This refactoring makes the affected integration tests environment-agnostic by splitting the expected output by local or kokoro-release based on the environment the tests are running in. 