### PR TITLE
Fix V22ManifestListTemplate cast when pulling an oci index manifest

### DIFF
--- a/jib-core/examples/build.gradle/README.md
+++ b/jib-core/examples/build.gradle/README.md
@@ -10,10 +10,11 @@ For example, the following snippet is a simple example that creates a Gradle tas
 // Imports Jib Core as a library to use in this build script.
 buildscript {
   repositories {
+    mavenLocal()
     mavenCentral()
   }
   dependencies {
-    classpath 'com.google.cloud.tools:jib-core:0.20.0'
+    classpath 'com.google.cloud.tools:jib-core:0.23.0'
   }
 }
 
@@ -41,7 +42,9 @@ task('dojib') {
                     // Tells Jib to get registry credentials from a Docker config.
                     .addCredentialRetriever(
                         CredentialRetrieverFactory
-                            .forImage(ImageReference.parse(targetImage))
+                            .forImage(
+                                    ImageReference.parse(targetImage),
+                                    logEvent -> logger.log(LogLevel.valueOf(logEvent.getLevel().name()), logEvent.getMessage()))
                             .dockerConfig())))
     println 'done'
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -47,7 +47,6 @@ import com.google.cloud.tools.jib.image.json.PlatformNotFoundInBaseImageExceptio
 import com.google.cloud.tools.jib.image.json.UnknownManifestFormatException;
 import com.google.cloud.tools.jib.image.json.UnlistedPlatformInManifestListException;
 import com.google.cloud.tools.jib.image.json.V21ManifestTemplate;
-import com.google.cloud.tools.jib.image.json.V22ManifestListTemplate;
 import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.cloud.tools.jib.registry.ManifestAndDigest;
 import com.google.cloud.tools.jib.registry.RegistryClient;
@@ -468,7 +467,7 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
     ImmutableList.Builder<Image> images = ImmutableList.builder();
     for (Platform platform : buildContext.getContainerConfiguration().getPlatforms()) {
       String manifestDigest =
-          lookUpPlatformSpecificImageManifest((V22ManifestListTemplate) manifestList, platform);
+          lookUpPlatformSpecificImageManifest((ManifestListTemplate) manifestList, platform);
 
       Optional<ManifestAndConfigTemplate> manifestAndConfigFound =
           manifestsAndConfigs.stream()

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
@@ -38,9 +38,11 @@ import com.google.cloud.tools.jib.image.Image;
 import com.google.cloud.tools.jib.image.LayerCountMismatchException;
 import com.google.cloud.tools.jib.image.LayerPropertyNotFoundException;
 import com.google.cloud.tools.jib.image.json.BadContainerConfigurationFormatException;
+import com.google.cloud.tools.jib.image.json.BuildableManifestTemplate;
 import com.google.cloud.tools.jib.image.json.ContainerConfigurationTemplate;
 import com.google.cloud.tools.jib.image.json.ImageMetadataTemplate;
 import com.google.cloud.tools.jib.image.json.ManifestAndConfigTemplate;
+import com.google.cloud.tools.jib.image.json.ManifestListTemplate;
 import com.google.cloud.tools.jib.image.json.ManifestTemplate;
 import com.google.cloud.tools.jib.image.json.OciIndexTemplate;
 import com.google.cloud.tools.jib.image.json.PlatformNotFoundInBaseImageException;
@@ -350,7 +352,7 @@ public class PullBaseImageStepTest {
   }
 
   @Test
-  public void testGetCachedBaseImages_v22ManifestCached()
+  public void testGetCachedBaseImages_manifestCached()
       throws InvalidImageReferenceException, IOException, CacheCorruptedException,
           UnlistedPlatformInManifestListException, BadContainerConfigurationFormatException,
           LayerCountMismatchException, PlatformNotFoundInBaseImageException {
@@ -363,7 +365,7 @@ public class PullBaseImageStepTest {
     containerConfigJson.setOs("fat system");
     ManifestAndConfigTemplate manifestAndConfig =
         new ManifestAndConfigTemplate(
-            new V22ManifestTemplate(), containerConfigJson, "sha256:digest");
+            Mockito.mock(BuildableManifestTemplate.class), containerConfigJson, "sha256:digest");
     ImageMetadataTemplate imageMetadata =
         new ImageMetadataTemplate(null, Arrays.asList(manifestAndConfig));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
@@ -377,7 +379,7 @@ public class PullBaseImageStepTest {
   }
 
   @Test
-  public void testGetCachedBaseImages_v22ManifestListCached()
+  public void testGetCachedBaseImages_manifestListCached()
       throws InvalidImageReferenceException, IOException, CacheCorruptedException,
           UnlistedPlatformInManifestListException, BadContainerConfigurationFormatException,
           LayerCountMismatchException, PlatformNotFoundInBaseImageException {
@@ -390,7 +392,7 @@ public class PullBaseImageStepTest {
     containerConfigJson1.setContainerUser("user1");
     containerConfigJson2.setContainerUser("user2");
 
-    V22ManifestListTemplate manifestList = Mockito.mock(V22ManifestListTemplate.class);
+    ManifestListTemplate manifestList = Mockito.mock(ManifestListTemplate.class);
     Mockito.when(manifestList.getDigestsForPlatform("arch1", "os1"))
         .thenReturn(Arrays.asList("sha256:digest1"));
     Mockito.when(manifestList.getDigestsForPlatform("arch2", "os2"))
@@ -401,9 +403,13 @@ public class PullBaseImageStepTest {
             manifestList,
             Arrays.asList(
                 new ManifestAndConfigTemplate(
-                    new V22ManifestTemplate(), containerConfigJson1, "sha256:digest1"),
+                    Mockito.mock(BuildableManifestTemplate.class),
+                    containerConfigJson1,
+                    "sha256:digest1"),
                 new ManifestAndConfigTemplate(
-                    new V22ManifestTemplate(), containerConfigJson2, "sha256:digest2")));
+                    Mockito.mock(BuildableManifestTemplate.class),
+                    containerConfigJson2,
+                    "sha256:digest2")));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
     Mockito.when(
             cache.areAllLayersCached(imageMetadata.getManifestsAndConfigs().get(0).getManifest()))
