### PR TITLE
fix: correct gcloud storage ACL syntax in GCS release scripts

### DIFF
--- a/jib-cli/scripts/update_gcs_latest.sh
+++ b/jib-cli/scripts/update_gcs_latest.sh
@@ -29,7 +29,7 @@ destination="gs://jib-versions/jib-cli"
 
 echo $versionString > jib-cli-temp
 gcloud storage cp jib-cli-temp $destination
-gcloud storage objects update --add-acl-grant=allUsers=READ $destination
+gcloud storage objects update --add-acl-grant=entity=allUsers,role=READER $destination
 rm jib-cli-temp
 
 gcsResult=$(curl https://storage.googleapis.com/jib-versions/jib-cli)

--- a/jib-gradle-plugin/scripts/update_gcs_latest.sh
+++ b/jib-gradle-plugin/scripts/update_gcs_latest.sh
@@ -29,7 +29,7 @@ destination="gs://jib-versions/jib-gradle"
 
 echo $versionString > jib-gradle
 gcloud storage cp jib-gradle $destination
-gcloud storage objects update --add-acl-grant=allUsers:READ $destination
+gcloud storage objects update --add-acl-grant=entity=allUsers,role=READER $destination
 rm jib-gradle
 
 gcsResult=$(curl https://storage.googleapis.com/jib-versions/jib-gradle)

--- a/jib-maven-plugin/scripts/update_gcs_latest.sh
+++ b/jib-maven-plugin/scripts/update_gcs_latest.sh
@@ -29,7 +29,7 @@ destination="gs://jib-versions/jib-maven"
 
 echo $versionString > jib-maven
 gcloud storage cp jib-maven $destination
-gcloud storage objects update --add-acl-grant=allUsers:READ $destination
+gcloud storage objects update --add-acl-grant=entity=allUsers,role=READER $destination
 rm jib-maven
 
 gcsResult=$(curl https://storage.googleapis.com/jib-versions/jib-maven)


### PR DESCRIPTION
After #4493 the scripts fail with errors like "Bad syntax for dict arg: [allUsers:READ]"

See also https://docs.cloud.google.com/storage/docs/gsutil-transition-to-gcloud
