### PR TITLE
chore: update release script for jib-gradle-plugin

### DIFF
--- a/jib-gradle-plugin/scripts/release.sh
+++ b/jib-gradle-plugin/scripts/release.sh
@@ -7,19 +7,13 @@ readonly PUBLISH_SECRET=$(cat "${KOKORO_KEYSTORE_DIR}/72743_gradle_publish_secre
 
 set -o xtrace
 
-gcloud components install docker-credential-gcr
-
-# docker-credential-gcr uses GOOGLE_APPLICATION_CREDENTIALS as the credentials key file
-export readonly GOOGLE_APPLICATION_CREDENTIALS="${KOKORO_KEYSTORE_DIR}/72743_jib_integration_testing_key"
-docker-credential-gcr configure-docker
+# From default hostname, get id of container to exclude
+CONTAINER_ID=$(hostname)
+echo "$CONTAINER_ID"
 
 # Stops any left-over containers.
-docker stop $(docker ps --all --quiet) || true
-docker kill $(docker ps --all --quiet) || true
-
-# Sets the integration testing project.
-export readonly JIB_INTEGRATION_TESTING_PROJECT=jib-integration-testing
-
+docker stop $(docker ps --all --quiet | grep -v "$CONTAINER_ID") || true
+docker kill $(docker ps --all --quiet | grep -v "$CONTAINER_ID") || true
 cd github/jib
 
 echo "gradle publish"


### PR DESCRIPTION
Resolves two encountered issues:
* The `gcloud` command is now hanging indefinitely waiting for user input. Enabling quiet mode with `-q` can resolve it similar to https://github.com/GoogleCloudPlatform/appengine-plugins-core/pull/921, but since we've stopped running integration tests as part of the gradle plugin release task, I've removed the credentials-related setup altogether.
* Ports changes for stopping docker containers in CI scripts from https://github.com/GoogleContainerTools/jib/pull/3886 also into this release script as well.
