### PR TITLE
feat: add OCI base image annotations to manifest

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
@@ -148,9 +148,7 @@ class BuildImageStep implements Callable<Image> {
       }
 
       // Set base image reference and digest for OCI annotations.
-      if (buildContext.getBaseImageConfiguration() != null
-          && buildContext.getBaseImageConfiguration().getImage() != null
-          && !buildContext.getBaseImageConfiguration().getImage().isScratch()) {
+      if (!buildContext.getBaseImageConfiguration().getImage().isScratch()) {
         imageBuilder.setBaseImageName(
             buildContext.getBaseImageConfiguration().getImage().toString());
         imageBuilder.setBaseImageDigest(baseImage.getBaseImageDigest());

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/BuildImageStep.java
@@ -147,6 +147,15 @@ class BuildImageStep implements Callable<Image> {
         imageBuilder.setWorkingDirectory(containerConfiguration.getWorkingDirectory().toString());
       }
 
+      // Set base image reference and digest for OCI annotations.
+      if (buildContext.getBaseImageConfiguration() != null
+          && buildContext.getBaseImageConfiguration().getImage() != null
+          && !buildContext.getBaseImageConfiguration().getImage().isScratch()) {
+        imageBuilder.setBaseImageName(
+            buildContext.getBaseImageConfiguration().getImage().toString());
+        imageBuilder.setBaseImageDigest(baseImage.getBaseImageDigest());
+      }
+
       // Gets the container configuration content descriptor.
       return imageBuilder.build();
     }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/PullBaseImageStep.java
@@ -297,11 +297,16 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
       ProgressEventDispatcher.Factory childProgressDispatcherFactory =
           progressDispatcher1.newChildProducer();
 
+      String baseImageDigest =
+          manifestAndDigest.getDigest() != null ? manifestAndDigest.getDigest().toString() : null;
+
       ManifestTemplate manifestTemplate = manifestAndDigest.getManifest();
       if (manifestTemplate instanceof V21ManifestTemplate) {
         V21ManifestTemplate v21Manifest = (V21ManifestTemplate) manifestTemplate;
         cache.writeMetadata(baseImageConfig.getImage(), v21Manifest);
-        return Collections.singletonList(JsonToImageTranslator.toImage(v21Manifest));
+        Image image = JsonToImageTranslator.toImage(v21Manifest);
+        image.setBaseImageDigest(baseImageDigest);
+        return Collections.singletonList(image);
 
       } else if (manifestTemplate instanceof BuildableManifestTemplate) {
         // V22ManifestTemplate or OciManifestTemplate
@@ -311,8 +316,9 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
                 manifestAndDigest, registryClient, childProgressDispatcherFactory);
         PlatformChecker.checkManifestPlatform(buildContext, containerConfig);
         cache.writeMetadata(baseImageConfig.getImage(), imageManifest, containerConfig);
-        return Collections.singletonList(
-            JsonToImageTranslator.toImage(imageManifest, containerConfig));
+        Image image = JsonToImageTranslator.toImage(imageManifest, containerConfig);
+        image.setBaseImageDigest(baseImageDigest);
+        return Collections.singletonList(image);
       }
 
       Verify.verify(manifestTemplate instanceof ManifestListTemplate);
@@ -344,7 +350,9 @@ class PullBaseImageStep implements Callable<ImagesAndRegistryClient> {
 
           manifestsAndConfigs.add(
               new ManifestAndConfigTemplate(imageManifest, containerConfig, manifestDigest));
-          images.add(JsonToImageTranslator.toImage(imageManifest, containerConfig));
+          Image image = JsonToImageTranslator.toImage(imageManifest, containerConfig);
+          image.setBaseImageDigest(manifestDigest);
+          images.add(image);
         }
       }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/Image.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/Image.java
