### PR TITLE
fix: support parsing manifest JSON containing `LayerSources:` from latest Docker

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -2,9 +2,15 @@
 All notable changes to this project will be documented in this file.
 
 ## [unreleased]
+
 ### Added
+-
+
 ### Changed
+-
+
 ### Fixed
+- fix: support parsing manifest JSON containing `LayerSources:` from latest Docker. ([#4171](https://github.com/GoogleContainerTools/jib/pull/4171))
 
 ## 0.25.0
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplate.java
@@ -28,7 +28,7 @@ import java.util.List;
  * a tag is missing, it explicitly should use "latest".
  *
  * <p>Note that this is a template for a single Manifest entry, while the entire Docker Manifest
- * should be {@code List<DockerLoadManifestEntryTemplate>}.
+ * should be {@code List<DockerManifestEntryTemplate>}.
  *
  * <p>Example manifest entry JSON:
  *

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplate.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.docker.json;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.common.annotations.VisibleForTesting;
@@ -46,6 +47,7 @@ import java.util.List;
  * @see <a href="https://github.com/moby/moby/blob/master/image/tarexport/load.go">Docker load
  *     source</a>
  */
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class DockerManifestEntryTemplate implements JsonTemplate {
 
   @JsonProperty("Config")

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/docker/json/DockerManifestEntryTemplateTest.java
@@ -55,7 +55,7 @@ public class DockerManifestEntryTemplateTest {
   @Test
   public void testFromJson() throws URISyntaxException, IOException {
     // Loads the expected JSON string.
-    Path jsonFile = Paths.get(Resources.getResource("core/json/loadmanifest.json").toURI());
+    Path jsonFile = Paths.get(Resources.getResource("core/json/loadmanifest2.json").toURI());
     String sourceJson = new String(Files.readAllBytes(jsonFile), StandardCharsets.UTF_8);
     DockerManifestEntryTemplate template =
         new ObjectMapper().readValue(sourceJson, DockerManifestEntryTemplate[].class)[0];

--- a/jib-core/src/test/resources/core/json/loadmanifest2.json
+++ b/jib-core/src/test/resources/core/json/loadmanifest2.json
@@ -1,0 +1,1 @@
+[{"Config":"config.json","RepoTags":["testregistry/testrepo:testtag"],"Layers":["layer1.tar.gz","layer2.tar.gz","layer3.tar.gz"],"LayerSources":{}}]

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 -
 
 ### Fixed
--
+- fix: support parsing manifest JSON containing `LayerSources:` from latest Docker. ([#4171](https://github.com/GoogleContainerTools/jib/pull/4171))
 
 ## 3.4.0
 
@@ -92,7 +92,6 @@ Thanks to our community contributors @wwadge, @oliver-brm, @rquinio and @gsquare
 ### Fixed
 
 - Fixed setting image format in Kotlin ([#3593](https://github.com/GoogleContainerTools/jib/pull/3593)).
-
 
 ## 3.2.0
 

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 -
 
 ### Fixed
--
+- fix: support parsing manifest JSON containing `LayerSources:` from latest Docker. ([#4171](https://github.com/GoogleContainerTools/jib/pull/4171))
 
 ## 3.4.0
 
@@ -74,7 +74,6 @@ Thanks to our community contributors @wwadge, @oliver-brm, @rquinio and @gsquare
 ### Changed
 
 - Upgraded jackson-databind to 2.13.2.2 ([#3612](https://github.com/GoogleContainerTools/jib/pull/3612)).
-
 
 ## 3.2.0
 


### PR DESCRIPTION
Fixes #4171 🛠️
