### PR TITLE
Make `DockerClientResolver#resolve` threadsafe

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClientResolver.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/DockerClientResolver.java
@@ -23,9 +23,6 @@ import java.util.ServiceLoader;
 
 public class DockerClientResolver {
 
-  private static final ServiceLoader<DockerClient> dockerClients =
-      ServiceLoader.load(DockerClient.class);
-
   private DockerClientResolver() {}
 
   /**
@@ -35,6 +32,7 @@ public class DockerClientResolver {
    * @return dockerClient if any is found
    */
   public static Optional<DockerClient> resolve(Map<String, String> parameters) {
+    ServiceLoader<DockerClient> dockerClients = ServiceLoader.load(DockerClient.class);
     for (DockerClient dockerClient : dockerClients) {
       if (dockerClient.supported(parameters)) {
         return Optional.of(dockerClient);


### PR DESCRIPTION
This is a fix for #3981. I believe that description on the issue explains the rationale behind this change but I'd be happy to clarify if there are any questions.

- [x] Create a new issue at https://github.com/GoogleContainerTools/jib/issues/new/choose.
- [ ] Ensure that your implementation plan is approved by the team.
- [x] Verify that integration tests and unit tests are passing after the change.
- [x] Address all checkstyle issues. Refer to
  the [style guide](https://github.com/GoogleContainerTools/jib/blob/master/STYLE_GUIDE.md).

Fixes #3981 🛠️
