### PR TITLE
chore: update changelogs to prepare for release

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -6,9 +6,15 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
-- Replaced usages of `com.google.api.client.util.Base64` with `java.util.Base64` ([#3872](https://github.com/GoogleContainerTools/jib/pull/3872))
+- Replaced deprecated usages of `com.google.api.client.util.Base64` with `java.util.Base64` ([#3872](https://github.com/GoogleContainerTools/jib/pull/3872))
+- Replaced deprecated usages of `ObjectMapper.configure` in jackson ([#3890](https://github.com/GoogleContainerTools/jib/pull/3890))
 
 ### Fixed
+- Fixed `V22ManifestListTemplate` cast to allow pulling an OCI index manifest from cache ([#3974](https://github.com/GoogleContainerTools/jib/pull/3974))
+- Specified `CompressorStreamFactory` to decompress compressed layer until EOF in `CacheStorageWriter` ([#3983](https://github.com/GoogleContainerTools/jib/pull/3983))
+- Fixed multithreading issue from `DockerClientResolver.resolve` by not sharing a static `ServiceLoader` instance ([#3993](https://github.com/GoogleContainerTools/jib/pull/3993))
+
+Thanks to our community contributors @Sineaggi, @rquinio, @patrickpichler, @erdi!
 
 ## 0.23.0
 

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 ## [unreleased]
 
 ### Added
+- Support lazy configuration for `jib.container.mainClass` and `jib.container.jvmFlags` parameters ([#3936](https://github.com/GoogleContainerTools/jib/pull/3936))
 
 ### Changed
+- Log an info instead of warning when entrypoint makes the image to ignore jvm parameters ([#3904](https://github.com/GoogleContainerTools/jib/pull/3904))
 
 ### Fixed
+
+Thanks to our community contributors @rmannibucau, @erdi!
 
 ## 3.3.1
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -6,8 +6,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 ### Changed
+- Log an info instead of warning when entrypoint makes the image to ignore jvm parameters ([#3904](https://github.com/GoogleContainerTools/jib/pull/3904))
 
 ### Fixed
+
+Thanks to our community contributors @rmannibucau!
 
 ## 3.3.1
 


### PR DESCRIPTION
Updates changelog to prepare for next releases: 
* jib-core 0.24.0
* jib-maven-plugin 3.3.2
* jib-gradle-plugin 3.3.2
