### PR TITLE
fix: handle caching when detecting a repo requires auth

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RegistryCredentialRetriever.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/RegistryCredentialRetriever.java
@@ -39,7 +39,13 @@ class RegistryCredentialRetriever {
   /** Retrieves credentials for the target image. */
   static Optional<Credential> getTargetImageCredential(BuildContext buildContext)
       throws CredentialRetrievalException {
-    return retrieve(buildContext.getTargetImageConfiguration(), buildContext.getEventHandlers());
+    final Optional<Credential> credential =
+        retrieve(buildContext.getTargetImageConfiguration(), buildContext.getEventHandlers());
+    if (!credential.isPresent()) {
+      logNoCredentialsRetrieved(
+          buildContext.getTargetImageConfiguration(), buildContext.getEventHandlers());
+    }
+    return credential;
   }
 
   private static Optional<Credential> retrieve(
@@ -52,10 +58,14 @@ class RegistryCredentialRetriever {
       }
     }
 
+    return Optional.empty();
+  }
+
+  private static void logNoCredentialsRetrieved(
+      ImageConfiguration imageConfiguration, EventHandlers eventHandlers) {
     String registry = imageConfiguration.getImageRegistry();
     String repository = imageConfiguration.getImageRepository();
     eventHandlers.dispatch(
         LogEvent.info("No credentials could be retrieved for " + registry + "/" + repository));
-    return Optional.empty();
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryUnauthorizedExceptionHandler.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryUnauthorizedExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.google.cloud.tools.jib.registry;
+
+import com.google.cloud.tools.jib.api.RegistryException;
+import com.google.cloud.tools.jib.api.RegistryUnauthorizedException;
+import java.io.IOException;
+import java.util.function.Supplier;
+
+public interface RegistryUnauthorizedExceptionHandler {
+
+  /**
+   * Handle the exception caught by the registry client when it attempted to communicate with the
+   * registry.
+   *
+   * <p>The most obvious action is to simply throw {@code ex}. Other possible actions are to
+   * reauthenticate the client.
+   *
+   * @param registryClient the registry client which may be reconfigured
+   * @param ex the exception being handled on behalf of the client
+   * @return a supplier to use if another exception occurs on the next retry
+   * @throws IOException if an I/O error occurs
+   * @throws RegistryException if a registry error occurs
+   */
+  Supplier<RegistryUnauthorizedExceptionHandler> handle(
+      RegistryClient registryClient, RegistryUnauthorizedException ex)
+      throws IOException, RegistryException;
+}

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStepTest.java
@@ -54,6 +54,7 @@ import com.google.cloud.tools.jib.json.JsonTemplateMapper;
 import com.google.cloud.tools.jib.registry.ManifestAndDigest;
 import com.google.cloud.tools.jib.registry.RegistryClient;
 import com.google.cloud.tools.jib.registry.credentials.CredentialRetrievalException;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableListMultimap;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -94,6 +95,10 @@ public class PullBaseImageStepTest {
     Mockito.when(buildContext.getBaseImageLayersCache()).thenReturn(cache);
     Mockito.when(buildContext.newBaseImageRegistryClientFactory())
         .thenReturn(registryClientFactory);
+    Mockito.when(registryClientFactory.setCredential(Mockito.any()))
+        .thenReturn(registryClientFactory);
+    Mockito.when(registryClientFactory.setUnauthorizedExceptionHandlerSupplier(Mockito.any()))
+        .thenReturn(registryClientFactory);
     Mockito.when(registryClientFactory.newRegistryClient()).thenReturn(registryClient);
     Mockito.when(buildContext.getContainerConfiguration()).thenReturn(containerConfig);
     Mockito.when(containerConfig.getPlatforms())
@@ -101,6 +106,7 @@ public class PullBaseImageStepTest {
     Mockito.when(progressDispatcherFactory.create(Mockito.anyString(), Mockito.anyLong()))
         .thenReturn(progressDispatcher);
     Mockito.when(progressDispatcher.newChildProducer()).thenReturn(progressDispatcherFactory);
+    Mockito.when(imageConfiguration.getCredentialRetrievers()).thenReturn(ImmutableList.of());
 
     pullBaseImageStep = new PullBaseImageStep(buildContext, progressDispatcherFactory);
   }
@@ -678,6 +684,10 @@ public class PullBaseImageStepTest {
     manifest.setContainerConfiguration(1234, digest);
 
     RegistryClient.Factory clientFactory = Mockito.mock(RegistryClient.Factory.class);
+    Mockito.doCallRealMethod().when(clientFactory).setCredential(Mockito.any());
+    Mockito.doCallRealMethod()
+        .when(clientFactory)
+        .setUnauthorizedExceptionHandlerSupplier(Mockito.any());
     RegistryClient client = Mockito.mock(RegistryClient.class);
     Mockito.when(clientFactory.newRegistryClient()).thenReturn(client);
     Mockito.when(client.pullManifest(Mockito.any()))
@@ -709,6 +719,10 @@ public class PullBaseImageStepTest {
     manifest.setContainerConfiguration(1234, digest);
 
     RegistryClient.Factory clientFactory = Mockito.mock(RegistryClient.Factory.class);
+    Mockito.doCallRealMethod().when(clientFactory).setCredential(Mockito.any());
+    Mockito.doCallRealMethod()
+        .when(clientFactory)
+        .setUnauthorizedExceptionHandlerSupplier(Mockito.any());
     RegistryClient client = Mockito.mock(RegistryClient.class);
     Mockito.when(clientFactory.newRegistryClient()).thenReturn(client);
     Mockito.when(client.pullManifest(eq("sha256:aaaaaaa")))

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RegistryCredentialRetrieverTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/builder/steps/RegistryCredentialRetrieverTest.java
@@ -73,12 +73,12 @@ public class RegistryCredentialRetrieverTest {
     Assert.assertFalse(
         RegistryCredentialRetriever.getBaseImageCredential(buildContext).isPresent());
 
-    Mockito.verify(mockEventHandlers)
-        .dispatch(LogEvent.info("No credentials could be retrieved for baseregistry/baserepo"));
+    // Base image credential retrieval does not log when no credentials found
 
     Assert.assertFalse(
         RegistryCredentialRetriever.getTargetImageCredential(buildContext).isPresent());
 
+    // Only target image credential retrieval logs when no credentials found
     Mockito.verify(mockEventHandlers)
         .dispatch(LogEvent.info("No credentials could be retrieved for targetregistry/targetrepo"));
   }
@@ -107,8 +107,16 @@ public class RegistryCredentialRetrieverTest {
       List<CredentialRetriever> baseCredentialRetrievers,
       List<CredentialRetriever> targetCredentialRetrievers)
       throws CacheDirectoryCreationException {
-    ImageReference baseImage = ImageReference.of("baseregistry", "baserepo", null);
-    ImageReference targetImage = ImageReference.of("targetregistry", "targetrepo", null);
+    ImageReference baseImage =
+        ImageReference.of(
+            "baseregistry",
+            "baserepo",
+            "sha256:1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
+    ImageReference targetImage =
+        ImageReference.of(
+            "targetregistry",
+            "targetrepo",
+            "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890");
     return BuildContext.builder()
         .setEventHandlers(mockEventHandlers)
         .setBaseImageConfiguration(


### PR DESCRIPTION
Thank you for your interest in contributing! For general guidelines, please refer to
the [contributing guide](https://github.com/GoogleContainerTools/jib/blob/master/CONTRIBUTING.md).

Please follow the guidelines below before opening an issue or a PR:

- [x] Ensure the issue was not already reported.
- [x] Create a new issue at <https://github.com/GoogleContainerTools/jib/issues/new/choose> if you are unable to find an existing issue addressing your problem. Make sure to include a title and clear description, as much relevant information as possible, and a code sample or an executable test case demonstrating the expected behavior that is not occurring.
- [x] Discuss the priority and potential solutions with the maintainers in the issue. The maintainers would review the issue and add a label "Accepting Contributions" once the issue is ready for accepting contributions.
- [ ] Open a PR only if the issue is labeled with "Accepting Contributions", ensure the PR description clearly describes the problem and solution. Note that an open PR without an issues labeled with "Accepting Contributions" will not be accepted.
- [ ] Verify that integration tests and unit tests are passing after the change.
- [ ] Address all checkstyle issues. Refer to the [style guide](https://github.com/GoogleContainerTools/jib/blob/master/STYLE_GUIDE.md).

Jib may in some circumstances incorrectly determine that a repository
does not require authentication. Take for instance the case where
caching is used for the manifests or other components of a base image.
If the initial request succeeds then Jib assumes the repository does not
require authentication. In the case of a cache miss where authentication
is required, this may result in a 401 which is not handled and fails the
build. Jib should use the /v2/ endpoint to initially determine if the
repository requires authentication.

Fixes: <https://github.com/GoogleContainerTools/jib/issues/4385>