### PR TITLE
ci: fix kokoro windows build scripts

### DIFF
--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
@@ -34,7 +34,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -182,13 +181,6 @@ public class BuildFilesTest {
       throws URISyntaxException, InvalidImageReferenceException, IOException {
     Path buildfile =
         Paths.get(Resources.getResource("buildfiles/projects/templating/multiLine.yaml").toURI());
-
-    String replaceThisMultiline = "replace" + System.lineSeparator() + "this";
-    System.out.println(replaceThisMultiline.replace("\r", "\\r").replace("\n", "\\n"));
-    String replaceThisMultiline2 = "replace" + System.getProperty("line.separator") + "this";
-    System.out.println(replaceThisMultiline2.replace("\r", "\\r").replace("\n", "\\n"));
-    System.out.println(Charset.defaultCharset().displayName());
-
     Mockito.when(buildCli.getTemplateParameters())
         .thenReturn(ImmutableMap.of("replace" + "\n" + "this", "creationTime: 1234"));
     JibContainerBuilder jibContainerBuilder =

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
@@ -182,9 +182,15 @@ public class BuildFilesTest {
     Path buildfile =
         Paths.get(Resources.getResource("buildfiles/projects/templating/multiLine.yaml").toURI());
 
+    String replaceThisMultiline = "replace" + System.lineSeparator() + "this";
+    System.out.println(replaceThisMultiline);
+    String replaceThisMultiline2 = "replace" + System.getProperty("line.separator") + "this";
+    System.out.println(replaceThisMultiline2);
+
     Mockito.when(buildCli.getTemplateParameters())
         .thenReturn(
-            ImmutableMap.of("replace" + System.lineSeparator() + "this", "creationTime: 1234"));
+            ImmutableMap.of(
+                "replace" + System.getProperty("line.separator") + "this", "creationTime: 1234"));
     JibContainerBuilder jibContainerBuilder =
         BuildFiles.toJibContainerBuilder(
             buildfile.getParent(), buildfile, buildCli, commonCliOptions, consoleLogger);

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
@@ -181,6 +181,7 @@ public class BuildFilesTest {
       throws URISyntaxException, InvalidImageReferenceException, IOException {
     Path buildfile =
         Paths.get(Resources.getResource("buildfiles/projects/templating/multiLine.yaml").toURI());
+
     Mockito.when(buildCli.getTemplateParameters())
         .thenReturn(ImmutableMap.of("replace" + "\n" + "this", "creationTime: 1234"));
     JibContainerBuilder jibContainerBuilder =

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
@@ -183,9 +183,9 @@ public class BuildFilesTest {
         Paths.get(Resources.getResource("buildfiles/projects/templating/multiLine.yaml").toURI());
 
     String replaceThisMultiline = "replace" + System.lineSeparator() + "this";
-    System.out.println(replaceThisMultiline);
+    System.out.println(replaceThisMultiline.replace("\r", "\\r").replace("\n", "\\n"));
     String replaceThisMultiline2 = "replace" + System.getProperty("line.separator") + "this";
-    System.out.println(replaceThisMultiline2);
+    System.out.println(replaceThisMultiline2.replace("\r", "\\r").replace("\n", "\\n"));
 
     Mockito.when(buildCli.getTemplateParameters())
         .thenReturn(

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/buildfile/BuildFilesTest.java
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.io.Resources;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
@@ -186,11 +187,10 @@ public class BuildFilesTest {
     System.out.println(replaceThisMultiline.replace("\r", "\\r").replace("\n", "\\n"));
     String replaceThisMultiline2 = "replace" + System.getProperty("line.separator") + "this";
     System.out.println(replaceThisMultiline2.replace("\r", "\\r").replace("\n", "\\n"));
+    System.out.println(Charset.defaultCharset().displayName());
 
     Mockito.when(buildCli.getTemplateParameters())
-        .thenReturn(
-            ImmutableMap.of(
-                "replace" + System.getProperty("line.separator") + "this", "creationTime: 1234"));
+        .thenReturn(ImmutableMap.of("replace" + "\n" + "this", "creationTime: 1234"));
     JibContainerBuilder jibContainerBuilder =
         BuildFiles.toJibContainerBuilder(
             buildfile.getParent(), buildfile, buildCli, commonCliOptions, consoleLogger);

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
@@ -89,7 +89,6 @@ public class UpdateChecker {
           String fileContents =
               new String(Files.readAllBytes(lastUpdateCheck), StandardCharsets.UTF_8);
           Instant modifiedTime = Instant.parse(fileContents);
-          System.out.println("parsed lastUpdateCheck time: " + modifiedTime);
           if (modifiedTime.plus(Duration.ofDays(1)).isAfter(Instant.now())) {
             return Optional.empty();
           }
@@ -116,9 +115,7 @@ public class UpdateChecker {
         Path lastUpdateCheckTemp =
             Files.createTempFile(configDir, LAST_UPDATE_CHECK_FILENAME, null);
         lastUpdateCheckTemp.toFile().deleteOnExit();
-        String timeNow = Instant.now().toString();
-        System.out.println("updating lastUpdateCheck file, time now = " + timeNow);
-        Files.write(lastUpdateCheckTemp, timeNow.getBytes(StandardCharsets.UTF_8));
+        Files.write(lastUpdateCheckTemp, Instant.now().toString().getBytes(StandardCharsets.UTF_8));
         Files.move(lastUpdateCheckTemp, lastUpdateCheck, StandardCopyOption.REPLACE_EXISTING);
 
         if (currentVersion.equals(version.latest)) {

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/UpdateChecker.java
@@ -89,6 +89,7 @@ public class UpdateChecker {
           String fileContents =
               new String(Files.readAllBytes(lastUpdateCheck), StandardCharsets.UTF_8);
           Instant modifiedTime = Instant.parse(fileContents);
+          System.out.println("parsed lastUpdateCheck time: " + modifiedTime);
           if (modifiedTime.plus(Duration.ofDays(1)).isAfter(Instant.now())) {
             return Optional.empty();
           }
@@ -115,7 +116,9 @@ public class UpdateChecker {
         Path lastUpdateCheckTemp =
             Files.createTempFile(configDir, LAST_UPDATE_CHECK_FILENAME, null);
         lastUpdateCheckTemp.toFile().deleteOnExit();
-        Files.write(lastUpdateCheckTemp, Instant.now().toString().getBytes(StandardCharsets.UTF_8));
+        String timeNow = Instant.now().toString();
+        System.out.println("updating lastUpdateCheck file, time now = " + timeNow);
+        Files.write(lastUpdateCheckTemp, timeNow.getBytes(StandardCharsets.UTF_8));
         Files.move(lastUpdateCheckTemp, lastUpdateCheck, StandardCopyOption.REPLACE_EXISTING);
 
         if (currentVersion.equals(version.latest)) {

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/UpdateCheckerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/UpdateCheckerTest.java
@@ -68,8 +68,10 @@ public class UpdateCheckerTest {
   }
 
   @Test
-  public void testPerformUpdateCheck_newVersionFound() throws IOException {
+  public void testPerformUpdateCheck_newVersionFound() throws IOException, InterruptedException {
     Instant before = Instant.now();
+    System.out.println("before: " + before.toString());
+    Thread.sleep(500);
     setupLastUpdateCheck();
     Optional<String> message =
         UpdateChecker.performUpdateCheck(
@@ -80,6 +82,7 @@ public class UpdateCheckerTest {
     String modifiedTime =
         new String(
             Files.readAllBytes(configDir.resolve("lastUpdateCheck")), StandardCharsets.UTF_8);
+    System.out.println("modifiedTime: " + modifiedTime);
     assertThat(Instant.parse(modifiedTime)).isGreaterThan(before);
   }
 
@@ -129,9 +132,12 @@ public class UpdateCheckerTest {
   }
 
   @Test
-  public void testPerformUpdateCheck_emptyLastUpdateCheck() throws IOException {
+  public void testPerformUpdateCheck_emptyLastUpdateCheck()
+      throws IOException, InterruptedException {
     Files.createFile(configDir.resolve("lastUpdateCheck"));
     Instant before = Instant.now();
+    System.out.println("before: " + before.toString());
+    Thread.sleep(500);
     Optional<String> message =
         UpdateChecker.performUpdateCheck(
             configDir, "1.0.2", testWebServer.getEndpoint(), "tool-name", ignored -> {});
@@ -140,6 +146,7 @@ public class UpdateCheckerTest {
     String modifiedTime =
         new String(
             Files.readAllBytes(configDir.resolve("lastUpdateCheck")), StandardCharsets.UTF_8);
+    System.out.println("modifiedTime: " + modifiedTime);
     assertThat(Instant.parse(modifiedTime)).isGreaterThan(before);
   }
 
@@ -217,8 +224,9 @@ public class UpdateCheckerTest {
   }
 
   private void setupLastUpdateCheck() throws IOException {
+    String oldLastUpdateCheck = Instant.now().minus(Duration.ofDays(2)).toString();
+    System.out.println("setUpLastUpdateCheck at time: " + oldLastUpdateCheck);
     Files.write(
-        configDir.resolve("lastUpdateCheck"),
-        Instant.now().minus(Duration.ofDays(2)).toString().getBytes(StandardCharsets.UTF_8));
+        configDir.resolve("lastUpdateCheck"), oldLastUpdateCheck.getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/UpdateCheckerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/UpdateCheckerTest.java
@@ -70,8 +70,7 @@ public class UpdateCheckerTest {
   @Test
   public void testPerformUpdateCheck_newVersionFound() throws IOException, InterruptedException {
     Instant before = Instant.now();
-    System.out.println("before: " + before.toString());
-    Thread.sleep(500);
+    Thread.sleep(100);
     setupLastUpdateCheck();
     Optional<String> message =
         UpdateChecker.performUpdateCheck(
@@ -82,7 +81,6 @@ public class UpdateCheckerTest {
     String modifiedTime =
         new String(
             Files.readAllBytes(configDir.resolve("lastUpdateCheck")), StandardCharsets.UTF_8);
-    System.out.println("modifiedTime: " + modifiedTime);
     assertThat(Instant.parse(modifiedTime)).isGreaterThan(before);
   }
 
@@ -102,8 +100,9 @@ public class UpdateCheckerTest {
   }
 
   @Test
-  public void testPerformUpdateCheck_onLatest() throws IOException {
+  public void testPerformUpdateCheck_onLatest() throws IOException, InterruptedException {
     Instant before = Instant.now();
+    Thread.sleep(100);
     setupLastUpdateCheck();
     Optional<String> message =
         UpdateChecker.performUpdateCheck(
@@ -118,8 +117,9 @@ public class UpdateCheckerTest {
   }
 
   @Test
-  public void testPerformUpdateCheck_noLastUpdateCheck() throws IOException {
+  public void testPerformUpdateCheck_noLastUpdateCheck() throws IOException, InterruptedException {
     Instant before = Instant.now();
+    Thread.sleep(100);
     Optional<String> message =
         UpdateChecker.performUpdateCheck(
             configDir, "1.0.2", testWebServer.getEndpoint(), "tool-name", ignored -> {});
@@ -136,8 +136,7 @@ public class UpdateCheckerTest {
       throws IOException, InterruptedException {
     Files.createFile(configDir.resolve("lastUpdateCheck"));
     Instant before = Instant.now();
-    System.out.println("before: " + before.toString());
-    Thread.sleep(500);
+    Thread.sleep(100);
     Optional<String> message =
         UpdateChecker.performUpdateCheck(
             configDir, "1.0.2", testWebServer.getEndpoint(), "tool-name", ignored -> {});
@@ -146,7 +145,6 @@ public class UpdateCheckerTest {
     String modifiedTime =
         new String(
             Files.readAllBytes(configDir.resolve("lastUpdateCheck")), StandardCharsets.UTF_8);
-    System.out.println("modifiedTime: " + modifiedTime);
     assertThat(Instant.parse(modifiedTime)).isGreaterThan(before);
   }
 
@@ -171,8 +169,9 @@ public class UpdateCheckerTest {
   }
 
   @Test
-  public void testPerformUpdateCheck_badLastUpdateTime() throws IOException {
+  public void testPerformUpdateCheck_badLastUpdateTime() throws IOException, InterruptedException {
     Instant before = Instant.now();
+    Thread.sleep(100);
     Files.write(
         configDir.resolve("lastUpdateCheck"), "bad timestamp".getBytes(StandardCharsets.UTF_8));
     Optional<String> message =
@@ -224,9 +223,8 @@ public class UpdateCheckerTest {
   }
 
   private void setupLastUpdateCheck() throws IOException {
-    String oldLastUpdateCheck = Instant.now().minus(Duration.ofDays(2)).toString();
-    System.out.println("setUpLastUpdateCheck at time: " + oldLastUpdateCheck);
     Files.write(
-        configDir.resolve("lastUpdateCheck"), oldLastUpdateCheck.getBytes(StandardCharsets.UTF_8));
+        configDir.resolve("lastUpdateCheck"),
+        Instant.now().minus(Duration.ofDays(2)).toString().getBytes(StandardCharsets.UTF_8));
   }
 }

--- a/kokoro/continuous.bat
+++ b/kokoro/continuous.bat
@@ -1,8 +1,7 @@
 @echo on
 
 REM Java 9 does not work with Mockito mockmaker.
-set JAVA_HOME=c:\program files\java\jdk1.8.0_152
-set PATH=%JAVA_HOME%\bin;%PATH%
+echo %JAVA_HOME%
 
 cd github/jib
 

--- a/kokoro/presubmit.bat
+++ b/kokoro/presubmit.bat
@@ -1,8 +1,7 @@
 @echo on
 
 REM Java 9 does not work with Mockito mockmaker.
-set JAVA_HOME=c:\program files\java\jdk1.8.0_152
-set PATH=%JAVA_HOME%\bin;%PATH%
+echo %JAVA_HOME%
 
 cd github/jib
 


### PR DESCRIPTION
Resolves #3978.

Individual issues addressed:

- [Java 8 issue](https://github.com/GoogleContainerTools/jib/issues/3978#issue-1652650425): updated scripts to use the new environment's default `JAVA_HOME` (`C:\Program Files\Java\jdk1.8.0_211`) and removes the previously set location.

- [BuildFilesTest issue](https://github.com/GoogleContainerTools/jib/issues/3978#issuecomment-1494919703): switched test to unix-based newline instead of `System.lineSeparator()` in `BuildFilesTest`.

- [UpdateCheckerTest issue](https://github.com/GoogleContainerTools/jib/issues/3978#issuecomment-1496091582): added extra lag time between operations in `UpdateCheckerTest` with before/after timestamp comparison.
