### PR TITLE
test: update integration test assertions for docker inspect output

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
@@ -127,7 +127,7 @@ public class ContainerizerIntegrationTest {
     MatcherAssert.assertThat(
         dockerInspectExposedPorts,
         CoreMatchers.containsString(
-            "\"1000/tcp\":{},\"2000/udp\":{},\"2001/udp\":{},\"2002/udp\":{},\"3000/udp\":{}"));
+            "\"1000/tcp\":{},\"2000/tcp\":{},\"2001/tcp\":{},\"2002/tcp\":{},\"3000/udp\":{}"));
     MatcherAssert.assertThat(
         dockerInspectLabels,
         CoreMatchers.containsString("\"key1\":\"value1\",\"key2\":\"value2\""));

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
@@ -127,7 +127,7 @@ public class ContainerizerIntegrationTest {
     MatcherAssert.assertThat(
         dockerInspectExposedPorts,
         CoreMatchers.containsString(
-            "\"1000/tcp\":{},\"2000/udp\":{},\"2001/udp\":{},\"2002/udp\":{},\"2003/udp\":{}"));
+            "\"1000/tcp\":{},\"2000/udp\":{},\"2001/udp\":{},\"2002/udp\":{},\"3000/udp\":{}"));
     MatcherAssert.assertThat(
         dockerInspectLabels,
         CoreMatchers.containsString("\"key1\":\"value1\",\"key2\":\"value2\""));

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/ContainerizerIntegrationTest.java
@@ -115,28 +115,24 @@ public class ContainerizerIntegrationTest {
 
   private static void assertDockerInspect(String imageReference)
       throws IOException, InterruptedException {
-    String dockerContainerConfig = new Command("docker", "inspect", imageReference).run();
-    MatcherAssert.assertThat(
-        dockerContainerConfig,
-        CoreMatchers.containsString(
-            "            \"ExposedPorts\": {\n"
-                + "                \"1000/tcp\": {},\n"
-                + "                \"2000/tcp\": {},\n"
-                + "                \"2001/tcp\": {},\n"
-                + "                \"2002/tcp\": {},\n"
-                + "                \"3000/udp\": {}"));
-    MatcherAssert.assertThat(
-        dockerContainerConfig,
-        CoreMatchers.containsString(
-            "            \"Labels\": {\n"
-                + "                \"key1\": \"value1\",\n"
-                + "                \"key2\": \"value2\"\n"
-                + "            }"));
+    String dockerInspectExposedPorts =
+        new Command("docker", "inspect", "-f", "'{{json .Config.ExposedPorts}}'", imageReference)
+            .run();
+    String dockerInspectLabels =
+        new Command("docker", "inspect", "-f", "'{{json .Config.Labels}}'", imageReference).run();
     String dockerConfigEnv =
         new Command("docker", "inspect", "-f", "{{.Config.Env}}", imageReference).run();
+    String history = new Command("docker", "history", imageReference).run();
+
+    MatcherAssert.assertThat(
+        dockerInspectExposedPorts,
+        CoreMatchers.containsString(
+            "\"1000/tcp\":{},\"2000/udp\":{},\"2001/udp\":{},\"2002/udp\":{},\"2003/udp\":{}"));
+    MatcherAssert.assertThat(
+        dockerInspectLabels,
+        CoreMatchers.containsString("\"key1\":\"value1\",\"key2\":\"value2\""));
     MatcherAssert.assertThat(dockerConfigEnv, CoreMatchers.containsString("env1=envvalue1"));
     MatcherAssert.assertThat(dockerConfigEnv, CoreMatchers.containsString("env2=envvalue2"));
-    String history = new Command("docker", "history", imageReference).run();
     MatcherAssert.assertThat(history, CoreMatchers.containsString("jib-integration-test"));
     MatcherAssert.assertThat(history, CoreMatchers.containsString("bazel build ..."));
   }

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/DefaultTargetProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/DefaultTargetProjectIntegrationTest.java
@@ -41,23 +41,19 @@ public class DefaultTargetProjectIntegrationTest {
    */
   private static void assertDockerInspect(String imageReference)
       throws IOException, InterruptedException {
-    String dockerInspect = new Command("docker", "inspect", imageReference).run();
+    String dockerInspectExposedPorts =
+        new Command("docker", "inspect", "-f", "'{{json .Config.ExposedPorts}}'", imageReference)
+            .run();
+    String dockerInspectLabels =
+        new Command("docker", "inspect", "-f", "'{{json .Config.Labels}}'", imageReference).run();
+
     MatcherAssert.assertThat(
-        dockerInspect,
+        dockerInspectExposedPorts,
         CoreMatchers.containsString(
-            "            \"ExposedPorts\": {\n"
-                + "                \"1000/tcp\": {},\n"
-                + "                \"2000/udp\": {},\n"
-                + "                \"2001/udp\": {},\n"
-                + "                \"2002/udp\": {},\n"
-                + "                \"2003/udp\": {}"));
+            "\"1000/tcp\":{},\"2000/udp\":{},\"2001/udp\":{},\"2002/udp\":{},\"2003/udp\":{}"));
     MatcherAssert.assertThat(
-        dockerInspect,
-        CoreMatchers.containsString(
-            "            \"Labels\": {\n"
-                + "                \"key1\": \"value1\",\n"
-                + "                \"key2\": \"value2\"\n"
-                + "            }"));
+        dockerInspectLabels,
+        CoreMatchers.containsString("\"key1\":\"value1\",\"key2\":\"value2\""));
   }
 
   @Test

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/EmptyProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/EmptyProjectIntegrationTest.java
@@ -24,6 +24,7 @@ import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import java.io.IOException;
 import java.security.DigestException;
 import java.time.Instant;
