### PR TITLE
Redact OAuth2 refresh token from authentication-failure exception message (CWE-532)

### DIFF
--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
@@ -238,12 +238,12 @@ public class RegistryAuthenticator {
   @VisibleForTesting
   String getRedactedAuthRequestParameters(
       @Nullable Credential credential, Map<String, String> repositoryScopes) {
-    String serviceScope = getServiceScopeRequestParameters(repositoryScopes);
-    return isOAuth2Auth(credential)
-        ? serviceScope
-            + "&client_id=jib.da031fe481a93ac107a95a96462358f9"
-            + "&grant_type=refresh_token&refresh_token=<redacted>"
-        : serviceScope;
+    String parameters = getAuthRequestParameters(credential, repositoryScopes);
+    if (isOAuth2Auth(credential)) {
+      String password = Verify.verifyNotNull(credential).getPassword();
+      return parameters.replace("&refresh_token=" + password, "&refresh_token=<redacted>");
+    }
+    return parameters;
   }
 
   @VisibleForTesting

--- a/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
+++ b/jib-core/src/main/java/com/google/cloud/tools/jib/registry/RegistryAuthenticator.java
@@ -224,6 +224,28 @@ public class RegistryAuthenticator {
         : serviceScope;
   }
 
+  /**
+   * Same content as {@link #getAuthRequestParameters}, but with the OAuth2 refresh token
+   * redacted. Use this (never {@link #getAuthRequestParameters}) when building human-readable
+   * text such as exception messages or log output, since those routinely end up in build/CI
+   * logs -- the real, unredacted parameters must only ever be used for the actual HTTP request
+   * body sent to the registry's token endpoint.
+   *
+   * @param credential the credential used to authenticate
+   * @param repositoryScopes the repository scopes to authenticate for
+   * @return the auth request parameters, with any refresh token redacted
+   */
+  @VisibleForTesting
+  String getRedactedAuthRequestParameters(
+      @Nullable Credential credential, Map<String, String> repositoryScopes) {
+    String serviceScope = getServiceScopeRequestParameters(repositoryScopes);
+    return isOAuth2Auth(credential)
+        ? serviceScope
+            + "&client_id=jib.da031fe481a93ac107a95a96462358f9"
+            + "&grant_type=refresh_token&refresh_token=<redacted>"
+        : serviceScope;
+  }
+
   @VisibleForTesting
   boolean isOAuth2Auth(@Nullable Credential credential) {
     return credential != null && credential.isOAuth2RefreshToken();
@@ -292,7 +314,7 @@ public class RegistryAuthenticator {
               "Did not get token in authentication response from "
                   + getAuthenticationUrl(credential, repositoryScopes)
                   + "; parameters: "
-                  + getAuthRequestParameters(credential, repositoryScopes));
+                  + getRedactedAuthRequestParameters(credential, repositoryScopes));
         }
         return Authorization.fromBearerToken(responseJson.getToken());
       }


### PR DESCRIPTION
## Summary

Fixes a CWE-532 (insertion of sensitive information into a log file) issue in `RegistryAuthenticator`: when an OAuth2-authenticated registry's token endpoint responds without a `token`/`access_token` field, the resulting `RegistryAuthenticationFailedException` message embedded the caller's actual OAuth2 refresh token in plaintext. That exception message flows to build output, which is routinely captured in CI logs.

A corresponding OSS VRP report for this issue is being prepared.

## The problem

`getAuthRequestParameters()` builds the real OAuth2 token-exchange request body, including the actual refresh token:

```java
+ "&grant_type=refresh_token&refresh_token="
+ Verify.verifyNotNull(credential).getPassword()
```

That's correct and necessary for the real HTTP request. The bug is that the *same* method's output was also reused when building a human-readable exception message on failure:

```java
throw new RegistryAuthenticationFailedException(
    registryUrl, imageName,
    "Did not get token in authentication response from " + getAuthenticationUrl(...)
        + "; parameters: " + getAuthRequestParameters(credential, repositoryScopes));
```

This fires whenever the registry's auth server responds 200 without a token field — a realistic, non-malicious failure mode (misconfigured auth server, unexpected response shape, etc.), not something requiring an attacker.

## The fix

Adds `getRedactedAuthRequestParameters()`, identical to `getAuthRequestParameters()` except the refresh token is replaced with the literal string `<redacted>`. The real (unredacted) method continues to be used for the actual request body sent to the registry — only the exception-message call site was switched to the redacted variant.

## Testing

Manually verified with a local mock OAuth2 registry that responds 200 with no `token` field. Before this fix, the resulting exception message contained the real refresh token in plaintext. After this fix, it contains `refresh_token=<redacted>` instead, while the actual token exchange request itself is unaffected (still uses the real token).

Happy to add a JUnit test alongside this if preferred.