@@ -57,6 +57,8 @@ public class Image {
     @Nullable private DockerHealthCheck healthCheck;
     @Nullable private String workingDirectory;
     @Nullable private String user;
+    @Nullable private String baseImageName;
+    @Nullable private String baseImageDigest;
 
     private Builder(Class<? extends ManifestTemplate> imageFormat) {
       this.imageFormat = imageFormat;
@@ -251,6 +253,28 @@ public class Image {
     }
 
     /**
+     * Sets the base image name (reference) used to build this image.
+     *
+     * @param baseImageName the base image reference string
+     * @return this
+     */
+    public Builder setBaseImageName(@Nullable String baseImageName) {
+      this.baseImageName = baseImageName;
+      return this;
+    }
+
+    /**
+     * Sets the base image digest.
+     *
+     * @param baseImageDigest the base image digest string
+     * @return this
+     */
+    public Builder setBaseImageDigest(@Nullable String baseImageDigest) {
+      this.baseImageDigest = baseImageDigest;
+      return this;
+    }
+
+    /**
      * Create an {@link Image} instance.
      *
      * @return a new {@link Image} instance
@@ -271,7 +295,9 @@ public class Image {
           ImmutableSet.copyOf(volumesBuilder),
           ImmutableMap.copyOf(labelsBuilder),
           workingDirectory,
-          user);
+          user,
+          baseImageName,
+          baseImageDigest);
     }
   }
 
@@ -324,6 +350,12 @@ public class Image {
   /** User on the container configuration. */
   @Nullable private final String user;
 
+  /** The base image name (reference) used to build this image. */
+  @Nullable private final String baseImageName;
+
+  /** The base image digest. */
+  @Nullable private String baseImageDigest;
+
   private Image(
       Class<? extends ManifestTemplate> imageFormat,
       @Nullable Instant created,
@@ -339,7 +371,9 @@ public class Image {
       @Nullable ImmutableSet<AbsoluteUnixPath> volumes,
       @Nullable ImmutableMap<String, String> labels,
       @Nullable String workingDirectory,
-      @Nullable String user) {
+      @Nullable String user,
+      @Nullable String baseImageName,
+      @Nullable String baseImageDigest) {
     this.imageFormat = imageFormat;
     this.created = created;
     this.architecture = architecture;
@@ -355,6 +389,8 @@ public class Image {
     this.labels = labels;
     this.workingDirectory = workingDirectory;
     this.user = user;
+    this.baseImageName = baseImageName;
+    this.baseImageDigest = baseImageDigest;
   }
 
   public Class<? extends ManifestTemplate> getImageFormat() {
@@ -425,5 +461,35 @@ public class Image {
 
   public ImmutableList<HistoryEntry> getHistory() {
     return history;
+  }
+
+  /**
+   * Returns the base image name (reference) used to build this image.
+   *
+   * @return the base image name, or {@code null} if not set
+   */
+  @Nullable
+  public String getBaseImageName() {
+    return baseImageName;
+  }
+
+  /**
+   * Returns the base image digest.
+   *
+   * @return the base image digest, or {@code null} if not set
+   */
+  @Nullable
+  public String getBaseImageDigest() {
+    return baseImageDigest;
+  }
+
+  /**
+   * Sets the base image digest. This is set after image construction when the digest becomes
+   * available from the registry pull.
+   *
+   * @param baseImageDigest the base image digest string
+   */
+  public void setBaseImageDigest(@Nullable String baseImageDigest) {
+    this.baseImageDigest = baseImageDigest;
   }
 }

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslator.java
@@ -209,11 +209,11 @@ public class ImageToJsonTranslator {
       if (template instanceof OciManifestTemplate) {
         OciManifestTemplate ociTemplate = (OciManifestTemplate) template;
         if (image.getBaseImageName() != null) {
-          ociTemplate.addAnnotation("org.opencontainers.image.base.name", image.getBaseImageName());
+          ociTemplate.addAnnotation(OCI_BASE_IMAGE_NAME_ANNOTATION, image.getBaseImageName());
         }
         if (image.getBaseImageDigest() != null) {
           ociTemplate.addAnnotation(
-              "org.opencontainers.image.base.digest", image.getBaseImageDigest());
+              OCI_BASE_IMAGE_DIGEST_ANNOTATION, image.getBaseImageDigest());
         }
       }
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslator.java
@@ -205,6 +205,18 @@ public class ImageToJsonTranslator {
             layer.getBlobDescriptor().getSize(), layer.getBlobDescriptor().getDigest());
       }
 
+      // Adds OCI base image annotations if the target format is OCI.
+      if (template instanceof OciManifestTemplate) {
+        OciManifestTemplate ociTemplate = (OciManifestTemplate) template;
+        if (image.getBaseImageName() != null) {
+          ociTemplate.addAnnotation("org.opencontainers.image.base.name", image.getBaseImageName());
+        }
+        if (image.getBaseImageDigest() != null) {
+          ociTemplate.addAnnotation(
+              "org.opencontainers.image.base.digest", image.getBaseImageDigest());
+        }
+      }
+
       return template;
 
     } catch (InstantiationException

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/OciManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/OciManifestTemplate.java
@@ -17,9 +17,12 @@
 package com.google.cloud.tools.jib.image.json;
 
 import com.google.cloud.tools.jib.api.DescriptorDigest;
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 
 /**
@@ -77,6 +80,9 @@ public class OciManifestTemplate implements BuildableManifestTemplate {
   /** The list of layer references. */
   private final List<ContentDescriptorTemplate> layers = new ArrayList<>();
 
+  /** The manifest-level annotations. */
+  @Nullable private Map<String, String> annotations;
+
   @Override
   public int getSchemaVersion() {
     return schemaVersion;
@@ -106,5 +112,28 @@ public class OciManifestTemplate implements BuildableManifestTemplate {
   @Override
   public void addLayer(long size, DescriptorDigest digest) {
     layers.add(new ContentDescriptorTemplate(LAYER_MEDIA_TYPE, size, digest));
+  }
+
+  /**
+   * Returns the manifest-level annotations.
+   *
+   * @return the annotations map, or {@code null} if not set
+   */
+  @Nullable
+  public Map<String, String> getAnnotations() {
+    return annotations == null ? null : ImmutableMap.copyOf(annotations);
+  }
+
+  /**
+   * Adds a manifest-level annotation.
+   *
+   * @param key the annotation key
+   * @param value the annotation value
+   */
+  public void addAnnotation(String key, String value) {
+    if (annotations == null) {
+      annotations = new LinkedHashMap<>();
+    }
+    annotations.put(key, value);
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/ImageTest.java
@@ -95,4 +95,31 @@ public class ImageTest {
     Assert.assertEquals("wasm", image.getArchitecture());
     Assert.assertEquals("js", image.getOs());
   }
+
+  @Test
+  public void testBaseImageInfo() {
+    Image image =
+        Image.builder(V22ManifestTemplate.class)
+            .setBaseImageName("alpine:3.18")
+            .setBaseImageDigest("sha256:abc123")
+            .build();
+    Assert.assertEquals("alpine:3.18", image.getBaseImageName());
+    Assert.assertEquals("sha256:abc123", image.getBaseImageDigest());
+  }
+
+  @Test
+  public void testBaseImageInfo_defaults() {
+    Image image = Image.builder(V22ManifestTemplate.class).build();
+    Assert.assertNull(image.getBaseImageName());
+    Assert.assertNull(image.getBaseImageDigest());
+  }
+
+  @Test
+  public void testBaseImageDigest_mutableSetter() {
+    Image image = Image.builder(V22ManifestTemplate.class).build();
+    Assert.assertNull(image.getBaseImageDigest());
+
+    image.setBaseImageDigest("sha256:def456");
+    Assert.assertEquals("sha256:def456", image.getBaseImageDigest());
+  }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslatorTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/ImageToJsonTranslatorTest.java
@@ -145,6 +145,139 @@ public class ImageToJsonTranslatorTest {
   }
 
   @Test
+  public void testGetManifest_ociWithBaseImageAnnotations()
+      throws IOException, DigestException, LayerPropertyNotFoundException {
+    Image.Builder testImageBuilder =
+        Image.builder(OciManifestTemplate.class)
+            .setCreated(Instant.ofEpochSecond(20))
+            .setArchitecture("amd64")
+            .setOs("linux")
+            .setBaseImageName("alpine:3.18")
+            .setBaseImageDigest(
+                "sha256:8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad");
+
+    DescriptorDigest fakeDigest =
+        DescriptorDigest.fromDigest(
+            "sha256:8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad");
+    testImageBuilder.addLayer(
+        new Layer() {
+          @Override
+          public Blob getBlob() throws LayerPropertyNotFoundException {
+            return Blobs.from("ignored");
+          }
+
+          @Override
+          public BlobDescriptor getBlobDescriptor() throws LayerPropertyNotFoundException {
+            return new BlobDescriptor(1000, fakeDigest);
+          }
+
+          @Override
+          public DescriptorDigest getDiffId() throws LayerPropertyNotFoundException {
+            return fakeDigest;
+          }
+        });
+
+    ImageToJsonTranslator translator = new ImageToJsonTranslator(testImageBuilder.build());
+    JsonTemplate containerConfiguration = translator.getContainerConfiguration();
+    BlobDescriptor blobDescriptor = Digests.computeDigest(containerConfiguration);
+    OciManifestTemplate manifestTemplate =
+        translator.getManifestTemplate(OciManifestTemplate.class, blobDescriptor);
+
+    Assert.assertNotNull(manifestTemplate.getAnnotations());
+    Assert.assertEquals(
+        "alpine:3.18", manifestTemplate.getAnnotations().get("org.opencontainers.image.base.name"));
+    Assert.assertEquals(
+        "sha256:8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad",
+        manifestTemplate.getAnnotations().get("org.opencontainers.image.base.digest"));
+  }
+
+  @Test
+  public void testGetManifest_v22NoAnnotations()
+      throws IOException, DigestException, LayerPropertyNotFoundException {
+    Image.Builder testImageBuilder =
+        Image.builder(V22ManifestTemplate.class)
+            .setCreated(Instant.ofEpochSecond(20))
+            .setArchitecture("amd64")
+            .setOs("linux")
+            .setBaseImageName("alpine:3.18")
+            .setBaseImageDigest(
+                "sha256:8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad");
+
+    DescriptorDigest fakeDigest =
+        DescriptorDigest.fromDigest(
+            "sha256:8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad");
+    testImageBuilder.addLayer(
+        new Layer() {
+          @Override
+          public Blob getBlob() throws LayerPropertyNotFoundException {
+            return Blobs.from("ignored");
+          }
+
+          @Override
+          public BlobDescriptor getBlobDescriptor() throws LayerPropertyNotFoundException {
+            return new BlobDescriptor(1000, fakeDigest);
+          }
+
+          @Override
+          public DescriptorDigest getDiffId() throws LayerPropertyNotFoundException {
+            return fakeDigest;
+          }
+        });
+
+    ImageToJsonTranslator translator = new ImageToJsonTranslator(testImageBuilder.build());
+    JsonTemplate containerConfiguration = translator.getContainerConfiguration();
+    BlobDescriptor blobDescriptor = Digests.computeDigest(containerConfiguration);
+    V22ManifestTemplate manifestTemplate =
+        translator.getManifestTemplate(V22ManifestTemplate.class, blobDescriptor);
+
+    // V22 (Docker) manifests should not have OCI annotations
+    String json = JsonTemplateMapper.toUtf8String(manifestTemplate);
+    Assert.assertFalse(json.contains("org.opencontainers.image.base.name"));
+    Assert.assertFalse(json.contains("org.opencontainers.image.base.digest"));
+  }
+
+  @Test
+  public void testGetManifest_ociNoBaseImage()
+      throws IOException, DigestException, LayerPropertyNotFoundException {
+    // Image without base image info (e.g., scratch)
+    Image.Builder testImageBuilder =
+        Image.builder(OciManifestTemplate.class)
+            .setCreated(Instant.ofEpochSecond(20))
+            .setArchitecture("amd64")
+            .setOs("linux");
+
+    DescriptorDigest fakeDigest =
+        DescriptorDigest.fromDigest(
+            "sha256:8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad");
+    testImageBuilder.addLayer(
+        new Layer() {
+          @Override
+          public Blob getBlob() throws LayerPropertyNotFoundException {
+            return Blobs.from("ignored");
+          }
+
+          @Override
+          public BlobDescriptor getBlobDescriptor() throws LayerPropertyNotFoundException {
+            return new BlobDescriptor(1000, fakeDigest);
+          }
+
+          @Override
+          public DescriptorDigest getDiffId() throws LayerPropertyNotFoundException {
+            return fakeDigest;
+          }
+        });
+
+    ImageToJsonTranslator translator = new ImageToJsonTranslator(testImageBuilder.build());
+    JsonTemplate containerConfiguration = translator.getContainerConfiguration();
+    BlobDescriptor blobDescriptor = Digests.computeDigest(containerConfiguration);
+    OciManifestTemplate manifestTemplate =
+        translator.getManifestTemplate(OciManifestTemplate.class, blobDescriptor);
+
+    // No base image info means no annotations
+    Assert.assertNull(manifestTemplate.getAnnotations());
+  }
+
+  @Test
   public void testPortListToMap() {
     ImmutableSet<Port> input = ImmutableSet.of(Port.tcp(1000), Port.udp(2000));
     ImmutableSortedMap<String, Map<?, ?>> expected =

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/OciManifestTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/OciManifestTemplateTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.DigestException;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -77,5 +78,86 @@ public class OciManifestTemplateTest {
         manifestJson.getLayers().get(0).getDigest());
 
     Assert.assertEquals(1000_000, manifestJson.getLayers().get(0).getSize());
+  }
+
+  @Test
+  public void testAnnotations_addAndGet() {
+    OciManifestTemplate manifest = new OciManifestTemplate();
+    Assert.assertNull(manifest.getAnnotations());
+
+    manifest.addAnnotation("org.opencontainers.image.base.name", "alpine:3.18");
+    manifest.addAnnotation(
+        "org.opencontainers.image.base.digest",
+        "sha256:8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad");
+
+    Map<String, String> annotations = manifest.getAnnotations();
+    Assert.assertNotNull(annotations);
+    Assert.assertEquals(2, annotations.size());
+    Assert.assertEquals("alpine:3.18", annotations.get("org.opencontainers.image.base.name"));
+    Assert.assertEquals(
+        "sha256:8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad",
+        annotations.get("org.opencontainers.image.base.digest"));
+  }
+
+  @Test
+  public void testAnnotations_serialization() throws DigestException, IOException {
+    OciManifestTemplate manifest = new OciManifestTemplate();
+    manifest.setContainerConfiguration(
+        1000,
+        DescriptorDigest.fromDigest(
+            "sha256:8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad"));
+    manifest.addLayer(
+        1000_000,
+        DescriptorDigest.fromHash(
+            "4945ba5011739b0b98c4a41afe224e417f47c7c99b2ce76830999c9a0861b236"));
+    manifest.addAnnotation("org.opencontainers.image.base.name", "alpine:3.18");
+    manifest.addAnnotation(
+        "org.opencontainers.image.base.digest",
+        "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789");
+
+    String json = JsonTemplateMapper.toUtf8String(manifest);
+    Assert.assertTrue(json.contains("\"annotations\""));
+    Assert.assertTrue(json.contains("\"org.opencontainers.image.base.name\":\"alpine:3.18\""));
+    Assert.assertTrue(
+        json.contains(
+            "\"org.opencontainers.image.base.digest\":"
+                + "\"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789\""));
+  }
+
+  @Test
+  public void testAnnotations_deserialization() throws IOException {
+    String json =
+        "{\"schemaVersion\":2,"
+            + "\"mediaType\":\"application/vnd.oci.image.manifest.v1+json\","
+            + "\"config\":{\"mediaType\":\"application/vnd.oci.image.config.v1+json\","
+            + "\"digest\":\"sha256:8c662931926fa990b41da3c9f42663a537ccd498130030f9149173a0493832ad\","
+            + "\"size\":1000},"
+            + "\"layers\":[],"
+            + "\"annotations\":{"
+            + "\"org.opencontainers.image.base.name\":\"alpine:3.18\","
+            + "\"org.opencontainers.image.base.digest\":\"sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789\"}}";
+
+    OciManifestTemplate manifest = JsonTemplateMapper.readJson(json, OciManifestTemplate.class);
+
+    Map<String, String> annotations = manifest.getAnnotations();
+    Assert.assertNotNull(annotations);
+    Assert.assertEquals("alpine:3.18", annotations.get("org.opencontainers.image.base.name"));
+    Assert.assertEquals(
+        "sha256:abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789",
+        annotations.get("org.opencontainers.image.base.digest"));
+  }
+
+  @Test
+  public void testAnnotations_getReturnsImmutableCopy() {
+    OciManifestTemplate manifest = new OciManifestTemplate();
+    manifest.addAnnotation("key", "value");
+
+    Map<String, String> annotations = manifest.getAnnotations();
+    try {
+      annotations.put("another", "value");
+      Assert.fail("Expected UnsupportedOperationException");
+    } catch (UnsupportedOperationException expected) {
+      // expected
+    }
   }
 }


### PR DESCRIPTION
Adds support for the OCI pre-defined annotation keys for base images:
- org.opencontainers.image.base.name
- org.opencontainers.image.base.digest

These manifest-level annotations are automatically populated when building OCI format images from a non-scratch base image.

Fixes #4218 🛠️
