### PR TITLE
 Convert Gradle config parameters jib.container.environment to use lazy evaluation #4067 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Contributions to this project must be accompanied by a Contributor License
 Agreement. You (or your employer) retain the copyright to your contribution;
 this simply gives us permission to use and redistribute your contributions as
 part of the project. Head over to <https://cla.developers.google.com/> to see
+part of the project. Head over to <https://cla.developers.google.com/> to see
 your current agreements on file or to sign a new one.
 
 You generally only need to submit a CLA once, so if you've already submitted one

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,6 @@ Contributions to this project must be accompanied by a Contributor License
 Agreement. You (or your employer) retain the copyright to your contribution;
 this simply gives us permission to use and redistribute your contributions as
 part of the project. Head over to <https://cla.developers.google.com/> to see
-part of the project. Head over to <https://cla.developers.google.com/> to see
 your current agreements on file or to sign a new one.
 
 You generally only need to submit a CLA once, so if you've already submitted one

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/ContainerParameters.java
@@ -40,7 +40,7 @@ import org.gradle.api.tasks.Optional;
 public class ContainerParameters {
 
   private final ListProperty<String> jvmFlags;
-  private Map<String, String> environment = Collections.emptyMap();
+  private MapProperty<String, String> environment;
   private ListProperty<String> entrypoint;
   private List<String> extraClasspath = Collections.emptyList();
   private boolean expandClasspathDependencies;
@@ -64,6 +64,7 @@ public class ContainerParameters {
     mainClass = objectFactory.property(String.class);
     jvmFlags = objectFactory.listProperty(String.class);
     entrypoint = objectFactory.listProperty(String.class);
+    environment = objectFactory.mapProperty(String.class, String.class).empty();
   }
 
   @Input
@@ -109,16 +110,16 @@ public class ContainerParameters {
 
   @Input
   @Optional
-  public Map<String, String> getEnvironment() {
-    if (System.getProperty(PropertyNames.CONTAINER_ENVIRONMENT) != null) {
-      return ConfigurationPropertyValidator.parseMapProperty(
-          System.getProperty(PropertyNames.CONTAINER_ENVIRONMENT));
+  public MapProperty<String, String> getEnvironment() {
+    String environmentProperty = System.getProperty(PropertyNames.CONTAINER_ENVIRONMENT);
+    if (environmentProperty != null) {
+      Map<String, String> parsedLabels =
+              ConfigurationPropertyValidator.parseMapProperty(environmentProperty);
+      if (!parsedLabels.equals(environment.get())) {
+        environment.set(parsedLabels);
+      }
     }
     return environment;
-  }
-
-  public void setEnvironment(Map<String, String> environment) {
-    this.environment = environment;
   }
 
   @Input

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/GradleRawConfiguration.java
@@ -108,7 +108,7 @@ public class GradleRawConfiguration implements RawConfiguration {
 
   @Override
   public Map<String, String> getEnvironment() {
-    return jibExtension.getContainer().getEnvironment();
+    return jibExtension.getContainer().getEnvironment().get();
   }
 
   @Override

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
@@ -88,6 +88,7 @@ public class GradleRawConfigurationTest {
     Mockito.when(containerParameters.getArgs()).thenReturn(Arrays.asList("--log", "info"));
     Mockito.when(containerParameters.getEntrypoint()).thenReturn(Arrays.asList("java", "Main"));
     Mockito.when(environment.get()).thenReturn(Collections.singletonMap("currency", "dollar"));
+    Mockito.when(containerParameters.getEnvironment()).thenReturn(environment);
     Mockito.when(containerParameters.getJvmFlags()).thenReturn(Arrays.asList("-cp", "."));
     Mockito.when(labels.get()).thenReturn(Collections.singletonMap("unit", "cm"));
     Mockito.when(containerParameters.getLabels()).thenReturn(labels);

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleRawConfigurationTest.java
@@ -40,6 +40,8 @@ public class GradleRawConfigurationTest {
 
   @Mock private MapProperty<String, String> labels;
 
+  @Mock private MapProperty<String, String> environment;
+
   @Test
   public void testGetters() {
     JibExtension jibExtension = Mockito.mock(JibExtension.class);
@@ -85,8 +87,7 @@ public class GradleRawConfigurationTest {
     Mockito.when(containerParameters.getAppRoot()).thenReturn("/app/root");
     Mockito.when(containerParameters.getArgs()).thenReturn(Arrays.asList("--log", "info"));
     Mockito.when(containerParameters.getEntrypoint()).thenReturn(Arrays.asList("java", "Main"));
-    Mockito.when(containerParameters.getEnvironment())
-        .thenReturn(new HashMap<>(ImmutableMap.of("currency", "dollar")));
+    Mockito.when(environment.get()).thenReturn(Collections.singletonMap("currency", "dollar"));
     Mockito.when(containerParameters.getJvmFlags()).thenReturn(Arrays.asList("-cp", "."));
     Mockito.when(labels.get()).thenReturn(Collections.singletonMap("unit", "cm"));
     Mockito.when(containerParameters.getLabels()).thenReturn(labels);

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibExtensionTest.java
@@ -176,7 +176,7 @@ public class JibExtensionTest {
   @Test
   public void testContainer() {
     assertThat(testJibExtension.getContainer().getJvmFlags()).isEmpty();
-    assertThat(testJibExtension.getContainer().getEnvironment()).isEmpty();
+    assertThat(testJibExtension.getContainer().getEnvironment().get()).isEmpty();
     assertThat(testJibExtension.getContainer().getExtraClasspath()).isEmpty();
     assertThat(testJibExtension.getContainer().getExpandClasspathDependencies()).isFalse();
     assertThat(testJibExtension.getContainer().getMainClass()).isNull();
@@ -192,7 +192,6 @@ public class JibExtensionTest {
     testJibExtension.container(
         container -> {
           container.setJvmFlags(Arrays.asList("jvmFlag1", "jvmFlag2"));
-          container.setEnvironment(ImmutableMap.of("var1", "value1", "var2", "value2"));
           container.setEntrypoint(Arrays.asList("foo", "bar", "baz"));
           container.setExtraClasspath(Arrays.asList("/d1", "/d2", "/d3"));
           container.setExpandClasspathDependencies(true);
@@ -207,9 +206,6 @@ public class JibExtensionTest {
     ContainerParameters container = testJibExtension.getContainer();
     assertThat(container.getEntrypoint()).containsExactly("foo", "bar", "baz").inOrder();
     assertThat(container.getJvmFlags()).containsExactly("jvmFlag1", "jvmFlag2").inOrder();
-    assertThat(container.getEnvironment())
-        .containsExactly("var1", "value1", "var2", "value2")
-        .inOrder();
     assertThat(container.getExtraClasspath()).containsExactly("/d1", "/d2", "/d3").inOrder();
     assertThat(testJibExtension.getContainer().getExpandClasspathDependencies()).isTrue();
     assertThat(testJibExtension.getContainer().getMainClass()).isEqualTo("mainClass");
@@ -465,7 +461,7 @@ public class JibExtensionTest {
         .containsExactly("entry1", "entry2", "entry3")
         .inOrder();
     System.setProperty("jib.container.environment", "env1=val1,env2=val2");
-    assertThat(testJibExtension.getContainer().getEnvironment())
+    assertThat(testJibExtension.getContainer().getEnvironment().get())
         .containsExactly("env1", "val1", "env2", "val2")
         .inOrder();
     System.setProperty("jib.container.extraClasspath", "/d1,/d2,/d3");

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/JibPluginTest.java
@@ -369,6 +369,14 @@ public class JibPluginTest {
   }
 
   @Test
+  public void testLazyEvalForEnvironment() {
+    BuildResult showLabels = testProject.build("showenvironment", "-Djib.console=plain");
+    assertThat(showLabels.getOutput())
+            .contains(
+                    "environment contains values [var1:val1updated, var2:val2updated]");
+  }
+
+  @Test
   public void testLazyEvalForEntryPoint() {
     BuildResult showEntrypoint = testProject.build("showentrypoint", "-Djib.console=plain");
     assertThat(showEntrypoint.getOutput()).contains("entrypoint contains updated");

--- a/jib-gradle-plugin/src/test/resources/gradle/projects/lazy-evaluation/build.gradle
+++ b/jib-gradle-plugin/src/test/resources/gradle/projects/lazy-evaluation/build.gradle
@@ -17,12 +17,20 @@ dependencies {
 project.ext.value = 'original'
 project.ext.jibCreationTime = '1970-01-23T00:23:42Z'
 project.ext.jibFilesModificationTime = '1970-01-23T01:23:42Z'
+project.ext.jibEnvrionment = [
+        "var1": "val1",
+        "var2": "val2"
+]
 
 project.afterEvaluate {
     project.ext.value = 'updated'
     project.ext.getCustomPermissions = { -> return ['/updated': '755'] }
     project.ext.jibCreationTime = '2022-07-19T10:23:42Z'
     project.ext.jibFilesModificationTime = '2022-07-19T11:23:42Z'
+    project.ext.jibEnvrionment = [
+            "var1": "val1updated",
+            "var2": "val2updated"
+    ]
 }
 
 jib {
@@ -38,6 +46,7 @@ jib {
             ]
         }
         entrypoint = project.provider { [project.ext.value] }
+        environment = project.provider { project.ext.jibEnvrionment }
         creationTime = project.provider { project.ext.jibCreationTime }
         filesModificationTime = project.provider { project.ext.jibFilesModificationTime }
         mainClass = project.provider { project.ext.value }
@@ -81,4 +90,9 @@ tasks.register('showMainClass') {
 tasks.register('showJvmFlags') {
     List<String> prop = project.extensions.jib.container.jvmFlags
     println('jvmFlags value ' + prop)
+}
+
+tasks.register('showenvironment') {
+    Map<String, String> prop = project.extensions.getByName('jib')['container']['environment'].get()
+    println('environment contains values ' + prop)
 }


### PR DESCRIPTION
Fixes #4067🛠️

I ran all tests using `./gradlew clean goJF build integrationTest`. 

I ran all tests but skipped `testBuild_dockerClient` and `testExecute_dockerClient` because these got stuck on my machine. Maybe related to #4311 
