### PR TITLE
fix: fix WWW-Authenticate header parsing for Basic authentication

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
@@ -72,9 +72,9 @@ public class RegistryAuthenticator {
       @Nullable String userAgent,
       FailoverHttpClient httpClient)
       throws RegistryAuthenticationFailedException {
-    // If the authentication method starts with 'basic ' (case insensitive), no registry
+    // If the authentication method starts with 'basic' (case insensitive), no registry
     // authentication is needed.
-    if (authenticationMethod.matches("^(?i)(basic) .*")) {
+    if (authenticationMethod.matches("^(?i)(basic).*")) {
       return Optional.empty();
     }
 

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.jib.registry;
 
+import static com.google.common.truth.Truth8.assertThat;
+
 import com.google.cloud.tools.jib.api.Credential;
 import com.google.cloud.tools.jib.api.RegistryAuthenticationFailedException;
 import com.google.cloud.tools.jib.http.FailoverHttpClient;
@@ -83,10 +85,11 @@ public class RegistryAuthenticatorTest {
                 "user-agent",
                 httpClient)
             .get();
-    Assert.assertEquals(
-        new URL("https://somerealm?service=someservice&scope=repository:someimage:scope"),
-        registryAuthenticator.getAuthenticationUrl(
-            null, Collections.singletonMap("someimage", "scope")));
+    assertThat(
+            registryAuthenticator.getAuthenticationUrl(
+                null, Collections.singletonMap("someimage", "scope")))
+        .isEqualTo(
+            new URL("https://somerealm?service=someservice&scope=repository:someimage:scope"));
 
     registryAuthenticator =
         RegistryAuthenticator.fromAuthenticationMethod(
@@ -95,10 +98,11 @@ public class RegistryAuthenticatorTest {
                 "user-agent",
                 httpClient)
             .get();
-    Assert.assertEquals(
-        new URL("https://somerealm?service=someservice&scope=repository:someimage:scope"),
-        registryAuthenticator.getAuthenticationUrl(
-            null, Collections.singletonMap("someimage", "scope")));
+    assertThat(
+            registryAuthenticator.getAuthenticationUrl(
+                null, Collections.singletonMap("someimage", "scope")))
+        .isEqualTo(
+            new URL("https://somerealm?service=someservice&scope=repository:someimage:scope"));
   }
 
   @Test
@@ -155,29 +159,34 @@ public class RegistryAuthenticatorTest {
 
   @Test
   public void testFromAuthenticationMethod_basic() throws RegistryAuthenticationFailedException {
-    Assert.assertFalse(
-        RegistryAuthenticator.fromAuthenticationMethod(
+    assertThat(
+            RegistryAuthenticator.fromAuthenticationMethod(
+                "Basic", registryEndpointRequestProperties, "user-agent", httpClient))
+        .isEmpty();
+
+    assertThat(
+            RegistryAuthenticator.fromAuthenticationMethod(
                 "Basic realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
                 registryEndpointRequestProperties,
                 "user-agent",
-                httpClient)
-            .isPresent());
+                httpClient))
+        .isEmpty();
 
-    Assert.assertFalse(
-        RegistryAuthenticator.fromAuthenticationMethod(
+    assertThat(
+            RegistryAuthenticator.fromAuthenticationMethod(
                 "BASIC realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
                 registryEndpointRequestProperties,
                 "user-agent",
-                httpClient)
-            .isPresent());
+                httpClient))
+        .isEmpty();
 
-    Assert.assertFalse(
-        RegistryAuthenticator.fromAuthenticationMethod(
+    assertThat(
+            RegistryAuthenticator.fromAuthenticationMethod(
                 "bASIC realm=\"https://somerealm\",service=\"someservice\",scope=\"somescope\"",
                 registryEndpointRequestProperties,
                 "user-agent",
-                httpClient)
-            .isPresent());
+                httpClient))
+        .isEmpty();
   }
 
   @Test

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/registry/RegistryAuthenticatorTest.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.registry;
 
+import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 
 import com.google.cloud.tools.jib.api.Credential;


### PR DESCRIPTION
Fixes #4032 🛠️

This accepts the Basic auth scheme without realm.
