### PR TITLE
Create parent directories for imageDigestOutputPath, imageIdOutputPath and imageJsonOutputPath

### DIFF
--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunner.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunner.java
@@ -233,14 +233,17 @@ public class JibBuildRunner {
 
       // when an image is built, write out the digest and id
       if (imageDigestOutputPath != null) {
+        createParentDirectories(imageDigestOutputPath);
         String imageDigest = jibContainer.getDigest().toString();
         Files.write(imageDigestOutputPath, imageDigest.getBytes(StandardCharsets.UTF_8));
       }
       if (imageIdOutputPath != null) {
+        createParentDirectories(imageIdOutputPath);
         String imageId = jibContainer.getImageId().toString();
         Files.write(imageIdOutputPath, imageId.getBytes(StandardCharsets.UTF_8));
       }
       if (imageJsonOutputPath != null) {
+        createParentDirectories(imageJsonOutputPath);
         ImageMetadataOutput metadataOutput = ImageMetadataOutput.fromJibContainer(jibContainer);
         String imageJson = metadataOutput.toJson();
         Files.write(imageJsonOutputPath, imageJson.getBytes(StandardCharsets.UTF_8));
@@ -326,4 +329,11 @@ public class JibBuildRunner {
     this.imageJsonOutputPath = imageJsonOutputPath;
     return this;
   }
+
+  private static void createParentDirectories(Path filePath) throws IOException {
+    Path parent = filePath.getParent();
+    if (parent != null)
+      Files.createDirectories(parent);
+  }
+
 }


### PR DESCRIPTION
Changed create parent directories for imageDigestOutputPath, imageIdOutputPath and imageJsonOutputPath. Currently only the parent directories for the tarball is created.

Fixes GoogleContainerTools#3789 (Maven jib:build fails if contain non-existing directories)