### PR TITLE
test: Modify resource file for flaking integration test that compares two build times

### DIFF
--- a/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
+++ b/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java
@@ -339,7 +339,7 @@ public class BuildImageMojoIntegrationTest {
     localRegistry.pullAndPushToLocal("gcr.io/distroless/java:latest", "distroless/java");
 
     // Make sure resource file has a consistent value at the beginning of each test
-    // (testExecute_simple overwrites it)
+    // (testExecute_simple and testBuild_tarBase overwrite it)
     Files.write(
         simpleTestProject
             .getProjectRoot()
@@ -434,11 +434,28 @@ public class BuildImageMojoIntegrationTest {
             + "/simplewithtarbase:maven"
             + System.nanoTime();
 
+    Instant before = Instant.now();
+
+    // The target registry these tests push to would already have all the layers cached from before,
+    // causing this test to fail sometimes with the second build being a bit slower than the first
+    // build. This file change makes sure that a new layer is always pushed the first time to solve
+    // this issue.
+    Files.write(
+        simpleTestProject
+            .getProjectRoot()
+            .resolve("src")
+            .resolve("main")
+            .resolve("resources")
+            .resolve("world"),
+        before.toString().getBytes(StandardCharsets.UTF_8));
+
     assertThat(
             buildAndRunFromLocalBase(
                 simpleTestProject.getProjectRoot(), targetImage, "tar://" + path, true))
         .isEqualTo(
-            "Hello, world. An argument.\n1970-01-01T00:00:01Z\nrw-r--r--\nrw-r--r--\nfoo\ncat\n"
+            "Hello, "
+                + before
+                + ". An argument.\n1970-01-01T00:00:01Z\nrw-r--r--\nrw-r--r--\nfoo\ncat\n"
                 + "1970-01-01T00:00:01Z\n1970-01-01T00:00:01Z\n");
   }
 


### PR DESCRIPTION
Not sure this is the cause for `testBuild_tarBase` test flakes we have been seeing in CI, but here is a guess from troubleshooting:

The errors occur when the second build takes longer than the first, despite caching mechanisms that should lead to a shorter build time.

`testExecute_simple`, the other integration test that compares two build times and has been passing successfully, has [an additional file update block](https://github.com/GoogleContainerTools/jib/blob/7ba06b4eedbeafd2e3e21666af54dcdf48f1bbff/jib-maven-plugin/src/integration-test/java/com/google/cloud/tools/jib/maven/BuildImageMojoIntegrationTest.java#L382-L395) so that it does not push the same hello world image to target local registry as other tests in the same class. This PR copies over this additional change, since perhaps this is applicable to `testBuild_tarBase` as well, resulting in unwanted caching behavior in the first build?

We could try merging this fix if the flaking issue resurfaces again.
