### PR TITLE
Publish jib-cli so it can be used from Java code

### DIFF
--- a/jib-cli/build.gradle
+++ b/jib-cli/build.gradle
@@ -1,6 +1,7 @@
 plugins {
   id 'application'
   id 'net.researchgate.release'
+  id 'maven-publish'
   id 'eclipse'
 }
 


### PR DESCRIPTION
I'm trying to use `jib` to publish my frontend image as well, just as I did for my Java backend. Previously I used the Docker CLI for this, but I'd like to create all my images without the use of a daemon or elevated rights. If the jib CLI itself would also be published to Maven central, I can re-use it from my Gradle build script to build a non-java image like so:

```
plugins {
  id("org.siouan.frontend-jdk21") version "10.0.0"
}

frontend {
  nodeVersion.set("24.2.0")
  assembleScript.set("run build")
  checkScript.set("run lint")
}

task<JavaExec>("jib") {
  group = "jib"
  description = "Builds and pushes the container image to the container registry."
  mainClass.set("com.google.cloud.tools.jib.cli.JibCli")
  dependsOn("assembleFrontend")
  args("build", "--image-metadata-out=build/jib-image.json", "--target", "my-image:latest")
}
```
