### PR TITLE
fix: support parsing manifest config JSON containing `data:` (#4340)

### DIFF
--- a/jib-core/CHANGELOG.md
+++ b/jib-core/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Fixed
+- fix: support parsing manifest config JSON containing `data:`. ([#4346](https://github.com/GoogleContainerTools/jib/pull/4346))
 
 ## 0.27.2
 - fix: allow pushing images with different arch/os to docker daemon [#4265](https://github.com/GoogleContainerTools/jib/issues/4265)

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
@@ -16,6 +16,7 @@
 
 package com.google.cloud.tools.jib.image.json;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.cloud.tools.jib.api.DescriptorDigest;
 import com.google.cloud.tools.jib.json.JsonTemplate;
 import com.google.common.annotations.VisibleForTesting;
@@ -40,6 +41,7 @@ public interface BuildableManifestTemplate extends ManifestTemplate {
    * @see <a href="https://github.com/opencontainers/image-spec/blob/master/descriptor.md">OCI
    *     Content Descriptors</a>
    */
+  @JsonIgnoreProperties(ignoreUnknown = true)
   class ContentDescriptorTemplate implements JsonTemplate {
 
     @SuppressWarnings("unused")

--- a/jib-core/src/test/resources/core/json/v22manifest_optional_properties.json
+++ b/jib-core/src/test/resources/core/json/v22manifest_optional_properties.json
@@ -4,7 +4,8 @@
   "config":{
     "mediaType": "type",
     "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    "size": 10
+    "size": 10,
+    "data": "eyJhcmNoaXRlY3R1cmUiOiJhbWQ2NCIsImhpc3RvcnkiOltdfQ=="
   },
   "layers":[
     {

--- a/jib-gradle-plugin/CHANGELOG.md
+++ b/jib-gradle-plugin/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Fixed
+- fix: support parsing manifest config JSON containing `data:`. ([#4346](https://github.com/GoogleContainerTools/jib/pull/4346))
 
 ## 3.4.4
 - fix: allow pushing images with different arch/os to docker daemon [#4265](https://github.com/GoogleContainerTools/jib/issues/4265)

--- a/jib-maven-plugin/CHANGELOG.md
+++ b/jib-maven-plugin/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 ### Fixed
+- fix: support parsing manifest config JSON containing `data:`. ([#4346](https://github.com/GoogleContainerTools/jib/pull/4346))
 
 ## 3.4.4
 - fix: allow pushing images with different arch/os to docker daemon [#4265](https://github.com/GoogleContainerTools/jib/issues/4265)


### PR DESCRIPTION
Fixes #4340 🛠️
