### PR TITLE
Support building multi-platform OCI index

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -534,7 +534,6 @@ The default when not specified is a single "amd64/linux" platform, whose behavio
 When multiple platforms are specified, Jib creates and pushes a manifest list (also known as a fat manifest) after building and pushing all the images for the specified platforms.
 
 As an incubating feature, there are certain limitations:
-- OCI image indices are not supported (as opposed to Docker manifest lists).
 - Only `architecture` and `os` are supported. If the base image manifest list contains multiple images with the given architecture and os, the first image will be selected.
 - Does not support using a local Docker daemon or tarball image for a base image.
 - Does not support pushing to a Docker daemon (`jib:dockerBuild` / `jibDockerBuild`) or building a local tarball (`jib:buildTar` / `jibBuildTar`).

--- a/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
+++ b/jib-core/src/integration-test/java/com/google/cloud/tools/jib/api/JibIntegrationTest.java
@@ -17,10 +17,12 @@
 package com.google.cloud.tools.jib.api;
 
 import com.google.cloud.tools.jib.Command;
+import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
 import com.google.cloud.tools.jib.api.buildplan.Platform;
 import com.google.cloud.tools.jib.blob.Blobs;
 import com.google.cloud.tools.jib.event.EventHandlers;
 import com.google.cloud.tools.jib.http.FailoverHttpClient;
+import com.google.cloud.tools.jib.image.json.OciIndexTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestListTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestListTemplate.ManifestDescriptorTemplate;
 import com.google.cloud.tools.jib.image.json.V22ManifestTemplate;
@@ -352,6 +354,33 @@ public class JibIntegrationTest {
     Assert.assertEquals("linux", platform1.getOs());
     Assert.assertEquals("amd64", platform2.getArchitecture());
     Assert.assertEquals("linux", platform2.getOs());
+  }
+
+  @Test
+  public void testScratch_multiPlatformOci()
+      throws IOException, InterruptedException, ExecutionException, RegistryException,
+          CacheDirectoryCreationException, InvalidImageReferenceException {
+    Jib.fromScratch()
+        .setFormat(ImageFormat.OCI)
+        .setPlatforms(
+            ImmutableSet.of(new Platform("arm64", "windows"), new Platform("amd64", "windows")))
+        .containerize(
+            Containerizer.to(
+                    RegistryImage.named(dockerHost + ":5000/jib-scratch:multi-platform-oci"))
+                .setAllowInsecureRegistries(true));
+
+    OciIndexTemplate manifestList =
+        (OciIndexTemplate) registryClient.pullManifest("multi-platform-oci").getManifest();
+    Assert.assertEquals(2, manifestList.getManifests().size());
+    OciIndexTemplate.ManifestDescriptorTemplate.Platform platform1 =
+        manifestList.getManifests().get(0).getPlatform();
+    OciIndexTemplate.ManifestDescriptorTemplate.Platform platform2 =
+        manifestList.getManifests().get(1).getPlatform();
+
+    Assert.assertEquals("arm64", platform1.getArchitecture());
+    Assert.assertEquals("windows", platform1.getOs());
+    Assert.assertEquals("amd64", platform2.getArchitecture());
+    Assert.assertEquals("windows", platform2.getOs());
   }
 
   @Test

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ManifestListGenerator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ManifestListGenerator.java
@@ -20,7 +20,6 @@ import com.google.api.client.util.Preconditions;
 import com.google.cloud.tools.jib.blob.BlobDescriptor;
 import com.google.cloud.tools.jib.hash.Digests;
 import com.google.cloud.tools.jib.image.Image;
-import com.google.cloud.tools.jib.image.json.V22ManifestListTemplate.ManifestDescriptorTemplate;
 import java.io.IOException;
 import java.util.List;
 
@@ -44,23 +43,27 @@ public class ManifestListGenerator {
    */
   public <T extends BuildableManifestTemplate> ManifestTemplate getManifestListTemplate(
       Class<T> manifestTemplateClass) throws IOException {
-    Preconditions.checkArgument(
-        manifestTemplateClass == V22ManifestTemplate.class,
-        "Build an OCI image index is not yet supported");
     Preconditions.checkState(!images.isEmpty(), "no images given");
 
+    if (manifestTemplateClass == V22ManifestTemplate.class) {
+      return getV22ManifestListTemplate();
+
+    } else if (manifestTemplateClass == OciManifestTemplate.class) {
+      return getOciIndexTemplate();
+    }
+    throw new IllegalArgumentException(
+        "Unsupported manifestTemplateClass format " + manifestTemplateClass);
+  }
+
+  private V22ManifestListTemplate getV22ManifestListTemplate() throws IOException {
     V22ManifestListTemplate manifestList = new V22ManifestListTemplate();
     for (Image image : images) {
-      ImageToJsonTranslator imageTranslator = new ImageToJsonTranslator(image);
-
-      BlobDescriptor configDescriptor =
-          Digests.computeDigest(imageTranslator.getContainerConfiguration());
-
       BuildableManifestTemplate manifestTemplate =
-          imageTranslator.getManifestTemplate(manifestTemplateClass, configDescriptor);
+          getBuildableManifestTemplate(V22ManifestTemplate.class, image);
       BlobDescriptor manifestDescriptor = Digests.computeDigest(manifestTemplate);
 
-      ManifestDescriptorTemplate manifest = new ManifestDescriptorTemplate();
+      V22ManifestListTemplate.ManifestDescriptorTemplate manifest =
+          new V22ManifestListTemplate.ManifestDescriptorTemplate();
       manifest.setMediaType(manifestTemplate.getManifestMediaType());
       manifest.setSize(manifestDescriptor.getSize());
       manifest.setDigest(manifestDescriptor.getDigest().toString());
@@ -68,5 +71,32 @@ public class ManifestListGenerator {
       manifestList.addManifest(manifest);
     }
     return manifestList;
+  }
+
+  private OciIndexTemplate getOciIndexTemplate() throws IOException {
+    OciIndexTemplate manifestList = new OciIndexTemplate();
+    for (Image image : images) {
+      BuildableManifestTemplate manifestTemplate =
+          getBuildableManifestTemplate(OciManifestTemplate.class, image);
+      BlobDescriptor manifestDescriptor = Digests.computeDigest(manifestTemplate);
+
+      OciIndexTemplate.ManifestDescriptorTemplate manifest =
+          new OciIndexTemplate.ManifestDescriptorTemplate(
+              manifestTemplate.getManifestMediaType(),
+              manifestDescriptor.getSize(),
+              manifestDescriptor.getDigest());
+      manifest.setPlatform(image.getArchitecture(), image.getOs());
+      manifestList.addManifest(manifest);
+    }
+    return manifestList;
+  }
+
+  private <T extends BuildableManifestTemplate>
+      BuildableManifestTemplate getBuildableManifestTemplate(
+          Class<T> manifestTemplateClass, Image image) throws IOException {
+    ImageToJsonTranslator imageTranslator = new ImageToJsonTranslator(image);
+    BlobDescriptor configDescriptor =
+        Digests.computeDigest(imageTranslator.getContainerConfiguration());
+    return imageTranslator.getManifestTemplate(manifestTemplateClass, configDescriptor);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/GoogleContainerTools/jib/issues/2748 🛠️ (revival of https://github.com/GoogleContainerTools/jib/pull/3975)

Removes the limitation of building OCI indexes when using multi-platform.
Re-uses the existing configuration ImageFormat = Docker vs OCI to determine the format of the manifest list/index.
