### PR TITLE
Fix path traversal in local tar base-image manifest parsing (CWE-22)

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -278,7 +278,7 @@ public class LocalBaseImageSteps {
       // Check the first layer to see if the layers are compressed already. 'docker save' output
       // is uncompressed, but a jib-built tar has compressed layers.
       boolean layersAreCompressed =
-          !layerFiles.isEmpty() && isGzipped(resolveManifestPath(destination, layerFiles.get(0)));
+          !layerFiles.isEmpty() && isGzipped(resolveManifestPath(destination, canonicalDestination, layerFiles.get(0)));
 
       // Process layer blobs
       try (ProgressEventDispatcher progressEventDispatcher =

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -288,7 +288,7 @@ public class LocalBaseImageSteps {
         // Start compressing layers in parallel
         List<Future<PreparedLayer>> preparedLayers = new ArrayList<>();
         for (int index = 0; index < layerFiles.size(); index++) {
-          Path layerFile = resolveManifestPath(destination, layerFiles.get(index));
+          Path layerFile = resolveManifestPath(destination, canonicalDestination, layerFiles.get(index));
           DescriptorDigest diffId = configurationTemplate.getLayerDiffId(index);
           ProgressEventDispatcher.Factory layerProgressDispatcherFactory =
               progressEventDispatcher.newChildProducer();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -113,10 +113,11 @@ public class LocalBaseImageSteps {
    * @return the resolved, verified path
    * @throws IOException if the resolved path would escape {@code destination}
    */
-  private static Path resolveManifestPath(Path destination, String manifestDeclaredName)
+  @VisibleForTesting
+  static Path resolveManifestPath(
+      Path destination, String canonicalDestination, String manifestDeclaredName)
       throws IOException {
     Path resolved = destination.resolve(manifestDeclaredName);
-    String canonicalDestination = destination.toFile().getCanonicalPath();
     String canonicalResolved = resolved.toFile().getCanonicalPath();
     if (!canonicalResolved.startsWith(canonicalDestination + File.separator)) {
       throw new IOException(

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -47,6 +47,7 @@ import com.google.cloud.tools.jib.tar.TarExtractor;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.ByteStreams;
 import com.google.common.util.concurrent.Futures;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -94,6 +95,34 @@ public class LocalBaseImageSteps {
       int magic = (inputStream.read() & 0xff) | ((inputStream.read() << 8) & 0xff00);
       return magic == GZIPInputStream.GZIP_MAGIC;
     }
+  }
+
+  /**
+   * Resolves a file name declared in a base image tar's {@code manifest.json} (the {@code
+   * Config} field or an entry of the {@code Layers} array) against the tar's extraction
+   * directory, rejecting any manifest-declared name that would escape that directory.
+   *
+   * <p>{@code manifest.json} is part of the tar's own (potentially untrusted) contents, so an
+   * absolute path or a path containing {@code ..} segments must not be allowed to make Jib read
+   * an arbitrary file elsewhere on the host. This mirrors the containment check {@link
+   * com.google.cloud.tools.jib.tar.TarExtractor#extract} already applies to tar entry names.
+   *
+   * @param destination the tar's extraction directory
+   * @param manifestDeclaredName the {@code Config} or {@code Layers} file name from {@code
+   *     manifest.json}
+   * @return the resolved, verified path
+   * @throws IOException if the resolved path would escape {@code destination}
+   */
+  private static Path resolveManifestPath(Path destination, String manifestDeclaredName)
+      throws IOException {
+    Path resolved = destination.resolve(manifestDeclaredName);
+    String canonicalDestination = destination.toFile().getCanonicalPath();
+    String canonicalResolved = resolved.toFile().getCanonicalPath();
+    if (!canonicalResolved.startsWith(canonicalDestination + File.separator)) {
+      throw new IOException(
+          "Illegal file name in manifest.json, potential path traversal: " + manifestDeclaredName);
+    }
+    return resolved;
   }
 
   static Callable<LocalImage> retrieveDockerDaemonLayersStep(
@@ -225,7 +254,7 @@ public class LocalBaseImageSteps {
                 .readValue(manifestStream, DockerManifestEntryTemplate[].class)[0];
       }
 
-      Path configPath = destination.resolve(loadManifest.getConfig());
+      Path configPath = resolveManifestPath(destination, loadManifest.getConfig());
       ContainerConfigurationTemplate configurationTemplate =
           JsonTemplateMapper.readJsonFromFile(configPath, ContainerConfigurationTemplate.class);
       // Don't compute the digest of the loaded Java JSON instance.
@@ -248,7 +277,7 @@ public class LocalBaseImageSteps {
       // Check the first layer to see if the layers are compressed already. 'docker save' output
       // is uncompressed, but a jib-built tar has compressed layers.
       boolean layersAreCompressed =
-          !layerFiles.isEmpty() && isGzipped(destination.resolve(layerFiles.get(0)));
+          !layerFiles.isEmpty() && isGzipped(resolveManifestPath(destination, layerFiles.get(0)));
 
       // Process layer blobs
       try (ProgressEventDispatcher progressEventDispatcher =
@@ -257,7 +286,7 @@ public class LocalBaseImageSteps {
         // Start compressing layers in parallel
         List<Future<PreparedLayer>> preparedLayers = new ArrayList<>();
         for (int index = 0; index < layerFiles.size(); index++) {
-          Path layerFile = destination.resolve(layerFiles.get(index));
+          Path layerFile = resolveManifestPath(destination, layerFiles.get(index));
           DescriptorDigest diffId = configurationTemplate.getLayerDiffId(index);
           ProgressEventDispatcher.Factory layerProgressDispatcherFactory =
               progressEventDispatcher.newChildProducer();

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/builder/steps/LocalBaseImageSteps.java
@@ -255,7 +255,8 @@ public class LocalBaseImageSteps {
                 .readValue(manifestStream, DockerManifestEntryTemplate[].class)[0];
       }
 
-      Path configPath = resolveManifestPath(destination, loadManifest.getConfig());
+      String canonicalDestination = destination.toFile().getCanonicalPath();
+      Path configPath = resolveManifestPath(destination, canonicalDestination, loadManifest.getConfig());
       ContainerConfigurationTemplate configurationTemplate =
           JsonTemplateMapper.readJsonFromFile(configPath, ContainerConfigurationTemplate.class);
       // Don't compute the digest of the loaded Java JSON instance.


### PR DESCRIPTION
## Summary

Fixes a path traversal issue (CWE-22) in `LocalBaseImageSteps.cacheDockerImageTar`, reported to Google's OSS VRP as issue [536528963](https://issuetracker.google.com/issues/536528963) (closed there only because Jib's current reward tier makes product vulnerabilities ineligible for a monetary reward — the maintainers did not dispute the finding and invited a direct PR).

## The problem

When Jib containerizes using a local tar file as the base image (`Jib.from(TarImage.at(path))`, or the `tar://` image reference), it parses the tar's `manifest.json` and resolves the `Config` and `Layers` string fields directly against the extraction directory via `destination.resolve(...)`, with no path canonicalization or bounds-checking:

- `LocalBaseImageSteps.java` — the `Config` path resolution
- `LocalBaseImageSteps.java` — the gzip-sniff of the first layer
- `LocalBaseImageSteps.java` — each `Layers` entry inside the processing loop

Since `manifest.json` is part of the tar's own (potentially untrusted) contents, a crafted tar can set a `Layers` entry to an absolute path or a path containing `../` segments, causing Jib to read an arbitrary file elsewhere on the host filesystem, gzip-compress it, and embed it as a real layer blob in the *output* image — with no check that the content matches the declared `diffId`. If that output image is later pushed to a registry, the file's contents are exposed.

This mirrors the "Zip Slip" bug class, except the malicious path arrives via a manifest field trusted verbatim rather than an archive entry name. Notably, tar *extraction* in this same code path (`TarExtractor.extract`) already defends against exactly this kind of escape — this fix brings the manifest-parsing step up to the same standard.

## The fix

Adds a `resolveManifestPath(Path destination, String manifestDeclaredName)` helper that resolves the manifest-declared name and then canonicalizes and bounds-checks the result against the destination directory, throwing `IOException` if it would escape — the same pattern `TarExtractor.extract` already uses for tar entry names. All three unguarded `resolve()` call sites now go through this helper.

## Testing

Manually verified with a proof-of-concept malicious tar whose `manifest.json` `Layers` array pointed at an absolute path to a file outside the tar. Before this fix, that file's contents were read and embedded in the output image. After this fix, `cacheDockerImageTar` throws `IOException: Illegal file name in manifest.json, potential path traversal: ...` instead.

Happy to add a JUnit test alongside this if preferred — didn't want to guess at the project's existing test fixture conventions without seeing them first.
