### PR TITLE
Configurable Gradle SourceSet

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildDockerTask.java
@@ -111,7 +111,8 @@ public class BuildDockerTask extends DefaultTask implements JibTask {
             getProject(),
             getLogger(),
             tempDirectoryProvider,
-            jibExtension.getConfigurationName().get());
+            jibExtension.getConfigurationName().get(),
+            jibExtension.getSourceSetName().get());
     GlobalConfig globalConfig = GlobalConfig.readConfig();
     Future<Optional<String>> updateCheckFuture =
         TaskCommon.newUpdateChecker(projectProperties, globalConfig, getLogger());

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildImageTask.java
@@ -99,7 +99,8 @@ public class BuildImageTask extends DefaultTask implements JibTask {
             getProject(),
             getLogger(),
             tempDirectoryProvider,
-            jibExtension.getConfigurationName().get());
+            jibExtension.getConfigurationName().get(),
+            jibExtension.getSourceSetName().get());
     GlobalConfig globalConfig = GlobalConfig.readConfig();
     Future<Optional<String>> updateCheckFuture =
         TaskCommon.newUpdateChecker(projectProperties, globalConfig, getLogger());

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/BuildTarTask.java
@@ -94,7 +94,10 @@ public class BuildTarTask extends DefaultTask implements JibTask {
             .map(ExtraDirectoryParameters::getFrom)
             .collect(Collectors.toList());
     return GradleProjectProperties.getInputFiles(
-        getProject(), extraDirectories, jibExtension.getConfigurationName().get());
+        getProject(),
+        extraDirectories,
+        jibExtension.getConfigurationName().get(),
+        jibExtension.getSourceSetName().get());
   }
 
   /**
@@ -130,7 +133,8 @@ public class BuildTarTask extends DefaultTask implements JibTask {
             getProject(),
             getLogger(),
             tempDirectoryProvider,
-            jibExtension.getConfigurationName().get());
+            jibExtension.getConfigurationName().get(),
+            jibExtension.getSourceSetName().get());
     GlobalConfig globalConfig = GlobalConfig.readConfig();
     Future<Optional<String>> updateCheckFuture =
         TaskCommon.newUpdateChecker(projectProperties, globalConfig, getLogger());

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -246,8 +246,6 @@ public class JibExtension {
 
   @Input
   @Optional
-  @Input
-  @Optional
   public Property<String> getSourceSetName() {
     String property = System.getProperty(PropertyNames.SOURCE_SET_NAME);
     if (property != null && !property.equals(sourceSetName.get())) {

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -246,7 +246,13 @@ public class JibExtension {
 
   @Input
   @Optional
+  @Input
+  @Optional
   public Property<String> getSourceSetName() {
+    String property = System.getProperty(PropertyNames.SOURCE_SET_NAME);
+    if (property != null && !property.equals(sourceSetName.get())) {
+      sourceSetName.set(property);
+    }
     return sourceSetName;
   }
 

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibExtension.java
@@ -27,6 +27,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.SourceSet;
 
 /**
  * Plugin extension for {@link JibPlugin}.
@@ -96,6 +97,7 @@ public class JibExtension {
   private final Property<Boolean> allowInsecureRegistries;
   private final Property<String> containerizingMode;
   private final Property<String> configurationName;
+  private final Property<String> sourceSetName;
   private final ListProperty<ExtensionParameters> pluginExtensions;
   private final ExtensionParametersSpec extensionParametersSpec;
 
@@ -126,6 +128,7 @@ public class JibExtension {
         objectFactory
             .property(String.class)
             .convention(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+    sourceSetName = objectFactory.property(String.class).convention(SourceSet.MAIN_SOURCE_SET_NAME);
   }
 
   public void from(Action<? super BaseImageParameters> action) {
@@ -239,6 +242,12 @@ public class JibExtension {
       configurationName.set(property);
     }
     return configurationName;
+  }
+
+  @Input
+  @Optional
+  public Property<String> getSourceSetName() {
+    return sourceSetName;
   }
 
   @Nested

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/JibPlugin.java
@@ -186,7 +186,7 @@ public class JibPlugin implements Plugin<Project> {
               projectAfterEvaluation
                   .getExtensions()
                   .getByType(SourceSetContainer.class)
-                  .getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+                  .getByName(jibExtension.getSourceSetName().get());
           jibDependencies.add(mainSourceSet.getRuntimeClasspath());
           jibDependencies.add(
               projectAfterEvaluation

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2.java
@@ -158,14 +158,17 @@ public class FilesTaskV2 extends DefaultTask {
    * @param project the project
    */
   private void addProjectFiles(Project project) {
+    Preconditions.checkNotNull(jibExtension);
+
     // Add build config, settings, etc.
     addGradleFiles(project);
 
     // Add sources + resources
     SourceSetContainer sourceSetContainer =
         project.getExtensions().findByType(SourceSetContainer.class);
+    String sourceSetName = jibExtension.getSourceSetName().get();
     if (sourceSetContainer != null) {
-      SourceSet mainSourceSet = sourceSetContainer.findByName(SourceSet.MAIN_SOURCE_SET_NAME);
+      SourceSet mainSourceSet = sourceSetContainer.findByName(sourceSetName);
       if (mainSourceSet != null) {
         mainSourceSet
             .getAllSource()

--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/SyncMapTask.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/SyncMapTask.java
@@ -55,7 +55,8 @@ public class SyncMapTask extends DefaultTask {
               getProject(),
               getLogger(),
               tempDirectoryProvider,
-              jibExtension.getConfigurationName().get());
+              jibExtension.getConfigurationName().get(),
+              jibExtension.getSourceSetName().get());
 
       GradleRawConfiguration configuration = new GradleRawConfiguration(jibExtension);
 

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesExtensionTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesExtensionTest.java
@@ -40,6 +40,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.configuration.ConsoleOutput;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.tasks.SourceSet;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
@@ -238,7 +239,8 @@ public class GradleProjectPropertiesExtensionTest {
             mockLogger,
             mockTempDirectoryProvider,
             () -> loadedExtensions,
-            JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME,
+            SourceSet.MAIN_SOURCE_SET_NAME);
   }
 
   @Test

--- a/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
+++ b/jib-gradle-plugin/src/test/java/com/google/cloud/tools/jib/gradle/GradleProjectPropertiesTest.java
@@ -69,6 +69,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Property;
+import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.bundling.War;
 import org.gradle.jvm.tasks.Jar;
 import org.gradle.testfixtures.ProjectBuilder;
@@ -168,7 +169,8 @@ public class GradleProjectPropertiesTest {
             mockLogger,
             mockTempDirectoryProvider,
             mockExtensionLoader,
-            JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME,
+            SourceSet.MAIN_SOURCE_SET_NAME);
   }
 
   @Test
