### PR TITLE
fix: add timeout for docker info read to prevent Jib from getting stuck indefinitely

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
@@ -112,7 +112,7 @@ public class CliDockerClient implements DockerClient {
   /**
    * 10 minute timeout to ensure that Jib doesn't get stuck indefinitely when expecting a docker output
    */
-  public static final Long DOCKER_OUTPUT_TIMEOUT = (long) 10;
+  public static final Long DOCKER_OUTPUT_TIMEOUT = (long) 10 * 60 * 1000;
 
   /**
    * Checks if Docker is installed on the user's system by running the `docker` command.

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
@@ -110,7 +110,8 @@ public class CliDockerClient implements DockerClient {
   public static final Path DEFAULT_DOCKER_CLIENT = Paths.get("docker");
 
   /**
-   * 10 minute timeout to ensure that Jib doesn't get stuck indefinitely when expecting a docker output
+   * 10 minute timeout to ensure that Jib doesn't get stuck indefinitely when expecting a docker
+   * output.
    */
   public static final Long DOCKER_OUTPUT_TIMEOUT = (long) 10 * 60 * 1000;
 
@@ -293,7 +294,7 @@ public class CliDockerClient implements DockerClient {
     InputStream inputStream = infoProcess.getInputStream();
     if (infoProcess.waitFor() != 0) {
       throw new IOException(
-              "'docker info' command failed with error: " + getStderrOutput(infoProcess));
+          "'docker info' command failed with error: " + getStderrOutput(infoProcess));
     }
     return JsonTemplateMapper.readJson(inputStream, DockerInfoDetails.class);
   }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/docker/CliDockerClient.java
@@ -47,6 +47,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -102,6 +108,11 @@ public class CliDockerClient implements DockerClient {
 
   /** Default path to the docker executable. */
   public static final Path DEFAULT_DOCKER_CLIENT = Paths.get("docker");
+
+  /**
+   * 10 minute timeout to ensure that Jib doesn't get stuck indefinitely when expecting a docker output
+   */
+  public static final Long DOCKER_OUTPUT_TIMEOUT = (long) 10;
 
   /**
    * Checks if Docker is installed on the user's system by running the `docker` command.
@@ -188,13 +199,19 @@ public class CliDockerClient implements DockerClient {
   @Override
   public DockerInfoDetails info() throws IOException, InterruptedException {
     // Runs 'docker info'.
-    Process infoProcess = docker("info", "-f", "{{json .}}");
-    InputStream inputStream = infoProcess.getInputStream();
-    if (infoProcess.waitFor() != 0) {
-      throw new IOException(
-          "'docker info' command failed with error: " + getStderrOutput(infoProcess));
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    Future<DockerInfoDetails> readerFuture = executor.submit(this::fetchInfoDetails);
+    try {
+      DockerInfoDetails details = readerFuture.get(DOCKER_OUTPUT_TIMEOUT, TimeUnit.MILLISECONDS);
+      return details;
+    } catch (TimeoutException e) {
+      readerFuture.cancel(true); // Interrupt the reader thread
+      throw new IOException("Timeout reached while waiting for 'docker info' output");
+    } catch (ExecutionException e) {
+      throw new IOException("Failed to read output of 'docker info': " + e.getMessage());
+    } finally {
+      executor.shutdownNow();
     }
-    return JsonTemplateMapper.readJson(inputStream, DockerInfoDetails.class);
   }
 
   @Override
@@ -269,5 +286,15 @@ public class CliDockerClient implements DockerClient {
   /** Runs a {@code docker} command. */
   private Process docker(String... subCommand) throws IOException {
     return processBuilderFactory.apply(Arrays.asList(subCommand)).start();
+  }
+
+  private DockerInfoDetails fetchInfoDetails() throws IOException, InterruptedException {
+    Process infoProcess = docker("info", "-f", "{{json .}}");
+    InputStream inputStream = infoProcess.getInputStream();
+    if (infoProcess.waitFor() != 0) {
+      throw new IOException(
+              "'docker info' command failed with error: " + getStderrOutput(infoProcess));
+    }
+    return JsonTemplateMapper.readJson(inputStream, DockerInfoDetails.class);
   }
 }

--- a/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/mock-docker.sh
+++ b/jib-gradle-plugin/src/integration-test/resources/gradle/projects/simple/mock-docker.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [[ "$1" == "info" ]]; then
+  # Output the JSON string
+  echo "{\"OSType\":\"linux\",\"Architecture\":\"x86_64\"}"
+  exit 0
+fi
+
 # Read stdin to avoid broken pipe
 cat > /dev/null
 

--- a/jib-maven-plugin/src/test/resources/maven/projects/simple/mock-docker.sh
+++ b/jib-maven-plugin/src/test/resources/maven/projects/simple/mock-docker.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+if [[ "$1" == "info" ]]; then
+  # Output the JSON string
+  echo "{\"OSType\":\"linux\",\"Architecture\":\"x86_64\"}"
+  exit 0
+fi
+
 # Read stdin to avoid broken pipe
 cat > /dev/null
 


### PR DESCRIPTION
#4311 

1. Fixed gradle and maven integration tests to make mock docker executable output OSType and Architecture. As discovered in https://github.com/GoogleContainerTools/jib/issues/4311#issuecomment-2405793374, Jib ran successfully when the `docker` client was used but was getting stuck indefinitely when a custom docker client was provided through the `jib.dockerClient` feature. 
2. [Improvement] Added timeout to ensure that Jib doesn't indefinitely get stuck when an output from docker info isn't returned, instead we throw an exception with a helpful message.

Verified locally through `./gradlew integrationTest`