### PR TITLE
Fix OverlappingFileLockException in Gradle composite builds

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/filesystem/LockFile.java
@@ -31,7 +31,19 @@ import java.util.concurrent.locks.ReentrantLock;
 /** Creates and deletes lock files. */
 public class LockFile implements Closeable {
 
-  private static final ConcurrentHashMap<Path, Lock> lockMap = new ConcurrentHashMap<>();
+  // In Gradle composite builds with independent buildSrc directories, each included build loads
+  // jib-core in its own classloader. A normal static field creates separate lockMap instances per
+  // classloader, failing to prevent concurrent FileChannel.lock() calls on the same file and
+  // causing OverlappingFileLockException (#3347). This is admittedly a hack, but there is no
+  // clean way to share state across classloaders in the same JVM. System.getProperties() returns
+  // the same Hashtable regardless of classloader, so it serves as a JVM-global namespace.
+  // The map's key/value types (Path, Lock) are bootstrap-loaded, so they're safe to cast.
+  @SuppressWarnings("unchecked")
+  private static final ConcurrentHashMap<Path, Lock> lockMap =
+      (ConcurrentHashMap<Path, Lock>)
+          System.getProperties()
+              .computeIfAbsent(
+                  "jib.lockFile.lockMap", key -> new ConcurrentHashMap<Path, Lock>());
 
   private final Path lockFilePath;
   private final FileLock fileLock;


### PR DESCRIPTION
In Gradle composite builds where multiple included builds have independent buildSrc directories, each included build loads jib-core in its own classloader.
The static lockMap in LockFile becomes multiple separate instances (one per classloader) so the synchronization that prevents concurrent FileChannel.lock() calls on the same file doesn't work, causing OverlappingFileLockException.

My fix stores the shared lock map in System.getProperties(), which returns the same Hashtable instance regardless of which classloader calls it. This is admittedly a hack (there's no clean JVM API for cross-classloader shared state), but it's a pattern used by some other libraries facing classloader isolation (e.g. [RESTHeart](https://github.com/SoftInstigate/restheart/blob/master/mongoclient/src/main/java/org/restheart/mongodb/MongoClientSingleton.java#L206), also based on [this SO answer](https://stackoverflow.com/a/47445573)). Only bootstrap-classloader types (Path, Lock) are stored, so cross-classloader casting is safe.

Reproduction:
A Gradle composite build with 8 included builds, each with its own buildSrc declaring the jib plugin, running jibBuildTar in parallel. With jib 3.5.3, this reliably triggers the exception (and builds hang). With this fix applied, all 8 tasks complete successfully across repeated runs.
[jib-parallel-build-reproducer.zip](https://github.com/user-attachments/files/28172482/jib-parallel-build-reproducer.zip)

Fixes https://github.com/GoogleContainerTools/jib/issues/3347