### PR TITLE
Workaround for gradle plugin portal metadata requests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,13 @@ subprojects {
   group 'com.google.cloud.tools'
 
   repositories {
-    mavenCentral()
+    mavenCentral {
+      metadataSources {
+        mavenPom()
+        artifact()
+        ignoreGradleMetadataRedirection()
+      }
+    }
   }
 
   apply plugin: 'java'


### PR DESCRIPTION
Workaround for issue #3783, to avoid dependency on JCenter through gradle plugin portal.
