### PR TITLE
Adding backwards-compatible support for symbolic links.

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/cache/Cache.java
@@ -137,13 +137,14 @@ public class Cache {
    *
    * @param uncompressedLayerBlob the layer {@link Blob}
    * @param layerEntries the layer entries that make up the layer
+   * @param retainSymlinks - Whether symbolic links are to be retained or not.
    * @return the {@link CachedLayer} for the written layer
    * @throws IOException if an I/O exception occurs
    */
   public CachedLayer writeUncompressedLayer(
-      Blob uncompressedLayerBlob, ImmutableList<FileEntry> layerEntries) throws IOException {
+      Blob uncompressedLayerBlob, ImmutableList<FileEntry> layerEntries, boolean retainSymlinks) throws IOException {
     return cacheStorageWriter.writeUncompressed(
-        uncompressedLayerBlob, LayerEntriesSelector.generateSelector(layerEntries));
+        uncompressedLayerBlob, LayerEntriesSelector.generateSelector(layerEntries, retainSymlinks));
   }
 
   /**
@@ -207,14 +208,15 @@ public class Cache {
    * Retrieves the {@link CachedLayer} that was built from the {@code layerEntries}.
    *
    * @param layerEntries the layer entries to match against
+   * @param retainSymlinks - Whether symbolic links are to be retained or not.
    * @return a {@link CachedLayer} that was built from {@code layerEntries}, if found
    * @throws IOException if an I/O exception occurs
    * @throws CacheCorruptedException if the cache is corrupted
    */
