### PR TITLE
chore: update changelog and examples to use 3.5.3 jib-gradle-plugin

### DIFF
--- a/examples/helloworld/build.gradle
+++ b/examples/helloworld/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'com.google.cloud.tools.jib' version '3.5.2'
+  id 'com.google.cloud.tools.jib' version '3.5.3'
 }
 
 sourceCompatibility = 1.8

--- a/examples/java-agent/build.gradle
+++ b/examples/java-agent/build.gradle
@@ -1,6 +1,6 @@
 plugins {
   id 'java'
-  id 'com.google.cloud.tools.jib' version '3.5.2'
+  id 'com.google.cloud.tools.jib' version '3.5.3'
   id 'de.undercouch.download' version '4.0.0'
   id 'com.gorylenko.gradle-git-properties' version '2.2.0'
 }

--- a/examples/ktor/build.gradle.kts
+++ b/examples/ktor/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     application
     kotlin("jvm") version "1.3.10"
-    id("com.google.cloud.tools.jib") version "3.5.2"
+    id("com.google.cloud.tools.jib") version "3.5.3"
 }
 
 group = "example"

--- a/examples/micronaut/build.gradle
+++ b/examples/micronaut/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "groovy"
     id "com.github.johnrengelman.shadow" version "5.2.0"
     id "application"
-    id 'com.google.cloud.tools.jib' version '3.5.2'
+    id 'com.google.cloud.tools.jib' version '3.5.3'
 }
 
 version "0.1"

--- a/examples/multi-module/build.gradle
+++ b/examples/multi-module/build.gradle
@@ -2,5 +2,5 @@
 plugins {
   id 'org.springframework.boot' version '2.0.3.RELEASE' apply false
   id 'io.spring.dependency-management' version '1.0.6.RELEASE' apply false
-  id 'com.google.cloud.tools.jib' version '3.5.2' apply false
+  id 'com.google.cloud.tools.jib' version '3.5.3' apply false
 }

--- a/examples/spring-boot/build.gradle
+++ b/examples/spring-boot/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'idea'
     id 'org.springframework.boot' version '2.1.6.RELEASE'
     id 'io.spring.dependency-management' version '1.0.6.RELEASE'
-    id 'com.google.cloud.tools.jib' version '3.5.2'
+    id 'com.google.cloud.tools.jib' version '3.5.3'
 }
 
 repositories {

--- a/examples/vertx/build.gradle
+++ b/examples/vertx/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'io.vertx.vertx-plugin' version '0.1.0'
-    id 'com.google.cloud.tools.jib' version '3.5.2'
+    id 'com.google.cloud.tools.jib' version '3.5.3'
 }
 
 repositories {

--- a/jib-gradle-plugin/README.md
+++ b/jib-gradle-plugin/README.md
@@ -53,7 +53,7 @@ In your Gradle Java project, add the plugin to your `build.gradle`:
 
 ```groovy
 plugins {
-  id 'com.google.cloud.tools.jib' version '3.5.2'
+  id 'com.google.cloud.tools.jib' version '3.5.3'
 }
 ```
 


### PR DESCRIPTION
Update the changelog and examples to use latest jib-gradle-plugin release 3.5.3.
