### PR TITLE
ci: update integration tests that expect docker manifest format from distroless image

### DIFF
--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
@@ -20,7 +20,7 @@ import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.http.FailoverHttpClient;
-import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
+import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import java.io.IOException;
 import java.security.DigestException;
 import org.junit.Assert;
@@ -36,8 +36,8 @@ public class BlobCheckerIntegrationTest {
     RegistryClient registryClient =
         RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
-    V22ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
+    BuildableManifestTemplate manifestTemplate =
+        registryClient.pullManifest("latest", BuildableManifestTemplate.class).getManifest();
     DescriptorDigest blobDigest = manifestTemplate.getLayers().get(0).getDigest();
 
     Assert.assertEquals(blobDigest, registryClient.checkBlob(blobDigest).get().getDigest());

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
@@ -20,7 +20,7 @@ import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.http.FailoverHttpClient;
-import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
+import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import java.io.IOException;
 import java.security.DigestException;
 import org.junit.Assert;
@@ -36,8 +36,8 @@ public class BlobCheckerIntegrationTest {
     RegistryClient registryClient =
         RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
-    BuildableManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", BuildableManifestTemplate.class).getManifest();
+    V22ManifestTemplate manifestTemplate =
+        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
     DescriptorDigest blobDigest = manifestTemplate.getLayers().get(0).getDigest();
 
     Assert.assertEquals(blobDigest, registryClient.checkBlob(blobDigest).get().getDigest());

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobCheckerIntegrationTest.java
@@ -37,7 +37,10 @@ public class BlobCheckerIntegrationTest {
         RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
     V22ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
+        registryClient
+            .pullManifest(
+                ManifestPullerIntegrationTest.KNOWN_MANIFEST_V22_SHA, V22ManifestTemplate.class)
+            .getManifest();
     DescriptorDigest blobDigest = manifestTemplate.getLayers().get(0).getDigest();
 
     Assert.assertEquals(blobDigest, registryClient.checkBlob(blobDigest).get().getDigest());

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
@@ -42,7 +42,10 @@ public class BlobPullerIntegrationTest {
         RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
     V22ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
+        registryClient
+            .pullManifest(
+                ManifestPullerIntegrationTest.KNOWN_MANIFEST_V22_SHA, V22ManifestTemplate.class)
+            .getManifest();
 
     DescriptorDigest realDigest = manifestTemplate.getLayers().get(0).getDigest();
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
@@ -21,7 +21,7 @@ import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.http.FailoverHttpClient;
-import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
+import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import com.google.common.io.ByteStreams;
 import java.io.IOException;
 import java.security.DigestException;
@@ -41,8 +41,8 @@ public class BlobPullerIntegrationTest {
     RegistryClient registryClient =
         RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
-    BuildableManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", BuildableManifestTemplate.class).getManifest();
+    V22ManifestTemplate manifestTemplate =
+        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
 
     DescriptorDigest realDigest = manifestTemplate.getLayers().get(0).getDigest();
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/BlobPullerIntegrationTest.java
@@ -21,7 +21,7 @@ import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.blob.Blob;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.http.FailoverHttpClient;
-import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
+import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.common.io.ByteStreams;
 import java.io.IOException;
 import java.security.DigestException;
@@ -41,8 +41,8 @@ public class BlobPullerIntegrationTest {
     RegistryClient registryClient =
         RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
-    V22ManifestTemplate manifestTemplate =
-        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
+    BuildableManifestTemplate manifestTemplate =
+        registryClient.pullManifest("latest", BuildableManifestTemplate.class).getManifest();
 
     DescriptorDigest realDigest = manifestTemplate.getLayers().get(0).getDigest();
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestCheckerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestCheckerIntegrationTest.java
@@ -30,7 +30,7 @@ import org.junit.Test;
 /** Integration tests for {@link ManifestChecker}. */
 public class ManifestCheckerIntegrationTest {
 
-  /** A known manifest list sha for openjdk:11-jre-slim. */
+  /** A known manifest list sha for gcr.io/distroless/base. */
   private static final String KNOWN_MANIFEST =
       "sha256:44cbdb9c24e123882d7894ba78fb6f572d2496889885a47eb4b32241a8c07a00";
 

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.jib.registry;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.http.FailoverHttpClient;
@@ -26,8 +28,6 @@ import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestListTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
 import java.io.IOException;
-import org.hamcrest.CoreMatchers;
-import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -72,8 +72,8 @@ public class ManifestPullerIntegrationTest {
     V21ManifestTemplate manifestTemplate =
         registryClient.pullManifest("latest", V21ManifestTemplate.class).getManifest();
 
-    Assert.assertEquals(1, manifestTemplate.getSchemaVersion());
-    Assert.assertTrue(manifestTemplate.getFsLayers().size() > 0);
+    assertThat(manifestTemplate.getSchemaVersion()).isEqualTo(1);
+    assertThat(manifestTemplate.getFsLayers()).isNotEmpty();
   }
 
   @Test
@@ -87,8 +87,8 @@ public class ManifestPullerIntegrationTest {
             .pullManifest(KNOWN_MANIFEST_V22_SHA, V22ManifestTemplate.class)
             .getManifest();
 
-    Assert.assertEquals(2, manifestTemplate.getSchemaVersion());
-    Assert.assertTrue(manifestTemplate.getLayers().size() > 0);
+    assertThat(manifestTemplate.getSchemaVersion()).isEqualTo(2);
+    assertThat(manifestTemplate.getLayers()).isNotEmpty();
   }
 
   @Test
@@ -102,8 +102,8 @@ public class ManifestPullerIntegrationTest {
             .pullManifest(KNOWN_OCI_MANIFEST_SHA, OciManifestTemplate.class)
             .getManifest();
 
-    Assert.assertEquals(2, manifestTemplate.getSchemaVersion());
-    Assert.assertTrue(manifestTemplate.getLayers().size() > 0);
+    assertThat(manifestTemplate.getSchemaVersion()).isEqualTo(2);
+    assertThat(manifestTemplate.getLayers()).isNotEmpty();
   }
 
   @Test
@@ -112,21 +112,20 @@ public class ManifestPullerIntegrationTest {
         RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
 
-    // Ensures call to image at KNOWN_MANIFEST_LIST_SHA returns a manifest list
+    // Ensures call to image at the specified SHA returns a manifest list
     V22ManifestListTemplate manifestListTargeted =
         registryClient
             .pullManifest(KNOWN_MANIFEST_LIST_SHA, V22ManifestListTemplate.class)
             .getManifest();
-    Assert.assertEquals(2, manifestListTargeted.getSchemaVersion());
-    Assert.assertTrue(manifestListTargeted.getManifests().size() > 0);
+    assertThat(manifestListTargeted.getSchemaVersion()).isEqualTo(2);
+    assertThat(manifestListTargeted.getManifests()).isNotEmpty();
 
-    // Generic call to image at KNOWN_MANIFEST_LIST_SHA, should also return a manifest list
+    // Generic call to image at the specified SHA, should also return a manifest list
     ManifestTemplate manifestListGeneric =
         registryClient.pullManifest(KNOWN_MANIFEST_LIST_SHA).getManifest();
-    Assert.assertEquals(2, manifestListGeneric.getSchemaVersion());
-    MatcherAssert.assertThat(
-        manifestListGeneric, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
-    Assert.assertTrue(((V22ManifestListTemplate) manifestListGeneric).getManifests().size() > 0);
+    assertThat(manifestListGeneric.getSchemaVersion()).isEqualTo(2);
+    assertThat(manifestListGeneric).isInstanceOf(V22ManifestListTemplate.class);
+    assertThat(((V22ManifestListTemplate) manifestListGeneric).getManifests()).isNotEmpty();
   }
 
   @Test
@@ -135,18 +134,18 @@ public class ManifestPullerIntegrationTest {
         RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
 
-    // Ensures call to image at KNOWN_OCI_INDEX_SHA returns an OCI index
+    // Ensures call to image at the specified SHA returns an OCI index
     OciIndexTemplate manifestListTargeted =
         registryClient.pullManifest(KNOWN_OCI_INDEX_SHA, OciIndexTemplate.class).getManifest();
-    Assert.assertEquals(2, manifestListTargeted.getSchemaVersion());
-    Assert.assertTrue((manifestListTargeted.getManifests().size() > 0));
+    assertThat(manifestListTargeted.getSchemaVersion()).isEqualTo(2);
+    assertThat((manifestListTargeted.getManifests().size() > 0)).isTrue();
 
-    // Generic call to image at KNOWN_OCI_INDEX_SHA, should also return an OCI index
+    // Generic call to image at the specified SHA, should also return an OCI index
     ManifestTemplate manifestListGeneric =
         registryClient.pullManifest(KNOWN_OCI_INDEX_SHA).getManifest();
-    Assert.assertEquals(2, manifestListGeneric.getSchemaVersion());
-    MatcherAssert.assertThat(manifestListGeneric, CoreMatchers.instanceOf(OciIndexTemplate.class));
-    Assert.assertTrue(((OciIndexTemplate) manifestListGeneric).getManifests().size() > 0);
+    assertThat(manifestListGeneric.getSchemaVersion()).isEqualTo(2);
+    assertThat(manifestListGeneric).isInstanceOf(OciIndexTemplate.class);
+    assertThat(((OciIndexTemplate) manifestListGeneric).getManifests()).isNotEmpty();
   }
 
   @Test
@@ -159,10 +158,9 @@ public class ManifestPullerIntegrationTest {
       Assert.fail("Trying to pull nonexistent image should have errored");
 
     } catch (RegistryErrorException ex) {
-      MatcherAssert.assertThat(
-          ex.getMessage(),
-          CoreMatchers.containsString(
-              "pull image manifest for " + dockerHost + ":5000/busybox:nonexistent-tag"));
+      assertThat(ex)
+          .hasMessageThat()
+          .contains("pull image manifest for " + dockerHost + ":5000/busybox:nonexistent-tag");
     }
   }
 }

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -84,44 +84,22 @@ public class ManifestPullerIntegrationTest {
         RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
 
-    // Referencing a manifest list by sha256, should return a manifest list
-    ManifestTemplate manifestListSha256 =
-        registryClient.pullManifest(KNOWN_MANIFEST_LIST_SHA).getManifest();
-    Assert.assertEquals(2, manifestListSha256.getSchemaVersion());
-    MatcherAssert.assertThat(
-        manifestListSha256, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
-    Assert.assertTrue(((V22ManifestListTemplate) manifestListSha256).getManifests().size() > 0);
-
-    // Referencing a manifest list targeting a manifest pulls a manifest.
-    V22ManifestTemplate manifestTargeted =
+    // Ensures call to image at KNOWN_MANIFEST_LIST_SHA, returns a manifest list
+    V22ManifestListTemplate manifestListTargeted =
         registryClient
-            .pullManifest(KNOWN_MANIFEST_LIST_SHA, V22ManifestTemplate.class)
+            .pullManifest(KNOWN_MANIFEST_LIST_SHA, V22ManifestListTemplate.class)
             .getManifest();
-    Assert.assertEquals(2, manifestTargeted.getSchemaVersion());
-  }
+    Assert.assertEquals(2, manifestListTargeted.getSchemaVersion());
+    Assert.assertTrue(manifestListTargeted.getManifests().size() > 0);
 
-  //  @Test
-  //  public void testPull_defaultBaseImageManifest() throws IOException, RegistryException {
-  //    RegistryClient registryClient =
-  //        RegistryClient.factory(
-  //                EventHandlers.NONE, "registry-1.docker.io", "library/eclipse-temurin",
-  // httpClient)
-  //            .newRegistryClient();
-  //
-  //    // Ensure "11-jre" is a manifest list
-  //    V22ManifestListTemplate manifestListTargeted =
-  //        registryClient.pullManifest("11-jre", V22ManifestListTemplate.class).getManifest();
-  //    Assert.assertEquals(2, manifestListTargeted.getSchemaVersion());
-  //    Assert.assertTrue(manifestListTargeted.getManifests().size() > 0);
-  //
-  //    // Generic call to "11-jre" pulls a manifest list
-  //    ManifestTemplate manifestListGeneric = registryClient.pullManifest("11-jre").getManifest();
-  //    Assert.assertEquals(2, manifestListGeneric.getSchemaVersion());
-  //    MatcherAssert.assertThat(
-  //        manifestListGeneric, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
-  //    Assert.assertTrue(((V22ManifestListTemplate) manifestListGeneric).getManifests().size() >
-  // 0);
-  //  }
+    // Generic call to image at KNOWN_MANIFEST_LIST_SHA, should return a manifest list
+    ManifestTemplate manifestListGeneric =
+        registryClient.pullManifest(KNOWN_MANIFEST_LIST_SHA).getManifest();
+    Assert.assertEquals(2, manifestListGeneric.getSchemaVersion());
+    MatcherAssert.assertThat(
+        manifestListGeneric, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
+    Assert.assertTrue(((V22ManifestListTemplate) manifestListGeneric).getManifests().size() > 0);
+  }
 
   @Test
   public void testPull_unknownManifest() throws RegistryException, IOException {

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -38,6 +38,10 @@ public class ManifestPullerIntegrationTest {
   public static final String KNOWN_MANIFEST_LIST_SHA =
       "sha256:44cbdb9c24e123882d7894ba78fb6f572d2496889885a47eb4b32241a8c07a00";
 
+  /** A known docker manifest schema 2 sha for gcr.io/distroless/base. */
+  public static final String KNOWN_MANIFEST_V22_SHA =
+      "sha256:da5c568e59f3241b09e5699a525a37b3309ce2c182d8d20802b9eaee55711b19";
+
   @ClassRule public static LocalRegistry localRegistry = new LocalRegistry(5000);
   public final String dockerHost =
       System.getenv("DOCKER_IP") != null ? System.getenv("DOCKER_IP") : "localhost";

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/registry/ManifestPullerIntegrationTest.java
@@ -84,19 +84,6 @@ public class ManifestPullerIntegrationTest {
         RegistryClient.factory(EventHandlers.NONE, "gcr.io", "distroless/base", httpClient)
             .newRegistryClient();
 
-    // Ensure ":latest" is a manifest list
-    V22ManifestListTemplate manifestListTargeted =
-        registryClient.pullManifest("latest", V22ManifestListTemplate.class).getManifest();
-    Assert.assertEquals(2, manifestListTargeted.getSchemaVersion());
-    Assert.assertTrue(manifestListTargeted.getManifests().size() > 0);
-
-    // Generic call to ":latest" pulls a manifest list
-    ManifestTemplate manifestListGeneric = registryClient.pullManifest("latest").getManifest();
-    Assert.assertEquals(2, manifestListGeneric.getSchemaVersion());
-    MatcherAssert.assertThat(
-        manifestListGeneric, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
-    Assert.assertTrue(((V22ManifestListTemplate) manifestListGeneric).getManifests().size() > 0);
-
     // Referencing a manifest list by sha256, should return a manifest list
     ManifestTemplate manifestListSha256 =
         registryClient.pullManifest(KNOWN_MANIFEST_LIST_SHA).getManifest();
@@ -105,11 +92,36 @@ public class ManifestPullerIntegrationTest {
         manifestListSha256, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
     Assert.assertTrue(((V22ManifestListTemplate) manifestListSha256).getManifests().size() > 0);
 
-    // Call to ":latest" targeting a manifest pulls a manifest.
+    // Referencing a manifest list targeting a manifest pulls a manifest.
     V22ManifestTemplate manifestTargeted =
-        registryClient.pullManifest("latest", V22ManifestTemplate.class).getManifest();
+        registryClient
+            .pullManifest(KNOWN_MANIFEST_LIST_SHA, V22ManifestTemplate.class)
+            .getManifest();
     Assert.assertEquals(2, manifestTargeted.getSchemaVersion());
   }
+
+  //  @Test
+  //  public void testPull_defaultBaseImageManifest() throws IOException, RegistryException {
+  //    RegistryClient registryClient =
+  //        RegistryClient.factory(
+  //                EventHandlers.NONE, "registry-1.docker.io", "library/eclipse-temurin",
+  // httpClient)
+  //            .newRegistryClient();
+  //
+  //    // Ensure "11-jre" is a manifest list
+  //    V22ManifestListTemplate manifestListTargeted =
+  //        registryClient.pullManifest("11-jre", V22ManifestListTemplate.class).getManifest();
+  //    Assert.assertEquals(2, manifestListTargeted.getSchemaVersion());
+  //    Assert.assertTrue(manifestListTargeted.getManifests().size() > 0);
+  //
+  //    // Generic call to "11-jre" pulls a manifest list
+  //    ManifestTemplate manifestListGeneric = registryClient.pullManifest("11-jre").getManifest();
+  //    Assert.assertEquals(2, manifestListGeneric.getSchemaVersion());
+  //    MatcherAssert.assertThat(
+  //        manifestListGeneric, CoreMatchers.instanceOf(V22ManifestListTemplate.class));
+  //    Assert.assertTrue(((V22ManifestListTemplate) manifestListGeneric).getManifests().size() >
+  // 0);
+  //  }
 
   @Test
   public void testPull_unknownManifest() throws RegistryException, IOException {


### PR DESCRIPTION
Fixes #3963 to unblock CI (See issue for more error details and discussion).

Changes in this PR to address manifest format change in latest distroless image:
- Updates `BlobCheckerIntegrationTest` and `BlobPullerIntegrationTest` by using a fixed older version of the distroless image
- Removes use of “latest” tag in `ManifestPullerIntegrationTest`, and extends it to specifically cover OCI format using pinned image versions

