### PR TITLE
[jib cli] chore: remove duplicate test method for verifying --from argument

### DIFF
--- a/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
+++ b/jib-cli/src/integration-test/java/com/google/cloud/tools/jib/cli/JarCommandTest.java
@@ -323,22 +323,6 @@ public class JarCommandTest {
         new URL("http://" + HttpRequestTester.fetchDockerHostForHttpRequest() + ":8080"));
   }
 
-  @Test
-  public void testJar_baseImageSpecified()
-      throws IOException, URISyntaxException, InterruptedException {
-    Path jarPath = Paths.get(Resources.getResource("jarTest/standard/noDependencyJar.jar").toURI());
-    Integer exitCode =
-        new CommandLine(new JibCli())
-            .execute(
-                "jar",
-                "--target=docker://cli-gcr-base",
-                "--from=gcr.io/google-appengine/openjdk:8",
-                jarPath.toString());
-    assertThat(exitCode).isEqualTo(0);
-    String output = new Command("docker", "run", "--rm", "cli-gcr-base").run();
-    assertThat(output).isEqualTo("Hello World");
-  }
-
   public static void createJarFile(
       String name, String className, String classPath, String mainClass)
       throws IOException, URISyntaxException {


### PR DESCRIPTION
This test method was originally introduced to verify the `--from` parameter of the Jib CLI command in https://github.com/GoogleContainerTools/jib/pull/2972. However, this is already being verified by the other test methods in this class (see `testStandardJar_explodedMode_toDocker` for example). 

As part of cleanup for [Container Registry's shutdown](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown), this PR removes this redundant test. 