### PR TITLE
core: update Gradle instructions

### DIFF
--- a/jib-core/README.md
+++ b/jib-core/README.md
@@ -30,7 +30,7 @@ Add Jib Core as a dependency using Gradle:
 
 ```groovy
 dependencies {
-  compile 'com.google.cloud.tools:jib-core:0.25.0'
+  implementation("com.google.cloud.tools:jib-core:0.25.0")
 }
 ```
 


### PR DESCRIPTION
"compile" is deprecated. Also use a syntax that works both in Groovy and Kotlin