-  public Optional<CachedLayer> retrieve(ImmutableList<FileEntry> layerEntries)
+  public Optional<CachedLayer> retrieve(ImmutableList<FileEntry> layerEntries, boolean retainSymlinks)
       throws IOException, CacheCorruptedException {
     Optional<DescriptorDigest> optionalSelectedLayerDigest =
-        cacheStorageReader.select(LayerEntriesSelector.generateSelector(layerEntries));
+        cacheStorageReader.select(LayerEntriesSelector.generateSelector(layerEntries, retainSymlinks));
     if (!optionalSelectedLayerDigest.isPresent()) {
       return Optional.empty();
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/tar/TarStreamBuilder.java
@@ -63,7 +63,7 @@ public class TarStreamBuilder {
    */
   public void addTarArchiveEntry(TarArchiveEntry entry) {
     archiveMap.put(
-        entry, entry.isFile() ? Blobs.from(entry.getPath()) : Blobs.from(ignored -> {}, true));
+        entry, (entry.isFile() && !entry.isSymbolicLink()) ? Blobs.from(entry.getPath()) : Blobs.from(ignored -> {}, true));
   }
 
   /**

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/BuildAndCacheApplicationLayerStepTest.java
@@ -95,6 +95,9 @@ public class BuildAndCacheApplicationLayerStepTest {
   private FileEntriesLayer fakeExtraFilesLayerConfiguration;
   private FileEntriesLayer emptyLayerConfiguration;
 
+  private boolean retainSymlinks = false;
+
+
   @Before
   public void setUp() throws IOException, URISyntaxException, CacheDirectoryCreationException {
     fakeDependenciesLayerConfiguration =
@@ -170,15 +173,15 @@ public class BuildAndCacheApplicationLayerStepTest {
         ImmutableList.copyOf(fakeLayerConfigurations.get(4).getEntries());
 
     CachedLayer dependenciesCachedLayer =
-        cache.retrieve(dependenciesLayerEntries).orElseThrow(AssertionError::new);
+        cache.retrieve(dependenciesLayerEntries, retainSymlinks).orElseThrow(AssertionError::new);
     CachedLayer snapshotDependenciesCachedLayer =
-        cache.retrieve(snapshotDependenciesLayerEntries).orElseThrow(AssertionError::new);
+        cache.retrieve(snapshotDependenciesLayerEntries, retainSymlinks).orElseThrow(AssertionError::new);
     CachedLayer resourcesCachedLayer =
-        cache.retrieve(resourcesLayerEntries).orElseThrow(AssertionError::new);
+        cache.retrieve(resourcesLayerEntries, retainSymlinks).orElseThrow(AssertionError::new);
     CachedLayer classesCachedLayer =
-        cache.retrieve(classesLayerEntries).orElseThrow(AssertionError::new);
+        cache.retrieve(classesLayerEntries, retainSymlinks).orElseThrow(AssertionError::new);
     CachedLayer extraFilesCachedLayer =
-        cache.retrieve(extraFilesLayerEntries).orElseThrow(AssertionError::new);
+        cache.retrieve(extraFilesLayerEntries, retainSymlinks).orElseThrow(AssertionError::new);
 
     // Verifies that the cached layers are up-to-date.
     Assert.assertEquals(
@@ -226,11 +229,11 @@ public class BuildAndCacheApplicationLayerStepTest {
         ImmutableList.copyOf(fakeLayerConfigurations.get(3).getEntries());
 
     CachedLayer dependenciesCachedLayer =
-        cache.retrieve(dependenciesLayerEntries).orElseThrow(AssertionError::new);
+        cache.retrieve(dependenciesLayerEntries, retainSymlinks).orElseThrow(AssertionError::new);
     CachedLayer resourcesCachedLayer =
-        cache.retrieve(resourcesLayerEntries).orElseThrow(AssertionError::new);
+        cache.retrieve(resourcesLayerEntries, retainSymlinks).orElseThrow(AssertionError::new);
     CachedLayer classesCachedLayer =
-        cache.retrieve(classesLayerEntries).orElseThrow(AssertionError::new);
+        cache.retrieve(classesLayerEntries, retainSymlinks).orElseThrow(AssertionError::new);
 
     // Verifies that the cached layers are up-to-date.
     Assert.assertEquals(

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheTest.java
@@ -117,6 +117,8 @@ public class CacheTest {
   private long layerSize2;
   private ImmutableList<FileEntry> layerEntries2;
 
+  private boolean retainSymlinks = false;
+
   @Before
   public void setUp() throws IOException {
     Path directory = temporaryFolder.newFolder().toPath();
@@ -173,7 +175,7 @@ public class CacheTest {
       throws IOException, CacheDirectoryCreationException, CacheCorruptedException {
     Cache cache = Cache.withDirectory(temporaryFolder.newFolder().toPath());
 
-    verifyIsLayer1(cache.writeUncompressedLayer(layerBlob1, layerEntries1));
+    verifyIsLayer1(cache.writeUncompressedLayer(layerBlob1, layerEntries1, retainSymlinks));
     verifyIsLayer1(cache.retrieve(layerDigest1).orElseThrow(AssertionError::new));
     Assert.assertFalse(cache.retrieve(layerDigest2).isPresent());
   }
@@ -183,14 +185,14 @@ public class CacheTest {
       throws IOException, CacheDirectoryCreationException, CacheCorruptedException {
     Cache cache = Cache.withDirectory(temporaryFolder.newFolder().toPath());
 
-    verifyIsLayer1(cache.writeUncompressedLayer(layerBlob1, layerEntries1));
-    verifyIsLayer1(cache.retrieve(layerEntries1).orElseThrow(AssertionError::new));
+    verifyIsLayer1(cache.writeUncompressedLayer(layerBlob1, layerEntries1, retainSymlinks));
+    verifyIsLayer1(cache.retrieve(layerEntries1, retainSymlinks).orElseThrow(AssertionError::new));
     Assert.assertFalse(cache.retrieve(layerDigest2).isPresent());
 
     // A source file modification results in the cached layer to be out-of-date and not retrieved.
     Files.setLastModifiedTime(
         layerEntries1.get(0).getSourceFile(), FileTime.from(Instant.now().plusSeconds(1)));
-    Assert.assertFalse(cache.retrieve(layerEntries1).isPresent());
+    Assert.assertFalse(cache.retrieve(layerEntries1, retainSymlinks).isPresent());
   }
 
   @Test
@@ -198,12 +200,12 @@ public class CacheTest {
       throws IOException, CacheDirectoryCreationException, CacheCorruptedException {
     Cache cache = Cache.withDirectory(temporaryFolder.newFolder().toPath());
 
-    verifyIsLayer1(cache.writeUncompressedLayer(layerBlob1, layerEntries1));
-    verifyIsLayer2(cache.writeUncompressedLayer(layerBlob2, layerEntries2));
+    verifyIsLayer1(cache.writeUncompressedLayer(layerBlob1, layerEntries1, retainSymlinks));
+    verifyIsLayer2(cache.writeUncompressedLayer(layerBlob2, layerEntries2, retainSymlinks));
     verifyIsLayer1(cache.retrieve(layerDigest1).orElseThrow(AssertionError::new));
     verifyIsLayer2(cache.retrieve(layerDigest2).orElseThrow(AssertionError::new));
-    verifyIsLayer1(cache.retrieve(layerEntries1).orElseThrow(AssertionError::new));
-    verifyIsLayer2(cache.retrieve(layerEntries2).orElseThrow(AssertionError::new));
+    verifyIsLayer1(cache.retrieve(layerEntries1, retainSymlinks).orElseThrow(AssertionError::new));
+    verifyIsLayer2(cache.retrieve(layerEntries2, retainSymlinks).orElseThrow(AssertionError::new));
   }
 
   /**


### PR DESCRIPTION
Approach taken from @seanleblanc and extendes in such a way, that is stays entirely backwards compatible.

 Fixes #3506