### PR TITLE
fix: update slsa-github-generator to v1.2.2 and remove workaround

### DIFF
--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -117,9 +117,8 @@ jobs:
       actions: read # To read the workflow path.
       id-token: write # To sign the provenance.
       contents: write # To add assets to a release.
-    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.1
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.2
     with:
-      compile-generator: true # Workaround for https://github.com/slsa-framework/slsa-github-generator/issues/1163
       base64-subjects: "${{ needs.release.outputs.hashes }}"
 
   upload:


### PR DESCRIPTION
Fixes #3853. 

[v1.2.2 of slsa-github-generator](https://github.com/slsa-framework/slsa-github-generator/releases/tag/v1.2.2) has been released with fix for the provenance signing issue that required the `compile-generator` workaround added to unblock our last Jib CLI release. Updating to this version and removing the workaround from #3848.
