### PR TITLE
fix: fix filtering of `-Djavax.net.ssl.trustStore` from output generated by integration test 

### DIFF
--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -629,8 +629,11 @@ public class SingleProjectIntegrationTest {
     String output =
         JibRunHelper.buildToDockerDaemonAndRun(
             simpleTestProject, targetImage, "build-truststore-arg.gradle");
-    assertThat(Arrays.asList(output.split("\n"))).containsExactly("Hello, world. ",
-        "1970-01-01T00:00:01Z", "-Djavax.net.ssl.trustStore=/var/cache/proxy.crt.jks");
+    assertThat(Arrays.asList(output.split("\n")))
+        .containsExactly(
+            "Hello, world. ",
+            "1970-01-01T00:00:01Z",
+            "-Djavax.net.ssl.trustStore=/var/cache/proxy.crt.jks");
     assertThat(processOutput(output)).containsExactly("Hello, world. ", "1970-01-01T00:00:01Z");
   }
 }

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-truststore-arg.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-truststore-arg.gradle
@@ -14,7 +14,7 @@ dependencies {
   compile files('libs/dependency-1.0.0.jar')
 }
 
-jib{
+jib {
   to.image = System.getProperty("_TARGET_IMAGE")
   container {
     environment = [JAVA_TOOL_OPTIONS:'-Djavax.net.ssl.trustStore=/var/cache/proxy.crt.jks']

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-truststore-arg.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/build-truststore-arg.gradle
@@ -1,0 +1,22 @@
+plugins {
+  id 'java'
+  id 'com.google.cloud.tools.jib'
+}
+
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  compile files('libs/dependency-1.0.0.jar')
+}
+
+jib{
+  to.image = System.getProperty("_TARGET_IMAGE")
+  container {
+    environment = [JAVA_TOOL_OPTIONS:'-Djavax.net.ssl.trustStore=/var/cache/proxy.crt.jks']
+  }
+}


### PR DESCRIPTION
Follow-up to https://github.com/GoogleContainerTools/jib/pull/3769
