### PR TITLE
Avoid use of StartParameter.getSettingsFile() in _jibSkaffoldFilesV2 when Gradle version is 9 or higher

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2.java
@@ -142,7 +142,8 @@ public class FilesTaskV2 extends DefaultTask {
     skaffoldFilesOutput.addBuild(project.getBuildFile().toPath());
 
     // Add settings.gradle
-    if (GradleVersion.current().compareTo(GRADLE_9) < 0 && project.getGradle().getStartParameter().getSettingsFile() != null) {
+    if (GradleVersion.current().compareTo(GRADLE_9) < 0
+        && project.getGradle().getStartParameter().getSettingsFile() != null) {
       skaffoldFilesOutput.addBuild(
           project.getGradle().getStartParameter().getSettingsFile().toPath());
     } else if (Files.exists(projectPath.resolve(Settings.DEFAULT_SETTINGS_FILE))) {


### PR DESCRIPTION
This PR fixes #4052 for Gradle 9 and higher without  breaking backwards compatibility with earlier versions.

Fixes #4052 🛠️
