### PR TITLE
Issue #4506: ignore unknown "artifactType" field in manifest descriptors

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/OciIndexTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/OciIndexTemplate.java
@@ -125,6 +125,7 @@ public class OciIndexTemplate implements ManifestListTemplate {
    * href="https://github.com/opencontainers/image-spec/blob/main/image-index.md">OCI Image Index
    * Specification</a>
    */
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class ManifestDescriptorTemplate
       extends BuildableManifestTemplate.ContentDescriptorTemplate {
 

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/V22ManifestListTemplate.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/image/json/V22ManifestListTemplate.java
@@ -114,6 +114,7 @@ public class V22ManifestListTemplate implements ManifestListTemplate {
   }
 
   /** Template for inner JSON object representing a single platform specific manifest. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class ManifestDescriptorTemplate implements JsonTemplate {
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/OciIndexTemplateTest.java
+++ b/jib-core/src/test/java/com/google/cloud/tools/jib/image/json/OciIndexTemplateTest.java
@@ -76,6 +76,27 @@ public class OciIndexTemplateTest {
   }
 
   @Test
+  public void testFromJsonWithUnknownProperties()
+      throws IOException, URISyntaxException, DigestException {
+    // Loads a JSON index whose manifest descriptors carry an OCI 1.1 "artifactType" field, which
+    // Jib does not model. Unknown descriptor properties must be ignored rather than fail parsing.
+    // https://github.com/GoogleContainerTools/jib/issues/4506
+    Path jsonFile =
+        Paths.get(Resources.getResource("core/json/ociindex_artifacttype.json").toURI());
+
+    OciIndexTemplate ociIndexJson =
+        JsonTemplateMapper.readJsonFromFile(jsonFile, OciIndexTemplate.class);
+
+    Assert.assertEquals(2, ociIndexJson.getManifests().size());
+    Assert.assertEquals(
+        "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+        ociIndexJson.getDigestsForPlatform("amd64", "linux").get(0));
+    Assert.assertEquals(
+        "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
+        ociIndexJson.getDigestsForPlatform("arm64", "linux").get(0));
+  }
+
+  @Test
   public void testToJsonWithPlatform() throws DigestException, IOException, URISyntaxException {
     // Loads the expected JSON string.
     Path jsonFile = Paths.get(Resources.getResource("core/json/ociindex_platforms.json").toURI());

--- a/jib-core/src/test/resources/core/json/ociindex_artifacttype.json
+++ b/jib-core/src/test/resources/core/json/ociindex_artifacttype.json
@@ -1,0 +1,26 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.index.v1+json",
+  "manifests": [
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1395,
+      "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      },
+      "artifactType": "application/vnd.docker.container.image.v1+json"
+    },
+    {
+      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
+      "size": 1395,
+      "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
+      "platform": {
+        "architecture": "arm64",
+        "os": "linux"
+      },
+      "artifactType": "application/vnd.docker.container.image.v1+json"
+    }
+  ]
+}

--- a/jib-core/src/test/resources/core/json/v22manifest_list.json
+++ b/jib-core/src/test/resources/core/json/v22manifest_list.json
@@ -9,7 +9,8 @@
       "platform": {
         "architecture": "ppc64le",
         "os": "linux"
-      }
+      },
+      "artifactType": "application/vnd.docker.container.image.v1+json"
     },
     {
       "mediaType": "application/vnd.docker.image.manifest.v2+json",


### PR DESCRIPTION
Fixes #4506

## Problem

Newer Docker (29.5.1) emits the OCI 1.1 optional `artifactType` field on manifest descriptors in an image index. Jib does not model this field and the manifest descriptor templates were not marked to ignore unknown properties, so deserializing such a base (`FROM`) image's index/manifest-list fails:

```
Unrecognized field "artifactType" (class com.google.cloud.tools.jib.image.json.OciIndexTemplate$ManifestDescriptorTemplate), not marked as ignorable ...
```

## Fix

Add `@JsonIgnoreProperties(ignoreUnknown = true)` to the manifest descriptor templates in `OciIndexTemplate` and `V22ManifestListTemplate`, matching the precedent already used elsewhere in the JSON templates (`Platform`, `HistoryEntry`, `ContainerConfigurationTemplate`, etc.).

The descriptors in a base image's index are informational pointers Jib uses only to select the correct platform manifest, so ignoring unrecognized properties is the appropriate, forward-compatible behavior (it also covers other spec-defined descriptor fields such as `data`).

## Tests

- New `ociindex_artifacttype.json` resource (mirroring the manifest in the issue) and `OciIndexTemplateTest#testFromJsonWithUnknownProperties`, asserting parsing succeeds and platform digests resolve.
- Added `artifactType` to an entry in the existing `v22manifest_list.json` so `V22ManifestListTemplateTest` regression-covers the manifest-list case.
