### PR TITLE
docs: clarify the placement of java agent folder

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -403,7 +403,7 @@ Beware: in Java 8 and earlier, specifying only a port meant that the JDWP socket
 
 ### I would like to run my application with a javaagent.
 
-You can run your container with a javaagent by placing it somewhere in the `src/main/jib` directory to add it to the container's filesystem, then pointing to it using Jib's `container.jvmFlags` configuration.
+You can run your container with a javaagent by placing it somewhere in the `src/main/jib/myfolder` directory to add it to the container's filesystem, then pointing to it using Jib's `container.jvmFlags` configuration.
 
 #### Maven
 


### PR DESCRIPTION

Clarifying the placement of the java agent, since if we put the java agent directly on `src/main/jib` it won't be available in `/myfolder/agent.jar`

