### PR TITLE
docs: Fix typo for configuring outputPaths

### DIFF
--- a/jib-gradle-plugin/README.md
+++ b/jib-gradle-plugin/README.md
@@ -183,7 +183,7 @@ Then, ```gradle build``` will build and containerize your application.
 
 ### Additional Build Artifacts
 
-As part of an image build, Jib also writes out the _image digest_ and the _image ID_. By default, these are written out to `build/jib-image.digest` and `build/jib-image.id` respectively, but the locations can be configured using the `jib.outputFiles.digest` and `jib.outputFiles.imageId` configuration properties. See [Extended Usage](#outputpaths-closure) for more details.
+As part of an image build, Jib also writes out the _image digest_ and the _image ID_. By default, these are written out to `build/jib-image.digest` and `build/jib-image.id` respectively, but the locations can be configured using the `jib.outputPaths.digest` and `jib.outputPaths.imageId` configuration properties. See [Extended Usage](#outputpaths-closure) for more details.
 
 ## Multi Module Projects
 

--- a/jib-maven-plugin/README.md
+++ b/jib-maven-plugin/README.md
@@ -233,7 +233,7 @@ mvn package
 
 ### Additional Build Artifacts
 
-As part of an image build, Jib also writes out the _image digest_ and the _image ID_. By default, these are written out to `target/jib-image.digest` and `target/jib-image.id` respectively, but the locations can be configured using the `<outputFiles><digest>` and `<outputFiles><imageId>` configuration properties. See [Extended Usage](#outputpaths-object) for more details.
+As part of an image build, Jib also writes out the _image digest_ and the _image ID_. By default, these are written out to `target/jib-image.digest` and `target/jib-image.id` respectively, but the locations can be configured using the `<outputPaths><digest>` and `<outputPaths><imageId>` configuration properties. See [Extended Usage](#outputpaths-object) for more details.
 
 ## Multi Module Projects
 


### PR DESCRIPTION
Fix typo in docs, as pointed out in https://github.com/GoogleContainerTools/jib/issues/3789#issuecomment-1255420223.