### PR TITLE
fix: correct pushed image logging for latest tag                     …

### DIFF
--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunner.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunner.java
@@ -74,8 +74,12 @@ public class JibBuildRunner {
       String suffix) {
     StringJoiner successMessageBuilder = new StringJoiner(", ", prefix, suffix);
     successMessageBuilder.add(colorCyan(targetImageReference.toString()));
-    for (String tag : additionalTags) {
-      successMessageBuilder.add(colorCyan(targetImageReference.withQualifier(tag).toString()));
+   for (String tag : additionalTags) {
+      if (tag.equals(targetImageReference.getQualifier())) {
+        continue;
+      }
+      successMessageBuilder.add(
+          colorCyan(targetImageReference.withQualifier(tag).toStringWithQualifier()));
     }
     return successMessageBuilder.toString();
   }

--- a/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunner.java
+++ b/jib-plugins-common/src/main/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunner.java
@@ -73,9 +73,9 @@ public class JibBuildRunner {
       String prefix,
       String suffix) {
     StringJoiner successMessageBuilder = new StringJoiner(", ", prefix, suffix);
-    successMessageBuilder.add(colorCyan(targetImageReference.toString()));
-   for (String tag : additionalTags) {
-      if (tag.equals(targetImageReference.getQualifier())) {
+    successMessageBuilder.add(colorCyan(targetImageReference.toStringWithQualifier()));
+    for (String tag : additionalTags) {
+      if (targetImageReference.getQualifier().equals(tag)) {
         continue;
       }
       successMessageBuilder.add(

--- a/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunnerTest.java
+++ b/jib-plugins-common/src/test/java/com/google/cloud/tools/jib/plugins/common/JibBuildRunnerTest.java
@@ -25,6 +25,7 @@ import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.InsecureRegistryException;
 import com.google.cloud.tools.jib.api.JibContainer;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
+import com.google.cloud.tools.jib.api.LogEvent;
 import com.google.cloud.tools.jib.api.RegistryException;
 import com.google.cloud.tools.jib.api.RegistryUnauthorizedException;
 import com.google.cloud.tools.jib.registry.RegistryCredentialsNotSentException;
@@ -34,6 +35,8 @@ import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import org.apache.http.conn.HttpHostConnectException;
@@ -224,6 +227,40 @@ public class JibBuildRunnerTest {
     } catch (BuildStepsExecutionException ex) {
       Assert.assertEquals(TEST_HELPFUL_SUGGESTIONS.none(), ex.getMessage());
     }
+  }
+
+  @Test
+  public void testForBuildImage_successMessageIncludesLatestAndNoDuplicateUntaggedEntry()
+      throws Exception {
+    ImageReference targetImageReference = ImageReference.parse("repo/container");
+    Set<String> additionalTags = ImmutableSet.of("latest", "1.0.0-SNAPSHOT", "branch");
+    List<LogEvent> loggedEvents = new ArrayList<>();
+    JibBuildRunner runner =
+        JibBuildRunner.forBuildImage(
+            mockJibContainerBuilder,
+            mockContainerizer,
+            loggedEvents::add,
+            TEST_HELPFUL_SUGGESTIONS,
+            targetImageReference,
+            additionalTags);
+
+    Mockito.when(mockJibContainerBuilder.containerize(mockContainerizer))
+        .thenReturn(mockJibContainer);
+
+    runner.runBuild();
+
+    String successMessage =
+        loggedEvents.stream()
+            .map(LogEvent::getMessage)
+            .filter(message -> message.contains("Built and pushed"))
+            .findFirst()
+            .orElseThrow(AssertionError::new);
+
+    Assert.assertTrue(successMessage.contains("repo/container:latest"));
+    Assert.assertTrue(successMessage.contains("repo/container:1.0.0-SNAPSHOT"));
+    Assert.assertTrue(successMessage.contains("repo/container:branch"));
+    long occurrences = successMessage.split("repo/container", -1).length - 1L;
+    Assert.assertEquals(3, occurrences);
   }
 
   @Test


### PR DESCRIPTION
…                                                                ─╯

Replace image reference string formatting with toStringWithQualifier() for tagged images and avoid duplicate untagged entries in the success message.

Add a test covering latest and additional tags in build success logs.

Thank you for your interest in contributing! For general guidelines, please refer to
the [contributing guide](https://github.com/GoogleContainerTools/jib/blob/master/CONTRIBUTING.md).

Please follow the guidelines below before opening an issue or a PR:
- [ ] Ensure the issue was not already reported. 
- [ ] Create a new issue at https://github.com/GoogleContainerTools/jib/issues/new/choose if you are unable to find an existing issue addressing your problem. Make sure to include a title and clear description, as much relevant information as possible, and a code sample or an executable test case demonstrating the expected behavior that is not occurring.
- [ ] Discuss the priority and potential solutions with the maintainers in the issue. The maintainers would review the issue and add a label "Accepting Contributions" once the issue is ready for accepting contributions.
- [ ] Open a PR only if the issue is labeled with "Accepting Contributions", ensure the PR description clearly describes the problem and solution. Note that an open PR without an issues labeled with "Accepting Contributions" will not be accepted.
- [ ] Verify that integration tests and unit tests are passing after the change.
- [ ] Address all checkstyle issues. Refer to the [style guide](https://github.com/GoogleContainerTools/jib/blob/master/STYLE_GUIDE.md).

Fixes #4510 🛠️
