### PR TITLE
Fixing the problem of converting numbers to Persian and Arabic (64 to ۶۴)

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/api/DescriptorDigest.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/api/DescriptorDigest.java
@@ -37,7 +37,7 @@ public class DescriptorDigest {
   public static final int HASH_LENGTH = 64;
 
   /** Pattern matches a SHA-256 hash - 32 bytes in lowercase hexadecimal. */
-  private static final String HASH_REGEX = String.format("[a-f0-9]{%d}", HASH_LENGTH);
+  private static final String HASH_REGEX = String.format("[a-f0-9]{%s}", HASH_LENGTH);
 
   /** The algorithm prefix for the digest string. */
   private static final String DIGEST_PREFIX = "sha256:";


### PR DESCRIPTION
When the Windows region settings are set to Persian or Arabic, the `.\mvnw compile jib:build` command encounters an error.
The error message is as follows:

```
[ERROR] : Illegal repetition near index 251
[ERROR] : ^(?:((?:[a-zA-Z\d]|(?:[a-zA-Z\d][a-zA-Z\d-]*[a-zA-Z\d]))(?:\.(?:[a-zA-Z\d]|(?:[a-zA-Z\d][a-zA-Z\d-]*[a-zA-Z\d])))*(?::\d+)?)/)?((?:[a-z\d]+(?:(?:[_.]|__|-+)[a-z\d]+)*/)*[a-z\d]+(?:(?:[_.]|__|-+)[a-z\d]+)*)(?::([\w][\w.-]{0,127}))?(?:@(sha256:[a-f0-9]{۶۴}))?$
```
Error because number 64 convert to Persian or Arabic number character "۶۴"  

My change will fix the problem