@@ -423,7 +429,7 @@ public class PullBaseImageStepTest {
   }
 
   @Test
-  public void testGetCachedBaseImages_v22ManifestListCached_partialMatches()
+  public void testGetCachedBaseImages_manifestListCached_partialMatches()
       throws InvalidImageReferenceException, IOException, CacheCorruptedException,
           UnlistedPlatformInManifestListException, BadContainerConfigurationFormatException,
           LayerCountMismatchException, PlatformNotFoundInBaseImageException {
@@ -431,7 +437,7 @@ public class PullBaseImageStepTest {
     Mockito.when(buildContext.getBaseImageConfiguration())
         .thenReturn(ImageConfiguration.builder(imageReference).build());
 
-    V22ManifestListTemplate manifestList = Mockito.mock(V22ManifestListTemplate.class);
+    ManifestListTemplate manifestList = Mockito.mock(ManifestListTemplate.class);
     Mockito.when(manifestList.getDigestsForPlatform("arch1", "os1"))
         .thenReturn(Arrays.asList("sha256:digest1"));
     Mockito.when(manifestList.getDigestsForPlatform("arch2", "os2"))
@@ -442,7 +448,7 @@ public class PullBaseImageStepTest {
             manifestList,
             Arrays.asList(
                 new ManifestAndConfigTemplate(
-                    new V22ManifestTemplate(),
+                    Mockito.mock(BuildableManifestTemplate.class),
                     new ContainerConfigurationTemplate(),
                     "sha256:digest1")));
     Mockito.when(cache.retrieveMetadata(imageReference)).thenReturn(Optional.of(imageMetadata));
@@ -457,7 +463,7 @@ public class PullBaseImageStepTest {
   }
 
   @Test
-  public void testGetCachedBaseImages_v22ManifestListCached_onlyPlatforms()
+  public void testGetCachedBaseImages_manifestListCached_onlyPlatforms()
       throws InvalidImageReferenceException, IOException, CacheCorruptedException,
           UnlistedPlatformInManifestListException, PlatformNotFoundInBaseImageException,
           BadContainerConfigurationFormatException, LayerCountMismatchException {
@@ -465,7 +471,7 @@ public class PullBaseImageStepTest {
     Mockito.when(buildContext.getBaseImageConfiguration())
         .thenReturn(ImageConfiguration.builder(imageReference).build());
 
-    V22ManifestListTemplate manifestList = Mockito.mock(V22ManifestListTemplate.class);
+    ManifestListTemplate manifestList = Mockito.mock(ManifestListTemplate.class);
     Mockito.when(manifestList.getDigestsForPlatform("target-arch", "target-os"))
         .thenReturn(Arrays.asList("sha256:target-digest"));
 
@@ -474,10 +480,12 @@ public class PullBaseImageStepTest {
 
     ManifestAndConfigTemplate targetManifestAndConfig =
         new ManifestAndConfigTemplate(
-            new V22ManifestTemplate(), containerConfigJson, "sha256:target-digest");
+            Mockito.mock(BuildableManifestTemplate.class),
+            containerConfigJson,
+            "sha256:target-digest");
     ManifestAndConfigTemplate unrelatedManifestAndConfig =
         new ManifestAndConfigTemplate(
-            new V22ManifestTemplate(),
+            Mockito.mock(BuildableManifestTemplate.class),
             new ContainerConfigurationTemplate(),
             "sha256:unrelated-digest");
 


### PR DESCRIPTION
Fixes #3958

Since there's no more downcast in PullBaseImageStep of manifest lists actual implementation, use the parent class in the unit tests.
Also update jib-core gradle example to compile with 0.23.0.

I was able to reproduce via a gradle build using jib-core (from: gcr.io/distroless/java17-debian11:nonroot@sha256:5154596f58d81687d66c8302face284198caf65033cde6bf6667c488b21745e6)  and verify the fix works. Though I'm not sure why the issue wasn't caught by the new integration test cases added in #3965 ?

Before filing a pull request, make sure to do the following:

- [x] Create a new issue at https://github.com/GoogleContainerTools/jib/issues/new/choose.
- [x] Ensure that your implementation plan is approved by the team.
- [x] Verify that integration tests and unit tests are passing after the change.
- [x] Address all checkstyle issues. Refer to the [style guide](https://github.com/GoogleContainerTools/jib/blob/0ed7dca36864b6b19ff61629fc578018041fa15f/STYLE_GUIDE.md#style-guide).

This helps to reduce the chance of having a pull request rejected.
