### PR TITLE
Fix BuildTarTask input files to also include main SourceSet outputs

### DIFF
--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 - Upgraded Google HTTP libraries to 1.42.2 ([#3745](https://github.com/GoogleContainerTools/jib/pull/3745))
 
 ### Fixed
+- Fixed issue with `jibBuildTar`'s `UP-TO-DATE` check by adding back main `SourceSet`'s outputs to task dependency ([#3793](https://github.com/GoogleContainerTools/jib/pull/3793))
 
 ## 3.3.0
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -406,6 +406,7 @@ public class GradleProjectProperties implements ProjectProperties {
    * @param extraDirectories the image's configured extra directories
    * @return the input files
    */
+  @VisibleForTesting
   static FileCollection getInputFiles(
       Project project, List<Path> extraDirectories, String configurationName) {
     List<FileCollection> dependencyFileCollections = new ArrayList<>();

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -51,6 +51,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -213,9 +214,9 @@ public class GradleProjectPropertiesTest {
 
   @Test
   public void testGetInputFiles() throws URISyntaxException {
-    List<Path> extraDirectories = new ArrayList<>();
     Path applicationDirectory = getResource("gradle/application");
 
+    List<Path> extraDirectories = Arrays.asList(applicationDirectory.resolve("extra-directory"));
     FileCollection fileCollection =
         GradleProjectProperties.getInputFiles(
             project, extraDirectories, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
@@ -231,7 +232,8 @@ public class GradleProjectPropertiesTest {
             applicationDirectory.resolve("dependencies/another/one/dependency-1.0.0.jar"),
             applicationDirectory.resolve("dependencies/libraryA.jar"),
             applicationDirectory.resolve("dependencies/libraryB.jar"),
-            applicationDirectory.resolve("dependencies/library.jarC.jar"));
+            applicationDirectory.resolve("dependencies/library.jarC.jar"),
+            applicationDirectory.resolve("extra-directory"));
   }
 
   @Test

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -62,6 +62,7 @@ import java.util.zip.ZipOutputStream;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.java.archives.internal.DefaultManifest;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPlugin;
@@ -89,6 +90,8 @@ public class GradleProjectPropertiesTest {
   private static final Correspondence<FileEntry, String> EXTRACTION_PATH_OF =
       Correspondence.transforming(
           entry -> entry.getExtractionPath().toString(), "has extractionPath of");
+  private static final Correspondence<File, Path> FILE_PATH_OF =
+      Correspondence.transforming(File::toPath, "has Path of");
 
   private static final Instant EPOCH_PLUS_32 = Instant.ofEpochSecond(32);
 
@@ -206,6 +209,29 @@ public class GradleProjectPropertiesTest {
   public void testIsWarProject() {
     project.getPlugins().apply("war");
     assertThat(gradleProjectProperties.isWarProject()).isTrue();
+  }
+
+  @Test
+  public void testGetInputFiles() throws URISyntaxException {
+    List<Path> extraDirectories = new ArrayList<>();
+    Path applicationDirectory = getResource("gradle/application");
+
+    FileCollection fileCollection =
+        GradleProjectProperties.getInputFiles(
+            project, extraDirectories, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+
+    assertThat(fileCollection)
+        .comparingElementsUsing(FILE_PATH_OF)
+        .containsExactly(
+            applicationDirectory.resolve("build/classes/java/main"),
+            applicationDirectory.resolve("build/resources/main"),
+            applicationDirectory.resolve("dependencies/dependencyX-1.0.0-SNAPSHOT.jar"),
+            applicationDirectory.resolve("dependencies/dependency-1.0.0.jar"),
+            applicationDirectory.resolve("dependencies/more/dependency-1.0.0.jar"),
+            applicationDirectory.resolve("dependencies/another/one/dependency-1.0.0.jar"),
+            applicationDirectory.resolve("dependencies/libraryA.jar"),
+            applicationDirectory.resolve("dependencies/libraryB.jar"),
+            applicationDirectory.resolve("dependencies/library.jarC.jar"));
   }
 
   @Test

--- a/jib-gradle-plugin/src/test/resources/gradle/application/extra-directory/foo
+++ b/jib-gradle-plugin/src/test/resources/gradle/application/extra-directory/foo
@@ -1,0 +1,1 @@
+Unused file for committing extra directory


### PR DESCRIPTION
Fixes #3666. 

It looks like this issue was introduced when making the switch to custom configurations in https://github.com/GoogleContainerTools/jib/pull/3034. The previous use of `mainSourceSet.getRuntimeClasspath()` also included class and resource outputs for the main `SourceSet` that are now missed, so changes to the Java classes are no longer getting picked up as Gradle task inputs.

This PR adds back the `main` SourceSet’s outputs to [GradleProjectPriperties.getInputFiles()](https://github.com/GoogleContainerTools/jib/blob/eccebd0d52301fefce9017783c1c43fa8cc671c7/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java#L407).  (Perhaps this will need to be updated if `SourceSet` is ever made configurable, but currently this fix is consistent with the previous behavior of using `main`.) 

