### PR TITLE
chore: update docs and examples after core 0.23.0 and plugins 3.3.1 release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,8 +125,8 @@ To use a local build of the `jib-gradle-plugin`:
   1. Modify your test project's `build.gradle` to use the snapshot version
         ```groovy
         plugins {
-          // id 'com.google.cloud.tools.jib' version '3.3.0'
-          id 'com.google.cloud.tools.jib' version '3.3.1-SNAPSHOT'
+          // id 'com.google.cloud.tools.jib' version '3.3.1'
+          id 'com.google.cloud.tools.jib' version '3.3.2-SNAPSHOT'
         }
 
         ```

--- a/examples/dropwizard/pom.xml
+++ b/examples/dropwizard/pom.xml
@@ -26,7 +26,7 @@
         <dropwizard-template-config.version>1.5.0</dropwizard-template-config.version>
 
         <jib.container.appRoot>/app</jib.container.appRoot>
-        <jib-maven-plugin.version>3.3.0</jib-maven-plugin.version>
+        <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
     </properties>
 
     <dependencyManagement>

--- a/examples/helloworld/build.gradle
+++ b/examples/helloworld/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'com.google.cloud.tools.jib' version '3.3.0'
+  id 'com.google.cloud.tools.jib' version '3.3.1'
 }
 
 sourceCompatibility = 1.8

--- a/examples/helloworld/pom.xml
+++ b/examples/helloworld/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jib-maven-plugin.version>3.3.0</jib-maven-plugin.version>
+    <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
   </properties>
 

--- a/examples/java-agent/build.gradle
+++ b/examples/java-agent/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'com.google.cloud.tools.jib' version '3.3.0'
+  id 'com.google.cloud.tools.jib' version '3.3.1'
   id 'de.undercouch.download' version '4.0.0'
   id 'com.gorylenko.gradle-git-properties' version '2.2.0'
 }

--- a/examples/java-agent/pom.xml
+++ b/examples/java-agent/pom.xml
@@ -9,7 +9,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <jib-maven-plugin.version>3.3.0</jib-maven-plugin.version>
+    <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
     <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
     <download-maven-plugin.version>1.4.2</download-maven-plugin.version>
     <git-commit-id-plugin.version>3.0.1</git-commit-id-plugin.version>

--- a/examples/ktor/build.gradle.kts
+++ b/examples/ktor/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     application
     kotlin("jvm") version "1.3.10"
-    id("com.google.cloud.tools.jib") version "3.3.0"
+    id("com.google.cloud.tools.jib") version "3.3.1"
 }
 
 group = "example"

--- a/examples/micronaut/build.gradle
+++ b/examples/micronaut/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "groovy"
     id "com.github.johnrengelman.shadow" version "5.2.0"
     id "application"
-    id 'com.google.cloud.tools.jib' version '3.3.0'
+    id 'com.google.cloud.tools.jib' version '3.3.1'
 }
 
 version "0.1"

--- a/examples/multi-module/build.gradle
+++ b/examples/multi-module/build.gradle
@@ -2,5 +2,5 @@
 plugins {
   id 'org.springframework.boot' version '2.0.3.RELEASE' apply false
   id 'io.spring.dependency-management' version '1.0.6.RELEASE' apply false
-  id 'com.google.cloud.tools.jib' version '3.3.0' apply false
+  id 'com.google.cloud.tools.jib' version '3.3.1' apply false
 }

--- a/examples/multi-module/pom.xml
+++ b/examples/multi-module/pom.xml
@@ -41,7 +41,7 @@
         <plugin>
           <groupId>com.google.cloud.tools</groupId>
           <artifactId>jib-maven-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'idea'
     id 'org.springframework.boot' version '2.1.6.RELEASE'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
