### PR TITLE
docs: Fix typo for Jit CLI README.md

### DIFF
--- a/jib-cli/README.md
+++ b/jib-cli/README.md
@@ -90,7 +90,7 @@ $ ./jib-cli/build/install/jib/bin/jib
 
 ## Supported Commands
 
-The Jib CLI supports two commands:
+The Jib CLI supports three commands:
  1. `build` - containerizes using a [build file](#fully-annotated-build-file-jibyaml).
  2. `jar` - containerizes JAR files.
  3. `war` - containerizes WAR files.


### PR DESCRIPTION
This PR fixes an inconsistency in the Jib CLI documentation. The documentation stated that the CLI supports two commands, but the war command was added in [this commit](https://github.com/GoogleContainerTools/jib/commit/6844d3a830d55ec7b04e2df2fce354576fb89cb9), bringing the total to three commands.