### PR TITLE
Fix jackson deprecations

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java
@@ -19,6 +19,7 @@ package com.google.cloud.tools.jib.registry.credentials;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.registry.RegistryAliasGroup;
@@ -88,7 +89,9 @@ public class DockerConfigCredentialRetriever {
     }
 
     ObjectMapper objectMapper =
-        new ObjectMapper().configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
+        JsonMapper.builder()
+            .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
+            .build();
     try (InputStream fileIn = Files.newInputStream(dockerConfigFile)) {
       if (legacyConfigFormat) {
         // legacy config format is the value of the "auths":{ <map> } block of the new config (i.e.,


### PR DESCRIPTION
Fix a few jackson deprecations. `ObjectMapper.configure` has [been deprecated](https://javadoc.io/doc/com.fasterxml.jackson.core/jackson-databind/latest/com/fasterxml/jackson/databind/ObjectMapper.html#configure-com.fasterxml.jackson.databind.MapperFeature-boolean-)
```
> Task :jib:jib-core:compileJava
/Users/cwalker/git/jib/jib-core/src/main/java/com/google/cloud/tools/jib/registry/credentials/DockerConfigCredentialRetriever.java:91: warning: [deprecation] configure(MapperFeature,boolean) in ObjectMapper has been deprecated
        new ObjectMapper().configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true);
                          ^
/Users/cwalker/git/jib/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java:221: warning: [deprecation] configure(MapperFeature,boolean) in ObjectMapper has been deprecated
              .configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES, true)
              ^
2 warnings
```
The replacement being
```
Since 2.13 use {@code JsonMapper.builder().configure(...)
```
