### PR TITLE
Follow up: address order permutation in MutuallyExclusiveArgsException

### DIFF
--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/BuildTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/BuildTest.java
@@ -406,7 +406,7 @@ public class BuildTest {
                     new Build(), ArrayUtils.add(authArgs, "--target=ignored")));
     assertThat(meae)
         .hasMessageThat()
-        .containsMatch("^Error: (--(from-|to-)?credential-helper|\\[--username)");
+        .containsMatch("^Error: (\\[)*(--(from-|to-)?credential-helper|\\[--(username|password))");
   }
 
   @Test

--- a/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/WarTest.java
+++ b/jib-cli/src/test/java/com/google/cloud/tools/jib/cli/WarTest.java
@@ -432,7 +432,7 @@ public class WarTest {
                     new War(), ArrayUtils.addAll(authArgs, "--target=ignored", "my-app.war")));
     assertThat(meae)
         .hasMessageThat()
-        .containsMatch("^Error: (--(from-|to-)?credential-helper|\\[--username)");
+        .containsMatch("^Error: (\\[)*(--(from-|to-)?credential-helper|\\[--(username|password))");
   }
 
   @Test


### PR DESCRIPTION
Fixes #<4090> 🛠️

This PR is a follow up of the tentative PR https://github.com/GoogleContainerTools/jib/pull/4093, as the previous one is merged.  It addresses the same problem as described in the issue, but in `BuildTest` and `WarTest`, respectively. Same fix applies.