### PR TITLE
test: Troubleshoot Jib continuous build - SingleProjectIntegrationTest#testBuild_dockerClient is getting stuck indefinitely 

### DIFF
--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -35,4 +35,4 @@ export JIB_INTEGRATION_TESTING_PROJECT=jib-integration-testing
 
 cd github/jib
 
-./gradlew clean build integrationTest --info --stacktrace
+./gradlew clean build integrationTest --info --stacktrace -X

--- a/kokoro/continuous.sh
+++ b/kokoro/continuous.sh
@@ -35,4 +35,4 @@ export JIB_INTEGRATION_TESTING_PROJECT=jib-integration-testing
 
 cd github/jib
 
-./gradlew clean build integrationTest --info --stacktrace -X
+./gradlew clean build integrationTest --info --stacktrace --debug


### PR DESCRIPTION
The `SingleProjectIntegrationTest#testBuild_dockerClient` test is getting stuck indefinitely with no progress:
```
2024-08-26T10:48:27.892-0400 [DEBUG] [TestEventLogger] com.google.cloud.tools.jib.gradle.SingleProjectIntegrationTest > testBuild_dockerClient STARTED
2024-08-26T10:48:37.334-0400 [LIFECYCLE] [org.gradle.cache.internal.DefaultFileLockManager] 
2024-08-26T10:48:37.334-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Waiting to acquire shared lock on daemon addresses registry.
2024-08-26T10:48:37.334-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Lock acquired on daemon addresses registry.
2024-08-26T10:48:37.334-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Releasing lock on daemon addresses registry.
2024-08-26T10:48:37.334-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Waiting to acquire shared lock on daemon addresses registry.
2024-08-26T10:48:37.335-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Lock acquired on daemon addresses registry.
2024-08-26T10:48:37.335-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Releasing lock on daemon addresses registry.
2024-08-26T10:48:47.334-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Waiting to acquire shared lock on daemon addresses registry.
2024-08-26T10:48:47.334-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Lock acquired on daemon addresses registry.
2024-08-26T10:48:47.334-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Releasing lock on daemon addresses registry.
2024-08-26T10:48:47.335-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Waiting to acquire shared lock on daemon addresses registry.
2024-08-26T10:48:47.335-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Lock acquired on daemon addresses registry.
2024-08-26T10:48:47.335-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Releasing lock on daemon addresses registry.
2024-08-26T10:48:57.334-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Waiting to acquire shared lock on daemon addresses registry.
2024-08-26T10:48:57.334-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Lock acquired on daemon addresses registry.
2024-08-26T10:48:57.334-0400 [DEBUG] [org.gradle.cache.internal.DefaultFileLockManager] Releasing lock on daemon addresses registry.
. . .
```

I'm able to reproduce this locally as well with `./gradlew :jib-gradle-plugin:integrationTest --tests com.google.cloud.tools.jib.gradle.SingleProjectIntegrationTest.testBuild_dockerClient`.

**Where is it getting stuck?**

It gets stuck at this line: https://github.com/GoogleContainerTools/jib/blob/ff15988e5eb36c686e7db47abb31bdc15c88f44a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java#L196

**Other Observations**

- The process appears to be blocked waiting for a result to be returned from the `docker info` process. Interestingly, calling just `CliDockerClient#info()` in the test isn't resulting in the same issue. It is only when we call `./gradlew jibDockerBuild` that we run into the test method getting stuck indefinitely. 

- We are also running into the same issue when reading the input from a different process (e.g. `docker inspect`)

