### PR TITLE
fix global configuration path for Mac

### DIFF
--- a/jib-maven-plugin/README.md
+++ b/jib-maven-plugin/README.md
@@ -383,7 +383,7 @@ Property | Type | Default | Description
 Some options can be set in the global Jib configuration file. The file is at the following locations on each platform:
 
 * *Linux: `[config root]/google-cloud-tools-java/jib/config.json`, where `[config root]` is `$XDG_CONFIG_HOME` (`$HOME/.config/` if not set)*
-* *Mac: `[config root]/Google/Jib/config.json`, where `[config root]` is `$XDG_CONFIG_HOME` (`$HOME/Library/Preferences/Config/` if not set)*
+* *Mac: `[config root]/Google/Jib/config.json`, where `[config root]` is `$XDG_CONFIG_HOME` (`$HOME/Library/Preferences/` if not set)*
 * *Windows: `[config root]\Google\Jib\Config\config.json`, where `[config root]` is `%XDG_CONFIG_HOME%` (`%LOCALAPPDATA%` if not set)*
 
 #### Properties


### PR DESCRIPTION
No code change.
The  default  global configuration path  in Mac is `/Library/Preferences/Google/Jib/config.json` .

Before filing a pull request, make sure to do the following:

- [ ] Create a new issue at https://github.com/GoogleContainerTools/jib/issues/new/choose.
- [ ] Ensure that your implementation plan is approved by the team.
- [ ] Verify that integration tests and unit tests are passing after the change.
- [ ] Address all checkstyle issues. Refer to the [style guide](https://github.com/GoogleContainerTools/jib/blob/0ed7dca36864b6b19ff61629fc578018041fa15f/STYLE_GUIDE.md#style-guide).

This helps to reduce the chance of having a pull request rejected.
