### PR TITLE
Prototype having platform-dependent layers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -408,13 +408,13 @@ subprojects {
 
   // ensure no dependencies in the implementation group are project dependencies
   project.ext.ensureNoProjectDependencies = {
-    project.afterEvaluate {
-      project.configurations.implementation.dependencies.each { dependency ->
-        if (dependency instanceof ProjectDependency) {
-          throw new GradleException('disallowed project dependency:' + dependency + ', in project:' + project);
-        }
-      }
-    }
+//    project.afterEvaluate {
+//      project.configurations.implementation.dependencies.each { dependency ->
+//        if (dependency instanceof ProjectDependency) {
+//          throw new GradleException('disallowed project dependency:' + dependency + ', in project:' + project);
+//        }
+//      }
+//    }
   }
 
   /* TEST COVERAGE */

--- a/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/LayerObject.java
+++ b/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/LayerObject.java
@@ -23,6 +23,7 @@ import javax.annotation.concurrent.Immutable;
  *
  * <ul>
  *   <li>{@link Type#FILE_ENTRIES} indicates {@link FileEntriesLayer}.
+ *   <li>{@link Type#PLATFORM_DEPENDENT} indicates a {@link PlatformDependentLayer}.</li>
  * </ul>
  */
 @Immutable
@@ -30,6 +31,7 @@ public interface LayerObject {
 
   public static enum Type {
     FILE_ENTRIES,
+    PLATFORM_DEPENDENT
   }
 
   public Type getType();

--- a/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/PlatformDependentLayer.java
+++ b/jib-build-plan/src/main/java/com/google/cloud/tools/jib/api/buildplan/PlatformDependentLayer.java
@@ -1,0 +1,90 @@
+package com.google.cloud.tools.jib.api.buildplan;
+
+import javax.annotation.concurrent.Immutable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Immutable
+public class PlatformDependentLayer implements LayerObject {
+
+	public static class Builder {
+		private String name = "";
+		private Map<Platform, FileEntriesLayer> entries = new HashMap<>();
+
+		private Builder() {}
+
+		/**
+		 * Sets a name for this layer. This name does not affect the contents of the layer.
+		 *
+		 * @param name the name
+		 * @return this
+		 */
+		public Builder setName(String name) {
+			this.name = name;
+			return this;
+		}
+
+		public Builder setEntries(Map<Platform, FileEntriesLayer> entries) {
+			this.entries = new HashMap<>(entries);
+			return this;
+		}
+
+		public Builder addEntry(Platform platform, FileEntriesLayer layer) {
+			entries.put(platform, layer);
+			return this;
+		}
+
+		public PlatformDependentLayer build() {
+			return new PlatformDependentLayer(
+					name,
+					entries
+			);
+		}
+	}
+
+	/**
+	 * Gets a new {@link FileEntriesLayer.Builder} for {@link FileEntriesLayer}.
+	 *
+	 * @return a new {@link FileEntriesLayer.Builder}
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	private final String name;
+	private final Map<Platform, FileEntriesLayer> entries;
+
+	private PlatformDependentLayer(String name, Map<Platform, FileEntriesLayer> entries) {
+		this.name = name;
+		this.entries = Collections.unmodifiableMap(new HashMap<>(entries));
+	}
+
+	@Override
+	public Type getType() {
+		return Type.PLATFORM_DEPENDENT;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	/**
+	 * Gets the map of entries.
+	 *
+	 * @return the map of entries
+	 */
+	public Map<Platform, FileEntriesLayer> getEntries() {
+		return entries;
+	}
+
+	/**
+	 * Creates a builder configured with the current values.
+	 *
+	 * @return {@link Builder} configured with the current values
+	 */
+	public Builder toBuilder() {
+		return builder().setName(name).setEntries(entries);
+	}
+}

--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -13,7 +13,7 @@ java {
 }
 
 dependencies {
-  api dependencyStrings.BUILD_PLAN
+  api project(':jib-build-plan')
   implementation dependencyStrings.GOOGLE_HTTP_CLIENT
   implementation dependencyStrings.GOOGLE_HTTP_CLIENT_APACHE_V2
   implementation dependencyStrings.GOOGLE_AUTH_LIBRARY_OAUTH2_HTTP

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStep.java
@@ -19,6 +19,9 @@ package com.google.cloud.tools.jib.builder.steps;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.FileEntry;
+import com.google.cloud.tools.jib.api.buildplan.LayerObject;
+import com.google.cloud.tools.jib.api.buildplan.Platform;
+import com.google.cloud.tools.jib.api.buildplan.PlatformDependentLayer;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
 import com.google.cloud.tools.jib.builder.TimerEventDispatcher;
@@ -33,6 +36,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.stream.Stream;
 
 /** Builds and caches application layers. */
 class BuildAndCacheApplicationLayerStep implements Callable<PreparedLayer> {
@@ -46,24 +50,54 @@ class BuildAndCacheApplicationLayerStep implements Callable<PreparedLayer> {
    */
   static ImmutableList<BuildAndCacheApplicationLayerStep> makeList(
       BuildContext buildContext, ProgressEventDispatcher.Factory progressEventDispatcherFactory) {
-    List<FileEntriesLayer> layerConfigurations = buildContext.getLayerConfigurations();
+    List<? extends LayerObject> layerConfigurations = buildContext.getLayerConfigurations();
+    int fileLayerCount = 0;
+    for (LayerObject layerConfiguration : layerConfigurations) {
+      if (layerConfiguration instanceof FileEntriesLayer) {
+        fileLayerCount++;
+      } else if (layerConfiguration instanceof PlatformDependentLayer) {
+        fileLayerCount += ((PlatformDependentLayer) layerConfiguration).getEntries().size();
+      }
+    }
 
     try (ProgressEventDispatcher progressEventDispatcher =
             progressEventDispatcherFactory.create(
-                "launching application layer builders", layerConfigurations.size());
+                "launching application layer builders", fileLayerCount);
         TimerEventDispatcher ignored =
             new TimerEventDispatcher(
                 buildContext.getEventHandlers(), "Preparing application layer builders")) {
       return layerConfigurations.stream()
           // Skips the layer if empty.
-          .filter(layerConfiguration -> !layerConfiguration.getEntries().isEmpty())
-          .map(
-              layerConfiguration ->
-                  new BuildAndCacheApplicationLayerStep(
-                      buildContext,
-                      progressEventDispatcher.newChildProducer(),
-                      layerConfiguration.getName(),
-                      layerConfiguration))
+          .filter(layerConfiguration -> {
+            if (layerConfiguration instanceof FileEntriesLayer) {
+              return !((FileEntriesLayer) layerConfiguration).getEntries().isEmpty();
+            } else if (layerConfiguration instanceof PlatformDependentLayer) {
+              return !((PlatformDependentLayer) layerConfiguration).getEntries().isEmpty();
+            }
+            return true;
+          })
+          .flatMap(layerConfiguration -> {
+            if (layerConfiguration instanceof FileEntriesLayer) {
+              return Stream.of(new BuildAndCacheApplicationLayerStep(
+                  buildContext,
+                  progressEventDispatcher.newChildProducer(),
+                  layerConfiguration.getName(),
+                  (FileEntriesLayer) layerConfiguration,
+                  new Platform("amd64", "linux")));
+            } else if (layerConfiguration instanceof PlatformDependentLayer) {
+              return ((PlatformDependentLayer) layerConfiguration).getEntries().entrySet().stream().map(entry -> {
+                FileEntriesLayer fileLayer = entry.getValue();
+                return new BuildAndCacheApplicationLayerStep(
+                    buildContext,
+                    progressEventDispatcher.newChildProducer(),
+                    fileLayer.getName(),
+                    fileLayer,
+                    entry.getKey());
+              });
+            } else {
+              throw new UnsupportedOperationException("Unsupported LayerObject type " + layerConfiguration.getType());
+            }
+          })
           .collect(ImmutableList.toImmutableList());
     }
   }
@@ -73,16 +107,19 @@ class BuildAndCacheApplicationLayerStep implements Callable<PreparedLayer> {
 
   private final String layerName;
   private final FileEntriesLayer layerConfiguration;
+  private final Platform layerPlatform;
 
   private BuildAndCacheApplicationLayerStep(
       BuildContext buildContext,
       ProgressEventDispatcher.Factory progressEventDispatcherFactory,
       String layerName,
-      FileEntriesLayer layerConfiguration) {
+      FileEntriesLayer layerConfiguration,
+      Platform layerPlatform) {
     this.buildContext = buildContext;
     this.progressEventDispatcherFactory = progressEventDispatcherFactory;
     this.layerName = layerName;
     this.layerConfiguration = layerConfiguration;
+    this.layerPlatform = layerPlatform;
   }
 
   @Override
@@ -101,7 +138,7 @@ class BuildAndCacheApplicationLayerStep implements Callable<PreparedLayer> {
       // Don't build the layer if it exists already.
       Optional<CachedLayer> optionalCachedLayer = cache.retrieve(layerEntries);
       if (optionalCachedLayer.isPresent()) {
-        return new PreparedLayer.Builder(optionalCachedLayer.get()).setName(layerName).build();
+        return new PreparedLayer.Builder(optionalCachedLayer.get()).setName(layerName).setPlatform(layerPlatform).build();
       }
 
       Blob layerBlob = new ReproducibleLayerBuilder(layerEntries).build();
@@ -109,7 +146,7 @@ class BuildAndCacheApplicationLayerStep implements Callable<PreparedLayer> {
 
       eventHandlers.dispatch(LogEvent.debug(description + " built " + cachedLayer.getDigest()));
 
-      return new PreparedLayer.Builder(cachedLayer).setName(layerName).build();
+      return new PreparedLayer.Builder(cachedLayer).setName(layerName).setPlatform(layerPlatform).build();
     }
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
@@ -121,6 +121,8 @@ class BuildImageStep implements Callable<Image> {
 
       // Add built layers/configuration
       for (PreparedLayer applicationLayer : applicationLayers) {
+        if (!applicationLayer.appliesTo(baseImage)) continue;
+
         imageBuilder
             .addLayer(applicationLayer)
             .addHistory(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PreparedLayer.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PreparedLayer.java
@@ -17,9 +17,13 @@
 package com.google.cloud.tools.jib.builder.steps;
 
 import com.google.cloud.tools.jib.api.DescriptorDigest;
+import com.google.cloud.tools.jib.api.buildplan.Platform;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
+import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.Layer;
+
+import javax.annotation.Nullable;
 
 /**
  * Layer prepared from {@link BuildAndCacheApplicationLayerStep} and {@link
@@ -39,6 +43,7 @@ class PreparedLayer implements Layer {
     private Layer layer;
     private String name = "unnamed layer";
     private StateInTarget stateInTarget = StateInTarget.UNKNOWN;
+    @Nullable private Platform platform;
 
     Builder(Layer layer) {
       this.layer = layer;
@@ -55,19 +60,27 @@ class PreparedLayer implements Layer {
       return this;
     }
 
+    /** Sets the platform this layer is associated with. */
+    Builder setPlatform(@Nullable Platform platform) {
+      this.platform = platform;
+      return this;
+    }
+
     PreparedLayer build() {
-      return new PreparedLayer(layer, name, stateInTarget);
+      return new PreparedLayer(layer, name, stateInTarget, platform);
     }
   }
 
   private final Layer layer;
   private final String name;
   private final StateInTarget stateInTarget;
+  @Nullable private final Platform platform;
 
-  private PreparedLayer(Layer layer, String name, StateInTarget stateInTarget) {
+  private PreparedLayer(Layer layer, String name, StateInTarget stateInTarget, @Nullable Platform platform) {
     this.layer = layer;
     this.name = name;
     this.stateInTarget = stateInTarget;
+    this.platform = platform;
   }
 
   String getName() {
@@ -91,5 +104,15 @@ class PreparedLayer implements Layer {
   @Override
   public DescriptorDigest getDiffId() {
     return layer.getDiffId();
+  }
+
+  @Nullable
+  public Platform getPlatform() {
+    return platform;
+  }
+
+  public boolean appliesTo(Image baseImage) {
+    return platform == null ||
+        (baseImage.getArchitecture().equals(platform.getArchitecture()) && baseImage.getOs().equals(platform.getOs()));
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/configuration/BuildContext.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
+import com.google.cloud.tools.jib.api.buildplan.LayerObject;
 import com.google.cloud.tools.jib.cache.Cache;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.global.JibSystemProperties;
@@ -75,7 +76,7 @@ public class BuildContext implements Closeable {
     @Nullable private Path baseImageLayersCacheDirectory;
     private boolean allowInsecureRegistries = false;
     private boolean offline = false;
-    private ImmutableList<FileEntriesLayer> layerConfigurations = ImmutableList.of();
+    private ImmutableList<LayerObject> layerConfigurations = ImmutableList.of();
     private Class<? extends BuildableManifestTemplate> targetFormat = DEFAULT_TARGET_FORMAT;
     private String toolName = DEFAULT_TOOL_NAME;
     @Nullable private String toolVersion;
@@ -223,7 +224,7 @@ public class BuildContext implements Closeable {
      * @param layerConfigurations the configurations for the layers
      * @return this
      */
-    public Builder setLayerConfigurations(List<FileEntriesLayer> layerConfigurations) {
+    public Builder setLayerConfigurations(List<? extends LayerObject> layerConfigurations) {
       this.layerConfigurations = ImmutableList.copyOf(layerConfigurations);
       return this;
     }
@@ -392,7 +393,7 @@ public class BuildContext implements Closeable {
   private final Cache applicationLayersCache;
   private Class<? extends BuildableManifestTemplate> targetFormat;
   private final boolean offline;
-  private final ImmutableList<FileEntriesLayer> layerConfigurations;
+  private final ImmutableList<LayerObject> layerConfigurations;
   private final String toolName;
   @Nullable private final String toolVersion;
   private final EventHandlers eventHandlers;
@@ -413,7 +414,7 @@ public class BuildContext implements Closeable {
       Cache applicationLayersCache,
       Class<? extends BuildableManifestTemplate> targetFormat,
       boolean offline,
-      ImmutableList<FileEntriesLayer> layerConfigurations,
+      ImmutableList<LayerObject> layerConfigurations,
       String toolName,
       @Nullable String toolVersion,
       EventHandlers eventHandlers,
@@ -534,7 +535,7 @@ public class BuildContext implements Closeable {
    *
    * @return the list of layer configurations
    */
-  public ImmutableList<FileEntriesLayer> getLayerConfigurations() {
+  public ImmutableList<LayerObject> getLayerConfigurations() {
     return layerConfigurations;
   }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JavaContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JavaContainerBuilderTest.java
@@ -17,6 +17,7 @@
 package com.google.cloud.tools.jib.api;
 
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.FileEntry;
 import com.google.cloud.tools.jib.api.buildplan.RelativeUnixPath;
 import com.google.cloud.tools.jib.configuration.BuildContext;
@@ -47,7 +48,7 @@ public class JavaContainerBuilderTest {
         .findFirst()
         .map(
             layerConfiguration ->
-                layerConfiguration.getEntries().stream()
+                ((FileEntriesLayer) layerConfiguration).getEntries().stream()
                     .map(FileEntry::getExtractionPath)
                     .collect(Collectors.toList()))
         .orElse(ImmutableList.of());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/api/JibContainerBuilderTest.java
@@ -333,7 +333,7 @@ public class JibContainerBuilderTest {
         "some/base", buildContext.getBaseImageConfiguration().getImage().toString());
     Assert.assertEquals(OciManifestTemplate.class, buildContext.getTargetFormat());
     Assert.assertEquals(1, buildContext.getLayerConfigurations().size());
-    Assert.assertEquals(1, buildContext.getLayerConfigurations().get(0).getEntries().size());
+    Assert.assertEquals(1, ((FileEntriesLayer) buildContext.getLayerConfigurations().get(0)).getEntries().size());
     Assert.assertEquals(
         Arrays.asList(
             new FileEntry(
@@ -341,7 +341,7 @@ public class JibContainerBuilderTest {
                 AbsoluteUnixPath.get("/path/in/container"),
                 FilePermissions.fromOctalString("644"),
                 Instant.ofEpochSecond(1))),
-        buildContext.getLayerConfigurations().get(0).getEntries());
+        ((FileEntriesLayer) buildContext.getLayerConfigurations().get(0)).getEntries());
 
     ContainerConfiguration containerConfiguration = buildContext.getContainerConfiguration();
     Assert.assertEquals(Instant.ofEpochMilli(30), containerConfiguration.getCreationTime());

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStepTest.java
@@ -20,6 +20,7 @@ import com.google.cloud.tools.jib.api.CacheDirectoryCreationException;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.FileEntry;
+import com.google.cloud.tools.jib.api.buildplan.LayerObject;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.blob.Blobs;
 import com.google.cloud.tools.jib.builder.ProgressEventDispatcher;
@@ -152,7 +153,8 @@ public class BuildAndCacheApplicationLayerStepTest {
             fakeResourcesLayerConfiguration,
             fakeClassesLayerConfiguration,
             fakeExtraFilesLayerConfiguration);
-    Mockito.when(mockBuildContext.getLayerConfigurations()).thenReturn(fakeLayerConfigurations);
+    ImmutableList<? extends LayerObject> layers = fakeLayerConfigurations;
+    Mockito.when(mockBuildContext.getLayerConfigurations()).thenReturn((ImmutableList<LayerObject>) layers);
 
     // Populates the cache.
     List<Layer> applicationLayers = buildFakeLayersToCache();
@@ -212,7 +214,8 @@ public class BuildAndCacheApplicationLayerStepTest {
             fakeResourcesLayerConfiguration,
             fakeClassesLayerConfiguration,
             emptyLayerConfiguration);
-    Mockito.when(mockBuildContext.getLayerConfigurations()).thenReturn(fakeLayerConfigurations);
+    ImmutableList<? extends LayerObject> layers = fakeLayerConfigurations;
+    Mockito.when(mockBuildContext.getLayerConfigurations()).thenReturn((ImmutableList<LayerObject>) layers);
 
     // Populates the cache.
     List<Layer> applicationLayers = buildFakeLayersToCache();

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildContextTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/configuration/BuildContextTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
+import com.google.cloud.tools.jib.api.buildplan.LayerObject;
 import com.google.cloud.tools.jib.api.buildplan.Port;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.global.JibSystemProperties;
@@ -90,7 +91,7 @@ public class BuildContextTest {
     Class<? extends BuildableManifestTemplate> expectedTargetFormat = OciManifestTemplate.class;
     Path expectedApplicationLayersCacheDirectory = Paths.get("application/layers");
     Path expectedBaseImageLayersCacheDirectory = Paths.get("base/image/layers");
-    List<FileEntriesLayer> expectedLayerConfigurations =
+    List<LayerObject> expectedLayerConfigurations =
         Collections.singletonList(
             FileEntriesLayer.builder()
                 .addEntry(Paths.get("sourceFile"), AbsoluteUnixPath.get("/path/in/container"))

--- a/jib-gradle-plugin-extension-api/build.gradle
+++ b/jib-gradle-plugin-extension-api/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  api dependencyStrings.BUILD_PLAN
+  api project(':jib-build-plan')
   api dependencyStrings.EXTENSION_COMMON
   api gradleApi()
 }

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -41,8 +41,11 @@ import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.Future;
 import javax.annotation.Nullable;
+import javax.inject.Inject;
+
 import org.gradle.api.DefaultTask;
 import org.gradle.api.GradleException;
+import org.gradle.api.Project;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
@@ -53,6 +56,13 @@ public class BuildImageTask extends DefaultTask implements JibTask {
   private static final String HELPFUL_SUGGESTIONS_PREFIX = "Build image failed";
 
   @Nullable private JibExtension jibExtension;
+
+  private final Project project;
+
+  @Inject
+  public BuildImageTask(Project project) {
+    this.project = project;
+  }
 
   /**
    * This will call the property {@code "jib"} so that it is the same name as the extension. This
@@ -96,7 +106,7 @@ public class BuildImageTask extends DefaultTask implements JibTask {
 
     GradleProjectProperties projectProperties =
         GradleProjectProperties.getForProject(
-            getProject(),
+            project,
             getLogger(),
             tempDirectoryProvider,
             jibExtension.getConfigurationName().get());

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -33,6 +33,7 @@ import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.FileEntry;
 import com.google.cloud.tools.jib.api.buildplan.FilePermissions;
+import com.google.cloud.tools.jib.api.buildplan.LayerObject;
 import com.google.cloud.tools.jib.configuration.BuildContext;
 import com.google.cloud.tools.jib.filesystem.DirectoryWalker;
 import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
@@ -105,15 +106,17 @@ public class GradleProjectPropertiesTest {
     private final FileEntriesLayer snapshotsLayer;
 
     private ContainerBuilderLayers(BuildContext buildContext) {
-      resourcesLayer = getLayerByName(buildContext, LayerType.RESOURCES.getName());
-      classesLayer = getLayerByName(buildContext, LayerType.CLASSES.getName());
-      dependenciesLayer = getLayerByName(buildContext, LayerType.DEPENDENCIES.getName());
-      snapshotsLayer = getLayerByName(buildContext, LayerType.SNAPSHOT_DEPENDENCIES.getName());
+      resourcesLayer = getFileEntriesLayerByName(buildContext, LayerType.RESOURCES.getName());
+      classesLayer = getFileEntriesLayerByName(buildContext, LayerType.CLASSES.getName());
+      dependenciesLayer = getFileEntriesLayerByName(buildContext, LayerType.DEPENDENCIES.getName());
+      snapshotsLayer = getFileEntriesLayerByName(buildContext, LayerType.SNAPSHOT_DEPENDENCIES.getName());
     }
 
-    private static FileEntriesLayer getLayerByName(BuildContext buildContext, String name) {
-      List<FileEntriesLayer> layers = buildContext.getLayerConfigurations();
-      return layers.stream().filter(layer -> layer.getName().equals(name)).findFirst().get();
+    private static FileEntriesLayer getFileEntriesLayerByName(BuildContext buildContext, String name) {
+      List<LayerObject> layers = buildContext.getLayerConfigurations();
+      return ((FileEntriesLayer) layers.stream()
+          .filter(layer -> layer.getName().equals(name) && layer instanceof FileEntriesLayer)
+          .findFirst().get());
     }
   }
 

--- a/jib-maven-plugin-extension-api/build.gradle
+++ b/jib-maven-plugin-extension-api/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 dependencies {
-  api dependencyStrings.BUILD_PLAN
+  api project(':jib-build-plan')
   api dependencyStrings.EXTENSION_COMMON
   api dependencyStrings.MAVEN_CORE
 }

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -35,6 +35,7 @@ import com.google.cloud.tools.jib.api.RegistryImage;
 import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.FileEntry;
+import com.google.cloud.tools.jib.api.buildplan.LayerObject;
 import com.google.cloud.tools.jib.configuration.BuildContext;
 import com.google.cloud.tools.jib.filesystem.DirectoryWalker;
 import com.google.cloud.tools.jib.filesystem.TempDirectoryProvider;
@@ -108,17 +109,19 @@ public class MavenProjectPropertiesTest {
     @Nullable private final FileEntriesLayer extraFilesLayer;
 
     private ContainerBuilderLayers(BuildContext buildContext) {
-      resourcesLayer = getLayerByName(buildContext, LayerType.RESOURCES.getName());
-      classesLayer = getLayerByName(buildContext, LayerType.CLASSES.getName());
-      dependenciesLayer = getLayerByName(buildContext, LayerType.DEPENDENCIES.getName());
-      snapshotsLayer = getLayerByName(buildContext, LayerType.SNAPSHOT_DEPENDENCIES.getName());
-      extraFilesLayer = getLayerByName(buildContext, LayerType.EXTRA_FILES.getName());
+      resourcesLayer = getFileEntriesLayerByName(buildContext, LayerType.RESOURCES.getName());
+      classesLayer = getFileEntriesLayerByName(buildContext, LayerType.CLASSES.getName());
+      dependenciesLayer = getFileEntriesLayerByName(buildContext, LayerType.DEPENDENCIES.getName());
+      snapshotsLayer = getFileEntriesLayerByName(buildContext, LayerType.SNAPSHOT_DEPENDENCIES.getName());
+      extraFilesLayer = getFileEntriesLayerByName(buildContext, LayerType.EXTRA_FILES.getName());
     }
 
     @Nullable
-    private static FileEntriesLayer getLayerByName(BuildContext buildContext, String name) {
-      List<FileEntriesLayer> layers = buildContext.getLayerConfigurations();
-      return layers.stream().filter(layer -> layer.getName().equals(name)).findFirst().orElse(null);
+    private static FileEntriesLayer getFileEntriesLayerByName(BuildContext buildContext, String name) {
+      List<LayerObject> layers = buildContext.getLayerConfigurations();
+      return ((FileEntriesLayer) layers.stream()
+          .filter(layer -> layer.getName().equals(name) && layer instanceof FileEntriesLayer)
+          .findFirst().orElse(null));
     }
   }
 

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelperTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JavaContainerBuilderHelperTest.java
@@ -61,12 +61,12 @@ public class JavaContainerBuilderHelperTest {
       Correspondence.transforming(
           entry -> entry.getExtractionPath().toString(), "has extractionPath of");
 
-  private static FileEntriesLayer getLayerConfigurationByName(
+  private static FileEntriesLayer getFileEntriesLayerByName(
       BuildContext buildContext, String name) {
-    return buildContext.getLayerConfigurations().stream()
-        .filter(layer -> layer.getName().equals(name))
+    return ((FileEntriesLayer) buildContext.getLayerConfigurations().stream()
+        .filter(layer -> layer.getName().equals(name) && layer instanceof FileEntriesLayer)
         .findFirst()
-        .get();
+        .get());
   }
 
   @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -270,15 +270,15 @@ public class JavaContainerBuilderHelperTest {
                 .setExecutorService(MoreExecutors.newDirectExecutorService()));
 
     FileEntriesLayer resourcesLayerConfigurations =
-        getLayerConfigurationByName(buildContext, LayerType.RESOURCES.getName());
+        getFileEntriesLayerByName(buildContext, LayerType.RESOURCES.getName());
     FileEntriesLayer classesLayerConfigurations =
-        getLayerConfigurationByName(buildContext, LayerType.CLASSES.getName());
+        getFileEntriesLayerByName(buildContext, LayerType.CLASSES.getName());
     FileEntriesLayer dependenciesLayerConfigurations =
-        getLayerConfigurationByName(buildContext, LayerType.DEPENDENCIES.getName());
+        getFileEntriesLayerByName(buildContext, LayerType.DEPENDENCIES.getName());
     FileEntriesLayer snapshotsLayerConfigurations =
-        getLayerConfigurationByName(buildContext, LayerType.SNAPSHOT_DEPENDENCIES.getName());
+        getFileEntriesLayerByName(buildContext, LayerType.SNAPSHOT_DEPENDENCIES.getName());
     FileEntriesLayer projectDependenciesLayerConfigurations =
-        getLayerConfigurationByName(buildContext, LayerType.PROJECT_DEPENDENCIES.getName());
+        getFileEntriesLayerByName(buildContext, LayerType.PROJECT_DEPENDENCIES.getName());
 
     assertThat(projectDependenciesLayerConfigurations.getEntries())
         .comparingElementsUsing(SOURCE_FILE_OF)

--- a/proposals/container-build-plan-spec.md
+++ b/proposals/container-build-plan-spec.md
@@ -39,7 +39,30 @@ Although looking similar, the structure and semantics of similarly named propert
 
   "layers": [
     {
-      "type": "fileEntries"
+      "type": "platformDependent",
+      "entries": {
+        "amd64_linux": {
+          "type": "fileEntries",
+          "entries": [
+            "src": "/home/jane/workspace/build/jre/x64_linux/bin/java",
+            "dest": "/usr/bin/java",
+            "modificationTime": "2019-07-15T10:15:30+09:00",
+            "permissions": "600"
+          ]
+        },
+        "s390x_linux": {
+          "type": "fileEntries",
+          "entries": [
+            "src": "/home/jane/workspace/build/jre/s390x_linux/bin/java",
+            "dest": "/usr/bin/java",
+            "modificationTime": "2019-07-15T10:15:30+09:00",
+            "permissions": "600"
+          ]
+        }
+      }
+    },
+    {
+      "type": "fileEntries",
       "entries": [
         {
           "src": "/home/jane/workspace/bin/Main.class",
@@ -56,12 +79,12 @@ Although looking similar, the structure and semantics of similarly named propert
       ]
     },
     {
-      "type": "layerArchive"
+      "type": "layerArchive",
       "mediaType": "...",
       "path": "/home/jane/misc/cacerts.tar",
     },
     {
-      "type": "fileEntries"
+      "type": "fileEntries",
       "entries": [
         {
           "src": "/home/workspace/scripts/run.sh",


### PR DESCRIPTION
Despite building Java containers, it's not uncommon for platform-specific dependencies to be needed. Common examples include custom JREs produced via jlink and native libraries used via JNI. The image for each platform will typically still have the same layers, but the contents of one of the layers will differ.

To model this, a new "platform layer" is introduced. It associates various platforms with the file entries to be used for that platform. Importantly, the layer still shows as a single layer in the overall build plan, since each image must contain 1 such layer. To achieve this, a new LayerObject, the PlatformDependentLayer, is added to the API. The jib-core project is updated to understand this new LayerObject and select the platform-dependent entry based on the platform of the base image.

Relates to #2755. **This is a prototype. Do not review for merge.**
