### PR TITLE
Core: Include Guava as an API dependency

### DIFF
--- a/jib-core/build.gradle
+++ b/jib-core/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
   implementation dependencyStrings.COMMONS_COMPRESS
   zstdSupportImplementation  dependencyStrings.ZSTD_JNI
-  implementation dependencyStrings.GUAVA
+  api dependencyStrings.GUAVA
   implementation(platform(dependencyStrings.JACKSON_BOM))
   implementation dependencyStrings.JACKSON_DATABIND
   implementation dependencyStrings.JACKSON_DATATYPE_JSR310


### PR DESCRIPTION
There are classes in Core that expose Guava types as part of their public API. For example, Cache. In that case, Guava should be included as an API dependency, not just an implementation.