+import java.util.logging.Logger;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -32,6 +33,8 @@ import org.junit.Test;
 
 /** Integration tests for building empty project images. */
 public class EmptyProjectIntegrationTest {
+
+  private static final Logger LOGGER = Logger.getLogger(EmptyProjectIntegrationTest.class.getName());
 
   @ClassRule public static final TestProject emptyTestProject = new TestProject("empty");
 
@@ -44,9 +47,14 @@ public class EmptyProjectIntegrationTest {
    */
   private static void assertDockerInspect(String imageReference)
       throws IOException, InterruptedException {
-    String dockerInspect = new Command("docker", "inspect", imageReference).run();
+    String dockerInspectExposedPorts =
+            new Command("docker", "inspect", "-f", "'{{.Config.ExposedPorts}}'", imageReference).run();
+    String dockerInspectLabels =
+            new Command("docker", "inspect", "-f", "'{{.Config.Labels}}'", imageReference).run();
+    LOGGER.info(dockerInspectExposedPorts);
+    LOGGER.info(dockerInspectLabels);
     MatcherAssert.assertThat(
-        dockerInspect,
+        dockerInspectExposedPorts,
         CoreMatchers.containsString(
             "            \"ExposedPorts\": {\n"
                 + "                \"1000/tcp\": {},\n"
@@ -55,7 +63,7 @@ public class EmptyProjectIntegrationTest {
                 + "                \"2002/udp\": {},\n"
                 + "                \"2003/udp\": {}"));
     MatcherAssert.assertThat(
-        dockerInspect,
+        dockerInspectLabels,
         CoreMatchers.containsString(
             "            \"Labels\": {\n"
                 + "                \"key1\": \"value1\",\n"

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/EmptyProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/EmptyProjectIntegrationTest.java
@@ -24,7 +24,6 @@ import com.google.cloud.tools.jib.api.InvalidImageReferenceException;
 import java.io.IOException;
 import java.security.DigestException;
 import java.time.Instant;
-import java.util.logging.Logger;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -33,8 +32,6 @@ import org.junit.Test;
 
 /** Integration tests for building empty project images. */
 public class EmptyProjectIntegrationTest {
-
-  private static final Logger LOGGER = Logger.getLogger(EmptyProjectIntegrationTest.class.getName());
 
   @ClassRule public static final TestProject emptyTestProject = new TestProject("empty");
 
@@ -48,27 +45,17 @@ public class EmptyProjectIntegrationTest {
   private static void assertDockerInspect(String imageReference)
       throws IOException, InterruptedException {
     String dockerInspectExposedPorts =
-            new Command("docker", "inspect", "-f", "'{{.Config.ExposedPorts}}'", imageReference).run();
+        new Command("docker", "inspect", "-f", "'{{json .Config.ExposedPorts}}'", imageReference)
+            .run();
     String dockerInspectLabels =
-            new Command("docker", "inspect", "-f", "'{{.Config.Labels}}'", imageReference).run();
-    LOGGER.info(dockerInspectExposedPorts);
-    LOGGER.info(dockerInspectLabels);
+        new Command("docker", "inspect", "-f", "'{{json .Config.Labels}}'", imageReference).run();
     MatcherAssert.assertThat(
         dockerInspectExposedPorts,
         CoreMatchers.containsString(
-            "            \"ExposedPorts\": {\n"
-                + "                \"1000/tcp\": {},\n"
-                + "                \"2000/udp\": {},\n"
-                + "                \"2001/udp\": {},\n"
-                + "                \"2002/udp\": {},\n"
-                + "                \"2003/udp\": {}"));
+            "\"1000/tcp\":{},\"2000/udp\":{},\"2001/udp\":{},\"2002/udp\":{},\"2003/udp\":{}"));
     MatcherAssert.assertThat(
         dockerInspectLabels,
-        CoreMatchers.containsString(
-            "            \"Labels\": {\n"
-                + "                \"key1\": \"value1\",\n"
-                + "                \"key2\": \"value2\"\n"
-                + "            }"));
+        CoreMatchers.containsString("\"key1\":\"value1\",\"key2\":\"value2\""));
   }
 
   @Test

--- a/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
+++ b/jib-gradle-plugin/src/integration-test/java/com/google/cloud/tools/jib/gradle/SingleProjectIntegrationTest.java
@@ -107,8 +107,7 @@ public class SingleProjectIntegrationTest {
         new Command("docker", "inspect", "-f", "'{{json .Config.Labels}}'", imageReference).run();
 
     MatcherAssert.assertThat(
-        dockerInspectVolumes,
-        CoreMatchers.containsString("\"/var/log\":\"{}\",\"/var/log2\":\"{}\""));
+        dockerInspectVolumes, CoreMatchers.containsString("\"/var/log\":{},\"/var/log2\":{}"));
     MatcherAssert.assertThat(
         dockerInspectExposedPorts,
         CoreMatchers.containsString(


### PR DESCRIPTION
Fixes #3925. Integration tests that assert against the entire `docker inspect` output string are observing failures, likely due to a change in output format / whitespace. This PR updates them to fetch more specific fields and specify json format.

- [x] Verified by running continuous build against branch