@@ -219,7 +221,10 @@ public class GradleProjectPropertiesTest {
     List<Path> extraDirectories = Arrays.asList(applicationDirectory.resolve("extra-directory"));
     FileCollection fileCollection =
         GradleProjectProperties.getInputFiles(
-            project, extraDirectories, JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            project,
+            extraDirectories,
+            JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME,
+            SourceSet.MAIN_SOURCE_SET_NAME);
 
     assertThat(fileCollection)
         .comparingElementsUsing(FILE_PATH_OF)
@@ -341,7 +346,8 @@ public class GradleProjectPropertiesTest {
             mockLogger,
             mockTempDirectoryProvider,
             mockExtensionLoader,
-            JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME);
+            JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME,
+            SourceSet.MAIN_SOURCE_SET_NAME);
 
     gradleProjectProperties.createJibContainerBuilder(
         JavaContainerBuilder.from(RegistryImage.named("base")), ContainerizingMode.EXPLODED);

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/PropertyNames.java
@@ -59,6 +59,7 @@ public class PropertyNames {
   public static final String OUTPUT_PATHS_TAR = "jib.outputPaths.tar";
   public static final String CONTAINERIZING_MODE = "jib.containerizingMode";
   public static final String CONFIGURATION_NAME = "jib.configurationName";
+  public static final String SOURCE_SET_NAME = "jib.sourceSetName";
   public static final String SKIP = "jib.skip";
 
   public static final String CONTAINERIZE = "jib.containerize";


### PR DESCRIPTION
Fixes #4316

This introduces a new configuration option `sourceSetName` that just sets the name of the source set that should be used.
This is required to make the Gradle Jib plugin compatible with the Kotlin Multiplatform Plugin.
See https://youtrack.jetbrains.com/issue/KTOR-8464 for more about it.

The PR is inspired by #3034 which is a very similar change.
If this looks good, I can add integration tests the same way #3125 did.