### PR TITLE
Enable to skip update checks from pom properties

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleProjectProperties.java
@@ -455,6 +455,12 @@ public class GradleProjectProperties implements ProjectProperties {
   }
 
   @Override
+  public boolean isDisableUpdateCheck() {
+    return Boolean.parseBoolean(
+        String.valueOf(project.findProperty(PropertyNames.DISABLE_UPDATE_CHECKS)));
+  }
+
+  @Override
   public JibContainerBuilder runPluginExtensions(
       List<? extends ExtensionConfiguration> extensionConfigs,
       JibContainerBuilder jibContainerBuilder)

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/TaskCommon.java
@@ -50,6 +50,7 @@ class TaskCommon {
   static Future<Optional<String>> newUpdateChecker(
       ProjectProperties projectProperties, GlobalConfig globalConfig, Logger logger) {
     if (projectProperties.isOffline()
+        || projectProperties.isDisableUpdateCheck()
         || !logger.isLifecycleEnabled()
         || globalConfig.isDisableUpdateCheck()) {
       return Futures.immediateFuture(Optional.empty());

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MavenProjectProperties.java
@@ -482,6 +482,12 @@ public class MavenProjectProperties implements ProjectProperties {
     return session.isOffline();
   }
 
+  @Override
+  public boolean isDisableUpdateCheck() {
+    return Boolean.parseBoolean(
+        project.getProperties().getProperty(PropertyNames.DISABLE_UPDATE_CHECKS));
+  }
+
   @VisibleForTesting
   Path getWarArtifact() {
     Build build = project.getBuild();

--- a/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
+++ b/jib-maven-plugin/src/main/java/com/google/cloud/tools/jib/maven/MojoCommon.java
@@ -53,6 +53,7 @@ public class MojoCommon {
   static Future<Optional<String>> newUpdateChecker(
       ProjectProperties projectProperties, GlobalConfig globalConfig, Log logger) {
     if (projectProperties.isOffline()
+        || projectProperties.isDisableUpdateCheck()
         || !logger.isInfoEnabled()
         || globalConfig.isDisableUpdateCheck()) {
       return Futures.immediateFuture(Optional.empty());

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MavenProjectPropertiesTest.java
@@ -16,9 +16,12 @@
 
 package com.google.cloud.tools.jib.maven;
 
+import static com.google.cloud.tools.jib.plugins.common.PropertyNames.DISABLE_UPDATE_CHECKS;
 import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -1087,6 +1090,26 @@ public class MavenProjectPropertiesTest {
             getResource("maven/application/dependencies/another/one/dependency-1.0.0.jar"),
             testRepository.artifactPathOnDisk("com.test", "dependency", "1.0.0"),
             testRepository.artifactPathOnDisk("com.test", "dependencyX", "1.0.0-SNAPSHOT"));
+  }
+
+  @Test
+  public void testIsDisableCheck() {
+    final MavenProject project = new MavenProject();
+    final MavenProjectProperties properties =
+        new MavenProjectProperties(
+            mockJibPluginDescriptor,
+            project,
+            mockMavenSession,
+            mockLog,
+            mockTempDirectoryProvider,
+            Collections.emptyList(),
+            mockExtensionLoader);
+
+    project.getProperties().setProperty(DISABLE_UPDATE_CHECKS, "true");
+    assertTrue(properties.isDisableUpdateCheck());
+
+    project.getProperties().setProperty(DISABLE_UPDATE_CHECKS, "false");
+    assertFalse(mavenProjectProperties.isDisableUpdateCheck());
   }
 
   private BuildContext setUpBuildContext()

--- a/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MojoCommonTest.java
+++ b/jib-maven-plugin/src/test/java/com/google/cloud/tools/jib/maven/MojoCommonTest.java
@@ -16,6 +16,8 @@
 
 package com.google.cloud.tools.jib.maven;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -24,7 +26,10 @@ import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.plugins.common.ProjectProperties;
 import com.google.common.util.concurrent.Futures;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import org.apache.maven.monitor.logging.DefaultLog;
+import org.codehaus.plexus.logging.console.ConsoleLogger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -59,5 +64,19 @@ public class MojoCommonTest {
                 "Please see "
                     + ProjectInfo.GITHUB_URL
                     + "/blob/master/docs/privacy.md for info on disabling this update check."));
+  }
+
+  @Test
+  public void testUpdateChecker_disabledFromProjectProperties()
+      throws ExecutionException, InterruptedException {
+    when(mockProjectProperties.isDisableUpdateCheck()).thenReturn(true);
+
+    final Future<Optional<String>> future =
+        MojoCommon.newUpdateChecker(
+            mockProjectProperties,
+            null /* not tested since project property disable it before */,
+            new DefaultLog(new ConsoleLogger()));
+    assertEquals("com.google.common.util.concurrent.ImmediateFuture", future.getClass().getName());
+    assertFalse(future.get().isPresent());
   }
 }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/ProjectProperties.java
@@ -90,6 +90,8 @@ public interface ProjectProperties {
 
   boolean isOffline();
 
+  boolean isDisableUpdateCheck();
+
   JibContainerBuilder runPluginExtensions(
       List<? extends ExtensionConfiguration> extensionConfigs,
       JibContainerBuilder jibContainerBuilder)


### PR DESCRIPTION
Follow up of https://github.com/GoogleContainerTools/jib/issues/3350#issuecomment-885058082 since it is really bothering to not be able to disable update check for project in time - when you don't work on a single "everyday" project and disabling it globally is rarely the desired behavior (it is really a per project thing) but the properties were not read as expected so this PR ensures it is the case.

Thank you for your interest in contributing! For general guidelines, please refer to
the [contributing guide](https://github.com/GoogleContainerTools/jib/blob/master/CONTRIBUTING.md).

Please follow the guidelines below before opening an issue or a PR:
- [ ] Ensure the issue was not already reported. 
- [ ] Create a new issue at https://github.com/GoogleContainerTools/jib/issues/new/choose if you are unable to find an existing issue addressing your problem. Make sure to include a title and clear description, as much relevant information as possible, and a code sample or an executable test case demonstrating the expected behavior that is not occurring.
- [ ] Discuss the priority and potential solutions with the maintainers in the issue. The maintainers would review the issue and add a label "Accepting Contributions" once the issue is ready for accepting contributions.
- [ ] Open a PR only if the issue is labeled with "Accepting Contributions", ensure the PR description clearly describes the problem and solution. Note that an open PR without an issues labeled with "Accepting Contributions" will not be accepted.
- [ ] Verify that integration tests and unit tests are passing after the change.
- [ ] Address all checkstyle issues. Refer to the [style guide](https://github.com/GoogleContainerTools/jib/blob/master/STYLE_GUIDE.md).

Fixes #<issue_number_goes_here> 🛠️
