### PR TITLE
Simplify release steps

### DIFF
--- a/.github/RELEASE_TEMPLATES/cli_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/cli_release_checklist.md
@@ -13,9 +13,3 @@ labels: release
 - [ ] Update [CHANGELOG.md]({{ env.CHANGELOG_URL }})
 - [ ] Update [README.md]({{ env.README_URL }})
 - [ ] Merge PR ({{ env.RELEASE_PR }})
-- [ ] Update the current [milestone](https://github.com/GoogleContainerTools/jib/milestones), roll over any incomplete issues to next milestone.
-
-## Announce
-- [ ] Email jib users
-- [ ] Post to [gitter](https://gitter.im/google/jib)
-- [ ] Mention on all fixed issues that latest release has addressed the issue (usually any closed issues in a [milestone](https://github.com/GoogleContainerTools/jib/milestones))

--- a/.github/RELEASE_TEMPLATES/core_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/core_release_checklist.md
@@ -10,9 +10,3 @@ labels: release
 - [ ] Update [README.md]({{ env.README_URL }})
 - [ ] Publish [Release]({{ env.RELEASE_DRAFT }})
 - [ ] Merge PR ({{ env.RELEASE_PR }})
-- [ ] Update the current [milestone](https://github.com/GoogleContainerTools/jib/milestones), roll over any incomplete issues to next milestone.
-
-## Announce
-- [ ] Email jib users
-- [ ] Post to [gitter](https://gitter.im/google/jib)
-- [ ] Mention on all fixed issues that latest release has addressed the issue (usually any closed issues in a [milestone](https://github.com/GoogleContainerTools/jib/milestones))

--- a/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
+++ b/.github/RELEASE_TEMPLATES/plugin_release_checklist.md
@@ -11,20 +11,10 @@ labels: release
 ## Github
 - [ ] Update [CHANGELOG.md]({{ env.CHANGELOG_URL }})
 - [ ] Update [README.md]({{ env.README_URL }})
-- [ ] Update [CONTRIBUTING.md](https://github.com/GoogleContainerTools/jib/blob/master/CONTRIBUTING.md)
-- [ ] Update [examples](https://github.com/GoogleContainerTools/jib/tree/master/examples)
+- [ ] Search/replace the old published version with the new published version in [examples](https://github.com/GoogleContainerTools/jib/tree/master/examples)
 - [ ] Publish [Release]({{ env.RELEASE_DRAFT }})
 - [ ] Merge PR ({{ env.RELEASE_PR }})
-- [ ] Update the current [milestone](https://github.com/GoogleContainerTools/jib/milestones), roll over any incomplete issues to next milestone.
-
-#### Skaffold
-- [ ] Update versions in Skaffold ([example PR](https://github.com/GoogleContainerTools/skaffold/pull/4639))
 
 #### Jib-Extensions
 - [ ] Update versions in [Jib Extensions](https://github.com/GoogleContainerTools/jib-extensions)
 - [ ] If there were Gradle API or Jib API changes, double-check compatibility and update Version Matrix on jib-extensions. It may require re-releasing first-party extensions. See [jib-extensions#45](https://github.com/GoogleContainerTools/jib-extensions/pull/45), [jib-extensions#44](https://github.com/GoogleContainerTools/jib-extensions/pull/44), and [jib-extensions#42](https://github.com/GoogleContainerTools/jib-extensions/pull/42)
-
-## Announce
-- [ ] Email jib users
-- [ ] Post to [gitter](https://gitter.im/google/jib)
-- [ ] Mention on all fixed issues that latest release has addressed the issue (usually any closed issues in a [milestone](https://github.com/GoogleContainerTools/jib/milestones))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,11 +122,11 @@ To use a local build of the `jib-gradle-plugin`:
           }
         }
         ```
-  1. Modify your test project's `build.gradle` to use the snapshot version
+  1. Modify your test project's `build.gradle` to use the [latest snapshot version](jib-gradle-plugin/gradle.properties)
         ```groovy
         plugins {
-          // id 'com.google.cloud.tools.jib' version '3.3.1'
-          id 'com.google.cloud.tools.jib' version '3.3.2-SNAPSHOT'
+          // id 'com.google.cloud.tools.jib' version 'major.minor.patch'
+          id 'com.google.cloud.tools.jib' version 'major.minor.patch-SNAPSHOT'
         }
 
         ```


### PR DESCRIPTION
For scaffold update, I suggested they use renovate-bot the last time I was releasing.
For milestones, we don't currently use Github's milestones in Jib.
For communication, most users rely on automated methods like dependabot.

I also updated CONTRIBUTING file to not require a manual update at every release.

The only thing I'd like to remove that I can't is updating the "examples" -- it is best if the samples use the correct jib version, but there is no parent relationship. Maybe having dependabot update those ourselves would work?