### PR TITLE
Expose mediaType on ContentDescriptorTemplate

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/BuildableManifestTemplate.java
@@ -42,7 +42,6 @@ public interface BuildableManifestTemplate extends ManifestTemplate {
    */
   class ContentDescriptorTemplate implements JsonTemplate {
 
-    @SuppressWarnings("unused")
     @Nullable
     private String mediaType;
 
@@ -60,6 +59,11 @@ public interface BuildableManifestTemplate extends ManifestTemplate {
     /** Necessary for Jackson to create from JSON. */
     @SuppressWarnings("unused")
     protected ContentDescriptorTemplate() {}
+
+    @Nullable
+    public String getMediaType() {
+      return mediaType;
+    }
 
     public long getSize() {
       return size;

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/cache/CacheStorageWriterTest.java
@@ -288,6 +288,7 @@ public class CacheStorageWriterTest {
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
         savedManifest2.getLayers().stream()
             .map(layer -> layer.getDigest().getHash())

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/OciManifestTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/OciManifestTemplateTest.java
@@ -71,11 +71,15 @@ public class OciManifestTemplateTest {
 
     Assert.assertEquals(1000, manifestJson.getContainerConfiguration().getSize());
 
+    BuildableManifestTemplate.ContentDescriptorTemplate layer = manifestJson.getLayers().get(0);
+
     Assert.assertEquals(
         DescriptorDigest.fromHash(
             "4945ba5011739b0b98c4a41afe224e417f47c7c99b2ce76830999c9a0861b236"),
-        manifestJson.getLayers().get(0).getDigest());
+        layer.getDigest());
 
-    Assert.assertEquals(1000_000, manifestJson.getLayers().get(0).getSize());
+    Assert.assertEquals(1000_000, layer.getSize());
+
+    Assert.assertEquals("application/vnd.oci.image.layer.v1.tar+gzip", layer.getMediaType());
   }
 }

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/V22ManifestTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/V22ManifestTemplateTest.java
@@ -75,12 +75,16 @@ public class V22ManifestTemplateTest {
 
     Assert.assertEquals(1000, manifestJson.getContainerConfiguration().getSize());
 
+    ContentDescriptorTemplate layer = manifestJson.getLayers().get(0);
+
     Assert.assertEquals(
         DescriptorDigest.fromHash(
             "4945ba5011739b0b98c4a41afe224e417f47c7c99b2ce76830999c9a0861b236"),
-        manifestJson.getLayers().get(0).getDigest());
+        layer.getDigest());
 
-    Assert.assertEquals(1000_000, manifestJson.getLayers().get(0).getSize());
+    Assert.assertEquals(1000_000, layer.getSize());
+
+    Assert.assertEquals("application/vnd.docker.image.rootfs.diff.tar.gzip", layer.getMediaType());
   }
 
   @Test
@@ -92,7 +96,7 @@ public class V22ManifestTemplateTest {
         JsonTemplateMapper.readJsonFromFile(jsonFile, V22ManifestTemplate.class);
 
     List<ContentDescriptorTemplate> layers = manifestJson.getLayers();
-    Assert.assertEquals(4, layers.size());
+    Assert.assertEquals(5, layers.size());
     Assert.assertNull(layers.get(0).getUrls());
     Assert.assertNull(layers.get(0).getAnnotations());
 

--- a/jib-core/src/test/resources/core/json/v22manifest_optional_properties.json
+++ b/jib-core/src/test/resources/core/json/v22manifest_optional_properties.json
@@ -30,6 +30,11 @@
       "size": 4,
       "urls": ["cool-url"],
       "annotations": {"key1":"value1", "key2":"value2"}
+    },
+    {
+      "mediaType": "application/vnd.docker.image.rootfs.diff.tar.gzip",
+      "digest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "size": 5
     }
   ]
 }


### PR DESCRIPTION
## Motivation

`ContentDescriptorTemplate` stores `mediaType` but does not expose it,
while other descriptor fields (digest, size, urls, annotations) are accessible
via public getters.

This makes it difficult to work with OCI artifacts without using reflection.

## Change

Adds a public getter:

```java
@Nullable
public String getMediaType()
```

## Use case

Needed to inspect layer descriptors and select artifacts based on media type,
for example Helm chart layers: `application/vnd.cncf.helm.chart.content.v1.tar+gzip`

Notes

- No behavioral change
- Only exposes already parsed data
- Consistent with existing descriptor getters

Fixes #4498 🛠️
