### PR TITLE
fix: update gradlePluginPortal workaround for JCenter availability issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,22 +70,7 @@ subprojects {
   group 'com.google.cloud.tools'
 
   repositories {
-    mavenCentral {
-      metadataSources {
-        mavenPom()
-        artifact()
-        ignoreGradleMetadataRedirection()
-      }
-    }
-    // Workaround from: https://github.com/gradle/gradle/issues/15406#issuecomment-1020352934
-    gradlePluginPortal {
-      this as MavenArtifactRepository
-      metadataSources {
-        mavenPom()
-        artifact()
-        ignoreGradleMetadataRedirection()
-      }
-    }
+    mavenCentral()
   }
 
   apply plugin: 'java'

--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ subprojects {
       this as MavenArtifactRepository
       metadataSources {
         mavenPom()
+        artifact()
         ignoreGradleMetadataRedirection()
       }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -70,10 +70,12 @@ subprojects {
   group 'com.google.cloud.tools'
 
   repositories {
-    mavenCentral {
+    mavenCentral()
+    // Workaround from: https://github.com/gradle/gradle/issues/15406#issuecomment-1020352934
+    gradlePluginPortal {
+      this as MavenArtifactRepository
       metadataSources {
         mavenPom()
-        artifact()
         ignoreGradleMetadataRedirection()
       }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,13 @@ subprojects {
   group 'com.google.cloud.tools'
 
   repositories {
-    mavenCentral()
+    mavenCentral {
+      metadataSources {
+        mavenPom()
+        artifact()
+        ignoreGradleMetadataRedirection()
+      }
+    }
     // Workaround from: https://github.com/gradle/gradle/issues/15406#issuecomment-1020352934
     gradlePluginPortal {
       this as MavenArtifactRepository

--- a/jib-cli/src/integration-test/resources/jarTest/spring-boot/settings-layered.gradle
+++ b/jib-cli/src/integration-test/resources/jarTest/spring-boot/settings-layered.gradle
@@ -1,2 +1,8 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 rootProject.name = 'spring-boot'
 rootProject.buildFileName = 'build-layered.gradle'

--- a/jib-cli/src/integration-test/resources/jarTest/spring-boot/settings.gradle
+++ b/jib-cli/src/integration-test/resources/jarTest/spring-boot/settings.gradle
@@ -1,1 +1,7 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 rootProject.name = 'spring-boot'

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/spring-boot/settings.gradle
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/spring-boot/settings.gradle
@@ -1,1 +1,7 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 rootProject.name = 'spring-boot'

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,18 @@
+pluginManagement {
+    repositories {
+        mavenCentral()
+        // Workaround from: https://github.com/gradle/gradle/issues/15406#issuecomment-1020352934
+        gradlePluginPortal {
+            this as MavenArtifactRepository
+            metadataSources {
+                mavenPom()
+                artifact()
+                ignoreGradleMetadataRedirection()
+            }
+        }
+    }
+}
+
 include ":jib-build-plan"
 include ":jib-plugins-extension-common"
 include ":jib-gradle-plugin-extension-api"


### PR DESCRIPTION
Fixing workaround from #3784 which modified metadata sources in `build.gradle`'s `subprojects.repositories` block, when it should have been made in `settings.gradle`'s `pluginManagement.repositories` block instead.

Reference: https://discuss.gradle.org/t/plugin-portal-dependency-resolution-failing-due-to-jcenter-usage/44131

This changes dependency resolution to deprioritize gradle plugin portal (with JCenter workaround) in favour of maven central, given the latest availability issues encountered.