### PR TITLE
Replace google api util base64 with java util base64

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/http/Authorization.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/http/Authorization.java
@@ -16,8 +16,8 @@
 
 package com.google.cloud.tools.jib.http;
 
-import com.google.api.client.util.Base64;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Objects;
 
 /**
@@ -38,7 +38,7 @@ public class Authorization {
    */
   public static Authorization fromBasicCredentials(String username, String secret) {
     String credentials = username + ":" + secret;
-    String token = Base64.encodeBase64String(credentials.getBytes(StandardCharsets.UTF_8));
+    String token = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
     return new Authorization("Basic", token);
   }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryClient.java
@@ -18,7 +18,6 @@ package com.google.cloud.tools.jib.registry;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.api.client.http.HttpStatusCodes;
-import com.google.api.client.util.Base64;
 import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.LogEvent;
@@ -44,6 +43,7 @@ import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Multimap;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
@@ -195,10 +195,10 @@ public class RegistryClient {
     // parts (header, payload, signature), collated with a ".".  The header and payload are
     // JSON objects.
     String[] jwtParts = token.split("\\.", -1);
-    byte[] payloadData;
-    if (jwtParts.length != 3 || (payloadData = Base64.decodeBase64(jwtParts[1])) == null) {
+    if (jwtParts.length != 3) {
       return null;
     }
+    byte[] payloadData = Base64.getDecoder().decode(jwtParts[1]);
 
     // The payload looks like:
     // {

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
@@ -19,7 +19,6 @@ package com.google.cloud.tools.jib.registry.credentials;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.api.client.util.Base64;
 import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.registry.RegistryAliasGroup;
@@ -31,6 +30,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Base64;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -144,7 +144,7 @@ public class DockerConfigCredentialRetriever {
         if (auth.getAuth() != null) {
           // 'auth' is a basic authentication token that should be parsed back into credentials
           String usernameColonPassword =
-              new String(Base64.decodeBase64(auth.getAuth()), StandardCharsets.UTF_8);
+              new String(Base64.getDecoder().decode(auth.getAuth()), StandardCharsets.UTF_8);
           String username = usernameColonPassword.substring(0, usernameColonPassword.indexOf(":"));
           String password = usernameColonPassword.substring(usernameColonPassword.indexOf(":") + 1);
           logger.accept(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/DockerRegistryBearerTokenTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/DockerRegistryBearerTokenTest.java
@@ -16,10 +16,10 @@
 
 package com.google.cloud.tools.jib.registry;
 
-import com.google.api.client.util.Base64;
 import com.google.cloud.tools.jib.http.Authorization;
 import com.google.common.collect.Multimap;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -53,8 +53,8 @@ public class DockerRegistryBearerTokenTest {
   @Test
   public void testDecode_nonToken() {
     String base64Text =
-        Base64.encodeBase64String(
-            "something other than a JWT token".getBytes(StandardCharsets.UTF_8));
+        Base64.getEncoder()
+            .encodeToString("something other than a JWT token".getBytes(StandardCharsets.UTF_8));
     Multimap<String, String> decoded = RegistryClient.decodeTokenRepositoryGrants(base64Text);
     Assert.assertNull(decoded);
   }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigTest.java
@@ -16,7 +16,6 @@
 
 package com.google.cloud.tools.jib.registry.credentials;
 
-import com.google.api.client.util.Base64;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.cloud.tools.jib.registry.credentials.json.DockerConfigTemplate;
 import com.google.common.io.Resources;
@@ -25,6 +24,7 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Base64;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -32,7 +32,7 @@ import org.junit.Test;
 public class DockerConfigTest {
 
   private static String decodeBase64(String base64String) {
-    return new String(Base64.decodeBase64(base64String), StandardCharsets.UTF_8);
+    return new String(Base64.getDecoder().decode(base64String), StandardCharsets.UTF_8);
   }
 
   @Test


### PR DESCRIPTION
Replace usage of the `com.google.api.client.util.Base64` (which is deprecated) with `java.util.Base64`.