### PR TITLE
fix: make FilesTaskV2 gradle 9 compatible

### DIFF
--- a/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2.java
+++ b/jib-gradle-plugin/src/main/java/com/google/cloud/tools/jib/gradle/skaffold/FilesTaskV2.java
@@ -253,7 +253,7 @@ public class FilesTaskV2 extends DefaultTask {
    * @return the resolved project
    * @throws RuntimeException if the dependent project could not be resolved
    */
-    private Project getDependentProject(ProjectDependency projectDependency) {
+  private Project getDependentProject(ProjectDependency projectDependency) {
     // Try getDependencyProject() first (Gradle 6-8)
     try {
       java.lang.reflect.Method getDependencyProjectMethod =


### PR DESCRIPTION
Fix for _jibSkaffoldFilesV2 task fails on Gradle 9.0+ due to the removal of the [ProjectDependency.getDependencyProject](https://docs.gradle.org/8.11.1/userguide/upgrading_version_8.html#deprecate_get_dependency_project) method and [getSettingsFile](https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#removal_of_custom_build_layout_options) method.

### Changes

In order to allow for us to run tests against gradle 9 this change uses reflection for any methods not available in both gradle 6 && gradle 9.

1) Use reflection to either use getDependentProject (9) or getPath (6-8) to retrieve a project dependancy.
2) Use reflection to check for getSettingsFile, if method doesn't exist or file doesn't exist use the default settings file (if exists)

### Testing Verified
 1) testFilesTask_multiProjectComplexService passed on both gradle 6 && gradle 9 [see PR here](https://github.com/GoogleContainerTools/jib/pull/4478) with gradle 9 testing matrix added
 2) created [reproducer project](https://github.com/ldetmer/test-mm-gradle9) and ran ./gradlew _jibSkaffoldFilesV2 --stacktrace.  It failed using current production version, but passed with local build from this PR.


Fixes #4469 🛠️