-    id 'com.google.cloud.tools.jib' version '3.3.0'
+    id 'com.google.cloud.tools.jib' version '3.3.1'
 }
 
 repositories {

--- a/examples/spring-boot/pom.xml
+++ b/examples/spring-boot/pom.xml
@@ -29,7 +29,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.3.1</version>
             </plugin>
         </plugins>
     </build>

--- a/examples/vertx/build.gradle
+++ b/examples/vertx/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'io.vertx.vertx-plugin' version '0.1.0'
-    id 'com.google.cloud.tools.jib' version '3.3.0'
+    id 'com.google.cloud.tools.jib' version '3.3.1'
 }
 
 repositories {

--- a/jib-cli/CHANGELOG.md
+++ b/jib-cli/CHANGELOG.md
@@ -6,14 +6,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
-
-### Fixed
-
-## 0.12.0
-
-### Changed
 - Upgraded Google HTTP libraries to 1.42.2 ([#3745](https://github.com/GoogleContainerTools/jib/pull/3745))
 - Re-synchronized jackson dependencies with BOM to use latest versions ([#3768](https://github.com/GoogleContainerTools/jib/pull/3768))
+
+### Fixed
 
 ## 0.11.0
 

--- a/jib-cli/CHANGELOG.md
+++ b/jib-cli/CHANGELOG.md
@@ -6,10 +6,14 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
-- Upgraded Google HTTP libraries to 1.42.2 ([#3745](https://github.com/GoogleContainerTools/jib/pull/3745))
-- Re-synchronized jackson dependencies with BOM to use latest versions ([#3768](https://github.com/GoogleContainerTools/jib/pull/3768))
 
 ### Fixed
+
+## 0.12.0
+
+### Changed
+- Upgraded Google HTTP libraries to 1.42.2 ([#3745](https://github.com/GoogleContainerTools/jib/pull/3745))
+- Re-synchronized jackson dependencies with BOM to use latest versions ([#3768](https://github.com/GoogleContainerTools/jib/pull/3768))
 
 ## 0.11.0
 

--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
+
+### Fixed
+
+## 0.23.0
+
+### Changed
 - Upgraded Google HTTP libraries to 1.42.2 ([#3745](https://github.com/GoogleContainerTools/jib/pull/3745))
 - Re-synchronized jackson dependencies with BOM to use latest versions ([#3768](https://github.com/GoogleContainerTools/jib/pull/3768))
 

--- a/jib-core/README.md
+++ b/jib-core/README.md
@@ -22,7 +22,7 @@ Add Jib Core as a dependency using Maven:
 <dependency>
   <groupId>com.google.cloud.tools</groupId>
   <artifactId>jib-core</artifactId>
-  <version>0.22.0</version>
+  <version>0.23.0</version>
 </dependency>
 ```
 
@@ -30,7 +30,7 @@ Add Jib Core as a dependency using Gradle:
 
 ```groovy
 dependencies {
-  compile 'com.google.cloud.tools:jib-core:0.22.0'
+  compile 'com.google.cloud.tools:jib-core:0.23.0'
 }
 ```
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 ## [unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+## 3.3.1
+
+### Added
 - Added lazy evaluation for `jib.container.creationTime` and `jib.container.filesModificationTime` parameters using Gradle Property and Provider. ([#3709](https://github.com/GoogleContainerTools/jib/pull/3709))
 
 ### Changed

--- a/jib-gradle-plugin/README.md
+++ b/jib-gradle-plugin/README.md
@@ -53,7 +53,7 @@ In your Gradle Java project, add the plugin to your `build.gradle`:
 
 ```groovy
 plugins {
-  id 'com.google.cloud.tools.jib' version '3.3.0'
+  id 'com.google.cloud.tools.jib' version '3.3.1'
 }
 ```
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -6,9 +6,13 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
-- Upgraded Google HTTP libraries to 1.42.2 ([#3745](https://github.com/GoogleContainerTools/jib/pull/3745))
 
 ### Fixed
+
+## 3.3.1
+
+### Changed
+- Upgraded Google HTTP libraries to 1.42.2 ([#3745](https://github.com/GoogleContainerTools/jib/pull/3745))
 
 ## 3.3.0
 

--- a/jib-maven-plugin/README.md
+++ b/jib-maven-plugin/README.md
@@ -48,7 +48,7 @@ For information about the project, see the [Jib project README](../README.md).
 You can containerize your application easily with one command:
 
 ```shell
-mvn compile com.google.cloud.tools:jib-maven-plugin:3.3.0:build -Dimage=<MY IMAGE>
+mvn compile com.google.cloud.tools:jib-maven-plugin:3.3.1:build -Dimage=<MY IMAGE>
 ```
 
 This builds and pushes a container image for your application to a container registry. *If you encounter authentication issues, see [Authentication Methods](#authentication-methods).*
@@ -56,7 +56,7 @@ This builds and pushes a container image for your application to a container reg
 To build to a Docker daemon, use:
 
 ```shell
-mvn compile com.google.cloud.tools:jib-maven-plugin:3.3.0:dockerBuild
+mvn compile com.google.cloud.tools:jib-maven-plugin:3.3.1:dockerBuild
 ```
 
 If you would like to set up Jib as part of your Maven build, follow the guide below.
@@ -74,7 +74,7 @@ In your Maven Java project, add the plugin to your `pom.xml`:
       <plugin>
         <groupId>com.google.cloud.tools</groupId>
         <artifactId>jib-maven-plugin</artifactId>
-        <version>3.3.0</version>
+        <version>3.3.1</version>
         <configuration>
           <to>
             <image>myimage</image>


### PR DESCRIPTION
Corresponding to post-release actions in #3834, #3836, #3838.