### PR TITLE
chore: update release script for jib-maven-plugin

### DIFF
--- a/jib-maven-plugin/kokoro/release_build.sh
+++ b/jib-maven-plugin/kokoro/release_build.sh
@@ -5,5 +5,10 @@ set -o errexit
 # Display commands to stderr.
 set -o xtrace
 
+# Append to JAVA_TOOL_OPTIONS to suppress warnings from kokoro container os.
+if [ "${KOKORO_JOB_CLUSTER}" = "GCP_UBUNTU_DOCKER" ]; then
+  JAVA_TOOL_OPTIONS="${JAVA_TOOL_OPTIONS} -Xlog:os+container=error"
+fi
+
 cd github/jib
 ./gradlew :jib-maven-plugin:prepareRelease


### PR DESCRIPTION
This PR adds a workaround to the `jib-maven-plugin` release script related to the Kokoro environment migration:

```
com.google.cloud.tools.jib.maven.skaffold.PackageGoalsMojoTest > testPackageGoalsMojo_complexServiceRemoteProfile FAILED
    java.lang.AssertionError: expected:<[build]> but was:<[[0.002s][warning][os,container] Duplicate cpuset controllers detected. Picking /sys/fs/cgroup/cpuset, skipping /tmpfs/docker/overlay2/344b91503161185dd904a5615aded79b8e6933f6fa7eb0ecbca3452428eff1f3/merged/sys/fs/cgroup/cpuset., build]>
        at org.junit.Assert.fail(Assert.java:89)
```

The additional warning pollutes output in a couple of test assertions where logged contents are verified. It is suppressed in the CI environment with `JAVA_TOOL_OPTIONS: -Xlog:os+container=error`, but this environment variable is overwritten in the release-specific configurations.
