### PR TITLE
fix: bump slsa-github-generator version from 1.2.0 to 1.2.1

### DIFF
--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -117,7 +117,7 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
     with:
       base64-subjects: "${{ needs.release.outputs.hashes }}"
 


### PR DESCRIPTION
To fix jib-cli release workflow, which is encountering error at `Generate Builder` step. 
See: [slsa-github-generator 1.2.1 release notes](https://github.com/slsa-framework/slsa-github-generator/releases/tag/v1.2.1).

Will merge after PRs to wrap up core and plugins release.
