### PR TITLE
chore: remove unused file related to wiki page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,1 +1,0 @@
-These docs generate [googlecontainertools.github.io/jib](https://googlecontainertools.github.io/jib/).

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,0 @@
-theme: jekyll-theme-slate
-
-# Slate theme-specific configuration.
-# See https://github.com/pages-themes/slate


### PR DESCRIPTION
I believe these files are not used anymore as we mived the FAQ to the [docs folder](https://github.com/GoogleContainerTools/jib/blob/master/docs/faq.md) within the repository.

Fixes https://github.com/GoogleContainerTools/jib/issues/4380