### PR TITLE
chore: Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/jib-cli-release.yml
+++ b/.github/workflows/jib-cli-release.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Generate SLSA subject for Jib CLI release binaries
         id: hash
         working-directory: jib-cli/build/distributions
-        run: echo "::set-output name=hashes::$(cat zip.sha256 | base64 -w0)"
+        run: echo "hashes=$(cat zip.sha256 | base64 -w0)" >> $GITHUB_OUTPUT
 
       - name: Create pull request
         uses: repo-sync/pull-request@v2.6.2

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
+        run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Resolve  #3920 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: echo "::set-output name=hashes::$(cat zip.sha256 | base64 -w0)"
```

```yml
run: echo "::set-output name=date::$(date +'%Y-%m-%d' --utc)"
```

**TO-BE**

```yml
run: echo "hashes=$(cat zip.sha256 | base64 -w0)" >> $GITHUB_OUTPUT
```

```yml
run: echo "date=$(date +'%Y-%m-%d' --utc)" >> $GITHUB_OUTPUT
```
