### PR TITLE
chore: disable gradle parallel build in project properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx1024m
 org.gradle.caching=true
-org.gradle.parallel=true


### PR DESCRIPTION
Opening this PR to troubleshoot CI errors  on main branch after https://github.com/GoogleContainerTools/jib/pull/3892 - I'm suspecting that the current test suite setup is not compatible with gradle parallel execution, since the errors look like port allocation conflicts: 

```
com.google.cloud.tools.jib.gradle.SingleProjectIntegrationTest > classMethod FAILED
    java.lang.RuntimeException: Command 'docker run --rm -d -p 5000:5000 --name registry-e0dea1b8-cf48-4b92-8e29-2aecf7a1426c -v /tmpfs/auth:/auth -e REGISTRY_AUTH=htpasswd -e REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm -e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd registry:2' failed: docker: Error response from daemon: driver failed programming external connectivity on endpoint registry-e0dea1b8-cf48-4b92-8e29-2aecf7a1426c (6a10f2a8355015612352481752b5ce747778cae172898881509655ccbd207f42): 
Bind for 0.0.0.0:5000 failed: port is already allocated.
```
