### PR TITLE
Address order permutation in CommandLine.MutuallyExclusiveArgsException

### DIFF
--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/JarTest.java
@@ -434,7 +434,7 @@ public class JarTest {
                     new Jar(), ArrayUtils.addAll(authArgs, "--target=ignored", "my-app.jar")));
     assertThat(meae)
         .hasMessageThat()
-        .containsMatch("^Error: (--(from-|to-)?credential-helper|\\[--username)");
+        .containsMatch("^Error: (\\[)*(--(from-|to-)?credential-helper|\\[--(username|password))");
   }
 
   @Test


### PR DESCRIPTION
Fixes #<4090> 🛠️
**Description**:
As described in the issue, `JarTest` verifies incompatible credential options passed to cli by checking the message of a raised `MutuallyExclusiveArgsException`. While `Picocli` command line uses a `Set` to keep track of options, the exception message String does not ensure the order of the conflict credential options to be appeared. 

**Fix**
Since `Picocli` cli does not specify determined order of credential options, the unit tests in `JarTest` shall not either. Made minor changes in the regex pattern to address possible permutations.
