### PR TITLE
Override default token resolution order in docker-credential-gcr for integration testing

### DIFF
--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -13,6 +13,8 @@ fi
 # docker-credential-gcr uses GOOGLE_APPLICATION_CREDENTIALS as the credentials key file
 export GOOGLE_APPLICATION_CREDENTIALS=${KOKORO_KEYSTORE_DIR}/72743_jib_integration_testing_key
 
+# Overrides default search order to check credentials in GOOGLE_APPLICATION_CREDENTIALS
+docker-credential-gcr config --token-source="env"
 docker-credential-gcr configure-docker
 
 # Stops any left-over containers.


### PR DESCRIPTION
Troubleshooting potential causes for intermittent authentication errors that we started observing in MacOS continuous CI:

```
java.lang.RuntimeException: Command 'docker pull gcr.io/jib-integration-testing/simpleimage:maven4639084933994' failed: Error response from daemon: unauthorized: You don't have the needed permissions to perform this operation, and you may have invalid credentials. To authenticate your request, follow the steps in: https://cloud.google.com/container-registry/docs/advanced-authentication
```

This PR adds an additional line into continuous build script to have `GOOGLE_APPLICATION_CREDENTIALS` searched first by `docker-credential-gcr` and overrides the [default search order](https://github.com/GoogleCloudPlatform/docker-credential-gcr#gcr-credentials).