### PR TITLE
fix: replace integrationTest task with build task when making gradle plugin release

### DIFF
--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -68,7 +68,6 @@ pluginBundle {
 }
 
 gradlePlugin {
-  testSourceSets sourceSets.integrationTest, sourceSets.test
   plugins {
     jibPlugin {
       id = 'com.google.cloud.tools.jib'
@@ -78,7 +77,7 @@ gradlePlugin {
     }
   }
 }
-tasks.publishPlugins.dependsOn integrationTest
+tasks.publishPlugins.dependsOn build
 /* RELEASE */
 
 /* ECLIPSE */

--- a/jib-gradle-plugin/build.gradle
+++ b/jib-gradle-plugin/build.gradle
@@ -68,6 +68,7 @@ pluginBundle {
 }
 
 gradlePlugin {
+  testSourceSets sourceSets.integrationTest, sourceSets.test
   plugins {
     jibPlugin {
       id = 'com.google.cloud.tools.jib'


### PR DESCRIPTION
Currently the release build for jib-gradle-plugin additionally runs integration tests before publishing to plugin portal. 

The recent Kokoro release environment changes introduced a number of compatibility issues in our current integration test suite. After attempting patching workarounds, this PR replaces the integration test check with full build (including unit tests) instead. 

