### PR TITLE
fix: address windows deadlock issue when determining docker environment info

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
@@ -189,11 +189,12 @@ public class CliDockerClient implements DockerClient {
   public DockerInfoDetails info() throws IOException, InterruptedException {
     // Runs 'docker info'.
     Process infoProcess = docker("info", "-f", "{{json .}}");
+    InputStream inputStream = infoProcess.getInputStream();
     if (infoProcess.waitFor() != 0) {
       throw new IOException(
           "'docker info' command failed with error: " + getStderrOutput(infoProcess));
     }
-    return JsonTemplateMapper.readJson(infoProcess.getInputStream(), DockerInfoDetails.class);
+    return JsonTemplateMapper.readJson(inputStream, DockerInfoDetails.class);
   }
 
   @Override


### PR DESCRIPTION
For https://github.com/GoogleContainerTools/jib/issues/4267

Reproducer: https://github.com/mpeddada1/windows_deadlock (note that this reproducer doesn't using `docker` but showcases the same issue observed in https://github.com/GoogleContainerTools/jib/issues/4267). According to the official documentation:

```
Because some native platforms only provide limited buffer size for standard input and output streams, failure to promptly write the input stream or read the output stream of the subprocess may cause the subprocess to block, or even deadlock.
```