### PR TITLE
fix: add compile-generator workaround for SLSA

### DIFF
--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -119,6 +119,7 @@ jobs:
       contents: write # To add assets to a release.
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
     with:
+      compile-generator: true # Workaround for https://github.com/slsa-framework/slsa-github-generator/issues/1163
       base64-subjects: "${{ needs.release.outputs.hashes }}"
 
   upload:


### PR DESCRIPTION
Latest attempts to release Jib CLI v0.12.0 has been running into SLSA (added in #3722, #3726) issues similar to described in https://github.com/slsa-framework/slsa-github-generator/issues/1163#issuecomment-1293012316. 

We have bumped slsa-github-generator version to v1.2.1, and this PR adds the suggested `compile-generator: true` workaround. 

@laurentsimon @ianlewis Would you be able to help provide any additional pointers or context on this issue?
